### PR TITLE
feat(simulation): VoN spatial level — RDR-003 Phase 0 Step 0 [Luciferase-hic]

### DIFF
--- a/docs/rdr/RDR-003-fcc-aligned-spatial-indexing.md
+++ b/docs/rdr/RDR-003-fcc-aligned-spatial-indexing.md
@@ -469,6 +469,39 @@ Document is right-sized for a multi-phase architectural change spanning three mo
 
 ## Revision History
 
+### 2026-05-23: Phase 0 Step 0 implementation — formula correction
+
+Implementation of Step 0 (Luciferase-hic) surfaced an algebraic error in the literal default-level formula recorded earlier in this section. The text said:
+
+> `level = clamp(MAX_LEVEL - ceil(log2(worldExtent / (8 * medianAoiRadius))), MIN_USEFUL_LEVEL, MAX_LEVEL)` targeting r ≈ 8·cell-edge
+
+Evaluating the literal formula for the default configuration (`worldExtent = 200`, `medianAoiRadius = 50`) produces:
+
+```
+worldExtent / (8 * medianAoiRadius) = 200 / 400 = 0.5
+log2(0.5) = -1
+ceil(-1) = -1
+21 - (-1) = 22 → clamp to MAX_LEVEL = 21
+```
+
+That gives level 21 (cell-edge = 1, `r/cell-edge = 50`) which contradicts both the same paragraph's "r ≈ 8·cell-edge" target and research-003's empirical recommendation of level 17–18.
+
+Solving the target relation directly:
+
+```
+r = 8 · cell-edge
+cell-edge = 2^(MAX_LEVEL - L)
+→ L = MAX_LEVEL - log2(r / 8)
+    = MAX_LEVEL + 3 - log2(r)
+    = 24 - log2(r)
+```
+
+For r=50: L = 24 - ceil(log2(50)) = 24 - 6 = 18 ✓ (matches research-003).
+
+**Adopted formula:** `L = clamp(24 - ceil(log2(r)), MIN_USEFUL_LEVEL=8, MAX_LEVEL=21)`. The `worldExtent` parameter, present in the literal but not load-bearing in the target relation, was dropped from the default-computation API. Implemented in `simulation/.../bubble/SpatialLevelHeuristic.java`.
+
+Step 0 also threaded the level explicitly through `Manager` (no-arg constructor) and `BubbleBounds.fromEntityPositions` (new parameterized overload, no-arg overload delegates to `DEFAULT_SPATIAL_LEVEL`). The six other `(byte) 10` hardcodes in the simulation module (`GridMultiBubbleSimulation`, `BubbleLifecycle`, `AdaptiveSplitPolicy`, `DelosSocketTransport`, `GhostStateManager`, `EntityVisualizationServer`) were left untouched — out of Step 0 scope; potential follow-up beads if any prove to need similar threading.
+
 ### 2026-05-23: Initial Draft
 
 Created from 360°-analysis session 2026-05-22/23. Five parallel agents (web research, mixedbread archive scan, lucien code integration, portal code audit, mathematical rigor) converged on the three-phase plan with Phase 0 prepended. Math corrections folded in: 48 orthoschemes/RD not 24, no obtuse-vertex children due to FCC parity, AoI speedup range 2-3× to 15-20×, Greiner-Grosso refinement exact and closed. Phase 2 cost re-estimated up (substantial, not "weeks") after discovering `TetreeKey` hardcodes 8-fanout. Phase 0 inserted ahead of Phase 1 after discovering VoN has no spatial index at all.

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/BubbleBounds.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/BubbleBounds.java
@@ -91,14 +91,38 @@ public final class BubbleBounds implements Serializable {
     }
 
     /**
-     * Create bounds from entity positions.
+     * Create bounds from entity positions at the default spatial level.
      * <p>
-     * Finds the smallest tetrahedron (at level 10) that encompasses all positions.
+     * Convenience overload that uses {@link SpatialLevelHeuristic#DEFAULT_SPATIAL_LEVEL}
+     * (currently {@code 18}, computed from the default-VoN AoI radius of {@code 50}).
+     * <p>
+     * <b>Behavior change (RDR-003 Phase 0 Step 0):</b> this overload previously hardcoded
+     * level {@code 10} (cell-edge {@code 2048}), which collapsed the entire default
+     * {@code 200}-unit world into a single Tetree cell. Callers that depended on the old
+     * single-cell bucketing should switch to {@link #fromEntityPositions(List, byte)} with
+     * an explicit level.
      *
      * @param positions List of entity positions
-     * @return BubbleBounds enclosing all positions
+     * @return BubbleBounds enclosing all positions at {@link SpatialLevelHeuristic#DEFAULT_SPATIAL_LEVEL}
      */
     public static BubbleBounds fromEntityPositions(List<Point3f> positions) {
+        return fromEntityPositions(positions, SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL);
+    }
+
+    /**
+     * Create bounds from entity positions at the specified Tetree refinement level.
+     * <p>
+     * The caller-supplied {@code spatialLevel} determines cell-edge granularity in
+     * absolute Tetree coordinate units ({@code 2^(MAX_REFINEMENT_LEVEL - spatialLevel)}).
+     * Callers that own a {@code spatialLevel} (e.g. {@code Manager} via
+     * {@link BubbleBoundsTracker}) should use this overload to thread the level explicitly.
+     *
+     * @param positions    List of entity positions
+     * @param spatialLevel Tetree refinement level for the root key
+     * @return BubbleBounds enclosing all positions at the given level
+     * @throws IllegalArgumentException if {@code positions} is empty
+     */
+    public static BubbleBounds fromEntityPositions(List<Point3f> positions, byte spatialLevel) {
         if (positions.isEmpty()) {
             throw new IllegalArgumentException("Cannot create bounds from empty position list");
         }
@@ -126,15 +150,15 @@ public final class BubbleBounds implements Serializable {
         float cy = (float) positions.stream().mapToDouble(p -> p.y).average().orElseThrow();
         float cz = (float) positions.stream().mapToDouble(p -> p.z).average().orElseThrow();
 
-        // Locate tetrahedron containing centroid at level 10
-        var tet = Tet.locatePointBeyRefinementFromRoot(cx, cy, cz, (byte) 10);
+        // Locate tetrahedron containing centroid at the requested level
+        var tet = Tet.locatePointBeyRefinementFromRoot(cx, cy, cz, spatialLevel);
         TetreeKey<?> key;
 
         if (tet != null) {
             key = tet.tmIndex();
         } else {
-            // Fallback to root tetrahedron if position is outside valid range
-            key = TetreeKey.create((byte) 10, 0L, 0L);
+            // Fallback to root tetrahedron at the requested level if position is outside valid range
+            key = TetreeKey.create(spatialLevel, 0L, 0L);
         }
 
         return new BubbleBounds(key, rdgMin, rdgMax);
@@ -265,13 +289,13 @@ public final class BubbleBounds implements Serializable {
     }
 
     /**
-     * Recalculate bounds from a new set of entity positions.
+     * Recalculate bounds from a new set of entity positions, preserving this instance's level.
      *
      * @param entityPositions New entity positions
-     * @return New BubbleBounds computed from positions
+     * @return New BubbleBounds computed from positions at the current level
      */
     public BubbleBounds recalculate(List<Point3f> entityPositions) {
-        return fromEntityPositions(entityPositions);
+        return fromEntityPositions(entityPositions, level());
     }
 
     /**

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/BubbleBoundsTracker.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/BubbleBoundsTracker.java
@@ -86,7 +86,7 @@ public class BubbleBoundsTracker implements EntityChangeListener {
 
         var positions = new ArrayList<>(entityPositions.values());
         if (!positions.isEmpty()) {
-            bounds = BubbleBounds.fromEntityPositions(positions);
+            bounds = BubbleBounds.fromEntityPositions(positions, spatialLevel);
         }
     }
 
@@ -96,7 +96,7 @@ public class BubbleBoundsTracker implements EntityChangeListener {
 
         // Update bounds
         if (bounds == null) {
-            bounds = BubbleBounds.fromEntityPositions(List.of(position));
+            bounds = BubbleBounds.fromEntityPositions(List.of(position), spatialLevel);
         } else {
             bounds = bounds.expand(position);
         }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/SpatialLevelHeuristic.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/SpatialLevelHeuristic.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026, Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.simulation.bubble;
+
+import com.hellblazer.luciferase.geometry.MortonCurve;
+
+/**
+ * Default-level heuristic for VoN spatial indexing (RDR-003 Phase 0 Step 0).
+ * <p>
+ * The Tetree subdivides the absolute integer-coordinate domain {@code [0, 2^21)}. At
+ * refinement level {@code L} the cell-edge in those units is {@code 2^(21 - L)}. VoN entity
+ * positions are placed directly into that coordinate system without rescaling, so AoI
+ * radii are comparable to cell-edges 1:1.
+ * <p>
+ * The "sweet spot" for spatial-index pruning is {@code r &approx; 8&middot;cell-edge}
+ * (RDR-003 &sect;Performance Expectations). Solving for {@code L} gives:
+ * <pre>
+ *   2^(21 - L) = r / 8
+ *   21 - L     = log2(r) - 3
+ *   L          = 24 - ceil(log2(r))
+ * </pre>
+ * which is then clamped to the safe range
+ * {@code [MIN_USEFUL_LEVEL, MortonCurve.MAX_REFINEMENT_LEVEL]}.
+ * <p>
+ * For the default VoN configuration ({@code aoiRadius = 50}) this produces
+ * {@link #DEFAULT_SPATIAL_LEVEL} {@code = 18} (cell-edge 8 units), giving {@code &asymp; 25}
+ * cells across the 200-unit default world.
+ *
+ * @author hal.hildebrand
+ */
+public final class SpatialLevelHeuristic {
+
+    /** Maximum refinement level supported by the Tetree (= {@link MortonCurve#MAX_REFINEMENT_LEVEL}). */
+    public static final byte MAX_LEVEL = MortonCurve.MAX_REFINEMENT_LEVEL;
+
+    /**
+     * Minimum level the heuristic will return.
+     * <p>
+     * At level 8 the cell-edge is {@code 2^13 = 8192} units. Below this level cells span
+     * the entire default-VoN world (200 units) and the spatial index degenerates to a
+     * linear scan.
+     */
+    public static final byte MIN_USEFUL_LEVEL = 8;
+
+    /**
+     * Default-AoI radius assumed by the no-arg paths in {@code Manager} and
+     * {@link BubbleBounds#fromEntityPositions(java.util.List)}.
+     * <p>
+     * Matches {@code Manager} default-constructor's historical {@code aoiRadius = 50.0f}.
+     */
+    public static final float DEFAULT_AOI_RADIUS = 50.0f;
+
+    /**
+     * Spatial level used by the no-arg default paths.
+     * <p>
+     * Computed at class-load time from {@link #DEFAULT_AOI_RADIUS}. With
+     * {@code aoiRadius = 50} this evaluates to {@code 18}.
+     */
+    public static final byte DEFAULT_SPATIAL_LEVEL = computeDefault(DEFAULT_AOI_RADIUS);
+
+    private SpatialLevelHeuristic() {
+    }
+
+    /**
+     * Compute a sensible default refinement level for a given AoI radius.
+     * <p>
+     * Targets {@code r &approx; 8&middot;cell-edge} via
+     * {@code L = clamp(24 &minus; ceil(log2(r)), MIN_USEFUL_LEVEL, MAX_LEVEL)}.
+     *
+     * @param aoiRadius positive, finite AoI radius in absolute Tetree coordinate units
+     * @return a refinement level in {@code [MIN_USEFUL_LEVEL, MAX_LEVEL]}
+     * @throws IllegalArgumentException if {@code aoiRadius} is not positive and finite
+     */
+    public static byte computeDefault(float aoiRadius) {
+        if (!(aoiRadius > 0f) || !Float.isFinite(aoiRadius)) {
+            throw new IllegalArgumentException(
+                "aoiRadius must be positive and finite, got " + aoiRadius);
+        }
+        int level = 24 - (int) Math.ceil(Math.log(aoiRadius) / Math.log(2.0));
+        if (level > MAX_LEVEL) {
+            return MAX_LEVEL;
+        }
+        if (level < MIN_USEFUL_LEVEL) {
+            return MIN_USEFUL_LEVEL;
+        }
+        return (byte) level;
+    }
+}

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Manager.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Manager.java
@@ -18,6 +18,7 @@
 package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
+import com.hellblazer.luciferase.simulation.bubble.SpatialLevelHeuristic;
 import com.hellblazer.luciferase.simulation.distributed.integration.Clock;
 import com.hellblazer.luciferase.simulation.lifecycle.EnhancedBubbleAdapter;
 import com.hellblazer.luciferase.simulation.lifecycle.LifecycleCoordinator;
@@ -71,11 +72,25 @@ public class Manager {
 
     /**
      * Create a Manager with default configuration.
+     * <p>
+     * Defaults: {@code spatialLevel = }{@link SpatialLevelHeuristic#DEFAULT_SPATIAL_LEVEL}
+     * (computed from {@code aoiRadius = 50}; currently {@code 18}),
+     * {@code targetFrameMs = 16}, {@code aoiRadius = 50.0}.
+     * <p>
+     * <b>Behavior change (RDR-003 Phase 0 Step 0):</b> the default {@code spatialLevel}
+     * previously was a hardcoded {@code 10} (cell-edge {@code 2048}), which collapsed the
+     * default {@code 200}-unit VoN world into a single Tetree cell and made any spatial-
+     * index query degenerate to a linear scan. It is now computed from the AoI radius via
+     * {@link SpatialLevelHeuristic#computeDefault(float)} targeting
+     * {@code r &approx; 8&middot;cell-edge}. Tests or callers that implicitly depended on
+     * single-cell bucketing should use the explicit 4-arg or 5-arg constructor with a
+     * deliberate {@code spatialLevel}.
      *
      * @param transportRegistry Transport registry for P2P communication
      */
     public Manager(LocalServerTransport.Registry transportRegistry) {
-        this(transportRegistry, (byte) 10, 16L, 50.0f);
+        this(transportRegistry, SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL, 16L,
+             SpatialLevelHeuristic.DEFAULT_AOI_RADIUS);
     }
 
     /**

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/BubbleBoundsLevelTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/BubbleBoundsLevelTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026, Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.simulation.bubble;
+
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3f;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests that {@link BubbleBounds#fromEntityPositions(java.util.List, byte)} honors the
+ * caller-provided spatial level, and that the no-arg overload uses
+ * {@link SpatialLevelHeuristic#DEFAULT_SPATIAL_LEVEL}.
+ * <p>
+ * RDR-003 Phase 0 Step 0: callers using the no-arg form previously got hardcoded level 10
+ * (cell-edge 2048 in the default 200-unit world — every entity collapsed into one cell).
+ * They now get level 18 (cell-edge 8 — ~25 cells across the default world), matching the
+ * r &approx; 8&middot;cell-edge target.
+ */
+class BubbleBoundsLevelTest {
+
+    private static final List<Point3f> POSITIONS = List.of(
+        new Point3f(50f, 50f, 50f),
+        new Point3f(60f, 50f, 50f),
+        new Point3f(55f, 55f, 55f)
+    );
+
+    @Test
+    void fromEntityPositions_explicitLevel_isHonored() {
+        for (byte level : new byte[]{8, 10, 15, 18, 21}) {
+            var bounds = BubbleBounds.fromEntityPositions(POSITIONS, level);
+            assertEquals(level, bounds.level(),
+                "Bounds should be at the explicit level requested");
+        }
+    }
+
+    @Test
+    void fromEntityPositions_noArgOverload_usesDefaultSpatialLevel() {
+        var bounds = BubbleBounds.fromEntityPositions(POSITIONS);
+        assertEquals(SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL, bounds.level(),
+            "No-arg overload must use SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL (= 18 for default r=50)");
+    }
+
+    @Test
+    void recalculate_preservesInstanceLevel() {
+        var initial = BubbleBounds.fromEntityPositions(POSITIONS, (byte) 15);
+        var recalculated = initial.recalculate(POSITIONS);
+        assertEquals((byte) 15, recalculated.level(),
+            "recalculate() must reuse the instance's existing level, not the default");
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/SpatialLevelHeuristicTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/SpatialLevelHeuristicTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026, Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.simulation.bubble;
+
+import com.hellblazer.luciferase.geometry.MortonCurve;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link SpatialLevelHeuristic}.
+ * <p>
+ * Verifies the level-default algorithm targets r ~ 8*cell-edge per RDR-003 Phase 0 Step 0:
+ * {@code L = clamp(24 - ceil(log2(r)), MIN_USEFUL_LEVEL, MAX_LEVEL)}.
+ */
+class SpatialLevelHeuristicTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        // r,  expectedLevel
+        "10,   20",
+        "20,   19",
+        "30,   19",
+        "32,   19",
+        "33,   18",
+        "50,   18",
+        "64,   18",
+        "65,   17",
+        "100,  17",
+        "128,  17",
+        "129,  16",
+        "200,  16"
+    })
+    void computeDefault_targetsApproxEightCellEdges(float aoiRadius, int expectedLevel) {
+        var actual = SpatialLevelHeuristic.computeDefault(aoiRadius);
+        assertEquals((byte) expectedLevel, actual,
+            "For r=" + aoiRadius + " expected level " + expectedLevel + " but got " + actual);
+    }
+
+    @Test
+    void defaultSpatialLevel_isEighteenForDefaultAoiOfFifty() {
+        // The default Manager configuration uses aoiRadius=50, world=200. The default-level
+        // constant must agree with computeDefault(50f) and equal 18 (cell-edge 8 units).
+        assertEquals((byte) 18, SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL);
+        assertEquals(SpatialLevelHeuristic.computeDefault(50.0f),
+                     SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL);
+    }
+
+    @Test
+    void verySmallRadius_clampsToMaxLevel() {
+        // r=1 → 24 - ceil(log2(1)) = 24 - 0 = 24 → clamp to MAX = 21.
+        assertEquals(SpatialLevelHeuristic.MAX_LEVEL,
+                     SpatialLevelHeuristic.computeDefault(1.0f));
+        assertEquals(SpatialLevelHeuristic.MAX_LEVEL,
+                     SpatialLevelHeuristic.computeDefault(0.001f));
+    }
+
+    @Test
+    void veryLargeRadius_clampsToMinUsefulLevel() {
+        // r=1e9 → 24 - ceil(log2(1e9)) = 24 - 30 = -6 → clamp to MIN_USEFUL=8.
+        assertEquals(SpatialLevelHeuristic.MIN_USEFUL_LEVEL,
+                     SpatialLevelHeuristic.computeDefault(1.0e9f));
+    }
+
+    @Test
+    void minAndMaxLevelConstants_matchExpectations() {
+        assertEquals(MortonCurve.MAX_REFINEMENT_LEVEL, SpatialLevelHeuristic.MAX_LEVEL);
+        assertEquals((byte) 8, SpatialLevelHeuristic.MIN_USEFUL_LEVEL);
+        assertTrue(SpatialLevelHeuristic.MIN_USEFUL_LEVEL < SpatialLevelHeuristic.MAX_LEVEL);
+    }
+
+    @Test
+    void zeroRadius_throws() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> SpatialLevelHeuristic.computeDefault(0.0f));
+    }
+
+    @Test
+    void negativeRadius_throws() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> SpatialLevelHeuristic.computeDefault(-1.0f));
+    }
+
+    @Test
+    void nanRadius_throws() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> SpatialLevelHeuristic.computeDefault(Float.NaN));
+    }
+
+    @Test
+    void infiniteRadius_throws() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> SpatialLevelHeuristic.computeDefault(Float.POSITIVE_INFINITY));
+    }
+}


### PR DESCRIPTION
## Summary

RDR-003 Phase 0 Step 0 — resolves the degenerate single-cell configuration in the default `Manager`. At the prior hardcoded level 10 the Tetree cell-edge was **2048 units** versus a **200-unit** default world, collapsing the entire world into a single cell and making any spatial-index query equivalent to a linear scan.

This is the gating step for the rest of RDR-003 Phase 0 (closes Luciferase-hic, unblocks Luciferase-d8a, Luciferase-jp7, Luciferase-mj7, Luciferase-ma7.1).

## Changes

- **NEW** `simulation/.../bubble/SpatialLevelHeuristic` with `computeDefault(r)` implementing `L = clamp(24 − ceil(log2(r)), MIN_USEFUL=8, MAX=21)`. For the default `aoiRadius = 50` this gives `L = 18` (cell-edge 8 units, ~25 cells across the 200-unit world), targeting `r ≈ 8·cell-edge` per the RDR §Approach.
- **Manager** no-arg constructor uses `SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL` in place of the `(byte) 10` literal. JavaDoc'd as a behavior change.
- **BubbleBounds.fromEntityPositions** — added `(positions, byte)` overload as the new primary API. The no-arg overload is kept for source compatibility and delegates with `DEFAULT_SPATIAL_LEVEL`. `recalculate()` now threads `this.level()`.
- **BubbleBoundsTracker** uses the parameterized overload with its existing `spatialLevel` field.
- **RDR-003 Revision History** — recorded the formula correction (the prior literal formula was algebraically inconsistent with the §Approach target and research-003 evidence).

The 6 other `(byte) 10` literals in the simulation module (`GridMultiBubbleSimulation`, `BubbleLifecycle`, `AdaptiveSplitPolicy`, `DelosSocketTransport`, `GhostStateManager`, `EntityVisualizationServer`) were left in place — out of Step 0 scope. Potential follow-up beads if any need similar threading.

## Behavioral contract

Source-compatible at all public APIs. **Behavior-incompatible** for the `Manager` no-arg constructor and the `BubbleBounds.fromEntityPositions(positions)` no-arg overload: callers that depended on single-cell bucketing under the default 200-unit world will now see finer (level-18) bucketing. Callers that need explicit control should use the parameterized constructors/overloads.

## Test plan

- [x] `SpatialLevelHeuristicTest` — 20 cases covering the algorithm table, clamp boundaries, and bad-input throws.
- [x] `BubbleBoundsLevelTest` — 3 cases verifying explicit-level overload, no-arg defaulting to `DEFAULT_SPATIAL_LEVEL`, and `recalculate()` preserving instance level.
- [x] Full simulation test suite: 2655 of 2656 pass; the 1 failure is a pre-existing wall-clock flake in `EntityMigrationContextTest.testMigrationContextTimeout` that has zero `bubble`/`spatial` dependencies and passes in isolation.
- [x] `ManagerTest` (17), `BubbleBoundsTest` (12), `BubbleBoundsRendererTest` (6) — all pass; no implicit level-10 dependencies surfaced.

## RDR linkage

- RDR: `docs/rdr/RDR-003-fcc-aligned-spatial-indexing.md` §Implementation Plan Phase 0 Step 0
- Bead: `Luciferase-hic`
- Unblocks: `Luciferase-d8a` (Phase 0 Step 1 JMH baseline at original level), `Luciferase-jp7` (Step 1b at corrected level), `Luciferase-mj7` (Step 2 — Tetree-backed SpatialNeighborIndex), `Luciferase-ma7.1` (Phase 0 review gate).