### PR TITLE
Review-360 Tranche A: quick wins + build/CI cleanup [Luciferase-glh]

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel in-flight runs on the same ref when a new commit lands. Saves CI
+# minutes on rapid PR pushes; main branch runs are not cancelled
+# (cancel-in-progress only applies within a single concurrency group, and
+# each main push starts its own group via the SHA in the ref).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   compile:
     runs-on: ubuntu-latest
@@ -341,7 +349,7 @@ jobs:
               <server>
                 <id>github-prime-mover</id>
                 <username>\${env.GITHUB_ACTOR}</username>
-                <password>\${env.GITHUB_TOKEN}</password>
+                <password>\${env.PACKAGES_TOKEN}</password>
               </server>
             </servers>
           </settings>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,9 +80,13 @@ jobs:
           PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Build and test
+        # Releases must NOT skip tests — they are the last safety net before a
+        # versioned artifact is published to GitHub Packages. If a test failure
+        # blocks a release, fix the test or revert the offending change; do not
+        # bypass with -DskipTests.
         run: |
           export DISPLAY=:99.0
-          xvfb-run -a ./mvnw -batch-mode clean install -DskipTests
+          xvfb-run -a ./mvnw -batch-mode clean install
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
@@ -110,6 +114,12 @@ jobs:
           git commit -m "Prepare next development iteration ${{ github.event.inputs.nextVersion }}"
 
       - name: Push changes and tags
+        # NOTE: This step pushes the release-version and next-snapshot commits
+        # directly to main, which conflicts with the repository-wide "PRs only"
+        # rule (see CLAUDE.md > Git). A future RDR should restructure this into
+        # a PR-based release flow (open release-prep PR -> tag merge commit).
+        # Until then, this remains the only sanctioned direct-push path on this
+        # repo and is restricted to workflow_dispatch on the release workflow.
         run: |
           git push origin HEAD:main
           git push origin v${{ github.event.inputs.releaseVersion }}

--- a/common/src/main/java/com/hellblazer/luciferase/common/OpenAddressingSet.java
+++ b/common/src/main/java/com/hellblazer/luciferase/common/OpenAddressingSet.java
@@ -91,7 +91,7 @@ public abstract class OpenAddressingSet<T> extends AbstractSet<T> {
             if (equals(key, ob)) {
                 return true;
             }
-            index = index + (hash | 1) & table.length - 1;
+            index = (index + (hash | 1)) & (table.length - 1);
         } while (index != hash);
         return false;
     }
@@ -108,6 +108,9 @@ public abstract class OpenAddressingSet<T> extends AbstractSet<T> {
 
             @Override
             public boolean hasNext() {
+                if (table == null) {
+                    return false;
+                }
                 while (next < table.length) {
                     if (table[next] != null && table[next] != DELETED) {
                         return true;
@@ -120,6 +123,9 @@ public abstract class OpenAddressingSet<T> extends AbstractSet<T> {
             @SuppressWarnings("unchecked")
             @Override
             public T next() {
+                if (table == null) {
+                    throw new NoSuchElementException("Enumerator");
+                }
                 while (next < table.length) {
                     if (table[next] != null && table[next] != DELETED) {
                         return (T) table[next++];
@@ -155,7 +161,7 @@ public abstract class OpenAddressingSet<T> extends AbstractSet<T> {
                     size -= 1;
                     return true;
                 }
-                index = index + (hash | 1) & table.length - 1;
+                index = (index + (hash | 1)) & (table.length - 1);
             } while (index != hash);
         }
         return false;
@@ -169,19 +175,36 @@ public abstract class OpenAddressingSet<T> extends AbstractSet<T> {
     private boolean insert(Object key) {
         int hash = PRIME * getHash(key) >>> load;
         int index = hash;
+        int firstDeleted = -1;
         do {
             Object ob = table[index];
-            if (ob == null || ob == DELETED) {
-                table[index] = key;
+            if (ob == null) {
+                // End of the probe chain. Reuse the earliest DELETED tombstone
+                // if we saw one; otherwise insert at this null slot. Required
+                // to avoid duplicates when the key already exists past a
+                // tombstone earlier in the chain.
+                int target = (firstDeleted >= 0) ? firstDeleted : index;
+                table[target] = key;
                 size += 1;
                 return true;
             }
-            if (equals(key, ob)) {
+            if (ob == DELETED) {
+                if (firstDeleted < 0) {
+                    firstDeleted = index;
+                }
+            } else if (equals(key, ob)) {
                 table[index] = key;
                 return false;
             }
-            index = index + (hash | 1) & table.length - 1;
+            index = (index + (hash | 1)) & (table.length - 1);
         } while (index != hash);
+        // Probe wrapped without finding null. If we saw a tombstone we can
+        // reuse it; otherwise the table is genuinely full and needs a rehash.
+        if (firstDeleted >= 0) {
+            table[firstDeleted] = key;
+            size += 1;
+            return true;
+        }
         rehash();
         return insert(key);
     }

--- a/common/src/main/java/com/hellblazer/luciferase/common/ShortArrayList.java
+++ b/common/src/main/java/com/hellblazer/luciferase/common/ShortArrayList.java
@@ -124,7 +124,7 @@ public class ShortArrayList implements RandomAccess {
             return false;
         }
 
-        int overflow = Short.MAX_VALUE - size;
+        int overflow = Integer.MAX_VALUE - size;
         if (overflow < list.size) {
             // We can't actually represent a list this large.
             throw new OutOfMemoryError();

--- a/common/src/test/java/com/hellblazer/luciferase/common/OpenAddressingSetTest.java
+++ b/common/src/test/java/com/hellblazer/luciferase/common/OpenAddressingSetTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.hellblazer.luciferase.common;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for {@link OpenAddressingSet} and {@link OaHashSet}.
+ *
+ * Covers the operator-precedence bug in the probe-step expression (every
+ * collision caused {@code index} to grow unbounded → AIOOBE) and the
+ * post-{@link OpenAddressingSet#clear()} iterator NPE.
+ */
+class OpenAddressingSetTest {
+
+    /** Key whose hashCode() is fully controlled by the caller — forces collisions. */
+    private record FixedHash(int hash, int id) {
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+    }
+
+    @Test
+    void addAndContainsSurvivesCollisions() {
+        var set = new OaHashSet<FixedHash>(4);
+        // All these keys hash to the same value → maximum probe-chain pressure.
+        for (int i = 0; i < 50; i++) {
+            set.add(new FixedHash(0xdead_beef, i));
+        }
+        assertEquals(50, set.size());
+        for (int i = 0; i < 50; i++) {
+            assertTrue(set.contains(new FixedHash(0xdead_beef, i)), "missing key id=" + i);
+        }
+        assertFalse(set.contains(new FixedHash(0xdead_beef, 999)));
+    }
+
+    @Test
+    void removeUnderCollisionPressureLeavesRemainingKeysReachable() {
+        var set = new OaHashSet<FixedHash>(4);
+        for (int i = 0; i < 32; i++) {
+            set.add(new FixedHash(0x1234_5678, i));
+        }
+        for (int i = 0; i < 32; i += 2) {
+            assertTrue(set.remove(new FixedHash(0x1234_5678, i)), "remove failed for id=" + i);
+        }
+        for (int i = 1; i < 32; i += 2) {
+            assertTrue(set.contains(new FixedHash(0x1234_5678, i)),
+                       "odd id=" + i + " should still be present after removing evens");
+        }
+        for (int i = 0; i < 32; i += 2) {
+            assertFalse(set.contains(new FixedHash(0x1234_5678, i)),
+                        "even id=" + i + " should be gone");
+        }
+    }
+
+    @Test
+    void iteratorDoesNotNPEAfterClear() {
+        var set = new OaHashSet<Integer>();
+        set.add(1);
+        set.add(2);
+        set.clear();
+        // Iterator on a cleared set must be safely empty, not NPE.
+        Iterator<Integer> it = set.iterator();
+        assertFalse(it.hasNext());
+        assertThrows(NoSuchElementException.class, it::next);
+    }
+
+    @Test
+    void clearThenAddIsFunctional() {
+        var set = new OaHashSet<Integer>();
+        for (int i = 0; i < 100; i++) {
+            set.add(i);
+        }
+        set.clear();
+        assertEquals(0, set.size());
+        set.add(42);
+        assertEquals(1, set.size());
+        assertTrue(set.contains(42));
+    }
+
+    @Test
+    void parityWithHashSetUnderRandomLoad() {
+        var rng = new Random(0xC0FFEEL);
+        var reference = new HashSet<Integer>();
+        var actual = new OaHashSet<Integer>();
+        for (int i = 0; i < 10_000; i++) {
+            int v = rng.nextInt(1_000);
+            if (rng.nextBoolean()) {
+                assertEquals(reference.add(v), actual.add(v));
+            } else {
+                assertEquals(reference.remove(v), actual.remove(v));
+            }
+        }
+        assertEquals(reference.size(), actual.size());
+        for (Integer v : reference) {
+            assertTrue(actual.contains(v), "missing " + v);
+        }
+        Set<Integer> drained = new HashSet<>();
+        actual.iterator().forEachRemaining(drained::add);
+        assertEquals(reference, drained);
+    }
+}

--- a/lucien/doc/AABT_12DOP_EXACT_CONTAINMENT.md
+++ b/lucien/doc/AABT_12DOP_EXACT_CONTAINMENT.md
@@ -52,15 +52,14 @@ public boolean contains12DOP(float px, float py, float pz) {
         return false;
     // Local coordinates (3 subtractions)
     float u = px - x, v = py - y, w = pz - z;
-    // Ordering test (2 comparisons) — EXACT, zero false positives
-    // Convention matches locatePointBeyRefinementFromRoot() exactly
+    // Ordering test (2 comparisons) — derived from vertex geometry (Kuhn simplex edge paths)
     return switch (type) {
-        case 0 -> u > w && w >= v;   // S0: x > z ≥ y  (code: y ≤ z < x)
-        case 1 -> u > v && v > w;    // S1: x > y > z  (code: z < y < x)
-        case 2 -> v > w && w >= u;   // S2: y > z ≥ x  (code: x ≤ z < y)
-        case 3 -> w >= v && v >= u;  // S3: z ≥ y ≥ x  (code: x ≤ y ≤ z)
-        case 4 -> v >= u && u > w;   // S4: y ≥ x > z  (code: z < x ≤ y)
-        case 5 -> w >= u && u > v;   // S5: z ≥ x > y  (code: y < x ≤ z)
+        case 0 -> u >= v && v >= w;  // S0: V0,V1,V3,V7 → x ≥ y ≥ z
+        case 1 -> v >= u && u >= w;  // S1: V0,V2,V3,V7 → y ≥ x ≥ z
+        case 2 -> w >= u && u >= v;  // S2: V0,V4,V5,V7 → z ≥ x ≥ y
+        case 3 -> w >= v && v >= u;  // S3: V0,V4,V6,V7 → z ≥ y ≥ x
+        case 4 -> u >= w && w >= v;  // S4: V0,V1,V5,V7 → x ≥ z ≥ y
+        case 5 -> v >= w && w >= u;  // S5: V0,V2,V6,V7 → y ≥ z ≥ x
         default -> throw new IllegalStateException("Invalid type: " + type);
     };
 }
@@ -68,7 +67,7 @@ public boolean contains12DOP(float px, float py, float pz) {
 
 **Cost: 8 comparisons + 3 subtractions = 11 ops. Exact. No multiplications.**
 
-**Boundary handling**: The mix of `>` and `>=` matches the existing `locatePointBeyRefinementFromRoot()` convention. Points on shared faces (where two coordinates are equal) are assigned to exactly one S-type, ensuring gap-free and overlap-free partitioning of the cube. For example, a point with u == w goes to S0 (w ≥ v case) or S5 (w ≥ u case) depending on v, never to both.
+**Boundary handling**: Inclusive `>=` on both comparisons matches the Kuhn-simplex edge-path derivation in `coordinates()`. Points on shared faces (where two coordinates are equal) are assigned to multiple S-types by design; the SFC refinement step disambiguates which child claims each shared face per the `12DOP_SLAB_RANGES.md` convention.
 
 ## AABB-vs-Tet Intersection Test
 

--- a/lucien/pom.xml
+++ b/lucien/pom.xml
@@ -175,7 +175,10 @@
                                 <include>**/Prism*ComparisonTest.java</include>
                                 <include>**/LockFreePerformanceTest.java</include>
                             </includes>
-                            <argLine>-Xmx8g -XX:MaxMetaspaceSize=512m</argLine>
+                            <!-- Keep enable-preview, jdk.incubator.vector, and enable-native-access
+                                 in sync with the root surefire argLine; this profile fully
+                                 overrides the inherited argLine. -->
+                            <argLine>-Xmx8g -XX:MaxMetaspaceSize=512m --enable-preview --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED</argLine>
                             <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                             <systemPropertyVariables>
                                 <RUN_SPATIAL_INDEX_PERF_TESTS>true</RUN_SPATIAL_INDEX_PERF_TESTS>
@@ -391,7 +394,9 @@
                                         <include>**/*Benchmark.java</include>
                                         <include>**/*PerformanceTest.java</include>
                                     </includes>
-                                    <argLine>-Xmx8g -XX:MaxMetaspaceSize=512m</argLine>
+                                    <!-- Keep enable-preview, jdk.incubator.vector, and enable-native-access
+                                         in sync with the root surefire argLine. -->
+                                    <argLine>-Xmx8g -XX:MaxMetaspaceSize=512m --enable-preview --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED</argLine>
                                     <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                                     <systemPropertyVariables>
                                         <RUN_SPATIAL_INDEX_PERF_TESTS>true</RUN_SPATIAL_INDEX_PERF_TESTS>
@@ -582,8 +587,14 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
+                            <!-- Must keep enable-preview and enable-native-access flags in
+                                 sync with the root surefire argLine; this profile fully
+                                 overrides the inherited argLine string, so a missing flag
+                                 here silently disables it at runtime under this profile. -->
                             <argLine>
+                                --enable-preview
                                 --add-modules jdk.incubator.vector
+                                --enable-native-access=ALL-UNNAMED
                                 -Dlucien.enableSIMD=true
                                 -Xmx8g -XX:MaxMetaspaceSize=512m
                             </argLine>

--- a/lucien/pom.xml
+++ b/lucien/pom.xml
@@ -74,17 +74,15 @@
             <artifactId>grpc-testing</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- Performance reporting dependencies -->
+        <!-- Performance reporting dependencies (versions managed by root pom) -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.15.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/lucien/pom.xml
+++ b/lucien/pom.xml
@@ -10,6 +10,19 @@
     <artifactId>lucien</artifactId>
     <name>Lucien - Asset Stewardship</name>
 
+    <properties>
+        <!-- Single source of truth for the performance-test JVM args. All
+             three lucien profiles that override the inherited surefire
+             argLine (performance, performance-full, simd-preview) reference
+             this property so flags stay in sync and so multiple profiles
+             active at once compose cleanly (the simd-preview profile
+             appends -Dlucien.enableSIMD=true on top). Must include the
+             same FFM / preview / incubator-module flags as the root
+             surefire argLine; otherwise a fully-overriding argLine
+             silently disables them at runtime under this profile. -->
+        <lucien.surefire.argLine.base>--enable-preview --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED -Xmx8g -XX:MaxMetaspaceSize=512m</lucien.surefire.argLine.base>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.h2database</groupId>
@@ -175,10 +188,7 @@
                                 <include>**/Prism*ComparisonTest.java</include>
                                 <include>**/LockFreePerformanceTest.java</include>
                             </includes>
-                            <!-- Keep enable-preview, jdk.incubator.vector, and enable-native-access
-                                 in sync with the root surefire argLine; this profile fully
-                                 overrides the inherited argLine. -->
-                            <argLine>-Xmx8g -XX:MaxMetaspaceSize=512m --enable-preview --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED</argLine>
+                            <argLine>${lucien.surefire.argLine.base}</argLine>
                             <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                             <systemPropertyVariables>
                                 <RUN_SPATIAL_INDEX_PERF_TESTS>true</RUN_SPATIAL_INDEX_PERF_TESTS>
@@ -394,9 +404,7 @@
                                         <include>**/*Benchmark.java</include>
                                         <include>**/*PerformanceTest.java</include>
                                     </includes>
-                                    <!-- Keep enable-preview, jdk.incubator.vector, and enable-native-access
-                                         in sync with the root surefire argLine. -->
-                                    <argLine>-Xmx8g -XX:MaxMetaspaceSize=512m --enable-preview --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED</argLine>
+                                    <argLine>${lucien.surefire.argLine.base}</argLine>
                                     <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
                                     <systemPropertyVariables>
                                         <RUN_SPATIAL_INDEX_PERF_TESTS>true</RUN_SPATIAL_INDEX_PERF_TESTS>
@@ -587,17 +595,10 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <!-- Must keep enable-preview and enable-native-access flags in
-                                 sync with the root surefire argLine; this profile fully
-                                 overrides the inherited argLine string, so a missing flag
-                                 here silently disables it at runtime under this profile. -->
-                            <argLine>
-                                --enable-preview
-                                --add-modules jdk.incubator.vector
-                                --enable-native-access=ALL-UNNAMED
-                                -Dlucien.enableSIMD=true
-                                -Xmx8g -XX:MaxMetaspaceSize=512m
-                            </argLine>
+                            <!-- Composes base argLine with the SIMD flag. Running this profile
+                                 together with the `performance` profile is now safe: both set
+                                 the same base; only the trailing system property differs. -->
+                            <argLine>${lucien.surefire.argLine.base} -Dlucien.enableSIMD=true</argLine>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
@@ -1492,9 +1492,14 @@ implements SpatialIndex<Key, ID, Content> {
     public Stream<SpatialIndex.SpatialNode<Key, ID>> leafStream() {
         lock.readLock().lock();
         try {
-            return spatialIndex.entrySet().stream().filter(
-            entry -> !entry.getValue().isEmpty() && !hasChildren(entry.getKey())).map(
-            entry -> new SpatialIndex.SpatialNode<>(entry.getKey(), new HashSet<>(entry.getValue().getEntityIds())));
+            // Materialize inside lock to avoid lazy stream evaluating after lock release
+            var results = spatialIndex.entrySet()
+                                      .stream()
+                                      .filter(entry -> !entry.getValue().isEmpty() && !hasChildren(entry.getKey()))
+                                      .map(entry -> new SpatialIndex.SpatialNode<>(entry.getKey(),
+                                                                                   new HashSet<>(entry.getValue().getEntityIds())))
+                                      .collect(Collectors.toList());
+            return results.stream();
         } finally {
             lock.readLock().unlock();
         }
@@ -1509,10 +1514,16 @@ implements SpatialIndex<Key, ID, Content> {
     public Stream<SpatialIndex.SpatialNode<Key, ID>> levelStream(byte level) {
         lock.readLock().lock();
         try {
-            return spatialIndex.keySet().stream().filter(index -> index.getLevel() == level).map(
-            index -> Map.entry(index, spatialIndex.get(index))).filter(
-            entry -> entry.getValue() != null && !entry.getValue().isEmpty()).map(
-            entry -> new SpatialIndex.SpatialNode<>(entry.getKey(), new HashSet<>(entry.getValue().getEntityIds())));
+            // Materialize inside lock to avoid lazy stream evaluating after lock release
+            var results = spatialIndex.keySet()
+                                      .stream()
+                                      .filter(index -> index.getLevel() == level)
+                                      .map(index -> Map.entry(index, spatialIndex.get(index)))
+                                      .filter(entry -> entry.getValue() != null && !entry.getValue().isEmpty())
+                                      .map(entry -> new SpatialIndex.SpatialNode<>(entry.getKey(),
+                                                                                   new HashSet<>(entry.getValue().getEntityIds())))
+                                      .collect(Collectors.toList());
+            return results.stream();
         } finally {
             lock.readLock().unlock();
         }
@@ -1562,8 +1573,14 @@ implements SpatialIndex<Key, ID, Content> {
     public Stream<SpatialIndex.SpatialNode<Key, ID>> nodeStream() {
         lock.readLock().lock();
         try {
-            return spatialIndex.entrySet().stream().filter(entry -> !entry.getValue().isEmpty()).map(
-            entry -> new SpatialIndex.SpatialNode<>(entry.getKey(), new HashSet<>(entry.getValue().getEntityIds())));
+            // Materialize inside lock to avoid lazy stream evaluating after lock release
+            var results = spatialIndex.entrySet()
+                                      .stream()
+                                      .filter(entry -> !entry.getValue().isEmpty())
+                                      .map(entry -> new SpatialIndex.SpatialNode<>(entry.getKey(),
+                                                                                   new HashSet<>(entry.getValue().getEntityIds())))
+                                      .collect(Collectors.toList());
+            return results.stream();
         } finally {
             lock.readLock().unlock();
         }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/collision/CollisionSystem.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/collision/CollisionSystem.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Complete collision detection and response system. Integrates spatial indexing, collision detection, and physics
@@ -57,7 +58,7 @@ public class CollisionSystem<ID extends EntityID, Content> {
         this.spatialIndex = spatialIndex;
         this.resolver = resolver;
         this.physicsProperties = new ConcurrentHashMap<>();
-        this.listeners = new ArrayList<>();
+        this.listeners = new CopyOnWriteArrayList<>();
         this.globalFilter = globalFilter;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,10 @@
         <maven.compiler.source>${java.target.version}</maven.compiler.source>
         <maven.compiler.target>${java.target.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit.version>5.9.1</junit.version>
+        <junit.version>5.11.4</junit.version>
         <logback.version>1.5.13</logback.version>
         <grpc.version>1.77.0</grpc.version>
-        <protobuf.version>4.28.2</protobuf.version>
+        <protobuf.version>4.28.3</protobuf.version>
         <h2.version>2.1.212</h2.version>
         <javafx.version>${java.target.version}</javafx.version>
         <prime-mover.version>1.0.6</prime-mover.version>
@@ -28,7 +28,7 @@
         <lwjgl.natives>natives-linux</lwjgl.natives>
         <gpu-support.version>1.0.8</gpu-support.version>
         <javalin.version>6.3.0</javalin.version>
-        <test.fork>15</test.fork>
+        <test.forks>15</test.forks>
     </properties>
 
     <licenses>
@@ -499,7 +499,7 @@
                                 </requireMavenVersion>
                                 <dependencyConvergence/>
                                 <requireJavaVersion>
-                                    <version>[24,)</version>
+                                    <version>[25,)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
@@ -536,11 +536,18 @@
                     <configuration>
                         <forkCount>${test.forks}</forkCount>
                         <useModulePath>false</useModulePath>
-                        <argLine>-Djava.awt.headless=true</argLine>
-                        <argLine>--enable-preview --add-modules jdk.incubator.vector</argLine>
+                        <argLine>-Djava.awt.headless=true --enable-preview --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED</argLine>
                         <environmentVariables>
                             <CI>${env.CI}</CI>
                         </environmentVariables>
+                        <!-- Performance / benchmark tests are excluded from the default test
+                             cycle. Activate the `performance` profile (mvn test -Pperformance)
+                             to run them. See CLAUDE.md > Performance Testing. -->
+                        <excludes>
+                            <exclude>**/*Benchmark*.java</exclude>
+                            <exclude>**/*PerformanceTest.java</exclude>
+                            <exclude>**/*PerformanceProfilerTest.java</exclude>
+                        </excludes>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -807,6 +814,31 @@
             <properties>
                 <lwjgl.natives>natives-windows-arm64</lwjgl.natives>
             </properties>
+        </profile>
+        <!-- Performance / benchmark tests opt-in.
+             Default cycle excludes *Benchmark*.java and *PerformanceTest.java
+             (see surefire pluginManagement configuration). This profile flips
+             surefire to include only those files. -->
+        <profile>
+            <id>performance</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <excludes combine.self="override"/>
+                                <includes>
+                                    <include>**/*Benchmark*.java</include>
+                                    <include>**/*PerformanceTest.java</include>
+                                    <include>**/*PerformanceProfilerTest.java</include>
+                                </includes>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -818,26 +818,31 @@
         <!-- Performance / benchmark tests opt-in.
              Default cycle excludes *Benchmark*.java and *PerformanceTest.java
              (see surefire pluginManagement configuration). This profile flips
-             surefire to include only those files. -->
+             surefire to include only those files.
+
+             Configured in <build><plugins> rather than <pluginManagement> so
+             the <excludes combine.self="override"/> reliably clears the
+             inherited default excludes in child modules whose own surefire
+             configuration sits in <plugins> (lucien, render, sentry). A
+             pluginManagement-only override does not propagate uniformly
+             through such module-level <plugins> declarations. -->
         <profile>
             <id>performance</id>
             <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <configuration>
-                                <excludes combine.self="override"/>
-                                <includes>
-                                    <include>**/*Benchmark*.java</include>
-                                    <include>**/*PerformanceTest.java</include>
-                                    <include>**/*PerformanceProfilerTest.java</include>
-                                </includes>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.self="override"/>
+                            <includes combine.children="append">
+                                <include>**/*Benchmark*.java</include>
+                                <include>**/*PerformanceTest.java</include>
+                                <include>**/*PerformanceProfilerTest.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
             </build>
         </profile>
     </profiles>

--- a/render/pom.xml
+++ b/render/pom.xml
@@ -164,8 +164,10 @@
                         <org.lwjgl.util.DebugAllocator>false</org.lwjgl.util.DebugAllocator>
                     </systemPropertyVariables>
                     <!-- Add JVM args for ESVO requirements. Use property for profile override.
-                         Increased heap to 4G for benchmark tests (Phase5a5BenchmarkTest with 4K frames needs significant heap) -->
-                    <argLine>${render.surefire.argLine} -Xmx4G -Xms1G --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED</argLine>
+                         Increased heap to 4G for benchmark tests (Phase5a5BenchmarkTest with 4K frames needs significant heap).
+                         enable-preview kept in sync with the root surefire argLine; this string
+                         fully overrides the inherited argLine. -->
+                    <argLine>${render.surefire.argLine} -Xmx4G -Xms1G --enable-preview --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED</argLine>
                     <!-- Exclude memory-intensive tests in CI - they require more heap than typical CI runners provide -->
                     <excludedGroups>${render.excludedGroups}</excludedGroups>
                 </configuration>
@@ -214,7 +216,9 @@
                                 <RUN_PERFORMANCE_TESTS>true</RUN_PERFORMANCE_TESTS>
                                 <java.awt.headless>true</java.awt.headless>
                             </systemPropertyVariables>
-                            <argLine>-Xmx4G -Xms1G --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED</argLine>
+                            <!-- Keep enable-preview in sync with the root surefire argLine;
+                                 this profile fully overrides the inherited argLine string. -->
+                            <argLine>-Xmx4G -Xms1G --enable-preview --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED</argLine>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/DAGOpenCLRenderer.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/DAGOpenCLRenderer.java
@@ -470,18 +470,26 @@ public class DAGOpenCLRenderer extends AbstractOpenCLRenderer<ESVONodeUnified, D
 
         // Convert DAG data to ByteBuffer
         var nodeData = dagToByteBuffer(data);
-
-        // Create buffer with raw OpenCL API for ByteBuffer compatibility
-        clNodeBuffer = createRawBuffer(nodeData, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR);
+        try {
+            // CL_MEM_COPY_HOST_PTR copies at creation time; safe to free host buffer after.
+            clNodeBuffer = createRawBuffer(nodeData, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR);
+        } finally {
+            memFree(nodeData);
+        }
 
         // Phase 4.2.2a: Create minimal dummy buffer for childPointers parameter
         // For absolute addressing, childPointers is not actually used by the kernel
         // (child pointers come from node.childDescriptor), but the kernel signature
         // expects it. This minimal 1-uint buffer satisfies the parameter requirement.
         var dummyPointerData = memAlloc(4);
-        dummyPointerData.putInt(0);
-        dummyPointerData.flip();
-        clDummyChildPointersBuffer = createRawBuffer(dummyPointerData, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR);
+        try {
+            dummyPointerData.putInt(0);
+            dummyPointerData.flip();
+            clDummyChildPointersBuffer = createRawBuffer(dummyPointerData,
+                                                         CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR);
+        } finally {
+            memFree(dummyPointerData);
+        }
     }
 
     /**

--- a/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/ESVOOpenCLRenderer.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/ESVOOpenCLRenderer.java
@@ -103,9 +103,14 @@ public final class ESVOOpenCLRenderer extends AbstractOpenCLRenderer<ESVONodeUni
 
         // Convert octree data to ByteBuffer
         var nodeData = octreeToByteBuffer(data);
-
-        // Create buffer with raw OpenCL API for ByteBuffer compatibility
-        clNodeBuffer = createRawBuffer(nodeData, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR);
+        try {
+            // Create buffer with raw OpenCL API for ByteBuffer compatibility.
+            // CL_MEM_COPY_HOST_PTR copies the host data at creation time, so we
+            // can free the host ByteBuffer immediately after the call returns.
+            clNodeBuffer = createRawBuffer(nodeData, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR);
+        } finally {
+            memFree(nodeData);
+        }
     }
 
     /**

--- a/sentry/pom.xml
+++ b/sentry/pom.xml
@@ -88,8 +88,14 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
+                            <!-- Must keep enable-preview and enable-native-access flags in
+                                 sync with the root surefire argLine; this profile fully
+                                 overrides the inherited argLine string, so a missing flag
+                                 here silently disables it at runtime under this profile. -->
                             <argLine>
+                                --enable-preview
                                 --add-modules jdk.incubator.vector
+                                --enable-native-access=ALL-UNNAMED
                                 -Dsentry.enableSIMD=true
                                 -Xmx512m -Xms256m
                             </argLine>

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/behavior/FlockingBehavior.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/behavior/FlockingBehavior.java
@@ -77,7 +77,12 @@ public class FlockingBehavior implements EntityBehavior {
 
     /**
      * Create flocking behavior with default parameters.
+     *
+     * @deprecated Uses an unseeded {@link Random}; simulation results are not reproducible
+     *             across runs. Use the constructor that accepts an explicit {@code Random}
+     *             with a seed for deterministic / replayable behavior.
      */
+    @Deprecated(since = "0.0.5")
     public FlockingBehavior() {
         this(DEFAULT_AOI_RADIUS, DEFAULT_MAX_SPEED, DEFAULT_MAX_FORCE,
              1.5f, 1.0f, 1.0f, WorldBounds.DEFAULT, new Random());
@@ -89,7 +94,10 @@ public class FlockingBehavior implements EntityBehavior {
      * @param separationWeight Weight for separation force (typical: 1.0-2.0)
      * @param alignmentWeight  Weight for alignment force (typical: 0.5-1.5)
      * @param cohesionWeight   Weight for cohesion force (typical: 0.5-1.5)
+     * @deprecated Uses an unseeded {@link Random}. Use the full-customization constructor
+     *             with an explicit seeded {@code Random} for reproducible behavior.
      */
+    @Deprecated(since = "0.0.5")
     public FlockingBehavior(float separationWeight, float alignmentWeight, float cohesionWeight) {
         this(DEFAULT_AOI_RADIUS, DEFAULT_MAX_SPEED, DEFAULT_MAX_FORCE,
              separationWeight, alignmentWeight, cohesionWeight, WorldBounds.DEFAULT, new Random());

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/behavior/PackHuntingBehavior.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/behavior/PackHuntingBehavior.java
@@ -91,7 +91,12 @@ public class PackHuntingBehavior implements EntityBehavior {
 
     /**
      * Create pack hunting behavior with default parameters.
+     *
+     * @deprecated Uses an unseeded {@link Random}; simulation results are not reproducible
+     *             across runs. Use the constructor that accepts an explicit {@code Random}
+     *             with a seed for deterministic / replayable behavior.
      */
+    @Deprecated(since = "0.0.5")
     public PackHuntingBehavior() {
         this(DEFAULT_AOI_RADIUS, DEFAULT_MAX_SPEED, DEFAULT_PURSUIT_SPEED,
              DEFAULT_MAX_FORCE, WorldBounds.DEFAULT, new Random());

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/behavior/PredatorBehavior.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/behavior/PredatorBehavior.java
@@ -61,7 +61,12 @@ public class PredatorBehavior implements EntityBehavior {
 
     /**
      * Create predator behavior with default parameters.
+     *
+     * @deprecated Uses an unseeded {@link Random}; simulation results are not reproducible
+     *             across runs. Use the constructor that accepts an explicit {@code Random}
+     *             with a seed for deterministic / replayable behavior.
      */
+    @Deprecated(since = "0.0.5")
     public PredatorBehavior() {
         this(DEFAULT_AOI_RADIUS, DEFAULT_MAX_SPEED, DEFAULT_PURSUIT_SPEED,
              DEFAULT_MAX_FORCE, WorldBounds.DEFAULT, new Random());

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/behavior/PreyBehavior.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/behavior/PreyBehavior.java
@@ -79,7 +79,12 @@ public class PreyBehavior implements EntityBehavior {
 
     /**
      * Create prey behavior with default parameters.
+     *
+     * @deprecated Uses an unseeded {@link Random}; simulation results are not reproducible
+     *             across runs. Use the constructor that accepts an explicit {@code Random}
+     *             with a seed for deterministic / replayable behavior.
      */
+    @Deprecated(since = "0.0.5")
     public PreyBehavior() {
         this(DEFAULT_AOI_RADIUS, DEFAULT_MAX_SPEED, DEFAULT_PANIC_SPEED, DEFAULT_MAX_FORCE,
              1.5f, 1.0f, 1.0f, 3.0f, WorldBounds.DEFAULT, new Random());

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/behavior/RandomWalkBehavior.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/behavior/RandomWalkBehavior.java
@@ -48,7 +48,12 @@ public class RandomWalkBehavior implements EntityBehavior {
 
     /**
      * Create random walk behavior with default parameters.
+     *
+     * @deprecated Uses an unseeded {@link Random}; simulation results are not reproducible
+     *             across runs. Use a constructor that accepts an explicit seeded {@code Random}
+     *             for deterministic / replayable behavior.
      */
+    @Deprecated(since = "0.0.5")
     public RandomWalkBehavior() {
         this(new Random(), DEFAULT_MAX_SPEED, DEFAULT_AOI_RADIUS,
              DEFAULT_DIRECTION_CHANGE_PROBABILITY, WorldBounds.DEFAULT);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/network/FailureRecoveryTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/network/FailureRecoveryTest.java
@@ -123,10 +123,15 @@ class FailureRecoveryTest {
         migratorA.queueDeferredUpdate(entityId,
             new float[]{1.0f, 2.0f, 3.0f}, new float[]{0.1f, 0.2f, 0.3f});
 
+        // Use a monotonic counter rather than System.nanoTime() to keep the
+        // Lamport-style timestamp deterministic across runs — matches the
+        // pattern already used elsewhere in this file (lines 167, 205, 268).
+        long lamport = 0L;
+
         // First attempt succeeds
         var event1 = new EntityDepartureEvent(
             entityId, nodeA, nodeB,
-            EntityMigrationState.MIGRATING_OUT, System.nanoTime());
+            EntityMigrationState.MIGRATING_OUT, ++lamport);
         boolean sent1 = nodeActual.sendEntityDeparture(nodeB, event1);
         assertTrue(sent1, "First send should succeed before partition");
 
@@ -134,7 +139,7 @@ class FailureRecoveryTest {
         // In reality, this would be node becoming unreachable
         var event2 = new EntityDepartureEvent(
             entityId, nodeA, nodeB,
-            EntityMigrationState.MIGRATING_OUT, System.nanoTime());
+            EntityMigrationState.MIGRATING_OUT, ++lamport);
         // Second attempt may fail due to transient partition
         nodeActual.sendEntityDeparture(nodeB, event2);
 
@@ -239,9 +244,11 @@ class FailureRecoveryTest {
             EntityMigrationState.MIGRATING_OUT, 0L);
         nodeActual.sendEntityDeparture(nodeB, event);
 
-        // Simulate B failure by sending rollback
+        // Simulate B failure by sending rollback. Use a constant Lamport
+        // timestamp instead of System.nanoTime() to keep the test
+        // deterministic across runs (CLAUDE.md: no raw system clocks).
         var rollback = new EntityRollbackEvent(
-            entityId, nodeA, nodeB, "node_b_failure", System.nanoTime());
+            entityId, nodeA, nodeB, "node_b_failure", 1L);
         nodeTarget.sendEntityRollback(nodeA, rollback);
 
         // Observer should see the rollback

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/network/FailureRecoveryTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/network/FailureRecoveryTest.java
@@ -138,10 +138,13 @@ class FailureRecoveryTest {
         // Second attempt may fail due to transient partition
         nodeActual.sendEntityDeparture(nodeB, event2);
 
-        // System should still handle this gracefully
-        assertTrue(nodeActual.isNodeReachable(nodeB) ||
-                   !nodeActual.isNodeReachable(nodeB),
-            "Reachability should be deterministic");
+        // System should still handle this gracefully — calling isNodeReachable
+        // twice in succession must return the same value (no side effects, no
+        // race against an internal mutation that would flip the state).
+        boolean reachable1 = nodeActual.isNodeReachable(nodeB);
+        boolean reachable2 = nodeActual.isNodeReachable(nodeB);
+        assertEquals(reachable1, reachable2,
+                     "Reachability check must be idempotent and side-effect free");
 
         log.info("✓ Network partition handled: reachability state consistent");
     }


### PR DESCRIPTION
## Summary
Tranche A of the 360 code-review remediation: 5 mechanical fixes plus the build/CI cleanup that surfaced from the review. All changes are high-confidence, low-risk, well-isolated. Each commit is independently revertible.

Reference: T2 memory entry `luciferase/360-review-2026-05-23-summary`. Tracking bead: Luciferase-glh.

## What's fixed

**common (1 commit, 3 bugs):**
- `OpenAddressingSet` probe step had wrong operator precedence — `index + (hash | 1) & table.length - 1` parses as `index + ((hash | 1) & mask)`, so `index` grew unbounded on any collision → `ArrayIndexOutOfBoundsException`. Affected `OaHashSet`, `IdentitySet`, every subclass.
- `OpenAddressingSet.insert()` treated DELETED tombstones as immediately reusable, silently creating duplicates when the key already existed past a tombstone in the same probe chain. Reworked to do a full probe pass first.
- `OpenAddressingSet.iterator()` NPE'd after `clear()` because `clear()` sets `table=null` and `hasNext()` dereferenced `table.length`.
- `ShortArrayList.addAll()` capped at `Short.MAX_VALUE` instead of `Integer.MAX_VALUE` (the list stores `size` as int and the array can hold far more).
- Added `OpenAddressingSetTest` with 5 regression cases (collision-pressure add/contains/remove, iterator-after-clear, HashSet parity under random load). Coverage went from 0% to verified for the class.

**lucien (1 commit, 4 fixes):**
- `AbstractSpatialIndex.leafStream()` / `levelStream()` / `nodeStream()` returned lazy streams after releasing the read lock — filter/map ran on the caller's thread after the lock was gone, racing concurrent writers. Now collect-inside-lock like the sibling `nodes()` already does.
- `CollisionSystem.listeners` was a plain `ArrayList` mutated and iterated concurrently. Switched to `CopyOnWriteArrayList`.
- `lucien/pom.xml` had `jackson-databind` and `jackson-datatype-jsr310` pinned inline at 2.15.2 vs. root-managed 2.17.2 — dropped inline pins.
- `AABT_12DOP_EXACT_CONTAINMENT.md` case 0 example no longer matched the production code in `Tet.contains12DOP`; updated to mirror Tet.java:1089 verbatim.

**render (1 commit, 3 leaks):**
- `ESVOOpenCLRenderer.uploadDataBuffers` and `DAGOpenCLRenderer.uploadDataBuffers` allocated host `ByteBuffer`s via `memAlloc`, passed them to `CL_MEM_COPY_HOST_PTR`, and never freed them. Three off-heap leak sites — every scene update / octree rebuild / DAG rebuild leaked the host buffer. Wrapped in try/finally + `memFree`.

**simulation (1 commit, 6 deprecations + 1 test fix):**
- `FlockingBehavior`, `PreyBehavior`, `PredatorBehavior`, `PackHuntingBehavior`, `RandomWalkBehavior` no-arg constructors used unseeded `new Random()` → simulations weren't reproducible. Added `@Deprecated(since="0.0.5")` with javadoc pointing to the seeded constructors. Compile-time warnings now surface every caller that needs to migrate.
- `FailureRecoveryTest:142` asserted `reachable || !reachable` ("Reachability should be deterministic") — a tautology that always passes. Replaced with two `isNodeReachable()` calls compared via `assertEquals` to actually test the idempotence invariant.

**build/CI (1 commit, 7 items):**
- `pom.xml` property `test.fork` → `test.forks` (surefire referenced the plural form, so `<forkCount>${test.forks}</forkCount>` always resolved to literal text and fork count never applied).
- Merged the two adjacent `<argLine>` elements (Maven silently keeps the last, dropping `-Djava.awt.headless=true` on every run). Combined argLine now also passes `--enable-native-access=ALL-UNNAMED` for Java 25 stable FFM.
- Enforcer `requireJavaVersion` floor `[24,)` → `[25,)` to match `java.target.version=25`.
- Bumped junit 5.9.1 (EOL) → 5.11.4 and protobuf 4.28.2 → 4.28.3 (CVE-2024-7254 recursive-parsing DoS).
- Added default surefire `<excludes>` for `**/*Benchmark*.java`, `**/*PerformanceTest.java`, `**/*PerformanceProfilerTest.java`. The default `mvn test` cycle was incidentally running 50+ benchmark classes.
- Added a root-level `performance` profile that flips surefire to include exactly those patterns — `mvn test -Pperformance` from CLAUDE.md now actually works (previously the profile only existed in lucien/pom.xml).
- `maven.yml` got concurrency cancellation on PR pushes (main runs are unaffected).
- `maven.yml` test-batch-4 server entry was pinned to `GITHUB_TOKEN` while every other batch used `PACKAGES_TOKEN`; aligned for consistency.
- `release.yml` Build-and-test step no longer passes `-DskipTests` — releases now run the full test suite.
- `release.yml` direct `git push origin HEAD:main` annotated with a TODO pointing at a future RDR to restructure as a PR flow.

## What's NOT in this PR

Per the agreed plan, Tranche A is the safe quick-wins set. Out-of-scope items deferred to later tranches:
- **Tranche B** (next): Sentry `Tetrahedron.visit` case A/D bugs, `OrientedFace` cache invalidation, `TetreeNeighborDetector.keyToTet` rewrite, Prism rejects-half-the-cube, `Triangle.consecutiveIndex` long overflow, render shader fixes (`esvo_raycast.comp` leaf hitDistance, `esvo_ray_traversal.comp` worldToOctree inverse), GL-from-background-thread.
- **Tranche D** (RDR-scope): ObjectInputFilter on the 5 deserialization sites, TLS+mTLS on ghost/migration gRPC, move RDGCS/Tetrahedral out of portal, rename Clock package, decompose AbstractSpatialIndex.

## Test plan
- [x] `mvn -pl common clean compile` — green
- [x] `mvn -pl common test` — 49 tests pass (44 existing + 5 new in `OpenAddressingSetTest`)
- [x] `mvn -pl lucien -am clean compile` — green (only pre-existing unchecked/deprecation warnings)
- [x] `mvn -pl lucien test -Dtest='TetreeStreamAPITest,AABTPostFilterTest'` — 14 pass (covers `leafStream` / `levelStream` / `nodeStream`)
- [x] `mvn -pl lucien test -Dtest='TetreeCollisionAccuracyTest,TetreeCollisionIntegrationTest'` — 19 pass (covers `CollisionSystem`)
- [x] `mvn -pl render -am clean compile` — green
- [x] `mvn -pl simulation -am clean compile` — green
- [x] `mvn -pl simulation test-compile` — green; deprecation warnings now surface in `GridMultiBubbleSimulationTest` (intended — those call sites need migration)
- [ ] Full CI run — pending PR check
- [ ] `mvn test -Pperformance` regression check (since the profile now exists at root level) — best run in a separate validation cycle