### PR TITLE
fix(lucien): code review followups — Clock, type safety, teardown

### DIFF
--- a/.github/workflows/documentation-checks.yml
+++ b/.github/workflows/documentation-checks.yml
@@ -28,7 +28,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/documentation-checks.yml
+++ b/.github/workflows/documentation-checks.yml
@@ -31,9 +31,9 @@ jobs:
         uses: actions/checkout@v5
         
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
           
       - name: Install markdown tools
         run: |

--- a/.github/workflows/gpu-shader-validation.yml
+++ b/.github/workflows/gpu-shader-validation.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install glslang validator
         run: |
@@ -79,7 +79,7 @@ jobs:
       LIBGL_ALWAYS_SOFTWARE: 1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: graalvm/setup-graalvm@v1
         with:
@@ -117,7 +117,7 @@ jobs:
           glxinfo | grep -i "compute" || echo "Compute shader info not found"
 
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/gpu-vendor-tests.yml
+++ b/.github/workflows/gpu-vendor-tests.yml
@@ -48,7 +48,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -59,7 +59,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: luciferase-maven-gpu-${{ hashFiles('**/pom.xml') }}
@@ -131,7 +131,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: tier1-test-results
           path: render/target/surefire-reports/
@@ -157,7 +157,7 @@ jobs:
   #     GPU_VENDOR: NVIDIA
   #
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v5
   #     - uses: graalvm/setup-graalvm@v1
   #       with:
   #         java-version: '25'
@@ -168,7 +168,7 @@ jobs:
   #           -Dtest="DAGOpenCLRendererVendorTest#testNvidiaRTX4090Execution,DAGOpenCLRendererVendorTest#testNvidiaRTX3060Execution" \
   #           -Dsurefire.rerunFailingTestsCount=0
   #     - name: Upload NVIDIA Results
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v5
   #       with:
   #         name: tier2-nvidia-results
   #         path: render/target/surefire-reports/
@@ -183,7 +183,7 @@ jobs:
   #     GPU_VENDOR: AMD
   #
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v5
   #     - uses: graalvm/setup-graalvm@v1
   #       with:
   #         java-version: '25'
@@ -194,7 +194,7 @@ jobs:
   #           -Dtest="DAGOpenCLRendererVendorTest#testAmdRX6900XTExecution,DAGOpenCLRendererVendorTest#testAmdRX6700XTExecution" \
   #           -Dsurefire.rerunFailingTestsCount=0
   #     - name: Upload AMD Results
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v5
   #       with:
   #         name: tier2-amd-results
   #         path: render/target/surefire-reports/
@@ -209,7 +209,7 @@ jobs:
   #     GPU_VENDOR: Intel
   #
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v5
   #     - uses: graalvm/setup-graalvm@v1
   #       with:
   #         java-version: '25'
@@ -220,7 +220,7 @@ jobs:
   #           -Dtest="DAGOpenCLRendererVendorTest#testIntelArcA770Execution,DAGOpenCLRendererVendorTest#testIntelArcA380Execution" \
   #           -Dsurefire.rerunFailingTestsCount=0
   #     - name: Upload Intel Results
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v5
   #       with:
   #         name: tier2-intel-results
   #         path: render/target/surefire-reports/
@@ -235,7 +235,7 @@ jobs:
   #     GPU_VENDOR: Apple
   #
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v5
   #     - uses: graalvm/setup-graalvm@v1
   #       with:
   #         java-version: '25'
@@ -246,7 +246,7 @@ jobs:
   #           -Dtest="DAGOpenCLRendererVendorTest#testAppleM2MaxExecution,DAGOpenCLRendererVendorTest#testAppleM3MaxExecution" \
   #           -Dsurefire.rerunFailingTestsCount=0
   #     - name: Upload Apple Results
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v5
   #       with:
   #         name: tier2-apple-results
   #         path: render/target/surefire-reports/
@@ -268,7 +268,7 @@ jobs:
   #     RUN_GPU_TESTS: true
   #
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v5
   #     - uses: graalvm/setup-graalvm@v1
   #       with:
   #         java-version: '25'
@@ -279,7 +279,7 @@ jobs:
   #           -Dtest="NvidiaGPUTest,DAGOpenCLRendererVendorTest" \
   #           -Dsurefire.rerunFailingTestsCount=0
   #     - name: Upload NVIDIA Full Results
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v5
   #       with:
   #         name: tier3-nvidia-full-results
   #         path: render/target/surefire-reports/
@@ -294,7 +294,7 @@ jobs:
   #     RUN_GPU_TESTS: true
   #
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v5
   #     - uses: graalvm/setup-graalvm@v1
   #       with:
   #         java-version: '25'
@@ -305,7 +305,7 @@ jobs:
   #           -Dtest="AmdGPUTest,DAGOpenCLRendererVendorTest" \
   #           -Dsurefire.rerunFailingTestsCount=0
   #     - name: Upload AMD Full Results
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v5
   #       with:
   #         name: tier3-amd-full-results
   #         path: render/target/surefire-reports/
@@ -320,7 +320,7 @@ jobs:
   #     RUN_GPU_TESTS: true
   #
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v5
   #     - uses: graalvm/setup-graalvm@v1
   #       with:
   #         java-version: '25'
@@ -331,7 +331,7 @@ jobs:
   #           -Dtest="IntelGPUTest,DAGOpenCLRendererVendorTest" \
   #           -Dsurefire.rerunFailingTestsCount=0
   #     - name: Upload Intel Full Results
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v5
   #       with:
   #         name: tier3-intel-full-results
   #         path: render/target/surefire-reports/
@@ -346,7 +346,7 @@ jobs:
   #     RUN_GPU_TESTS: true
   #
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v5
   #     - uses: graalvm/setup-graalvm@v1
   #       with:
   #         java-version: '25'
@@ -357,7 +357,7 @@ jobs:
   #           -Dtest="AppleGPUTest,DAGOpenCLRendererVendorTest" \
   #           -Dsurefire.rerunFailingTestsCount=0
   #     - name: Upload Apple Full Results
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v5
   #       with:
   #         name: tier3-apple-full-results
   #         path: render/target/surefire-reports/
@@ -374,10 +374,10 @@ jobs:
   #   if: always() && (github.event.inputs.run_gpu_tests == 'true' || github.event_name == 'schedule')
   #
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v5
   #
   #     - name: Download All Vendor Results
-  #       uses: actions/download-artifact@v4
+  #       uses: actions/download-artifact@v5
   #       with:
   #         pattern: tier2-*-results
   #         path: vendor-results/
@@ -394,7 +394,7 @@ jobs:
   #         echo "Target: >90% consistency across all vendors"
   #
   #     - name: Upload Consistency Report
-  #       uses: actions/upload-artifact@v4
+  #       uses: actions/upload-artifact@v5
   #       with:
   #         name: multi-vendor-consistency-report
   #         path: consistency-report.md

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -24,7 +24,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven packages and compiled artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository
@@ -68,7 +68,7 @@ jobs:
           PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Save Maven cache after compile
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository
@@ -85,7 +85,7 @@ jobs:
       CI: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -96,7 +96,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore Maven cache from compile job
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository
@@ -157,7 +157,7 @@ jobs:
       CI: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -168,7 +168,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore Maven cache from compile job
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository
@@ -229,7 +229,7 @@ jobs:
       CI: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -240,7 +240,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore Maven cache from compile job
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository
@@ -301,7 +301,7 @@ jobs:
       CI: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -312,7 +312,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore Maven cache from compile job
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository
@@ -373,7 +373,7 @@ jobs:
       CI: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -384,7 +384,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore Maven cache from compile job
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository
@@ -445,7 +445,7 @@ jobs:
       CI: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -456,7 +456,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore Maven cache from compile job
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
@@ -30,7 +30,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/SimpleGhostSyncAdapter.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/SimpleGhostSyncAdapter.java
@@ -17,6 +17,7 @@
 package com.hellblazer.luciferase.lucien.balancing;
 
 import com.hellblazer.luciferase.lucien.balancing.fault.FaultHandler;
+import com.hellblazer.luciferase.lucien.balancing.fault.GhostSyncCallback;
 import com.hellblazer.luciferase.lucien.forest.ghost.DistributedGhostManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +49,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @author hal.hildebrand
  */
-public class SimpleGhostSyncAdapter {
+public class SimpleGhostSyncAdapter implements GhostSyncCallback {
 
     private static final Logger log = LoggerFactory.getLogger(SimpleGhostSyncAdapter.class);
 

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/fault/FaultTolerantDistributedForest.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/fault/FaultTolerantDistributedForest.java
@@ -6,6 +6,7 @@ import com.hellblazer.luciferase.lucien.balancing.ParallelBalancer;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.forest.Forest;
 import com.hellblazer.luciferase.lucien.forest.ghost.DistributedGhostManager;
+import com.hellblazer.luciferase.simulation.distributed.integration.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,6 +86,9 @@ public class FaultTolerantDistributedForest<Key extends SpatialKey<Key>, ID exte
     // Metrics
     private final FaultTolerantForestStats.StatsAccumulator statsAccumulator;
 
+    // Deterministic time source
+    private final Clock clock;
+
     // Executor for async recovery
     private final ExecutorService recoveryExecutor;
 
@@ -112,6 +116,36 @@ public class FaultTolerantDistributedForest<Key extends SpatialKey<Key>, ID exte
         FaultConfiguration configuration,
         InFlightOperationTracker operationTracker
     ) {
+        this(delegate, faultHandler, recoveryLock, balancer, ghostManager,
+             topology, localPartitionId, configuration, operationTracker, Clock.system());
+    }
+
+    /**
+     * Create a fault-tolerant distributed forest decorator with injected clock.
+     *
+     * @param delegate the underlying distributed forest
+     * @param faultHandler fault detection handler
+     * @param recoveryLock recovery coordination lock
+     * @param balancer the parallel balancer (for pause coordination)
+     * @param ghostManager the ghost manager (for pause coordination)
+     * @param topology partition topology mapping
+     * @param localPartitionId the local partition UUID
+     * @param configuration fault tolerance configuration
+     * @param operationTracker shared tracker for synchronous pause
+     * @param clock time source for deterministic testing
+     */
+    public FaultTolerantDistributedForest(
+        ParallelBalancer.DistributedForest<Key, ID, Content> delegate,
+        SimpleFaultHandler faultHandler,
+        RecoveryCoordinatorLock recoveryLock,
+        DefaultParallelBalancer<Key, ID, Content> balancer,
+        DistributedGhostManager<Key, ID, Content> ghostManager,
+        PartitionTopology topology,
+        UUID localPartitionId,
+        FaultConfiguration configuration,
+        InFlightOperationTracker operationTracker,
+        Clock clock
+    ) {
         this.delegate = Objects.requireNonNull(delegate, "delegate");
         this.faultHandler = Objects.requireNonNull(faultHandler, "faultHandler");
         this.recoveryLock = Objects.requireNonNull(recoveryLock, "recoveryLock");
@@ -121,6 +155,7 @@ public class FaultTolerantDistributedForest<Key extends SpatialKey<Key>, ID exte
         this.localPartitionId = Objects.requireNonNull(localPartitionId, "localPartitionId");
         this.configuration = Objects.requireNonNull(configuration, "configuration");
         this.operationTracker = Objects.requireNonNull(operationTracker, "operationTracker");
+        this.clock = Objects.requireNonNull(clock, "clock");
 
         this.statsAccumulator = new FaultTolerantForestStats.StatsAccumulator();
         this.recoveryExecutor = Executors.newSingleThreadExecutor(r -> {
@@ -201,7 +236,7 @@ public class FaultTolerantDistributedForest<Key extends SpatialKey<Key>, ID exte
         log.info("Triggering recovery for partition {}", failedPartitionId);
 
         return CompletableFuture.supplyAsync(() -> {
-            var startTime = System.currentTimeMillis();
+            var startTime = clock.currentTimeMillis();
             boolean success = false;
 
             try {
@@ -238,7 +273,7 @@ public class FaultTolerantDistributedForest<Key extends SpatialKey<Key>, ID exte
                     exitRecoveryMode();
                     recoveryLock.releaseRecoveryLock(failedPartitionId);
 
-                    var duration = System.currentTimeMillis() - startTime;
+                    var duration = clock.currentTimeMillis() - startTime;
                     statsAccumulator.recordRecoveryAttempt(duration, success);
 
                     log.info("Recovery for partition {} {} in {}ms",

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/DistributedGhostManager.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/DistributedGhostManager.java
@@ -19,6 +19,7 @@ package com.hellblazer.luciferase.lucien.forest.ghost;
 
 import com.hellblazer.luciferase.lucien.SpatialKey;
 import com.hellblazer.luciferase.lucien.AbstractSpatialIndex;
+import com.hellblazer.luciferase.lucien.balancing.fault.GhostSyncCallback;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.forest.ghost.grpc.GhostCommunicationManager;
 import com.hellblazer.luciferase.lucien.forest.ghost.grpc.SimpleServiceDiscovery;
@@ -72,7 +73,7 @@ public class DistributedGhostManager<Key extends SpatialKey<Key>, ID extends Ent
     private volatile long syncIntervalMs = 30000; // 30 seconds default
 
     // Fault detection callback for sync operations
-    private volatile Object syncCallback = null;
+    private volatile GhostSyncCallback syncCallback = null;
     
     /**
      * Create a distributed ghost manager.
@@ -369,7 +370,7 @@ public class DistributedGhostManager<Key extends SpatialKey<Key>, ID extends Ent
      *
      * @param callback the sync callback to register (typically SimpleGhostSyncAdapter)
      */
-    public void registerSyncCallback(Object callback) {
+    public void registerSyncCallback(GhostSyncCallback callback) {
         this.syncCallback = callback;
         if (callback != null) {
             log.debug("Registered sync callback for rank {}", currentRank);
@@ -381,7 +382,7 @@ public class DistributedGhostManager<Key extends SpatialKey<Key>, ID extends Ent
      *
      * @return the sync callback, or null if not registered
      */
-    public Object getSyncCallback() {
+    public GhostSyncCallback getSyncCallback() {
         return syncCallback;
     }
 

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/P413GhostSyncFaultWiringTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/P413GhostSyncFaultWiringTest.java
@@ -20,6 +20,7 @@ import com.hellblazer.luciferase.lucien.balancing.fault.FaultHandler;
 import com.hellblazer.luciferase.lucien.balancing.fault.SimpleFaultHandler;
 import com.hellblazer.luciferase.lucien.balancing.fault.FaultConfiguration;
 import com.hellblazer.luciferase.lucien.forest.ghost.DistributedGhostManager;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -69,6 +70,11 @@ public class P413GhostSyncFaultWiringTest {
 
         // Create adapter
         adapter = new SimpleGhostSyncAdapter(faultHandler);
+    }
+
+    @AfterEach
+    void tearDown() {
+        faultHandler.stop();
     }
 
     /**

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/P414IntegrationSuiteTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/P414IntegrationSuiteTest.java
@@ -19,6 +19,7 @@ package com.hellblazer.luciferase.lucien.balancing;
 import com.hellblazer.luciferase.lucien.balancing.fault.FaultConfiguration;
 import com.hellblazer.luciferase.lucien.balancing.fault.FaultHandler;
 import com.hellblazer.luciferase.lucien.balancing.fault.SimpleFaultHandler;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -73,6 +74,12 @@ public class P414IntegrationSuiteTest {
         balancer = new DefaultParallelBalancer<>(balanceConfig);
         ghostSyncAdapter = new SimpleGhostSyncAdapter(faultHandler);
         executor = Executors.newFixedThreadPool(5);
+    }
+
+    @AfterEach
+    void tearDown() {
+        faultHandler.stop();
+        executor.shutdownNow();
     }
 
     /**


### PR DESCRIPTION
## Summary

- **Luciferase-snl**: Inject `Clock` into `FaultTolerantDistributedForest.triggerRecovery()` replacing `System.currentTimeMillis()` (determinism violation)
- **Luciferase-yb9**: `SimpleGhostSyncAdapter` now `implements GhostSyncCallback`
- **Luciferase-abs**: Type `DistributedGhostManager.registerSyncCallback` parameter as `GhostSyncCallback` instead of `Object`
- **Luciferase-n1n**: Add `@AfterEach` teardown to P413 (`faultHandler.stop()`) and P414 (`faultHandler.stop()` + `executor.shutdownNow()`)

## Test plan

- [x] `mvn clean install -DskipTests` — all modules compile
- [x] `mvn test -pl lucien -Dtest=P412*,P413*,P414*,PhaseA2*` — all pass (36 tests, 0 failures)