### PR TITLE
fix(simulation): two flaky-test fixes [Luciferase-b3v, x0t]

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/JoinProtocol.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/JoinProtocol.java
@@ -27,7 +27,17 @@ import java.util.function.Consumer;
  * - Enclosing neighbors via bounds overlap
  * - Performance target: JOIN latency < 100ms
  * <p>
- * Thread-safe: Delegates to thread-safe SpatialNeighborIndex.
+ * Thread-safe: {@link #join(Node, Point3D)} runs under a per-protocol lock so
+ * concurrent join attempts see a consistent view of the index between the
+ * neighbor-discovery and self-insertion steps. Without this serialisation,
+ * two joiners landing simultaneously could each call
+ * {@code findOverlapping(joiner.bounds())} BEFORE either has inserted into
+ * the index, so neither sees the other as a neighbor — producing a permanent
+ * bidirectional-link gap detected by neighbor-consistency (NC) metrics.
+ * Observed: {@code IntegrationTest.testConcurrentJoinsHandled} on M4 Max ran
+ * NC = 0.43 deterministically under the old unsynchronised implementation
+ * (Luciferase-x0t). Joins are per-bubble-lifecycle events (not per-tick), so
+ * the serialisation cost is negligible at production rates.
  *
  * @author hal.hildebrand
  */
@@ -35,6 +45,7 @@ public class JoinProtocol {
 
     private final SpatialNeighborIndex index;
     private final Consumer<Event> eventEmitter;
+    private final Object joinLock = new Object();
 
     /**
      * Create a JOIN protocol handler.
@@ -65,34 +76,41 @@ public class JoinProtocol {
         Objects.requireNonNull(joiner, "joiner cannot be null");
         Objects.requireNonNull(position, "position cannot be null");
 
-        // Check if already in index (idempotent)
-        if (index.get(joiner.id()) != null) {
-            return;  // Already joined
+        // Serialise concurrent joins so steps 1-5 below see a consistent index.
+        // Without this, two concurrent joiners each call findOverlapping before
+        // either inserts, miss each other, and form a permanent neighbor-link
+        // gap (see class JavaDoc / Luciferase-x0t).
+        synchronized (joinLock) {
+            // Check if already in index (idempotent)
+            if (index.get(joiner.id()) != null) {
+                return;  // Already joined
+            }
+
+            // Step 1: Route to acceptor (closest bubble)
+            Node acceptor = findAcceptor(joiner, position);
+
+            // Step 2: Get neighbor list from acceptor
+            Set<Node> neighbors = getNeighborList(joiner, acceptor);
+
+            // Step 3 & 4: Establish bidirectional neighbor relationships
+            for (Node neighbor : neighbors) {
+                // Add neighbor to joiner's list
+                joiner.addNeighbor(neighbor.id());
+
+                // Notify neighbor of new joiner
+                neighbor.notifyJoin(joiner);
+
+                // Add joiner to neighbor's list
+                neighbor.addNeighbor(joiner.id());
+            }
+
+            // Step 5: Add joiner to index
+            index.insert(joiner);
+
+            // Step 6: Emit JOIN event (still under lock to preserve emit order
+            // relative to index state — event consumers may snapshot the index)
+            eventEmitter.accept(new Event.Join(joiner.id(), position));
         }
-
-        // Step 1: Route to acceptor (closest bubble)
-        Node acceptor = findAcceptor(joiner, position);
-
-        // Step 2: Get neighbor list from acceptor
-        Set<Node> neighbors = getNeighborList(joiner, acceptor);
-
-        // Step 3 & 4: Establish bidirectional neighbor relationships
-        for (Node neighbor : neighbors) {
-            // Add neighbor to joiner's list
-            joiner.addNeighbor(neighbor.id());
-
-            // Notify neighbor of new joiner
-            neighbor.notifyJoin(joiner);
-
-            // Add joiner to neighbor's list
-            neighbor.addNeighbor(joiner.id());
-        }
-
-        // Step 5: Add joiner to index
-        index.insert(joiner);
-
-        // Step 6: Emit JOIN event
-        eventEmitter.accept(new Event.Join(joiner.id(), position));
     }
 
     /**

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/causality/EntityMigrationContextTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/causality/EntityMigrationContextTest.java
@@ -326,13 +326,21 @@ class EntityMigrationContextTest {
         var entityId = "testEntity";
         fsm.initializeOwned(entityId);
 
-        long startTime = System.currentTimeMillis();
-
         // When - Transition to MIGRATING_OUT
         fsm.transition(entityId, EntityMigrationState.MIGRATING_OUT);
 
         var context = fsm.getMigrationContext(entityId);
         assertNotNull(context, "Context should exist");
+
+        // Reference time is the FSM's actual recorded startTimeMs, NOT a separate
+        // System.currentTimeMillis() reading: the FSM samples its clock during
+        // transition() at a slightly different wall-clock instant than the test
+        // could capture externally, so a separate startTime is ±a-few-ms off the
+        // FSM's truth — making the startTime+1000ms boundary assertion flaky
+        // under CPU load (Luciferase-b3v). The FSM already supports Clock
+        // injection (EntityMigrationStateMachine.setClock); reading the
+        // recorded startTimeMs is the minimum-change deterministic anchor.
+        long startTime = context.startTimeMs;
 
         // Then - Verify timeout calculation
         assertEquals(1000L, context.timeoutMs - context.startTimeMs,


### PR DESCRIPTION
## Summary

Two unrelated flaky tests filed earlier in this RDR-003 arc — fixing while VoN/causality context is fresh.

### Luciferase-b3v — EntityMigrationContextTest.testMigrationContextTimeout

The test captured \`startTime = System.currentTimeMillis()\` BEFORE \`fsm.transition()\` captured its own internal \`startTimeMs\` (via Clock injection), so the \`startTime + 1000ms\` boundary check was off by a few ms under CPU load — flaky at the boundary.

**Fix**: read \`startTime\` from \`context.startTimeMs\` (the FSM's actual recorded start) instead of from a separate wall-clock reading. The boundary algebra becomes exact.

The FSM already has Clock injection; this is the minimum-change deterministic anchor (no production code touched).

### Luciferase-x0t — IntegrationTest.testConcurrentJoinsHandled

\`JoinProtocol.join()\` called \`index.findOverlapping(joiner.bounds())\` BEFORE \`index.insert(joiner)\`, so two concurrent joiners each missed the other as a neighbor — forming a permanent bidirectional-link gap. On Apple M4 Max this produced deterministic \`NC = 0.43 < 0.5\` threshold.

**Fix**: serialise \`join()\` under a per-protocol \`joinLock\` so steps 1-5 (findAcceptor → getNeighborList → bidirectional notify → insert → emit) execute atomically against concurrent joiners. Joins are per-bubble-lifecycle events (not per-tick), so the serialisation cost is negligible at production rates.

## Test plan

- [x] \`EntityMigrationContextTest#testMigrationContextTimeout\` — 3/3 consecutive local runs PASS
- [x] \`IntegrationTest#testConcurrentJoinsHandled\` — 5/5 consecutive local runs PASS
- [x] \`mvn test -pl simulation -Dtest='com.hellblazer.luciferase.simulation.{von,causality,bubble,integration}.**'\` — 887 pass, 7 skipped
- [ ] CI green on PR

**Closes**: Luciferase-b3v, Luciferase-x0t