### PR TITLE
Review-360 Tranche B: sentry/tetree/render-shader correctness fixes

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/neighbor/TetreeNeighborDetector.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/neighbor/TetreeNeighborDetector.java
@@ -328,38 +328,14 @@ public class TetreeNeighborDetector implements NeighborDetector<TetreeKey<? exte
     }
     
     /**
-     * Convert a TetreeKey to a Tet object.
+     * Convert a TetreeKey to a Tet object via the canonical TM-index decoder.
+     * Delegates to {@link TetreeKey#toTet()} (which walks all path bits from
+     * root to the key's level). The prior local implementation only read the
+     * current level's 3-bit cell and silently dropped every higher-level bit,
+     * producing tets positioned as if they were direct children of the root.
      */
     public Tet keyToTet(TetreeKey<?> key) {
-        // Extract the level and TM-index data from the key
-        byte level = key.getLevel();
-        
-        if (level == 0) {
-            // Root tetrahedron
-            return new Tet(0, 0, 0, (byte)0, (byte)0);
-        }
-        
-        // For non-root tetrahedra, we need to extract the coordinate and type
-        // information from the TM-index bits
-        
-        // Get the coordinate and type at the current level
-        byte coordBits = key.getCoordBitsAtLevel(level);
-        byte type = key.getTypeAtLevel(level);
-        
-        // The coordinate bits encode which child position this tet occupies
-        // We need to reconstruct the actual coordinates based on the parent
-        // For now, use a simplified approach
-        int x = coordBits & 1;
-        int y = (coordBits >> 1) & 1;
-        int z = (coordBits >> 2) & 1;
-        
-        // Scale coordinates based on level
-        int scale = 1 << (21 - level); // 2^(21-level)
-        x *= scale;
-        y *= scale;
-        z *= scale;
-        
-        return new Tet(x, y, z, level, type);
+        return key.toTet();
     }
     
     /**

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/Prism.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/Prism.java
@@ -384,10 +384,26 @@ public class Prism<ID extends com.hellblazer.luciferase.lucien.entity.EntityID, 
     @Override
     protected boolean shouldContinueKNNSearch(PrismKey nodeIndex, Point3f queryPoint,
                                             java.util.PriorityQueue<com.hellblazer.luciferase.lucien.entity.EntityDistance<ID>> candidates) {
-        // Always continue if we haven't reached k candidates yet
-        // Note: PriorityQueue doesn't have a capacity, we need to track k separately
-        // For now, always continue to ensure we find all nearby entities
-        return true;
+        // Standard kNN pruning: continue iff the closest possible point in this
+        // node's bounds is no farther than the worst (head of max-heap) candidate
+        // we already have. If the AABB's closest point is strictly farther, no
+        // entity inside this node can improve the candidate set.
+        if (candidates.isEmpty()) {
+            return true;
+        }
+        var furthest = candidates.peek();
+        if (furthest == null) {
+            return true;
+        }
+        var bounds = getBounds(nodeIndex);
+        var closestX = Math.max(bounds[0], Math.min(queryPoint.x, bounds[3]));
+        var closestY = Math.max(bounds[1], Math.min(queryPoint.y, bounds[4]));
+        var closestZ = Math.max(bounds[2], Math.min(queryPoint.z, bounds[5]));
+        var dx = closestX - queryPoint.x;
+        var dy = closestY - queryPoint.y;
+        var dz = closestZ - queryPoint.z;
+        var nodeDistance = (float) Math.sqrt(dx * dx + dy * dy + dz * dz);
+        return nodeDistance <= furthest.distance();
     }
     
     @Override
@@ -397,15 +413,43 @@ public class Prism<ID extends com.hellblazer.luciferase.lucien.entity.EntityID, 
     
     @Override
     protected boolean isNodeContainedInVolume(PrismKey nodeIndex, Spatial volume) {
+        // True containment: every point of the node must be inside the volume.
+        // We use the node's AABB as a conservative superset of the triangular
+        // prism it actually represents; if the AABB is contained, the prism
+        // (a subset of the AABB) is necessarily contained too. The prior code
+        // returned intersection instead of containment, which produced false
+        // positives that caused range queries to over-include nodes whose
+        // entities sat outside the requested volume.
         var bounds = getBounds(nodeIndex);
-        // Create an aabb for the node
-        var nodeAABB = new Spatial.aabb(
-            bounds[0], bounds[1], bounds[2],
-            bounds[3], bounds[4], bounds[5]
-        );
-        // Check if node is contained in volume by testing if volume contains all corners
-        // For now, just check intersection as a simpler test
-        return volume.intersects(bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]);
+        var minX = bounds[0];
+        var minY = bounds[1];
+        var minZ = bounds[2];
+        var maxX = bounds[3];
+        var maxY = bounds[4];
+        var maxZ = bounds[5];
+        return switch (volume) {
+            case Spatial.Cube cube ->
+                minX >= cube.originX() && minY >= cube.originY() && minZ >= cube.originZ()
+                && maxX <= cube.originX() + cube.extent()
+                && maxY <= cube.originY() + cube.extent()
+                && maxZ <= cube.originZ() + cube.extent();
+            case Spatial.aabb box ->
+                minX >= box.originX() && minY >= box.originY() && minZ >= box.originZ()
+                && maxX <= box.extentX() && maxY <= box.extentY() && maxZ <= box.extentZ();
+            case Spatial.Sphere sphere -> {
+                var r2 = sphere.radius() * sphere.radius();
+                for (int i = 0; i < 8; i++) {
+                    var cx = ((i & 1) != 0 ? maxX : minX) - sphere.centerX();
+                    var cy = ((i & 2) != 0 ? maxY : minY) - sphere.centerY();
+                    var cz = ((i & 4) != 0 ? maxZ : minZ) - sphere.centerZ();
+                    if (cx * cx + cy * cy + cz * cz > r2) {
+                        yield false;
+                    }
+                }
+                yield true;
+            }
+            default -> false; // Conservative: exclude for volume types we don't recognise.
+        };
     }
     
     @Override

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/PrismKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/PrismKey.java
@@ -106,13 +106,24 @@ public final class PrismKey implements SpatialKey<PrismKey> {
     public long consecutiveIndex() {
         var triangleId = triangle.consecutiveIndex();
         var lineId = line.consecutiveIndex();
-        
-        // Simple combination: line ID in high bits, triangle ID in low bits
-        // This ensures all combinations are unique
+
+        // Simple combination: line ID in high bits, triangle ID in low bits.
+        // Triangle.consecutiveIndex packs (type, x, y, n) into 3*level + 1
+        // bits at level L (x+y+n at L bits each, plus the type sign bit).
+        // The prior shift of level*2 + 2 bits was less than the triangle
+        // payload width and silently corrupted lineId by ORing into bits the
+        // triangle was already using, breaking uniqueness and SFC range
+        // queries. We now shift by exactly the triangle's bit width and mask
+        // the triangle payload so the two regions don't collide.
+        //
+        // At high levels this still overflows long (Line.z uses up to level
+        // bits, triangle uses up to 3L+1 bits, total can exceed 63). That is
+        // tracked as a separate concern alongside the proper-SFC TODO above
+        // — for practical use (level <= 15 here) the result is unique.
         var level = getLevel();
-        var triangleBits = level * 2 + 2; // Allow enough bits for triangle
-        
-        return (lineId << triangleBits) | triangleId;
+        var triangleBits = 3 * level + 1;
+        long triangleMask = (triangleBits >= 64) ? -1L : ((1L << triangleBits) - 1L);
+        return (lineId << triangleBits) | (triangleId & triangleMask);
     }
     
     @Override

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/PrismKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/PrismKey.java
@@ -289,9 +289,26 @@ public final class PrismKey implements SpatialKey<PrismKey> {
         if (other == null) {
             return 1;
         }
-        
-        // Compare by consecutive index for spatial ordering
-        return Long.compare(this.consecutiveIndex(), other.consecutiveIndex());
+
+        // Lexicographic comparison on (level, line.z, type, n, y, x).
+        // The previous implementation compared by Long.compare(consecutiveIndex())
+        // which silently collided: (1) keys at different levels could share an
+        // index because level was not part of the encoding, and (2) at level
+        // 21 the packed long encoding cannot fit lineId without bit collisions
+        // (21 bits line + 64 bits triangle > 63 bits). A direct field-by-field
+        // comparison is correct at every valid level (0..MAX_LEVEL=21) and is
+        // consistent with equals (which uses Objects.equals(triangle, line)).
+        int cmp = Byte.compare(triangle.getLevel(), other.triangle.getLevel());
+        if (cmp != 0) return cmp;
+        cmp = Integer.compare(line.getZ(), other.line.getZ());
+        if (cmp != 0) return cmp;
+        cmp = Byte.compare(triangle.getType(), other.triangle.getType());
+        if (cmp != 0) return cmp;
+        cmp = Integer.compare(triangle.getN(), other.triangle.getN());
+        if (cmp != 0) return cmp;
+        cmp = Integer.compare(triangle.getY(), other.triangle.getY());
+        if (cmp != 0) return cmp;
+        return Integer.compare(triangle.getX(), other.triangle.getX());
     }
     
     // Object methods

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/Triangle.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/Triangle.java
@@ -198,20 +198,27 @@ public final class Triangle {
     
     /**
      * Compute the space-filling curve index for this triangle element.
-     * 
-     * This implements a simplified version of t8code's triangular SFC algorithm.
+     *
+     * <p>This implements a simplified version of t8code's triangular SFC algorithm.
      * The full algorithm involves complex type transitions and cube_id computation
      * that preserves spatial locality through the triangular subdivision hierarchy.
-     * 
-     * For now, we use a simple linear combination of coordinates.
-     * TODO: Implement full t8code triangular SFC algorithm for optimal spatial locality.
-     * 
+     *
+     * <p>For now, we use a simple positional packing of coordinates. Each of
+     * {@code x}, {@code y}, {@code n} is bounded by {@code 2^level} at level L,
+     * and {@code type} is 0 or 1, so the encoding consumes {@code 3*level + 1}
+     * bits. At MAX_LEVEL=21 this is 64 bits and the result may be negative
+     * (sign bit set when {@code type=1}); the bit pattern remains a bijection
+     * with the input tuple, so callers using it as a hash/identity key are
+     * safe. The prior implementation used {@code level*2} as the per-field
+     * scale, doubling bit consumption and silently overflowing at level 11+,
+     * producing key collisions across distinct triangles.
+     *
+     * <p>TODO: Implement full t8code triangular SFC for optimal spatial locality.
+     *
      * @return the SFC index (consecutive index)
      */
     public long consecutiveIndex() {
-        // Simplified SFC - linear combination of coordinates
-        // This ensures different coordinates produce different indices
-        var levelScale = 1L << (level * 2); // Scale factor for this level
+        var levelScale = 1L << level;
         return x + (y * levelScale) + (n * levelScale * levelScale) + (type * levelScale * levelScale * levelScale);
     }
     

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismKeyTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismKeyTest.java
@@ -19,6 +19,9 @@ package com.hellblazer.luciferase.lucien.prism;
 import com.hellblazer.luciferase.lucien.SpatialKey;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
+
+import java.util.HashMap;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -461,8 +464,76 @@ class PrismKeyTest {
         // Should contain useful information
         assertTrue(str.length() > 40);
         assertFalse(str.contains("null"));
-        
+
         // Should show coordinates
         assertTrue(str.matches(".*\\(.*,.*,.*\\).*")); // Contains (x,y,z) pattern
+    }
+
+    @Test
+    @DisplayName("compareTo is consistent with equals across all valid levels")
+    void testCompareToInjectiveAtAllLevels() {
+        // Regression test for the PR #86 first-pass finding: PrismKey's
+        // long-packed consecutiveIndex collides at level 21 (3*21+1 = 64
+        // exceeds long width). compareTo must remain a total order
+        // consistent with equals at every level the constructor accepts —
+        // otherwise ConcurrentSkipListMap silently overwrites entries.
+        var seen = new HashMap<String, PrismKey>();
+        for (int level = 0; level <= Triangle.MAX_LEVEL; level++) {
+            // Build a small grid of keys at this level. The triangular
+            // constraint forces x + y < 2^level, so pick interior points.
+            int span = (level == 0) ? 1 : 2;
+            for (int x = 0; x < span; x++) {
+                for (int y = 0; y < span - x; y++) {
+                    for (int n = 0; n < span; n++) {
+                        for (int type = 0; type < (level == 0 ? 1 : 2); type++) {
+                            for (int z = 0; z < span; z++) {
+                                var triangle = new Triangle(level, type, x, y, n);
+                                var line = new Line(level, z);
+                                var key = new PrismKey(triangle, line);
+                                var fingerprint = String.format(
+                                    "L=%d/t=%d/x=%d/y=%d/n=%d/z=%d",
+                                    level, type, x, y, n, z);
+                                var prior = seen.put(fingerprint, key);
+                                assertNull(prior,
+                                    "Duplicate fingerprint within same level — test bug");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // Every distinct PrismKey must compareTo != 0 against every other.
+        var keys = seen.values().toArray(new PrismKey[0]);
+        for (int i = 0; i < keys.length; i++) {
+            assertEquals(0, keys[i].compareTo(keys[i]),
+                "Key must compareTo == 0 against itself");
+            for (int j = i + 1; j < keys.length; j++) {
+                int cmp = keys[i].compareTo(keys[j]);
+                assertNotEquals(0, cmp,
+                    String.format("Distinct keys collided in compareTo: %s vs %s",
+                                  keys[i], keys[j]));
+                // Total ordering: cmp(a,b) and cmp(b,a) must have opposite signs.
+                assertEquals(Integer.signum(cmp), -Integer.signum(keys[j].compareTo(keys[i])),
+                    "compareTo not antisymmetric");
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("compareTo is injective at MAX_LEVEL specifically")
+    void testCompareToInjectiveAtMaxLevel() {
+        // Direct probe of the level-21 collision class identified in the
+        // first-pass review. Construct two keys at MAX_LEVEL that differ
+        // only in Line.z — the buggy long-packed encoding made these compare
+        // equal because lineId << 64 reduces to lineId << 0.
+        int maxLevel = Triangle.MAX_LEVEL;
+        var triangle = new Triangle(maxLevel, 0, 0, 0, 0);
+        var lineA = new Line(maxLevel, 0);
+        var lineB = new Line(maxLevel, 1);
+        var keyA = new PrismKey(triangle, lineA);
+        var keyB = new PrismKey(triangle, lineB);
+        assertNotEquals(keyA, keyB, "Keys differing in Line.z must not be equal");
+        assertNotEquals(0, keyA.compareTo(keyB),
+            "compareTo must distinguish keys that differ only in Line.z at MAX_LEVEL");
     }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleTest.java
@@ -37,12 +37,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class TriangleTest {
 
     @Test
-    @DisplayName("consecutiveIndex is collision-free across levels 1..6 (exhaustive)")
+    @DisplayName("consecutiveIndex is collision-free across levels 1..6 (exhaustive over coordinate cube)")
     void testConsecutiveIndexCollisionFreeLowLevels() {
-        // Exhaustive sweep at low levels — cheap and complete. The level
-        // cap is 6 because exhaustive at level 10 would be 2 * 1024^3 = 2B
-        // combinations, too slow for unit tests. Levels 7..21 are covered
-        // by the sampled test below.
+        // Exhaustive sweep at low levels — cheap and complete over the
+        // coordinate cube [0, 2^level) for each of x/y/n. Note: this is a
+        // STRICT SUPERSET of the geometrically valid Triangle domain (the
+        // valid region is bounded by the triangular constraint x + y <
+        // 2^level, enforced by Triangle.fromWorldCoordinate but NOT by the
+        // direct constructor used here). Proving injectivity over the
+        // superset is a stronger claim than the valid domain alone, so this
+        // is conservative — any collision within the valid domain would
+        // also show here. The level cap is 6 because exhaustive at level
+        // 10 would be 2 * 1024^3 = 2B combinations, too slow for unit
+        // tests. Levels 7..21 are covered by the sampled test below.
         for (int level = 1; level <= 6; level++) {
             var seen = new HashSet<Long>();
             int maxCoord = 1 << level;

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.prism;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Collision-freeness tests for {@link Triangle#consecutiveIndex()}.
+ *
+ * <p>The original implementation used {@code 1L << (level * 2)} as the
+ * per-field scale, which doubled bit consumption and overflowed signed long
+ * at level 11+, producing key collisions across distinct triangles. The
+ * fix in PR #86 corrected the scale to {@code 1L << level}. These tests
+ * pin the corrected encoding so a regression to {@code level * 2} (or any
+ * other scaling mistake) is detected mechanically.
+ */
+class TriangleTest {
+
+    @Test
+    @DisplayName("consecutiveIndex is collision-free across levels 1..6 (exhaustive)")
+    void testConsecutiveIndexCollisionFreeLowLevels() {
+        // Exhaustive sweep at low levels — cheap and complete. The level
+        // cap is 6 because exhaustive at level 10 would be 2 * 1024^3 = 2B
+        // combinations, too slow for unit tests. Levels 7..21 are covered
+        // by the sampled test below.
+        for (int level = 1; level <= 6; level++) {
+            var seen = new HashSet<Long>();
+            int maxCoord = 1 << level;
+            for (int type = 0; type < 2; type++) {
+                for (int x = 0; x < maxCoord; x++) {
+                    for (int y = 0; y < maxCoord; y++) {
+                        for (int n = 0; n < maxCoord; n++) {
+                            long key = new Triangle(level, type, x, y, n).consecutiveIndex();
+                            boolean added = seen.add(key);
+                            assertTrue(added, String.format(
+                                "Triangle.consecutiveIndex collision at level=%d type=%d x=%d y=%d n=%d (key=%d)",
+                                level, type, x, y, n, key));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("consecutiveIndex is collision-free at levels 7..MAX_LEVEL (sampled)")
+    void testConsecutiveIndexCollisionFreeAtHighLevels() {
+        // Regression test for the level*2 overflow. Levels 7..MAX_LEVEL with
+        // a sparse sample — exhaustive would be O(2^(3*L)) which is intractable
+        // at L=21. The sample covers corners + interior representatives, which
+        // is sufficient to catch multiplicative-overflow collisions because
+        // overflow folds high values into low ones (any collision-producing
+        // wrap manifests across this coord set).
+        for (int level = 7; level <= Triangle.MAX_LEVEL; level++) {
+            var seen = new HashSet<Long>();
+            int maxCoord = 1 << level;
+            int[] coords = { 0, 1, maxCoord / 3, maxCoord / 2, maxCoord - 2, maxCoord - 1 };
+            for (int type = 0; type < 2; type++) {
+                for (int x : coords) {
+                    for (int y : coords) {
+                        for (int n : coords) {
+                            long key = new Triangle(level, type, x, y, n).consecutiveIndex();
+                            boolean added = seen.add(key);
+                            assertTrue(added, String.format(
+                                "Triangle.consecutiveIndex collision at level=%d type=%d x=%d y=%d n=%d (key=%d)",
+                                level, type, x, y, n, key));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("consecutiveIndex root (level=0) is 0")
+    void testRootIndexZero() {
+        // Anchor for the SFC: root triangle always indexes to 0. Used by
+        // PrismKey.createRoot and asserted by PrismKeyTest.testCompositeSFC.
+        assertEquals(0L, new Triangle(0, 0, 0, 0, 0).consecutiveIndex());
+    }
+}

--- a/render/src/main/java/com/hellblazer/luciferase/esvo/app/ESVOApplication.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvo/app/ESVOApplication.java
@@ -96,16 +96,20 @@ public class ESVOApplication {
 
         running.set(false);
 
-        // Shutdown background executor first so no new GL tasks can be
-        // queued during the rest of shutdown.
+        // Shutdown background executor: rejects NEW submissions but does
+        // not interrupt tasks already in-flight, so an in-flight staging
+        // task may still call pendingGlTasks.offer(...) after the clear()
+        // below. That leaked lambda is harmless because (a) the queue is
+        // not drained again after shutdown (renderFrame requires
+        // initialized=true, which we flip false at end-of-shutdown), and
+        // (b) the lambda's own gpuMemory.isDisposed() guard prevents any
+        // GL call against freed memory.
         if (backgroundExecutor != null) {
             backgroundExecutor.shutdown();
         }
 
-        // Drop any pending GL work — gpuMemory is about to be disposed and
-        // executing the queued lambdas would either no-op (the disposed
-        // guard catches it) or race the dispose() call. Either way the
-        // queue must not accumulate across the renderer lifecycle.
+        // Drop already-enqueued GL work — gpuMemory is about to be
+        // disposed and we will not run the queue again.
         pendingGlTasks.clear();
 
         // Clean up GPU memory

--- a/render/src/main/java/com/hellblazer/luciferase/esvo/app/ESVOApplication.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvo/app/ESVOApplication.java
@@ -8,6 +8,8 @@ import org.lwjgl.system.MemoryUtil;
 import javax.vecmath.Vector3f;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -27,6 +29,13 @@ public class ESVOApplication {
     private AdvancedRayTraversal rayTraversal;
     private OctreeGPUMemory gpuMemory;
     private ExecutorService backgroundExecutor;
+    /**
+     * GL-thread task queue. OpenGL calls must execute on the thread that owns
+     * the current GL context. Background tasks post upload work here; the
+     * render loop drains the queue at the start of each frame so the work runs
+     * synchronously on the GL thread.
+     */
+    private final Queue<Runnable> pendingGlTasks = new ConcurrentLinkedQueue<>();
     
     // Configuration
     private int renderWidth = 800;
@@ -145,16 +154,23 @@ public class ESVOApplication {
         if (!initialized.get()) {
             throw new IllegalStateException("Application not initialized");
         }
-        
+
         performanceMonitor.startFrame();
-        
+
         try {
+            // Drain queued GL work on the render thread before traversal so
+            // any pending uploads land in the current frame.
+            Runnable glTask;
+            while ((glTask = pendingGlTasks.poll()) != null) {
+                glTask.run();
+            }
+
             // Perform ray traversal for each pixel
             int raysTraversed = performRayTraversal();
             int nodesVisited = raysTraversed * 5; // Estimate
             int voxelsHit = raysTraversed / 2; // Estimate
             performanceMonitor.recordTraversal(raysTraversed, nodesVisited, voxelsHit);
-            
+
         } finally {
             // End frame is handled by next startFrame() call
         }
@@ -235,31 +251,34 @@ public class ESVOApplication {
     // Private helper methods
     
     private void uploadToGPU(String name, ESVOOctreeData octree) {
+        // CPU staging (writeNode -> backing ByteBuffer) is thread-safe and runs
+        // off the GL thread. The actual GL upload (gpuMemory.uploadToGPU) must
+        // execute on the render thread because OpenGL contexts are bound to a
+        // single thread; we post it to pendingGlTasks for the next frame drain.
+        // The prior code invoked uploadToGPU directly from the background
+        // executor, which is undefined behavior — GL calls from a thread
+        // without the current context are silent no-ops at best, segfaults
+        // at worst.
         backgroundExecutor.submit(() -> {
             try {
-                // Convert octree to GPU format and upload
-                // This would typically involve converting to the GPU memory layout
-                // and uploading via OpenCL/CUDA/Compute Shader
-                
-                // For now, we just reserve space
-                int nodeCount = octree.getNodeIndices().length;
-                long memoryRequired = nodeCount * 8L; // 8 bytes per node
-                
-                if (!gpuMemory.isDisposed()) {
-                    // Upload octree nodes to GPU
-                    int[] nodeIndices = octree.getNodeIndices();
-                    for (int i = 0; i < Math.min(nodeIndices.length, gpuMemory.getNodeCount()); i++) {
-                        var node = octree.getNode(nodeIndices[i]);
-                        if (node != null) {
-                            gpuMemory.writeNode(i, node.getChildMask(), node.getContourPtr());
-                        }
-                    }
-                    gpuMemory.uploadToGPU();
+                if (gpuMemory.isDisposed()) {
+                    return;
                 }
-                
+                int[] nodeIndices = octree.getNodeIndices();
+                for (int i = 0; i < Math.min(nodeIndices.length, gpuMemory.getNodeCount()); i++) {
+                    var node = octree.getNode(nodeIndices[i]);
+                    if (node != null) {
+                        gpuMemory.writeNode(i, node.getChildMask(), node.getContourPtr());
+                    }
+                }
+                pendingGlTasks.offer(() -> {
+                    if (!gpuMemory.isDisposed()) {
+                        gpuMemory.uploadToGPU();
+                    }
+                });
             } catch (Exception e) {
                 // Log error but don't crash the application
-                System.err.println("Failed to upload octree to GPU: " + e.getMessage());
+                System.err.println("Failed to stage octree for GPU upload: " + e.getMessage());
             }
         });
     }

--- a/render/src/main/java/com/hellblazer/luciferase/esvo/app/ESVOApplication.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvo/app/ESVOApplication.java
@@ -93,24 +93,31 @@ public class ESVOApplication {
         if (!initialized.get()) {
             return;
         }
-        
+
         running.set(false);
-        
-        // Shutdown background executor
+
+        // Shutdown background executor first so no new GL tasks can be
+        // queued during the rest of shutdown.
         if (backgroundExecutor != null) {
             backgroundExecutor.shutdown();
         }
-        
+
+        // Drop any pending GL work — gpuMemory is about to be disposed and
+        // executing the queued lambdas would either no-op (the disposed
+        // guard catches it) or race the dispose() call. Either way the
+        // queue must not accumulate across the renderer lifecycle.
+        pendingGlTasks.clear();
+
         // Clean up GPU memory
         if (gpuMemory != null) {
             gpuMemory.dispose(); // Use dispose() method
         }
-        
+
         // Clear scene
         if (scene != null) {
             scene.clear();
         }
-        
+
         initialized.set(false);
     }
     

--- a/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/ComputeShaderRenderer.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/ComputeShaderRenderer.java
@@ -131,14 +131,20 @@ public final class ComputeShaderRenderer {
         
         // Use compute shader program
         glUseProgram(raycastProgram.getOpenGLId());
-        
+
+        // Ensure any prior writes to the octree SSBO (e.g. async upload) are
+        // visible to the compute shader before it reads them. Without this
+        // barrier the dispatch can read stale GPU memory and produce empty
+        // frames or wrong hits.
+        glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+
         // Dispatch compute shader
         int groupsX = (frameWidth + WORKGROUP_SIZE_X - 1) / WORKGROUP_SIZE_X;
         int groupsY = (frameHeight + WORKGROUP_SIZE_Y - 1) / WORKGROUP_SIZE_Y;
-        
+
         glDispatchCompute(groupsX, groupsY, WORKGROUP_SIZE_Z);
-        
-        // Ensure all writes are complete
+
+        // Ensure all image writes are visible to subsequent samplers / readback.
         glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
         
         // Check for errors

--- a/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/OctreeGPUMemory.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/OctreeGPUMemory.java
@@ -36,7 +36,12 @@ public final class OctreeGPUMemory {
     private ByteBuffer nodeBuffer;
     private final long bufferSize;
     private final int nodeCount;
-    private boolean disposed = false;
+    // volatile because isDisposed() is read by background-staging threads
+    // that prepare uploads off the GL thread. Without it the JMM does not
+    // guarantee the staging thread sees writes made on the dispose/GL
+    // thread, so the guard before glBufferData could silently observe a
+    // stale false and dispatch GL calls against freed buffers.
+    private volatile boolean disposed = false;
     
     // Resource manager for GPU resources
     private final UnifiedResourceManager resourceManager = UnifiedResourceManager.getInstance();

--- a/render/src/main/java/com/hellblazer/luciferase/esvt/gpu/ESVTComputeRenderer.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvt/gpu/ESVTComputeRenderer.java
@@ -411,7 +411,22 @@ public final class ESVTComputeRenderer {
                 coarseSampler = 0;
                 glDeleteSamplers(s);
             }
-            createOutputTexture();
+            try {
+                createOutputTexture();
+            } catch (RuntimeException re) {
+                // The old textures are already freed; createOutputTexture
+                // failed (driver OOM, lost context, etc.) so the renderer
+                // is no longer usable. Flip initialized to false so
+                // renderFrame fails fast at its initialized check instead
+                // of NPE-ing on the null output/coarse textures. The
+                // caller is expected to react to the rethrown exception
+                // (e.g. re-init at a smaller resolution or surface the
+                // error).
+                initialized = false;
+                log.error("ESVTComputeRenderer.resize: createOutputTexture failed at {}x{}; renderer marked uninitialized",
+                          frameWidth, frameHeight, re);
+                throw re;
+            }
 
             log.info("Resized ESVTComputeRenderer: {}x{}", frameWidth, frameHeight);
         }

--- a/render/src/main/java/com/hellblazer/luciferase/esvt/gpu/ESVTComputeRenderer.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvt/gpu/ESVTComputeRenderer.java
@@ -176,13 +176,18 @@ public final class ESVTComputeRenderer {
         // Use compute shader program
         glUseProgram(raycastProgram.getOpenGLId());
 
+        // Ensure any prior writes to the ESVT SSBO (e.g. async upload) are
+        // visible to the compute shader before it reads them. Without this
+        // barrier the dispatch can read stale GPU memory.
+        glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+
         // Dispatch compute shader
         int groupsX = (frameWidth + WORKGROUP_SIZE_X - 1) / WORKGROUP_SIZE_X;
         int groupsY = (frameHeight + WORKGROUP_SIZE_Y - 1) / WORKGROUP_SIZE_Y;
 
         glDispatchCompute(groupsX, groupsY, WORKGROUP_SIZE_Z);
 
-        // Ensure all writes are complete
+        // Ensure all image writes are visible to subsequent samplers / readback.
         glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
 
         // Check for errors
@@ -258,6 +263,10 @@ public final class ESVTComputeRenderer {
         // Bind coarse texture for output
         glBindImageTexture(COARSE_OUTPUT_BINDING, coarseTexture.getOpenGLId(), 0, false, 0,
                           GL_WRITE_ONLY, GL_R32F);
+
+        // Ensure any prior writes to the ESVT SSBO are visible before the
+        // coarse pass reads from it.
+        glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
 
         // Dispatch at coarse resolution
         int coarseGroupsX = (coarseWidth + WORKGROUP_SIZE_X - 1) / WORKGROUP_SIZE_X;
@@ -381,15 +390,26 @@ public final class ESVTComputeRenderer {
         this.frameHeight = newHeight;
 
         if (initialized) {
+            // Null each handle as soon as it's closed. If a later close()
+            // throws (driver error, lost context) the surviving handle won't
+            // be re-closed by a subsequent dispose() — the prior code left
+            // both references intact through the close sequence, so a
+            // resize-time exception would leak a double-close on the next
+            // dispose() and crash the GL driver.
             if (outputTexture != null) {
-                outputTexture.close();
+                var t = outputTexture;
+                outputTexture = null;
+                t.close();
             }
             if (coarseTexture != null) {
-                coarseTexture.close();
+                var t = coarseTexture;
+                coarseTexture = null;
+                t.close();
             }
             if (coarseSampler != 0) {
-                glDeleteSamplers(coarseSampler);
+                int s = coarseSampler;
                 coarseSampler = 0;
+                glDeleteSamplers(s);
             }
             createOutputTexture();
 

--- a/render/src/main/resources/shaders/esvo_raycast.comp
+++ b/render/src/main/resources/shaders/esvo_raycast.comp
@@ -77,10 +77,18 @@ int getChildOffset(int validMask, int childIndex) {
     return popc8(mask);
 }
 
-// Critical Bug Fix #2: Transform world coordinates to octree space [0,1]
+// Transform world coordinates to octree space [0,1].
+// World -> object requires inverse(objectToWorld); object -> octree requires
+// inverse(octreeToObject). The prior implementation applied octreeToObject as
+// the forward direction, which transformed octree-space points back into
+// object space (the wrong direction). Result: rays were placed in the wrong
+// coordinate system and traversal returned spurious / missed hits.
+// TODO: precompute inverse on the CPU and upload as a uniform to avoid the
+// per-invocation inverse() cost.
 vec3 worldToOctree(vec3 worldPos) {
-    vec4 objPos = camera.octreeToObject * vec4(worldPos, 1.0);
-    vec3 normalized = (objPos.xyz + 1.0) * 0.5; // [-1,1] to [0,1]
+    vec4 objPos = inverse(camera.objectToWorld) * vec4(worldPos, 1.0);
+    vec4 octreePos = inverse(camera.octreeToObject) * objPos;
+    vec3 normalized = (octreePos.xyz + 1.0) * 0.5; // [-1,1] to [0,1]
     return normalized + vec3(OCTREE_MIN); // With OCTREE_MIN=0.0, stays in [0,1]
 }
 
@@ -160,15 +168,14 @@ vec4 traverseOctree(Ray ray) {
             continue;
         }
         
-        // Check if leaf node
-        if (nonLeafMask == 0) {
-            // Leaf node - we hit geometry
-            hit = true;
-            hitPoint = ray.origin + ray.direction * hitDistance;
-            hitNormal = vec3(0, 1, 0); // Placeholder normal
-            break;
-        }
-        
+        // Note: when nonLeafMask == 0 every valid child of this node is a leaf.
+        // The per-child intersection loop below still handles that case correctly
+        // (each leaf child is tested via intersectAABB, hitDistance is updated to
+        // t.x of the closest leaf, and hitPoint is computed from that t). The
+        // prior code took an early-exit branch here that set hit = true and
+        // computed hitPoint from the uninitialized hitDistance = 0, which placed
+        // every leaf hit at the camera origin.
+
         // Internal node - traverse children
         float cellSize = OCTREE_SIZE / float(1 << (currentScale + 1));
         int childPointer = getChildPointer(node);

--- a/sentry/src/main/java/com/hellblazer/sentry/OrientedFace.java
+++ b/sentry/src/main/java/com/hellblazer/sentry/OrientedFace.java
@@ -33,18 +33,6 @@ import static com.hellblazer.sentry.V.*;
  */
 
 public abstract class OrientedFace implements Iterable<Vertex> {
-    
-    // Cache for adjacent vertex
-    private Vertex cachedAdjacentVertex;
-    private boolean adjacentVertexCached = false;
-    
-    /**
-     * Invalidate the cached adjacent vertex. Should be called when topology changes.
-     */
-    protected void invalidateAdjacentVertexCache() {
-        adjacentVertexCached = false;
-        cachedAdjacentVertex = null;
-    }
 
     /**
      * Perform a flip for deletion of the vertex from the tetrahedralization. The incident and adjacent tetrahedra form
@@ -79,14 +67,21 @@ public abstract class OrientedFace implements Iterable<Vertex> {
         if (reflexEdges == 0 && isConvex(indexOf(n)) && isLocallyDelaunay(index, n, ears)) {
             // Only one face of the opposing tetrahedron is visible
             var created = flip2to3();
-            if (created[0].includes(n)) {
-                if (created[1].includes(n)) {
-                    ears.add(created[0].getFace(created[0].ordinalOf(created[1])));
+            // flip2to3 may return fewer than 3 tetrahedra when degenerate-pair removal
+            // killed one or more. The ear-promotion logic below requires the canonical
+            // 3-tet shape; if we got fewer, no ear can be safely promoted (the
+            // degenerate-removal already collapsed the relevant topology). Process the
+            // canonical case and skip otherwise — both branches still consume this ear.
+            if (created.length == 3) {
+                if (created[0].includes(n)) {
+                    if (created[1].includes(n)) {
+                        ears.add(created[0].getFace(created[0].ordinalOf(created[1])));
+                    } else {
+                        ears.add(created[0].getFace(created[0].ordinalOf(created[2])));
+                    }
                 } else {
-                    ears.add(created[0].getFace(created[0].ordinalOf(created[2])));
+                    ears.add(created[1].getFace(created[1].ordinalOf(created[2])));
                 }
-            } else {
-                ears.add(created[1].getFace(created[1].ordinalOf(created[2])));
             }
             return true;
         } else if (reflexEdges == 1) {
@@ -321,17 +316,9 @@ public abstract class OrientedFace implements Iterable<Vertex> {
      * @return
      */
     public Vertex getAdjacentVertex() {
-        if (!adjacentVertexCached) {
-            Tetrahedron adjacent = getAdjacent();
-            var current = adjacent == null ? null : adjacent.ordinalOf(getIncident());
-            if (current == null) {
-                cachedAdjacentVertex = null;
-            } else {
-                cachedAdjacentVertex = adjacent.getVertex(current);
-            }
-            adjacentVertexCached = true;
-        }
-        return cachedAdjacentVertex;
+        Tetrahedron adjacent = getAdjacent();
+        var current = adjacent == null ? null : adjacent.ordinalOf(getIncident());
+        return current == null ? null : adjacent.getVertex(current);
     }
 
     /**

--- a/sentry/src/main/java/com/hellblazer/sentry/OrientedFace.java
+++ b/sentry/src/main/java/com/hellblazer/sentry/OrientedFace.java
@@ -65,13 +65,24 @@ public abstract class OrientedFace implements Iterable<Vertex> {
         }
 
         if (reflexEdges == 0 && isConvex(indexOf(n)) && isLocallyDelaunay(index, n, ears)) {
-            // Only one face of the opposing tetrahedron is visible
+            // Only one face of the opposing tetrahedron is visible.
             var created = flip2to3();
-            // flip2to3 may return fewer than 3 tetrahedra when degenerate-pair removal
-            // killed one or more. The ear-promotion logic below requires the canonical
-            // 3-tet shape; if we got fewer, no ear can be safely promoted (the
-            // degenerate-removal already collapsed the relevant topology). Process the
-            // canonical case and skip otherwise — both branches still consume this ear.
+            // flip2to3 may return fewer than 3 tetrahedra when degenerate-pair
+            // removal killed one or more. The ear-promotion logic below requires
+            // the canonical 3-tet shape; if we got fewer, no ear can be safely
+            // promoted because the degenerate-removal already collapsed the
+            // relevant topology — the would-be ear faces do not exist as
+            // adjacencies anymore.
+            //
+            // INVARIANT: in both branches (length == 3 and length < 3) this
+            // method returns true, meaning "the receiver was processed; remove
+            // it from the ears list." The < 3 path intentionally does NOT add a
+            // replacement ear because the topology was simplified rather than
+            // refined; the caller's deletion-walk progresses by virtue of the
+            // smaller star, so missing the ear-add is correct, not a regression.
+            // A regression that re-introduced the unbounded created[0..2] access
+            // would manifest as ArrayIndexOutOfBoundsException during vertex
+            // deletion, not as a missing ear.
             if (created.length == 3) {
                 if (created[0].includes(n)) {
                     if (created[1].includes(n)) {

--- a/sentry/src/main/java/com/hellblazer/sentry/Tetrahedron.java
+++ b/sentry/src/main/java/com/hellblazer/sentry/Tetrahedron.java
@@ -983,7 +983,7 @@ public class Tetrahedron implements Iterable<OrientedFace> {
                     stack.push(nC);
                 }
                 if (nB != null) {
-                    stack.push(nC);
+                    stack.push(nB);
                 }
                 if (nD != null) {
                     stack.push(nD);
@@ -1019,7 +1019,7 @@ public class Tetrahedron implements Iterable<OrientedFace> {
                     stack.push(nB);
                 }
                 if (nA != null) {
-                    stack.push(nB);
+                    stack.push(nA);
                 }
                 if (nC != null) {
                     stack.push(nC);

--- a/sentry/src/test/java/com/hellblazer/sentry/TetrahedronTest.java
+++ b/sentry/src/test/java/com/hellblazer/sentry/TetrahedronTest.java
@@ -295,4 +295,57 @@ public class TetrahedronTest {
         Assertions.assertTrue(visited.equals(expected),
             "Star walk visited set must match expected adjacent set");
     }
+
+    /**
+     * Direct regression test for the case-A copy-paste bug in
+     * {@link Tetrahedron#visit(Vertex, StarVisitor, Stack, Set)}.
+     *
+     * <p>{@link #testVisitStarCompleteness} only exercises case D because
+     * {@link Tetrahedron#flip1to4} puts the inserted vertex at ordinal D
+     * in every child tetrahedron. This test directly constructs a tet where
+     * the central vertex sits at ordinal A and asserts that {@code visit}
+     * pushes the correct neighbor (nB) onto the stack rather than the buggy
+     * one (nC). Pre-fix code path: case A with nB != null pushed nC.
+     */
+    @Test
+    @DisplayName("visit case A pushes nB, not nC, when central vertex is at ordinal A")
+    public void testVisitCaseAPushesCorrectNeighbor() {
+        var central = new Vertex(1000.0f, 1000.0f, 1000.0f);
+        var vb = new Vertex(2000.0f, 1000.0f, 1000.0f);
+        var vc = new Vertex(1000.0f, 2000.0f, 1000.0f);
+        var vd = new Vertex(1000.0f, 1000.0f, 2000.0f);
+        // Receiver: central is at ordinal A.
+        var receiver = new Tetrahedron(central, vb, vc, vd);
+
+        // Construct distinct sentinel neighbors so we can tell nB from nC
+        // by identity on the stack. Each sentinel shares the face opposite
+        // its ordinal with the receiver.
+        var nbVertex = new Vertex(3000.0f, 1000.0f, 1000.0f);
+        var ncVertex = new Vertex(1000.0f, 3000.0f, 1000.0f);
+        var ndVertex = new Vertex(1000.0f, 1000.0f, 3000.0f);
+        var nB = new Tetrahedron(central, nbVertex, vc, vd);
+        var nC = new Tetrahedron(central, vb, ncVertex, vd);
+        var nD = new Tetrahedron(central, vb, vc, ndVertex);
+        receiver.setNeighborB(nB);
+        receiver.setNeighborC(nC);
+        receiver.setNeighborD(nD);
+
+        var stack = new java.util.Stack<Tetrahedron>();
+        var visited = new java.util.HashSet<Tetrahedron>();
+        receiver.visit(central, (v, t, a, b, c) -> {
+            Assertions.assertSame(V.A, v, "Central vertex must be at ordinal A");
+        }, stack, visited);
+
+        // The buggy code path would have pushed nC twice (once for the nC
+        // branch, once for the nB branch) and never pushed nB. After the
+        // fix the stack contains exactly {nB, nC, nD}.
+        Assertions.assertEquals(3, stack.size(),
+            "Case A with all three nB/nC/nD non-null must push three neighbors");
+        Assertions.assertTrue(stack.contains(nB),
+            "Case A must push nB when nB != null (was pushing nC pre-fix)");
+        Assertions.assertTrue(stack.contains(nC),
+            "Case A must push nC when nC != null");
+        Assertions.assertTrue(stack.contains(nD),
+            "Case A must push nD when nD != null");
+    }
 }

--- a/sentry/src/test/java/com/hellblazer/sentry/TetrahedronTest.java
+++ b/sentry/src/test/java/com/hellblazer/sentry/TetrahedronTest.java
@@ -30,9 +30,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.Stack;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -214,5 +218,81 @@ public class TetrahedronTest {
         assertEquals(d, face.getVertex(0));
         assertEquals(b, face.getVertex(1));
         assertEquals(a, face.getVertex(2));
+    }
+
+    /**
+     * Star-walk completeness regression test for the PR #86 fix to
+     * {@link Tetrahedron#visit(Vertex, StarVisitor, Stack, Set)}.
+     *
+     * The cases-A and -D switch arms had copy-paste bugs that pushed the
+     * wrong neighbor onto the traversal stack:
+     *   case A: when nB != null, pushed nC instead of nB
+     *   case D: when nA != null, pushed nB instead of nA
+     * The result was that {@link Tetrahedron#visitStar} silently skipped
+     * neighbors. Each tetrahedron in the star is the receiver in a unique
+     * traversal step; the visitor is invoked once per tet with the central
+     * vertex's ordinal in that tet. So a complete star walk over a vertex
+     * present in N tets must invoke the visitor exactly N times.
+     */
+    @Test
+    @DisplayName("visitStar visits all tetrahedra adjacent to a vertex exactly once")
+    public void testVisitStarCompleteness() {
+        // myOwnPrivateIdaho builds the universe tetrahedron containing the
+        // four bounding vertices. flip1to4 splits it around an inserted
+        // central vertex into four tets — each of which has the new vertex
+        // as one of its corners. The star around the new vertex is exactly
+        // those four tets.
+        var idaho = MutableGrid.myOwnPrivateIdaho(new MutableGrid());
+        var central = new Vertex(0.0f, 0.0f, 0.0f);
+        var ears = new ArrayList<OrientedFace>();
+        var firstChild = idaho.flip1to4(central, ears);
+        Assertions.assertNotNull(firstChild,
+            "flip1to4 should return one of the four child tetrahedra");
+
+        var visited = new HashSet<Tetrahedron>();
+        firstChild.visitStar(central, (v, t, a, b, c) -> {
+            boolean added = visited.add(t);
+            Assertions.assertTrue(added,
+                "Star walk visited the same tetrahedron twice: " + t);
+            Assertions.assertSame(central, t.getVertex(v),
+                "Visitor ordinal must reference the central vertex");
+        });
+
+        // Verify completeness: the central vertex's adjacent set must equal
+        // what visitStar visited. Vertex.getAdjacent / similar lookups are
+        // not directly exposed; instead, reconstruct the expected star by
+        // walking from firstChild via every neighbor pointer and counting
+        // tets that include the central vertex.
+        var expected = new HashSet<Tetrahedron>();
+        var pending = new Stack<Tetrahedron>();
+        pending.push(firstChild);
+        while (!pending.isEmpty()) {
+            var t = pending.pop();
+            if (!expected.add(t)) {
+                continue;
+            }
+            // Only walk to neighbors that share the central vertex.
+            for (var ord : V.values()) {
+                var nb = t.getNeighbor(ord);
+                if (nb != null && !expected.contains(nb)) {
+                    boolean nbContainsCentral = false;
+                    for (var v : V.values()) {
+                        if (nb.getVertex(v) == central) {
+                            nbContainsCentral = true;
+                            break;
+                        }
+                    }
+                    if (nbContainsCentral) {
+                        pending.push(nb);
+                    }
+                }
+            }
+        }
+
+        assertEquals(expected.size(), visited.size(),
+            "Star walk must visit every tetrahedron containing the central vertex: "
+            + "expected " + expected.size() + ", visited " + visited.size());
+        Assertions.assertTrue(visited.equals(expected),
+            "Star walk visited set must match expected adjacent set");
     }
 }


### PR DESCRIPTION
## Summary

Tranche B of the 360 code-review remediation (Tranche A: #85). Twelve correctness bugs across the Delaunay tetrahedralization core, the tetree/prism spatial indexes, and the ESVO/ESVT render path. Stacked on Tranche A (`feature/review-360-A-quick-wins`); rebase onto main after #85 lands.

Tracking bead: `Luciferase-4g6`. Deferred follow-up: `Luciferase-fzm` (Prism full-cube coverage — RDR-scoped design change).

## Commits

| # | Concern | Bugs |
|---|---------|------|
| 1 | sentry | Tetrahedron.visit copy-paste (cases A/D push wrong neighbor); OrientedFace.flip[0] unbounded `created[]` access; drop stale `invalidateAdjacentVertexCache` with zero callers |
| 2 | lucien tetree/prism | TetreeNeighborDetector.keyToTet decode dropped higher-level path bits; Triangle.consecutiveIndex `level*2` overflow at level 11+; Prism.shouldContinueKNNSearch unconditional `true` defeating pruning; Prism.isNodeContainedInVolume returned intersection not containment |
| 3 | render | esvo_raycast.comp leaf hit used stale `hitDistance=0`; esvo_raycast.comp `worldToOctree` applied forward transform instead of inverse; ESVOApplication dispatched GL from background executor; ComputeShaderRenderer + ESVTComputeRenderer missed `GL_SHADER_STORAGE_BARRIER_BIT` before dispatch; ESVTComputeRenderer.resize had double-close risk on close() exception |
| 4 | lucien | PrismKey shift width aligned with new Triangle SFC bit layout |

## Test plan

- [x] `mvn -pl sentry test` (74 tests, 0 failures)
- [x] `mvn -pl lucien test` (Prism/Triangle/TetreeNeighborDetector targeted runs all pass; full suite: 2 known-flaky absolute-timing comparison tests trip under local batch JVM load, both `@DisabledIfEnvironmentVariable(CI=true)`)
- [x] `mvn -pl render test` (1887 tests, 0 failures, 181 skipped — GPU tests require sandbox disable)
- [ ] CI green on this branch
- [ ] Manual smoke: render a frame and verify leaves no longer appear at the camera (requires GUI; covered by review when merged)

## Deferred

- `Luciferase-fzm`: Prism full-cube coverage via two-prism tiling. The single-prism rejection of `normX + normY >= 1.0f` is correct geometry for a single triangular prism; covering the full cube needs a separate design (RDR-create first).
- PrismKey overflow at very high levels (>15) is a known limitation flagged by the existing SFC TODO; not addressed in this tranche.

Reference: T2 `luciferase/360-review-2026-05-23-summary`.