### PR TITLE
feat(simulation): Tetree-backed SpatialNeighborIndex — RDR-003 Phase 0 Step 2 [Luciferase-mj7]

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/SpatialNeighborIndex.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/SpatialNeighborIndex.java
@@ -1,54 +1,111 @@
+/*
+ * Copyright (c) 2026, Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 package com.hellblazer.luciferase.simulation.von;
 
+import com.hellblazer.luciferase.geometry.MortonCurve;
+import com.hellblazer.luciferase.lucien.Spatial;
+import com.hellblazer.luciferase.lucien.entity.UUIDEntityID;
+import com.hellblazer.luciferase.lucien.entity.UUIDGenerator;
+import com.hellblazer.luciferase.lucien.tetree.Tetree;
 import com.hellblazer.luciferase.simulation.bubble.BubbleBounds;
+import com.hellblazer.luciferase.simulation.bubble.SpatialLevelHeuristic;
 import javafx.geometry.Point3D;
 
+import javax.vecmath.Point3f;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
- * Spatial index for VON neighbor discovery using Tetree-based queries.
+ * Spatial index for VON neighbor discovery, backed by a {@link Tetree}.
  * <p>
- * This class REPLACES SFVoronoi from Thoth's Perceptron pattern.
- * Instead of computing Voronoi diagrams, it uses:
- * - k-nearest neighbor queries via position distance
- * - Bounds overlap detection via BubbleBounds.overlaps()
- * - AOI radius for boundary detection
+ * RDR-003 Phase 0 Step 2 replaces the previous {@code ConcurrentHashMap} flat
+ * implementation (linear scan over all entries for every AoI query) with a real
+ * spatial index. {@link #findWithinRadius} now delegates to
+ * {@link com.hellblazer.luciferase.lucien.AbstractSpatialIndex#findNeighborsIncludingGhosts};
+ * {@link #findKNearest} delegates to
+ * {@link com.hellblazer.luciferase.lucien.AbstractSpatialIndex#kNearestNeighbors}.
  * <p>
- * Key Architectural Point:
- * - NO Voronoi calculation - spatial index queries only
- * - Enclosing neighbors = bounds overlap
- * - Boundary neighbors = distance in (aoiRadius, aoiRadius + buffer]
+ * <b>Public API preserved.</b> Existing callers using the two-argument constructor
+ * continue to work; the spatial level is computed from the {@code aoiRadius} via
+ * {@link SpatialLevelHeuristic#computeDefault(float)}, targeting {@code r &approx;
+ * 8&middot;cell-edge} (RDR-003 §Approach). A new three-argument constructor lets
+ * deployments pin an explicit level when their AoI distribution diverges from the
+ * default.
  * <p>
- * Thread-safe: Uses ConcurrentHashMap for concurrent access.
+ * <b>Behavioral contract change.</b>
+ * {@link #updatePosition(UUID, Point3D)} is no longer a no-op &mdash; it now
+ * propagates the new centroid to the {@code Tetree} via
+ * {@link Tetree#updateEntity}. {@code MoveProtocol} already calls this method on
+ * every move, so existing callers get correct spatial bucketing automatically.
+ * Callers that never invoked {@code updatePosition} previously (relying on the
+ * "position is read fresh from {@code node.position()}" semantics of the linear-scan
+ * implementation) will see stale spatial bucketing for any node whose centroid
+ * drifts after insert. This is detected by the existing VoN test suite.
+ * <p>
+ * <b>Coordinate domain.</b> {@link Tetree} requires non-negative coordinates
+ * (tetrahedral SFC root is the positive octant). Callers must supply positions in
+ * {@code [0, +&infin;)}<sup>3</sup>. Negative components produce an
+ * {@link IllegalArgumentException} from the underlying Tetree &mdash; this matches
+ * the contract that the existing test suite already honors explicitly.
+ * <p>
+ * Thread-safe: {@link Tetree} provides internal read/write locking.
  *
  * @author hal.hildebrand
  */
 public class SpatialNeighborIndex {
 
-    private final Map<UUID, Node> nodes = new ConcurrentHashMap<>();
-    private final float aoiRadius;
-    private final float boundaryBuffer;
+    private final Tetree<UUIDEntityID, Node> tetree;
+    private final byte                       spatialLevel;
+    private final float                      aoiRadius;
+    private final float                      boundaryBuffer;
 
     /**
-     * Create a spatial neighbor index.
+     * Create a spatial neighbor index with the default heuristic-derived spatial level.
+     * <p>
+     * The spatial level is computed via
+     * {@link SpatialLevelHeuristic#computeDefault(float)} from {@code aoiRadius}. For
+     * the canonical VoN configuration ({@code aoiRadius = 50}, world extent
+     * {@code 200}) this resolves to level {@code 18} (cell-edge 8 units), placing
+     * {@code r &approx; 6&middot;cell-edge} in the favorable end of the spatial-index
+     * pruning curve.
      *
-     * @param aoiRadius       Area of Interest radius
-     * @param boundaryBuffer  Additional buffer for boundary detection
+     * @param aoiRadius      Area of Interest radius
+     * @param boundaryBuffer Additional buffer for boundary detection
      */
     public SpatialNeighborIndex(float aoiRadius, float boundaryBuffer) {
-        this.aoiRadius = aoiRadius;
+        this(aoiRadius, boundaryBuffer, SpatialLevelHeuristic.computeDefault(aoiRadius));
+    }
+
+    /**
+     * Create a spatial neighbor index with an explicit Tetree refinement level.
+     * <p>
+     * Use this constructor when the deployment's AoI distribution diverges from the
+     * heuristic-derived default (for example, multi-scale simulations where the
+     * AoI radius doesn't fit the {@code r &approx; 8&middot;cell-edge} target).
+     *
+     * @param aoiRadius      Area of Interest radius
+     * @param boundaryBuffer Additional buffer for boundary detection
+     * @param spatialLevel   Tetree refinement level for indexed entities
+     *                       (in {@code [0, MortonCurve.MAX_REFINEMENT_LEVEL]})
+     */
+    public SpatialNeighborIndex(float aoiRadius, float boundaryBuffer, byte spatialLevel) {
+        this.aoiRadius      = aoiRadius;
         this.boundaryBuffer = boundaryBuffer;
+        this.spatialLevel   = spatialLevel;
+        this.tetree         = new Tetree<>(new UUIDGenerator());
     }
 
     /**
      * Insert a node into the index.
      *
-     * @param node VON node to insert
+     * @param node VON node to insert. Its centroid (returned by {@link Node#position()})
+     *             must have non-negative coordinates &mdash; Tetree constraint.
      */
     public void insert(Node node) {
-        nodes.put(node.id(), node);
+        tetree.insert(new UUIDEntityID(node.id()), toPoint3f(node.position()), spatialLevel, node);
     }
 
     /**
@@ -57,7 +114,7 @@ public class SpatialNeighborIndex {
      * @param nodeId Node UUID to remove
      */
     public void remove(UUID nodeId) {
-        nodes.remove(nodeId);
+        tetree.removeEntity(new UUIDEntityID(nodeId));
     }
 
     /**
@@ -67,150 +124,156 @@ public class SpatialNeighborIndex {
      * @return Node or null if not found
      */
     public Node get(UUID nodeId) {
-        return nodes.get(nodeId);
+        return tetree.getEntity(new UUIDEntityID(nodeId));
     }
 
     /**
-     * Update a node's position.
+     * Update a node's spatial bucketing to reflect a new centroid.
      * <p>
-     * Note: Position is tracked via the node reference itself (bubble.centroid()).
-     * This method is a no-op but provided for API completeness.
+     * Unlike the linear-scan implementation this replaces, this method is NOT a
+     * no-op: the Tetree's spatial pruning depends on the entity being stored at
+     * its current centroid. Callers that move a node's centroid (e.g.
+     * {@code MoveProtocol.move}) MUST invoke this so subsequent queries see the
+     * correct spatial neighborhood.
      *
      * @param nodeId      Node UUID
-     * @param newPosition New position
+     * @param newPosition New centroid position (must have non-negative coordinates)
      */
     public void updatePosition(UUID nodeId, Point3D newPosition) {
-        // Position is tracked via node.position() which delegates to bubble.centroid()
-        // No explicit update needed - position is computed on-demand
+        tetree.updateEntity(new UUIDEntityID(nodeId), toPoint3f(newPosition), spatialLevel);
     }
 
     /**
      * Find closest node to a position.
-     * <p>
-     * Replaces SFVoronoi.closestTo().
      *
      * @param position Query position
      * @return Closest Node or null if index is empty
      */
     public Node findClosestTo(Point3D position) {
-        return nodes.values().stream()
-            .min(Comparator.comparingDouble(n -> distance(n.position(), position)))
-            .orElse(null);
+        var ids = tetree.kNearestNeighbors(toPoint3f(position), 1, Float.POSITIVE_INFINITY);
+        return ids.isEmpty() ? null : tetree.getEntity(ids.get(0));
     }
 
     /**
      * Find k nearest nodes to a position.
-     * <p>
-     * Replaces Voronoi neighbor discovery.
      *
      * @param position Query position
      * @param k        Number of neighbors
-     * @return List of k nearest nodes (may be < k if index has fewer nodes)
+     * @return List of up to k nearest nodes, sorted by distance
      */
     public List<Node> findKNearest(Point3D position, int k) {
-        return nodes.values().stream()
-            .sorted(Comparator.comparingDouble(n -> distance(n.position(), position)))
-            .limit(k)
-            .toList();
+        return tetree.kNearestNeighbors(toPoint3f(position), k, Float.POSITIVE_INFINITY).stream()
+            .map(tetree::getEntity)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
     }
 
     /**
-     * Find nodes whose bounds overlap with given bounds.
+     * Find nodes whose bounds overlap with the given bounds.
      * <p>
-     * Replaces Voronoi enclosing neighbors.
+     * Iterates all indexed nodes and applies {@link BubbleBounds#overlaps}. This is
+     * O(N) but is intentionally NOT spatially accelerated: the Tetree indexes by
+     * centroid, and a node's bounds can extend past its centroid into the query
+     * bounds even when the centroid itself lies outside the query's world-space
+     * envelope. A centroid-based broad-phase therefore misses valid candidates
+     * &mdash; observed concretely in
+     * {@code IntegrationTest.testConcurrentJoinsHandled} where neighbor consistency
+     * dropped from {@code &ge; 0.5} to {@code 0.43} with a spatial broad-phase.
+     * <p>
+     * RDR-003 Phase 0 scope is the AoI hot path ({@link #findWithinRadius},
+     * {@link #findKNearest}). {@code findOverlapping} fires once per bubble JOIN,
+     * not per tick. The optimisation would need bounds-aware indexing
+     * (e.g. inserting each node with an {@code EntityBounds} so the Tetree's
+     * spanning policy could be used) which is out of Step 2 scope.
      *
-     * @param bounds Bounds to test
-     * @return Set of overlapping nodes
+     * @param queryBounds Bounds to test against
+     * @return Set of nodes whose bounds overlap {@code queryBounds}
      */
-    public Set<Node> findOverlapping(BubbleBounds bounds) {
-        return nodes.values().stream()
-            .filter(n -> n.bounds().overlaps(bounds))
+    public Set<Node> findOverlapping(BubbleBounds queryBounds) {
+        return getAllNodes().stream()
+            .filter(n -> n.bounds().overlaps(queryBounds))
             .collect(Collectors.toSet());
     }
 
     /**
      * Find nodes within a radius of a position.
-     * <p>
-     * Useful for AOI queries.
      *
      * @param center Query position
      * @param radius Search radius
      * @return List of nodes within radius
      */
     public List<Node> findWithinRadius(Point3D center, float radius) {
-        return nodes.values().stream()
-            .filter(n -> distance(n.position(), center) <= radius)
-            .toList();
+        return tetree.findNeighborsIncludingGhosts(toPoint3f(center), radius).stream()
+            .map(result -> tetree.getEntity(result.entityId()))
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
     }
 
     /**
      * Check if target is a boundary neighbor of source.
      * <p>
-     * Boundary neighbors are at distance > aoiRadius and <= aoiRadius + buffer.
-     *
-     * @param source Source node
-     * @param target Target node
-     * @return true if target is in boundary zone
+     * Boundary neighbors are at distance &gt; {@code aoiRadius} and
+     * &le; {@code aoiRadius + boundaryBuffer}.
      */
     public boolean isBoundaryNeighbor(Node source, Node target) {
-        double dist = distance(source.position(), target.position());
+        double dist = source.position().distance(target.position());
         return dist > aoiRadius && dist <= (aoiRadius + boundaryBuffer);
     }
 
     /**
-     * Check if target is an enclosing neighbor of source.
-     * <p>
-     * Enclosing neighbors have overlapping bounds.
-     *
-     * @param source Source node
-     * @param target Target node
-     * @return true if bounds overlap
+     * Check if target is an enclosing neighbor of source (bounds overlap).
      */
     public boolean isEnclosingNeighbor(Node source, Node target) {
         return source.bounds().overlaps(target.bounds());
     }
 
     /**
-     * Get all nodes in the index.
-     *
-     * @return Collection of all VON nodes
+     * Get all nodes currently in the index.
      */
     public Collection<Node> getAllNodes() {
-        return nodes.values();
+        return tetree.entitiesInRegion(FULL_DOMAIN).stream()
+            .map(tetree::getEntity)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
     }
 
     /**
      * Get the number of nodes in the index.
-     *
-     * @return Node count
      */
     public int size() {
-        return nodes.size();
+        return tetree.entityCount();
     }
 
     /**
-     * Check if index is empty.
-     *
-     * @return true if no nodes in index
+     * Check if the index is empty.
      */
     public boolean isEmpty() {
-        return nodes.isEmpty();
-    }
-
-    /**
-     * Calculate Euclidean distance between two points.
-     *
-     * @param p1 First point
-     * @param p2 Second point
-     * @return Distance
-     */
-    private double distance(Point3D p1, Point3D p2) {
-        return p1.distance(p2);
+        return tetree.entityCount() == 0;
     }
 
     @Override
     public String toString() {
-        return String.format("SpatialNeighborIndex{nodes=%d, aoiRadius=%.2f, boundaryBuffer=%.2f}",
-                           nodes.size(), aoiRadius, boundaryBuffer);
+        return String.format("SpatialNeighborIndex{nodes=%d, level=%d, aoiRadius=%.2f, boundaryBuffer=%.2f}",
+                             size(), spatialLevel, aoiRadius, boundaryBuffer);
     }
+
+    // ==================== private helpers ====================
+
+    /**
+     * Cubic envelope covering the entire Tetree positive coordinate domain
+     * {@code [0, 2^MAX_REFINEMENT_LEVEL)}. Used by {@link #getAllNodes()} as a
+     * "give me everything" query.
+     */
+    private static final Spatial.Cube FULL_DOMAIN = new Spatial.Cube(0f, 0f, 0f,
+                                                                    (float) (1 << MortonCurve.MAX_REFINEMENT_LEVEL));
+
+    /**
+     * Convert a JavaFX double-precision {@link Point3D} to a vecmath single-precision
+     * {@link Point3f} for Tetree consumption. Float-mantissa precision (~7 decimal
+     * digits) is sufficient for VoN's 200-unit world.
+     */
+    private static Point3f toPoint3f(Point3D p) {
+        return new Point3f((float) p.getX(), (float) p.getY(), (float) p.getZ());
+    }
+
 }


### PR DESCRIPTION
## Summary

RDR-003 Phase 0 Step 2. Replaces the linear-scan `ConcurrentHashMap` implementation of `SpatialNeighborIndex` with a `Tetree<UUIDEntityID, Node>` — finally making the class name truthful (Voronoi Overlay Network's "spatial index" now is one).

`findWithinRadius` → `AbstractSpatialIndex.findNeighborsIncludingGhosts`. `findKNearest` → `AbstractSpatialIndex.kNearestNeighbors`. The two AoI hot-path bugs filed under `Luciferase-gig` and `Luciferase-ay7` close on merge.

## Public API

Preserved verbatim. The existing 2-argument constructor `SpatialNeighborIndex(aoiRadius, boundaryBuffer)` keeps working — it now uses `SpatialLevelHeuristic.computeDefault(aoiRadius)` to pick the Tetree's spatial level. For the canonical VoN configuration (`aoiRadius=50`, world=200), this is level 18.

A new 3-argument constructor `SpatialNeighborIndex(aoiRadius, boundaryBuffer, spatialLevel)` is additive; deployments with AoI distributions diverging from the heuristic can pin a specific level.

## Behavioral contract change

- **`updatePosition` is no longer a no-op.** The Tetree's spatial pruning depends on entities being stored at their current centroid; callers that move a node MUST invoke `updatePosition`. `MoveProtocol.move` already calls it, so existing callers get correct bucketing automatically.
- **Tetree requires non-negative coordinates.** Callers must supply positions in `[0, +∞)³`. Negative components produce an `IllegalArgumentException` from the underlying Tetree. The existing `SpatialNeighborIndexTest` already honors this contract explicitly (clamps test entity coords to ≥ 1).

## `findOverlapping` — design note

A spatial broad-phase via the world-cubic envelope of the query bounds + post-filter was implemented first but reverted. The Tetree indexes by centroid; a node's bounds can extend past its centroid into the query bounds even when the centroid lies outside the query envelope. Centroid-based pre-filtering therefore misses valid candidates — observed concretely when `IntegrationTest.testConcurrentJoinsHandled` dropped NC to 0.43 with the broad-phase impl.

`findOverlapping` is now iterate-all-and-filter (same as the prior linear-scan impl); rationale documented inline. This method is the JOIN-protocol path, not the AoI hot path that Phase 0 is closing. A future bounds-aware indexing optimization (e.g. inserting each node with `EntityBounds` to use the Tetree's spanning policy) would be a separate bead.

## Test plan

- [x] VoN suite (`SpatialNeighborIndexTest`, `JoinProtocolTest`, `MoveProtocolTest`, `LeaveProtocolTest`, `IntegrationTest`, `GhostSyncVONIntegrationTest`): 45/45 pass when run in isolation against this branch.
- [x] Full simulation suite: 2656/2656 pass on this branch. The known race-flake in `IntegrationTest.testConcurrentJoinsHandled` reproduces on `main` without any mj7 changes; filed separately as `Luciferase-x0t`. It passed in the full-suite run on this branch.
- [ ] CI confirms parity (matched expectation on PR #74/#75 history).

## What's NOT in this PR

- No JMH re-run vs the baseline JSON from PR #75. That's Phase 0 Step 3 (`Luciferase-sc4`), which is the differential analysis bead that closes on merge of the Tetree-backed-at-corrected-level benchmark.
- No optimization of `findOverlapping` to spatial indexing (separate follow-up bead if profiling shows the JOIN protocol is hot enough to need it).
- No changes to `MoveProtocol`, `JoinProtocol`, `LeaveProtocol`, or any other VoN caller.

## RDR linkage

- RDR: `docs/rdr/RDR-003-fcc-aligned-spatial-indexing.md` §Implementation Plan Phase 0 Step 2
- Bead: `Luciferase-mj7`
- Closes: `Luciferase-gig` (findWithinRadius O(N)), `Luciferase-ay7` (findKNearest O(N))
- Unblocks: `Luciferase-sc4` (Phase 0 Step 3 — Tetree-backed JMH validation against the linear-scan baseline JSON committed in PR #75).