### PR TITLE
feat(lucien,grpc): SpatialKey serialization SPI + registry [Luciferase-546]

### DIFF
--- a/grpc/src/main/proto/lucien/ghost.proto
+++ b/grpc/src/main/proto/lucien/ghost.proto
@@ -22,21 +22,30 @@ message EntityBounds {
     Point3f max = 2;
 }
 
-// Base spatial key message
+// Extensible spatial key envelope (Luciferase-546).
+//
+// Replaces the prior oneof<MortonKey | TetreeKey> schema. The key type is now
+// identified by a string discriminator (type_id) and the payload is opaque
+// bytes serialised by the corresponding SpatialKeySerde registered in
+// com.hellblazer.luciferase.lucien.SpatialKeySerdeRegistry. Adding a new
+// SpatialKey implementation does not require editing this .proto.
+//
+// Conventional type_ids: "morton" for octree MortonKey, "tetree" for
+// TetreeKey. The legacy MortonKey / TetreeKey messages below remain as the
+// canonical payload encodings used by the built-in serdes; they are no longer
+// directly embedded in SpatialKey.
 message SpatialKey {
-    oneof key_type {
-        MortonKey morton = 1;
-        TetreeKey tetree = 2;
-    }
+    string type_id = 1;
+    bytes payload = 2;
 }
 
-// Morton key for Octree
+// Morton key for Octree — serialised inside SpatialKey.payload by MortonKeySerde.
 message MortonKey {
     uint64 morton_code = 1;
     uint32 level = 2;
 }
 
-// Tetree key
+// Tetree key — serialised inside SpatialKey.payload by TetreeKeySerde.
 message TetreeKey {
     uint64 low = 1;
     uint64 high = 2;

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialKey.java
@@ -16,9 +16,6 @@
  */
 package com.hellblazer.luciferase.lucien;
 
-import com.hellblazer.luciferase.lucien.forest.ghost.proto.MortonKey;
-import com.hellblazer.luciferase.lucien.forest.ghost.proto.TetreeKey;
-
 /**
  * Base interface for all spatial index keys.
  *
@@ -76,38 +73,8 @@ public interface SpatialKey<K extends SpatialKey<K>> extends Comparable<K> {
     @Override
     String toString();
 
-    /**
-     * Convert this SpatialKey to its protobuf representation.
-     */
-    default com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey toProtoSpatialKey() {
-        var builder = com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey.newBuilder();
-        
-        if (this instanceof com.hellblazer.luciferase.lucien.octree.MortonKey mortonKey) {
-            builder.setMorton(mortonKey.toProto());
-        } else if (this instanceof com.hellblazer.luciferase.lucien.tetree.TetreeKey<?> tetreeKey) {
-            builder.setTetree(TetreeKey.newBuilder()
-                .setLevel(tetreeKey.getLevel())
-                .setLow(tetreeKey.getLowBits())
-                .setHigh(tetreeKey.getHighBits())
-                .build());
-        } else {
-            throw new UnsupportedOperationException("Unknown SpatialKey type: " + this.getClass().getName());
-        }
-        
-        return builder.build();
-    }
-
-    /**
-     * Create a SpatialKey from its protobuf representation.
-     */
-    static SpatialKey<?> fromProtoSpatialKey(com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey proto) {
-        return switch (proto.getKeyTypeCase()) {
-            case MORTON -> com.hellblazer.luciferase.lucien.octree.MortonKey.fromProto(proto.getMorton());
-            case TETREE -> {
-                var t = proto.getTetree();
-                yield com.hellblazer.luciferase.lucien.tetree.TetreeKey.create((byte) t.getLevel(), t.getLow(), t.getHigh());
-            }
-            case KEYTYPE_NOT_SET -> throw new IllegalArgumentException("SpatialKey protobuf has no key type set");
-        };
-    }
+    // toProtoSpatialKey() and fromProtoSpatialKey() were removed under
+    // Luciferase-546. Serialisation now lives in ProtobufConverters and routes
+    // through SpatialKeySerdeRegistry; adding a new SpatialKey implementation
+    // requires registering a SpatialKeySerde, not editing this file.
 }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialKeySerde.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialKeySerde.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien;
+
+/**
+ * Service provider interface (SPI) for serialising {@link SpatialKey}
+ * implementations to and from the wire-level protobuf envelope.
+ * <p>
+ * Each {@code SpatialKey} implementation supplies a singleton {@code Serde} that
+ * registers itself with {@link SpatialKeySerdeRegistry}; the central dispatcher
+ * in {@code ProtobufConverters} then routes serialisation by {@link #typeId()}
+ * without an {@code instanceof} switch. Adding a new key type requires only
+ * (a) authoring a {@code Serde}, (b) registering it. No edits to
+ * {@code SpatialKey.java}, {@code ProtobufConverters.java}, or
+ * {@code ghost.proto} are needed (Luciferase-546).
+ *
+ * @param <K> the concrete SpatialKey type this serde handles
+ * @author hal.hildebrand
+ */
+public interface SpatialKeySerde<K extends SpatialKey<K>> {
+
+    /**
+     * The discriminator string written to the {@code SpatialKey.type_id} proto
+     * field. Must be unique across all registered serdes. Conventional values
+     * are short lower-case names ("morton", "tetree"). Treat as a stable wire
+     * identifier; do not rename casually.
+     */
+    String typeId();
+
+    /**
+     * The concrete key class this serde handles. Used by
+     * {@link SpatialKeySerdeRegistry#forKey(SpatialKey)} for outbound dispatch.
+     * For key hierarchies (e.g. {@code TetreeKey} → {@code CompactTetreeKey},
+     * {@code ExtendedTetreeKey}), return the common abstract base; the registry
+     * walks the class hierarchy at lookup time.
+     */
+    Class<K> keyClass();
+
+    /**
+     * Serialise the key to opaque bytes for the {@code SpatialKey.payload}
+     * proto field. Format is private to this serde — typically a protobuf
+     * message body, but any deterministic byte encoding works as long as
+     * {@link #deserialize(byte[])} can round-trip it.
+     */
+    byte[] serialize(K key);
+
+    /**
+     * Inverse of {@link #serialize(SpatialKey)}.
+     */
+    K deserialize(byte[] payload);
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialKeySerdeRegistry.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialKeySerdeRegistry.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Central registry mapping {@link SpatialKeySerde#typeId()} discriminator
+ * strings and {@link SpatialKey} implementation classes to their serdes
+ * (Luciferase-546).
+ * <p>
+ * <b>Built-in registrations.</b> The two ship-with-lucien serde classes
+ * ({@code MortonKeySerde}, {@code TetreeKeySerde} in
+ * {@code com.hellblazer.luciferase.lucien.forest.ghost.grpc}) register
+ * themselves via class-initialisers on this registry. They are eagerly
+ * triggered from this class's static initialiser so that any consumer that
+ * touches the registry sees the built-ins without having to load each serde
+ * class by name first.
+ * <p>
+ * <b>Extension registrations.</b> Other modules and tests can register
+ * additional serdes by calling {@link #register(SpatialKeySerde)} once at
+ * class-init or test-setup time. Registrations are idempotent for the
+ * <i>same</i> serde instance (re-registering the same singleton is a no-op);
+ * registering a <i>different</i> serde under an already-claimed type-id or
+ * key-class throws {@link IllegalStateException} to surface the conflict
+ * loudly.
+ * <p>
+ * <b>Class-hierarchy lookup.</b> {@link #forKey(SpatialKey)} walks the
+ * superclass / interface chain of the key's runtime class so a serde
+ * registered against an abstract base (e.g. {@code TetreeKey}) handles all
+ * concrete subclasses ({@code CompactTetreeKey}, {@code ExtendedTetreeKey}).
+ * Lookups are O(class-hierarchy-depth) and the result is cached on hit.
+ *
+ * @author hal.hildebrand
+ */
+public final class SpatialKeySerdeRegistry {
+
+    private static final ConcurrentMap<String, SpatialKeySerde<?>>     BY_TYPE_ID  = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<Class<?>, SpatialKeySerde<?>>   BY_KEY_CLASS = new ConcurrentHashMap<>();
+
+    static {
+        // Trigger built-in serde class-init so their self-registration runs
+        // before any consumer queries the registry.
+        try {
+            Class.forName(
+                "com.hellblazer.luciferase.lucien.forest.ghost.grpc.MortonKeySerde");
+            Class.forName(
+                "com.hellblazer.luciferase.lucien.forest.ghost.grpc.TetreeKeySerde");
+        } catch (ClassNotFoundException e) {
+            throw new ExceptionInInitializerError("Built-in SpatialKeySerde class not on classpath: " + e.getMessage());
+        }
+    }
+
+    private SpatialKeySerdeRegistry() {
+        // Static-only.
+    }
+
+    /**
+     * Register a serde under its {@link SpatialKeySerde#typeId()} and
+     * {@link SpatialKeySerde#keyClass()}. Idempotent for the same instance;
+     * conflicting registrations throw.
+     */
+    public static void register(SpatialKeySerde<?> serde) {
+        Objects.requireNonNull(serde, "serde");
+        Objects.requireNonNull(serde.typeId(), "serde.typeId");
+        Objects.requireNonNull(serde.keyClass(), "serde.keyClass");
+
+        var existingByType = BY_TYPE_ID.putIfAbsent(serde.typeId(), serde);
+        if (existingByType != null && existingByType != serde) {
+            throw new IllegalStateException(
+                "SpatialKeySerde type-id '" + serde.typeId() + "' already registered to "
+                + existingByType.getClass().getName() + "; cannot re-register "
+                + serde.getClass().getName());
+        }
+
+        var existingByClass = BY_KEY_CLASS.putIfAbsent(serde.keyClass(), serde);
+        if (existingByClass != null && existingByClass != serde) {
+            // Roll back the type-id registration to keep the maps consistent.
+            BY_TYPE_ID.remove(serde.typeId(), serde);
+            throw new IllegalStateException(
+                "SpatialKeySerde key-class " + serde.keyClass().getName() + " already registered to "
+                + existingByClass.getClass().getName() + "; cannot re-register "
+                + serde.getClass().getName());
+        }
+    }
+
+    /**
+     * Look up the serde registered for a given type-id. Returns {@code null}
+     * if no serde is registered.
+     */
+    public static SpatialKeySerde<?> forTypeId(String typeId) {
+        return BY_TYPE_ID.get(typeId);
+    }
+
+    /**
+     * Look up the serde that handles a given key instance. Searches the
+     * runtime class's hierarchy (superclasses + implemented interfaces) so
+     * subclasses of a registered base class are routed to the base's serde.
+     * On hit, caches the resolution on the concrete class for O(1) subsequent
+     * lookups. Returns {@code null} if no compatible serde is registered.
+     */
+    @SuppressWarnings("unchecked")
+    public static <K extends SpatialKey<K>> SpatialKeySerde<K> forKey(K key) {
+        Objects.requireNonNull(key, "key");
+        var runtimeClass = key.getClass();
+        var cached = BY_KEY_CLASS.get(runtimeClass);
+        if (cached != null) {
+            return (SpatialKeySerde<K>) cached;
+        }
+        // Walk the class hierarchy looking for a registered base.
+        for (Class<?> c = runtimeClass.getSuperclass(); c != null && c != Object.class; c = c.getSuperclass()) {
+            var serde = BY_KEY_CLASS.get(c);
+            if (serde != null) {
+                BY_KEY_CLASS.putIfAbsent(runtimeClass, serde);  // Cache for next time
+                return (SpatialKeySerde<K>) serde;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * For test isolation only: clear all registrations. Production code MUST
+     * NOT call this — built-in serdes are re-registered the next time the
+     * registry's static initialiser is touched, but extension serdes are not.
+     */
+    static void clearForTesting() {
+        BY_TYPE_ID.clear();
+        BY_KEY_CLASS.clear();
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementRequestManager.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementRequestManager.java
@@ -76,11 +76,6 @@ public class RefinementRequestManager {
      */
     public RefinementRequest buildRequest(int requesterRank, int roundNumber,
                                          List<SpatialKey> boundaryKeys, int treeLevel) {
-        // TODO: Implement SpatialKey to proto conversion
-        // The boundaryKeys need to be converted to proto lucien.ghost.SpatialKey messages.
-        // This requires checking the key type (MortonKey vs TetreeKey) and converting appropriately.
-        // For now, we add placeholder keys to prevent null pointer exceptions.
-
         totalRequests.incrementAndGet();
 
         log.debug("Building refinement request: rank={}, round={}, level={}, keys={}",
@@ -93,9 +88,13 @@ public class RefinementRequestManager {
             .setTreeLevel(treeLevel)
             .setTimestamp(System.currentTimeMillis());
 
-        // TODO: Convert boundary keys to proto format and add them
-        // For now, placeholder implementation - needs proper SpatialKey conversion
-        // .addAllBoundaryKeys(convertedKeys)
+        // Convert each boundary key to proto via the SpatialKeySerdeRegistry
+        // (Luciferase-546). Type-agnostic: any SpatialKey impl with a registered
+        // serde flows through unchanged.
+        for (var key : boundaryKeys) {
+            builder.addBoundaryKeys(
+                com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters.spatialKeyToProtobuf(key));
+        }
 
         return builder.build();
     }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/ElementGhostManager.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/ElementGhostManager.java
@@ -413,7 +413,7 @@ public class ElementGhostManager<Key extends SpatialKey<Key>, ID extends EntityI
     private void processReceivedGhostElement(com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostElement ghostElementProto) {
         try {
             // Convert protobuf ghost element to local representation
-            var spatialKey = com.hellblazer.luciferase.lucien.SpatialKey.fromProtoSpatialKey(ghostElementProto.getSpatialKey());
+            var spatialKey = com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters.spatialKeyFromProtobuf(ghostElementProto.getSpatialKey());
             
             // Convert protobuf position to javax.vecmath.Point3f
             var protoPos = ghostElementProto.getPosition();

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/MortonKeySerde.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/MortonKeySerde.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.forest.ghost.grpc;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.hellblazer.luciferase.lucien.SpatialKeySerde;
+import com.hellblazer.luciferase.lucien.SpatialKeySerdeRegistry;
+import com.hellblazer.luciferase.lucien.octree.MortonKey;
+
+/**
+ * Built-in {@link SpatialKeySerde} for {@link MortonKey} (Luciferase-546).
+ * <p>
+ * Wire format: the existing {@code ghost.proto MortonKey} message
+ * (morton_code + level) marshalled to bytes. Discriminator: {@code "morton"}.
+ * <p>
+ * Registers itself with {@link SpatialKeySerdeRegistry} via class-init; the
+ * registry triggers this class-init from its own static initialiser.
+ *
+ * @author hal.hildebrand
+ */
+public final class MortonKeySerde implements SpatialKeySerde<MortonKey> {
+
+    public static final  String          TYPE_ID  = "morton";
+    public static final  MortonKeySerde  INSTANCE = new MortonKeySerde();
+
+    static {
+        SpatialKeySerdeRegistry.register(INSTANCE);
+    }
+
+    private MortonKeySerde() {
+    }
+
+    @Override
+    public String typeId() {
+        return TYPE_ID;
+    }
+
+    @Override
+    public Class<MortonKey> keyClass() {
+        return MortonKey.class;
+    }
+
+    @Override
+    public byte[] serialize(MortonKey key) {
+        return com.hellblazer.luciferase.lucien.forest.ghost.proto.MortonKey.newBuilder()
+            .setMortonCode(key.getMortonCode())
+            .setLevel(key.getLevel())
+            .build()
+            .toByteArray();
+    }
+
+    @Override
+    public MortonKey deserialize(byte[] payload) {
+        try {
+            var proto = com.hellblazer.luciferase.lucien.forest.ghost.proto.MortonKey.parseFrom(payload);
+            return new MortonKey(proto.getMortonCode(), (byte) proto.getLevel());
+        } catch (InvalidProtocolBufferException e) {
+            throw new IllegalArgumentException("MortonKeySerde payload is not a valid proto MortonKey", e);
+        }
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/ProtobufConverters.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/ProtobufConverters.java
@@ -17,14 +17,13 @@
 
 package com.hellblazer.luciferase.lucien.forest.ghost.grpc;
 
+import com.google.protobuf.ByteString;
 import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.SpatialKeySerde;
+import com.hellblazer.luciferase.lucien.SpatialKeySerdeRegistry;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.entity.LongEntityID;
 import com.hellblazer.luciferase.lucien.entity.UUIDEntityID;
-import com.hellblazer.luciferase.lucien.octree.MortonKey;
-import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
-import com.hellblazer.luciferase.lucien.tetree.CompactTetreeKey;
-import com.hellblazer.luciferase.lucien.tetree.ExtendedTetreeKey;
 import com.hellblazer.luciferase.lucien.forest.ghost.proto.*;
 
 import javax.vecmath.Point3f;
@@ -45,72 +44,54 @@ public final class ProtobufConverters {
     }
     
     /**
-     * Converts a spatial key to protobuf format.
-     * 
+     * Converts a spatial key to its protobuf envelope (Luciferase-546).
+     * <p>
+     * Dispatches via {@link SpatialKeySerdeRegistry#forKey(SpatialKey)} —
+     * no {@code instanceof} switch. To add support for a new SpatialKey type,
+     * register a {@link SpatialKeySerde} for it; no edits to this method
+     * are required.
+     *
      * @param key the spatial key to convert
-     * @return the protobuf representation
-     * @throws IllegalArgumentException if the key type is unsupported
+     * @return the protobuf envelope (type_id + opaque payload)
+     * @throws IllegalArgumentException if no serde is registered for the key's class
      */
     public static com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey spatialKeyToProtobuf(
             com.hellblazer.luciferase.lucien.SpatialKey<?> key) {
-        
-        var builder = com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey.newBuilder();
-        
-        if (key instanceof MortonKey mortonKey) {
-            builder.setMorton(com.hellblazer.luciferase.lucien.forest.ghost.proto.MortonKey.newBuilder()
-                .setMortonCode(mortonKey.getMortonCode())
-                .setLevel(mortonKey.getLevel())
-                .build());
-        } else if (key instanceof TetreeKey<?> tetreeKey) {
-            builder.setTetree(com.hellblazer.luciferase.lucien.forest.ghost.proto.TetreeKey.newBuilder()
-                .setLow(tetreeKey.getLowBits())
-                .setHigh(tetreeKey.getHighBits())
-                .setLevel(tetreeKey.getLevel())
-                .build());
-        } else {
-            throw new IllegalArgumentException("Unsupported spatial key type: " + key.getClass());
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        SpatialKeySerde serde = SpatialKeySerdeRegistry.forKey((com.hellblazer.luciferase.lucien.SpatialKey) key);
+        if (serde == null) {
+            throw new IllegalArgumentException("No SpatialKeySerde registered for key class: " + key.getClass());
         }
-        
-        return builder.build();
+        @SuppressWarnings("unchecked")
+        var payload = serde.serialize(key);
+        return com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey.newBuilder()
+            .setTypeId(serde.typeId())
+            .setPayload(ByteString.copyFrom(payload))
+            .build();
     }
-    
+
     /**
-     * Converts a protobuf spatial key to domain object.
-     * 
-     * @param proto the protobuf spatial key
-     * @return the domain spatial key
-     * @throws IllegalArgumentException if the key type is not set or unsupported
+     * Converts a protobuf spatial key envelope back to a domain object
+     * (Luciferase-546). Dispatches via
+     * {@link SpatialKeySerdeRegistry#forTypeId(String)}.
+     *
+     * @param proto the protobuf envelope
+     * @return the deserialised spatial key
+     * @throws IllegalArgumentException if no serde is registered for the
+     *                                  envelope's {@code type_id}
      */
     public static com.hellblazer.luciferase.lucien.SpatialKey<?> spatialKeyFromProtobuf(
             com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey proto) {
-        
-        return switch (proto.getKeyTypeCase()) {
-            case MORTON -> new MortonKey(proto.getMorton().getMortonCode(), (byte) proto.getMorton().getLevel());
-            case TETREE -> {
-                var tetree = proto.getTetree();
-                yield createTetreeKey(tetree.getLow(), tetree.getHigh(), tetree.getLevel());
-            }
-            case KEYTYPE_NOT_SET -> throw new IllegalArgumentException("Spatial key type not set");
-        };
-    }
-    
-    /**
-     * Creates a TetreeKey from protobuf values.
-     * Automatically chooses between CompactTetreeKey and ExtendedTetreeKey based on level.
-     * 
-     * @param low the low bits
-     * @param high the high bits
-     * @param level the level
-     * @return the appropriate TetreeKey implementation
-     */
-    private static TetreeKey<?> createTetreeKey(long low, long high, int level) {
-        if (level <= 10) {
-            // Use CompactTetreeKey for levels 0-10
-            return new CompactTetreeKey((byte) level, low);
-        } else {
-            // Use ExtendedTetreeKey for levels 11-21
-            return new ExtendedTetreeKey((byte) level, low, high);
+        var typeId = proto.getTypeId();
+        if (typeId.isEmpty()) {
+            throw new IllegalArgumentException("SpatialKey protobuf has no type_id set");
         }
+        var serde = SpatialKeySerdeRegistry.forTypeId(typeId);
+        if (serde == null) {
+            throw new IllegalArgumentException(
+                "No SpatialKeySerde registered for type_id '" + typeId + "'");
+        }
+        return serde.deserialize(proto.getPayload().toByteArray());
     }
     
     /**

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/TetreeKeySerde.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/TetreeKeySerde.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.forest.ghost.grpc;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.hellblazer.luciferase.lucien.SpatialKeySerde;
+import com.hellblazer.luciferase.lucien.SpatialKeySerdeRegistry;
+import com.hellblazer.luciferase.lucien.tetree.CompactTetreeKey;
+import com.hellblazer.luciferase.lucien.tetree.ExtendedTetreeKey;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+
+/**
+ * Built-in {@link SpatialKeySerde} for {@link TetreeKey} and its concrete
+ * subclasses ({@link CompactTetreeKey}, {@link ExtendedTetreeKey})
+ * (Luciferase-546).
+ * <p>
+ * Wire format: the existing {@code ghost.proto TetreeKey} message
+ * (low + high + level) marshalled to bytes. Discriminator: {@code "tetree"}.
+ * <p>
+ * <b>Concrete-class dispatch.</b> On deserialise, {@code level <= 10} produces
+ * a {@link CompactTetreeKey}; higher levels produce an
+ * {@link ExtendedTetreeKey}. This preserves the level-based dispatch the
+ * legacy {@code ProtobufConverters.createTetreeKey} performed; the boundary
+ * is intentionally inclusive at level 10 to keep wire-compatible behaviour
+ * for callers that have round-tripped existing payloads.
+ * <p>
+ * Registered against the {@link TetreeKey} abstract base; the
+ * {@link SpatialKeySerdeRegistry} walks the class hierarchy at lookup time so
+ * both compact and extended runtime instances route to this serde.
+ *
+ * @author hal.hildebrand
+ */
+public final class TetreeKeySerde implements SpatialKeySerde<TetreeKey<?>> {
+
+    public static final  String          TYPE_ID  = "tetree";
+    public static final  TetreeKeySerde  INSTANCE = new TetreeKeySerde();
+
+    /** Inclusive level boundary below which {@link CompactTetreeKey} is the natural concrete type. */
+    private static final int             COMPACT_LEVEL_MAX = 10;
+
+    static {
+        SpatialKeySerdeRegistry.register(INSTANCE);
+    }
+
+    private TetreeKeySerde() {
+    }
+
+    @Override
+    public String typeId() {
+        return TYPE_ID;
+    }
+
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public Class<TetreeKey<?>> keyClass() {
+        // Raw cast: Class literals for parameterised types are not expressible in Java.
+        return (Class) TetreeKey.class;
+    }
+
+    @Override
+    public byte[] serialize(TetreeKey<?> key) {
+        return com.hellblazer.luciferase.lucien.forest.ghost.proto.TetreeKey.newBuilder()
+            .setLow(key.getLowBits())
+            .setHigh(key.getHighBits())
+            .setLevel(key.getLevel())
+            .build()
+            .toByteArray();
+    }
+
+    @Override
+    public TetreeKey<?> deserialize(byte[] payload) {
+        try {
+            var proto = com.hellblazer.luciferase.lucien.forest.ghost.proto.TetreeKey.parseFrom(payload);
+            var level = (byte) proto.getLevel();
+            return level <= COMPACT_LEVEL_MAX
+                ? new CompactTetreeKey(level, proto.getLow())
+                : new ExtendedTetreeKey(level, proto.getLow(), proto.getHigh());
+        } catch (InvalidProtocolBufferException e) {
+            throw new IllegalArgumentException("TetreeKeySerde payload is not a valid proto TetreeKey", e);
+        }
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/SpatialKeySerdeRegistryTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/SpatialKeySerdeRegistryTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien;
+
+import com.hellblazer.luciferase.lucien.forest.ghost.grpc.MortonKeySerde;
+import com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters;
+import com.hellblazer.luciferase.lucien.forest.ghost.grpc.TetreeKeySerde;
+import com.hellblazer.luciferase.lucien.octree.MortonKey;
+import com.hellblazer.luciferase.lucien.tetree.CompactTetreeKey;
+import com.hellblazer.luciferase.lucien.tetree.ExtendedTetreeKey;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for {@link SpatialKeySerdeRegistry} and the wire-level dispatch
+ * exposed by {@link ProtobufConverters} (Luciferase-546).
+ * <p>
+ * Built-in serdes ({@link MortonKeySerde}, {@link TetreeKeySerde}) round-trip
+ * through the registry. A {@code FakeKey} is registered at test time to
+ * exercise the extension path — demonstrating that adding a new SpatialKey
+ * type requires no edits to {@code SpatialKey.java},
+ * {@code ProtobufConverters.java}, or {@code ghost.proto}.
+ *
+ * @author hal.hildebrand
+ */
+public class SpatialKeySerdeRegistryTest {
+
+    static {
+        // Force registry class-init so built-in serdes register before any test runs.
+        SpatialKeySerdeRegistry.forTypeId("morton");
+        // Register the FakeKey serde once (test is idempotent — registry permits
+        // re-registering the same instance).
+        SpatialKeySerdeRegistry.register(FakeKeySerde.INSTANCE);
+    }
+
+    @Test
+    void builtinMortonKeyRoundTripsThroughRegistry() {
+        var original = new MortonKey(0xC0FFEE_AB_CDL, (byte) 7);
+        var envelope = ProtobufConverters.spatialKeyToProtobuf(original);
+        assertEquals("morton", envelope.getTypeId(), "envelope must carry the morton type_id");
+
+        var roundtrip = ProtobufConverters.spatialKeyFromProtobuf(envelope);
+        assertInstanceOf(MortonKey.class, roundtrip);
+        assertEquals(original, roundtrip);
+    }
+
+    @Test
+    void builtinCompactTetreeKeyRoundTripsThroughRegistry() {
+        var original = new CompactTetreeKey((byte) 5, 0x12345_6789_ABCDEL);
+        var envelope = ProtobufConverters.spatialKeyToProtobuf(original);
+        assertEquals("tetree", envelope.getTypeId());
+
+        var roundtrip = ProtobufConverters.spatialKeyFromProtobuf(envelope);
+        assertInstanceOf(CompactTetreeKey.class, roundtrip,
+                         "level <= 10 must deserialise as CompactTetreeKey");
+        assertEquals(original, roundtrip);
+    }
+
+    @Test
+    void builtinExtendedTetreeKeyRoundTripsThroughRegistry() {
+        var original = new ExtendedTetreeKey((byte) 15, 0x1111_2222_3333_4444L, 0x5555_6666_7777_8888L);
+        var envelope = ProtobufConverters.spatialKeyToProtobuf(original);
+        assertEquals("tetree", envelope.getTypeId());
+
+        var roundtrip = ProtobufConverters.spatialKeyFromProtobuf(envelope);
+        assertInstanceOf(ExtendedTetreeKey.class, roundtrip,
+                         "level > 10 must deserialise as ExtendedTetreeKey");
+        assertEquals(original, roundtrip);
+    }
+
+    @Test
+    void unknownTypeIdThrowsMeaningfulMessage() {
+        var envelope = com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey.newBuilder()
+            .setTypeId("not-registered")
+            .setPayload(com.google.protobuf.ByteString.copyFrom(new byte[] {1, 2, 3}))
+            .build();
+        var thrown = assertThrows(IllegalArgumentException.class,
+                                  () -> ProtobufConverters.spatialKeyFromProtobuf(envelope));
+        assertNotNull(thrown.getMessage());
+        assertEquals(true, thrown.getMessage().contains("not-registered"),
+                     "exception must name the unrecognised type_id");
+    }
+
+    @Test
+    void emptyTypeIdThrowsMeaningfulMessage() {
+        var envelope = com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey.newBuilder().build();
+        assertThrows(IllegalArgumentException.class,
+                     () -> ProtobufConverters.spatialKeyFromProtobuf(envelope),
+                     "an envelope with no type_id must be rejected");
+    }
+
+    @Test
+    void registryLooksUpByConcreteSubclass() {
+        // TetreeKeySerde is registered against the TetreeKey base; the registry's
+        // class-hierarchy walk must route both CompactTetreeKey and
+        // ExtendedTetreeKey to it.
+        var serdeForCompact = SpatialKeySerdeRegistry.forKey(new CompactTetreeKey((byte) 3, 42L));
+        var serdeForExtended = SpatialKeySerdeRegistry.forKey(
+            new ExtendedTetreeKey((byte) 12, 1L, 2L));
+        assertSame(serdeForCompact, serdeForExtended,
+                   "concrete subclasses must route to the same base-registered serde");
+        assertEquals("tetree", serdeForCompact.typeId());
+    }
+
+    @Test
+    void newKeyTypeRegistersAndRoundTripsWithoutEditingSpatialKeyOrProto() {
+        // ACCEPTANCE TEST (Luciferase-546): a fake key type, declared entirely in
+        // test code, registers via the SPI and round-trips through the dispatcher
+        // without any edits to SpatialKey.java, ProtobufConverters.java, or
+        // ghost.proto.
+        var original = new FakeKey(0xDEAD_BEEFL, (byte) 4);
+        var envelope = ProtobufConverters.spatialKeyToProtobuf(original);
+        assertEquals(FakeKeySerde.TYPE_ID, envelope.getTypeId());
+
+        var roundtrip = ProtobufConverters.spatialKeyFromProtobuf(envelope);
+        assertInstanceOf(FakeKey.class, roundtrip);
+        assertEquals(original, roundtrip);
+    }
+
+    @Test
+    void duplicateTypeIdRegistrationConflictThrows() {
+        // Registering a *different* serde under an already-claimed type_id
+        // (without it being the same singleton) must throw.
+        var conflict = new SpatialKeySerde<FakeKey>() {
+            @Override public String         typeId()    { return FakeKeySerde.TYPE_ID; }
+            @Override public Class<FakeKey> keyClass()  { return FakeKey.class; }
+            @Override public byte[] serialize(FakeKey key)    { return new byte[0]; }
+            @Override public FakeKey deserialize(byte[] payload) { return null; }
+        };
+        assertThrows(IllegalStateException.class,
+                     () -> SpatialKeySerdeRegistry.register(conflict));
+    }
+
+    // ============================================================
+    // Test fixtures: a minimal SpatialKey + its serde
+    // ============================================================
+
+    /** Trivial SpatialKey for testing the extension path. */
+    private record FakeKey(long index, byte level) implements SpatialKey<FakeKey> {
+        @Override public byte    getLevel()             { return level; }
+        @Override public FakeKey parent()               { return level == 0 ? null : new FakeKey(index / 2, (byte) (level - 1)); }
+        @Override public FakeKey root()                 { return new FakeKey(0, (byte) 0); }
+        @Override public int     compareTo(FakeKey o)   { return Long.compare(index, o.index); }
+    }
+
+    /** Serde for {@link FakeKey} demonstrating the extension SPI. */
+    private static final class FakeKeySerde implements SpatialKeySerde<FakeKey> {
+        static final         String       TYPE_ID  = "test.fake";
+        static final         FakeKeySerde INSTANCE = new FakeKeySerde();
+
+        @Override public String         typeId()   { return TYPE_ID; }
+        @Override public Class<FakeKey> keyClass() { return FakeKey.class; }
+
+        @Override
+        public byte[] serialize(FakeKey key) {
+            return ByteBuffer.allocate(Long.BYTES + Byte.BYTES).putLong(key.index()).put(key.level()).array();
+        }
+
+        @Override
+        public FakeKey deserialize(byte[] payload) {
+            var bb = ByteBuffer.wrap(payload);
+            return new FakeKey(bb.getLong(), bb.get());
+        }
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/ButterflyViolationAggregatorTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/ButterflyViolationAggregatorTest.java
@@ -303,20 +303,22 @@ class ButterflyViolationAggregatorTest {
                                             int localLevel, int ghostLevel,
                                             int levelDiff, int sourceRank) {
         return BalanceViolation.newBuilder()
-            .setLocalKey(SpatialKey.newBuilder()
-                .setMorton(com.hellblazer.luciferase.lucien.forest.ghost.proto.MortonKey.newBuilder()
-                    .setMortonCode(localKeyId)
-                    .build())
-                .build())
-            .setGhostKey(SpatialKey.newBuilder()
-                .setMorton(com.hellblazer.luciferase.lucien.forest.ghost.proto.MortonKey.newBuilder()
-                    .setMortonCode(ghostKeyId)
-                    .build())
-                .build())
+            .setLocalKey(mortonKey(localKeyId))
+            .setGhostKey(mortonKey(ghostKeyId))
             .setLocalLevel(localLevel)
             .setGhostLevel(ghostLevel)
             .setLevelDifference(levelDiff)
             .setSourceRank(sourceRank)
             .build();
+    }
+
+    /**
+     * Build a proto SpatialKey envelope from a long Morton code (level 0).
+     * Routes through the SpatialKeySerdeRegistry (Luciferase-546) so this
+     * helper does not need to know the new envelope shape.
+     */
+    private static SpatialKey mortonKey(long mortonCode) {
+        return com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters.spatialKeyToProtobuf(
+            new com.hellblazer.luciferase.lucien.octree.MortonKey(mortonCode, (byte) 0));
     }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/DistributedViolationAggregatorTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/DistributedViolationAggregatorTest.java
@@ -212,20 +212,18 @@ class DistributedViolationAggregatorTest {
                                             int localLevel, int ghostLevel,
                                             int levelDiff, int sourceRank) {
         return BalanceViolation.newBuilder()
-            .setLocalKey(SpatialKey.newBuilder()
-                .setMorton(com.hellblazer.luciferase.lucien.forest.ghost.proto.MortonKey.newBuilder()
-                    .setMortonCode(localKeyId)
-                    .build())
-                .build())
-            .setGhostKey(SpatialKey.newBuilder()
-                .setMorton(com.hellblazer.luciferase.lucien.forest.ghost.proto.MortonKey.newBuilder()
-                    .setMortonCode(ghostKeyId)
-                    .build())
-                .build())
+            .setLocalKey(mortonKey(localKeyId))
+            .setGhostKey(mortonKey(ghostKeyId))
             .setLocalLevel(localLevel)
             .setGhostLevel(ghostLevel)
             .setLevelDifference(levelDiff)
             .setSourceRank(sourceRank)
             .build();
+    }
+
+    /** Build a proto SpatialKey envelope from a long Morton code (Luciferase-546 serde dispatch). */
+    private static SpatialKey mortonKey(long mortonCode) {
+        return com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters.spatialKeyToProtobuf(
+            new com.hellblazer.luciferase.lucien.octree.MortonKey(mortonCode, (byte) 0));
     }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/Phase4E2ETest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/Phase4E2ETest.java
@@ -571,21 +571,19 @@ class Phase4E2ETest {
                                                     int localLevel, int ghostLevel,
                                                     int levelDiff, int sourceRank) {
         return BalanceViolation.newBuilder()
-            .setLocalKey(SpatialKey.newBuilder()
-                .setMorton(com.hellblazer.luciferase.lucien.forest.ghost.proto.MortonKey.newBuilder()
-                    .setMortonCode(localKeyId)
-                    .build())
-                .build())
-            .setGhostKey(SpatialKey.newBuilder()
-                .setMorton(com.hellblazer.luciferase.lucien.forest.ghost.proto.MortonKey.newBuilder()
-                    .setMortonCode(ghostKeyId)
-                    .build())
-                .build())
+            .setLocalKey(mortonKey(localKeyId))
+            .setGhostKey(mortonKey(ghostKeyId))
             .setLocalLevel(localLevel)
             .setGhostLevel(ghostLevel)
             .setLevelDifference(levelDiff)
             .setSourceRank(sourceRank)
             .build();
+    }
+
+    /** Build a proto SpatialKey envelope from a long Morton code (Luciferase-546 serde dispatch). */
+    private static SpatialKey mortonKey(long mortonCode) {
+        return com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters.spatialKeyToProtobuf(
+            new com.hellblazer.luciferase.lucien.octree.MortonKey(mortonCode, (byte) 0));
     }
 
     /**

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/grpc/BalanceCoordinatorIntegrationTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/grpc/BalanceCoordinatorIntegrationTest.java
@@ -84,9 +84,7 @@ class BalanceCoordinatorIntegrationTest {
 
     @Test
     void testRequestRefinement() {
-        var spatialKey = SpatialKey.newBuilder()
-            .setMorton(MortonKey.newBuilder().setMortonCode(0x12345L).build())
-            .build();
+        var spatialKey = mortonKey(0x12345L);
 
         var request = RefinementRequest.newBuilder()
             .setRequesterRank(1)
@@ -144,12 +142,8 @@ class BalanceCoordinatorIntegrationTest {
     @Test
     void testExchangeViolations() {
         var violation = BalanceViolation.newBuilder()
-            .setLocalKey(SpatialKey.newBuilder()
-                .setMorton(MortonKey.newBuilder().setMortonCode(100L).build())
-                .build())
-            .setGhostKey(SpatialKey.newBuilder()
-                .setMorton(MortonKey.newBuilder().setMortonCode(200L).build())
-                .build())
+            .setLocalKey(mortonKey(100L))
+            .setGhostKey(mortonKey(200L))
             .setLocalLevel(5)
             .setGhostLevel(7)
             .setLevelDifference(2)
@@ -239,5 +233,11 @@ class BalanceCoordinatorIntegrationTest {
                 .setTimestamp(System.currentTimeMillis())
                 .build();
         }
+    }
+
+    /** Build a proto SpatialKey envelope from a long Morton code (Luciferase-546 serde dispatch). */
+    private static SpatialKey mortonKey(long mortonCode) {
+        return com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters.spatialKeyToProtobuf(
+            new com.hellblazer.luciferase.lucien.octree.MortonKey(mortonCode, (byte) 0));
     }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/grpc/BalanceProtoSerializationTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/grpc/BalanceProtoSerializationTest.java
@@ -39,9 +39,7 @@ class BalanceProtoSerializationTest {
 
     @Test
     void testRefinementRequestSerialization() {
-        var spatialKey = SpatialKey.newBuilder()
-            .setMorton(MortonKey.newBuilder().setMortonCode(0x12345L).build())
-            .build();
+        var spatialKey = mortonKey(0x12345L);
 
         var request = RefinementRequest.newBuilder()
             .setRequesterRank(1)
@@ -123,5 +121,11 @@ class BalanceProtoSerializationTest {
         } catch (Exception e) {
             fail("Failed to deserialize: " + e.getMessage());
         }
+    }
+
+    /** Build a proto SpatialKey envelope from a long Morton code (Luciferase-546 serde dispatch). */
+    private static SpatialKey mortonKey(long mortonCode) {
+        return com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters.spatialKeyToProtobuf(
+            new com.hellblazer.luciferase.lucien.octree.MortonKey(mortonCode, (byte) 0));
     }
 }


### PR DESCRIPTION
## Summary

Closes Luciferase-546. Adding a new SpatialKey implementation no longer requires editing \`SpatialKey.java\`, \`ProtobufConverters.java\`, or \`ghost.proto\`. New keys register a \`SpatialKeySerde\` with \`SpatialKeySerdeRegistry\`; the central dispatcher routes by runtime class on outbound, by \`type_id\` discriminator on inbound.

## Wire-schema change (ghost.proto)

\`\`\`diff
 message SpatialKey {
-    oneof key_type {
-        MortonKey morton = 1;
-        TetreeKey tetree = 2;
-    }
+    string type_id = 1;
+    bytes  payload = 2;
 }
\`\`\`

Standalone \`MortonKey\` / \`TetreeKey\` messages remain as canonical payload encodings. Wire format breaks once vs the old shape (per design discussion; no production rolling-upgrade scenario).

## New types

| | |
|---|---|
| \`SpatialKeySerde<K>\` | SPI: \`typeId()\`, \`keyClass()\`, \`serialize\`, \`deserialize\` |
| \`SpatialKeySerdeRegistry\` | static maps (type-id → serde, key-class → serde) with class-hierarchy walk for outbound lookup |
| \`MortonKeySerde\` | type-id \`morton\`; built-in, self-registers |
| \`TetreeKeySerde\` | type-id \`tetree\`; built-in, self-registers against \`TetreeKey\` abstract base; preserves \`level <= 10 → Compact / level > 10 → Extended\` dispatch |

## Dispatcher consolidation

The \`instanceof\` switch lived in **two** places that had drifted (agent's finding):
- \`SpatialKey.toProtoSpatialKey\` / \`fromProtoSpatialKey\` — **removed** (zero callers of instance method; one caller of static updated)
- \`ProtobufConverters.spatialKey{To,From}Protobuf\` — rewritten to dispatch through registry, no key-type-specific code

## Bonus fix

\`RefinementRequestManager.buildRequest\` had a TODO at line 79 ("Implement SpatialKey to proto conversion") — fulfilled via the registry; the method now correctly populates \`boundary_keys\`.

## Test plan

- [x] **Integration test** (\`SpatialKeySerdeRegistryTest\`, 8 tests): built-in Morton + Compact/Extended Tetree round-trips, class-hierarchy lookup, \`FakeKey\` extension acceptance (zero edits to SpatialKey/Converters/.proto), error paths (unknown type-id, empty type-id, conflicting registration)
- [x] 590 lucien tests pass across balancing + ghost + SPI packages
- [x] 582 lucien balancing tests pass after \`RefinementRequestManager\` TODO fix
- [x] 5 migrated test files (\`ButterflyViolationAggregatorTest\`, \`Phase4E2ETest\`, \`DistributedViolationAggregatorTest\`, \`BalanceCoordinatorIntegrationTest\`, \`BalanceProtoSerializationTest\`) — all pass
- [ ] CI green on PR

**Closes**: Luciferase-546