### PR TITLE
Scaffold RDR-004..008 for deferred Tranche D items

### DIFF
--- a/docs/rdr/RDR-004-von-socketserver-deserialization-hardening.md
+++ b/docs/rdr/RDR-004-von-socketserver-deserialization-hardening.md
@@ -1,0 +1,69 @@
+---
+title: "Harden Network Deserialization on the VoN SocketServer"
+id: RDR-004
+type: Security
+status: draft
+priority: high
+author: hal.hildebrand
+reviewed-by: pending
+created: 2026-05-24
+related_issues: [Luciferase-irh, RDR-003]
+---
+
+# RDR-004: Harden Network Deserialization on the VoN SocketServer
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+The VoN transport reads Java-serialized objects directly off a network socket with **no `ObjectInputFilter`**. `SocketServer.handleClient` (`simulation/src/main/java/com/hellblazer/luciferase/simulation/von/transport/SocketServer.java:134`) constructs `new ObjectInputStream(clientSocket.getInputStream())` and loops on `readObject()`, casting to `TransportVonMessage`. `SocketClient.java:107-109` does the same on the response path.
+
+Unfiltered `ObjectInputStream.readObject()` on **untrusted network input** is the canonical Java deserialization RCE vector: an attacker who can connect to the listening socket can deliver a serialized gadget chain that executes during deserialization, *before* the `(TransportVonMessage)` cast is ever reached. This is materially more dangerous than the file-based deserialization sites already hardened with allow-list filters in Tranche D-1 (PR #88) — those require a malicious file on disk; this requires only network reach to the VoN port.
+
+This is explicitly a **threat-model decision, not a tactical filter add** (the reason it was deferred from D-1): the right fix depends on the trust boundary of the VoN socket and whether Java serialization should remain the wire format at all.
+
+## Context
+
+### Background
+
+The 360-review pass (2026-05-23, T2 `luciferase/360-review-2026-05-23-summary`) flagged this as a CRITICAL finding alongside four file-input `ObjectInputStream` sites. The file sites were hardened in Tranche D-1 (PR #88) with strict `ObjectInputFilter` allow-lists. The network site was deferred to this RDR because:
+
+1. The fix interacts with the VoN transport's trust assumptions (is the socket loopback-only? cluster-internal? exposed?).
+2. An allow-list filter is the *minimum*; replacing Java serialization with a schema-based wire format (the project already uses protobuf/gRPC elsewhere) may be the correct long-term answer.
+3. `SocketServer` does not currently enforce a bind constraint (separate MEDIUM finding `review-finding-security/network-bind`), compounding the exposure.
+
+### Technical Environment
+
+- **Module**: `simulation` (von/transport package)
+- **Key files**:
+  - `simulation/src/main/java/.../von/transport/SocketServer.java:134` — unfiltered `ObjectInputStream` on the inbound network path; `readObject()` at :136
+  - `simulation/src/main/java/.../von/transport/SocketClient.java:107,109` — unfiltered `ObjectInputStream` on the response path
+  - `simulation/src/main/java/.../von/TransportVonMessage.java` — the expected payload record (serializable)
+  - `simulation/src/main/java/.../von/transport/SocketTransport.java` — Fireflies-virtual-synchrony ACK wrapper (CLAUDE.md documents the transport semantics)
+- **Prior art in-repo**: Tranche D-1 `ObjectInputFilter.Config.createFilter("<type>;java.util.*;java.lang.*;...;!*")` pattern in `render` deserializers — directly reusable shape if an allow-list is the chosen direction.
+- **Related security findings** (T2 scratch, 2026-05-23): `review-finding-security/network-bind` (no loopback enforcement), `review-finding-security/grpc-auth` (RDR-005).
+
+## Approach
+
+> To be completed in `/nx:rdr-research` + design. Initial candidate directions:
+
+1. **Threat-model the VoN socket** — determine the actual trust boundary: loopback-only dev, cluster-internal (mutually authenticated peers via Fireflies view), or untrusted. The answer gates how much hardening is warranted.
+2. **Option A — ObjectInputFilter allow-list** (minimum): restrict to `TransportVonMessage` + the JDK/vecmath types it transitively carries, mirroring the D-1 file-site pattern. Cheap, reversible, but Java serialization remains the format.
+3. **Option B — replace the wire format with protobuf** (structural): the project already depends on gRPC/protobuf; a `TransportVonMessage` proto eliminates Java serialization entirely on this path. Larger change; aligns with RDR-005 (gRPC) and removes the gadget surface rather than filtering it.
+4. **Option C — bind/peer-identity constraint**: combine a filter with a loopback or Fireflies-view-authenticated bind so only known peers can connect (overlaps RDR-005's auth model).
+5. Decide single direction; sequence against RDR-005 (shared auth/transport concerns).
+
+## Open Questions
+
+- Is the VoN socket ever exposed beyond loopback / a trusted cluster subnet in any deployment?
+- Should VoN transport migrate to gRPC entirely (converging with RDR-005), making this moot?
+- Does the Fireflies view already give us a peer-identity primitive we can gate `accept()` on?
+
+## Decision
+
+_Pending research + gate._
+
+## Consequences
+
+_Pending._

--- a/docs/rdr/RDR-005-grpc-tls-auth-model.md
+++ b/docs/rdr/RDR-005-grpc-tls-auth-model.md
@@ -1,0 +1,75 @@
+---
+title: "gRPC TLS + Authentication Model for Ghost and Balancing Services"
+id: RDR-005
+type: Security
+status: draft
+priority: high
+author: hal.hildebrand
+reviewed-by: pending
+created: 2026-05-24
+related_issues: [Luciferase-va5, RDR-004]
+---
+
+# RDR-005: gRPC TLS + Authentication Model for Ghost and Balancing Services
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+Every gRPC channel in the distributed stack is created with `.usePlaintext()` and no authentication or peer-identity binding:
+
+- `lucien/.../forest/ghost/grpc/GhostServiceClient.java:379` — `.usePlaintext() // For development - use TLS in production`
+- `lucien/.../balancing/grpc/BalanceCoordinatorClient.java:461` — same
+- `simulation/.../distributed/network/GrpcBubbleNetworkChannel.java:349` — `.usePlaintext() // For testing; use TLS in production`
+
+Plaintext gRPC means: (a) traffic is unencrypted and tamperable on the wire; (b) any process that can reach the port can call ghost-exchange and balance-coordination RPCs with no credential; (c) there is no binding between an RPC caller and a known cluster member. For a system whose whole point is distributed spatial coordination across processes, this is an unauthenticated control plane.
+
+The "use TLS in production" comments acknowledge the gap but there is no production path: no cert provisioning, no trust store, no peer-identity check. This RDR must decide the **auth model** (not just "turn on TLS"), because the mechanism choice (mTLS vs. token vs. Fireflies-derived identity) drives cert/secret distribution, rotation, and how an RPC is bound to a cluster member.
+
+## Context
+
+### Background
+
+Flagged HIGH in the 360-review (T2 `luciferase/360-review-2026-05-23-summary`, `review-finding-security/grpc-auth`). Deferred from Tranche D-1 because it is a design decision spanning three modules and intersecting the Delos/Fireflies membership layer the project already uses for view management.
+
+The project already has a membership/identity substrate: **Fireflies** (Delos) provides authenticated cluster views (see CLAUDE.md "Fireflies Virtual Synchrony"; `FirefliesViewMonitor`, `FirefliesMembershipView`). Delos ships certificate-backed member identities. This is the most promising basis for peer identity rather than inventing a parallel auth scheme.
+
+### Technical Environment
+
+- **Modules**: `lucien` (ghost + balancing gRPC clients/servers), `simulation` (bubble network channel), `grpc` (proto defs)
+- **Key files**:
+  - `lucien/.../forest/ghost/grpc/GhostServiceClient.java:379` and the corresponding `GhostServiceImpl`/server builder
+  - `lucien/.../balancing/grpc/BalanceCoordinatorClient.java:461` and its server
+  - `simulation/.../distributed/network/GrpcBubbleNetworkChannel.java:349`
+  - `grpc/` — protobuf service definitions
+- **Identity substrate**: Delos `fireflies` + `memberships` artifacts (already dependencies of `simulation`); certificate-backed member identities.
+- **Related**: RDR-004 (VoN transport hardening) — shares the "what is the trust boundary / peer identity" question and should be sequenced together; D7/RDR-007 (lucien-distributed split) will relocate these gRPC clients, so the auth wiring should land in a way that survives that move.
+
+## Approach
+
+> To be completed in `/nx:rdr-research` + design. Initial candidate directions:
+
+1. **Inventory the gRPC surface** — enumerate every server/client builder and RPC, and which run cross-process vs in-process (`InProcessServerBuilder` test usages should stay plaintext).
+2. **Auth model decision** — primary candidates:
+   - **mTLS with Fireflies/Delos certificates**: reuse the existing member certs as gRPC transport credentials; peer identity = cert subject = cluster member. Strongest binding; leverages existing PKI.
+   - **Token / bearer-credential**: simpler to wire but needs a token issuer + rotation; weaker peer binding.
+   - **Channel credentials + server interceptor** that validates the caller against the current Fireflies view.
+3. **Cert/secret distribution + rotation** — how members obtain and refresh credentials; tie to Delos lifecycle.
+4. **In-process / test carve-out** — keep `InProcessServerBuilder` and CI plaintext for tests without weakening production (profile/config gate, not code-branch on an env var).
+5. **Sequencing with RDR-007** — land the auth wiring so the lucien→lucien-distributed module split doesn't have to redo it.
+
+## Open Questions
+
+- Can Delos/Fireflies member certificates be used directly as gRPC `TlsChannelCredentials` / `TlsServerCredentials`?
+- Is there a deployment where these services are reachable outside a trusted subnet (raising urgency)?
+- Should the bubble network channel (simulation) and the ghost/balancing channels (lucien) share one credential mechanism, or do they have different trust boundaries?
+- How do tests run without real certs — in-process transport, a dev credential, or a test profile?
+
+## Decision
+
+_Pending research + gate._
+
+## Consequences
+
+_Pending._

--- a/docs/rdr/RDR-006-break-simulation-portal-coupling.md
+++ b/docs/rdr/RDR-006-break-simulation-portal-coupling.md
@@ -1,0 +1,68 @@
+---
+title: "Break the simulation→portal Coupling (BubbleBounds JavaFX Pull-In)"
+id: RDR-006
+type: Architecture
+status: draft
+priority: medium
+author: hal.hildebrand
+reviewed-by: pending
+created: 2026-05-24
+related_issues: [Luciferase-jvs, Luciferase-7n1, RDR-003]
+---
+
+# RDR-006: Break the simulation→portal Coupling (BubbleBounds JavaFX Pull-In)
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+`simulation` — the distributed, headless-by-design simulation module — has a hard compile dependency on `portal`, the JavaFX 3D visualization module. The coupling is concrete: `BubbleBounds` (`simulation/src/main/java/.../bubble/BubbleBounds.java:7`) imports `com.hellblazer.luciferase.portal.Tetrahedral` and constructs it (`:49,65,130,201`) to do RDGCS coordinate transforms (`Tetrahedral.toRDG()` / `toCartesian()`).
+
+`portal` depends on JavaFX 25 (and LWJGL). So every distributed-simulation deployment — including headless cluster nodes that never render anything — drags the entire JavaFX toolkit onto the classpath transitively through `BubbleBounds`, a core domain type used throughout the simulation. This is an architecture-layer inversion: a UI/visualization module is a dependency of the distributed compute core.
+
+The geometry `BubbleBounds` actually needs (RD grid coordinate math) is pure math with no UI. It does not belong in the JavaFX module.
+
+## Context
+
+### Background
+
+Flagged in the 360-review architecture pass (T2 `luciferase/360-review-2026-05-23-summary`; architecture finding `a1542d17`): "simulation→portal coupling (BubbleBounds imports portal.Tetrahedral which is a JavaFX UI subclass — pulls JavaFX onto distributed simulation classpath)." RDR-003 documented that the RD coordinate math (`Tetrahedral`, `RDG`, `RDGCS`) currently lives in `portal` and is mathematically correct but visualization-coupled.
+
+This RDR overlaps the Clock-package-rename concern (`Luciferase-7n1`): both are about putting domain primitives in the right module rather than where they accreted.
+
+### Technical Environment
+
+- **Modules**: `simulation` (consumer), `portal` (current home of the RD math + JavaFX), `common`/`lucien` (candidate new homes for the extracted geometry), possibly a new `geometry`-style module
+- **Key files**:
+  - `simulation/src/main/java/.../bubble/BubbleBounds.java:7,36,49,65,130,199-201` — the coupling: `import portal.Tetrahedral`, `transient Tetrahedral coordSystem`, repeated `new Tetrahedral()`
+  - `portal/src/main/java/.../Tetrahedral.java` — RDGCS transforms; per RDR-003 the math is verified-correct, UI-independent in substance but packaged in the JavaFX module
+  - `portal/src/main/java/.../RDG.java`, `RDGCS.java` — companion RD coordinate-system classes
+  - `pom.xml` module graph — `simulation` → `portal` → JavaFX 25
+- **Prior art / constraints**: RDR-003 (FCC/RD spatial indexing) depends on this RD math and would benefit from it living in a non-UI module. `portal-rdfcc-quality` beads catalog dormant bugs + zero coverage in the RD classes — extraction is a chance to add tests.
+
+## Approach
+
+> To be completed in `/nx:rdr-research` + design. Initial candidate directions:
+
+1. **Isolate the UI-free geometry** — determine the exact subset of `Tetrahedral`/`RDG`/`RDGCS` that is pure RD coordinate math (no `javafx.*` references) vs. what is genuinely visualization (mesh/scene-graph helpers).
+2. **Pick the new home** — `common` (already a leaf-ish dependency), `lucien` (spatial-index module, natural for spatial math), or a new small `geometry`/`rd-geom` module. Must NOT depend on JavaFX.
+3. **Extract + re-point** — move the UI-free RD math to the chosen module; `BubbleBounds` and any other non-UI consumers depend on that; `portal` keeps (or re-depends on) the math for its rendering and adds only the JavaFX-specific layer.
+4. **Verify JavaFX drops off the headless classpath** — `mvn dependency:tree -pl simulation` must show no `javafx-*` after the change.
+5. **Add coverage** for the extracted RD math (currently zero per `portal-rdfcc-quality`).
+6. Consider folding the Clock package rename (`Luciferase-7n1`) into the same "domain primitives in the right module" pass.
+
+## Open Questions
+
+- Is `Tetrahedral` cleanly separable, or is the RD math entangled with JavaFX `Point3D`/`Transform` types that would need swapping to `vecmath`?
+- New dedicated module vs. landing in `common`/`lucien` — what does the dependency graph prefer?
+- Does `portal` then depend on the new module (re-import the math) or keep its own copy for rendering?
+- Scope: bundle `Luciferase-7n1` (Clock rename) here, or keep separate?
+
+## Decision
+
+_Pending research + gate._
+
+## Consequences
+
+_Pending._

--- a/docs/rdr/RDR-007-extract-lucien-distributed-module.md
+++ b/docs/rdr/RDR-007-extract-lucien-distributed-module.md
@@ -1,0 +1,70 @@
+---
+title: "Extract a lucien-distributed Module (gRPC Clients out of lucien)"
+id: RDR-007
+type: Architecture
+status: draft
+priority: medium
+author: hal.hildebrand
+reviewed-by: pending
+created: 2026-05-24
+related_issues: [Luciferase-8cv, RDR-005]
+---
+
+# RDR-007: Extract a lucien-distributed Module (gRPC Clients out of lucien)
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+`lucien` is meant to be the core, non-distributed spatial-index library (Octree/Tetree/Prism/SFC). But it currently owns gRPC service clients and servers for distributed coordination:
+
+- `lucien/src/main/java/.../forest/ghost/grpc/` — ghost-layer exchange over gRPC
+- `lucien/src/main/java/.../balancing/grpc/` — balance-coordination over gRPC
+
+This means the core spatial-index library compile-depends on gRPC/protobuf/netty and carries distributed-systems concerns (network channels, `usePlaintext`, RPC lifecycle) that have nothing to do with being a spatial index. A consumer who just wants an in-memory Octree pulls the entire gRPC stack. It also blurs the layering: distributed ghost/balancing logic should sit *above* the spatial-index core, not inside it.
+
+The fix is a module split: a new `lucien-distributed` (or `lucien-grpc`) module that depends on `lucien` and the `grpc` proto module, holding the gRPC clients/servers, leaving `lucien` itself free of network/RPC dependencies.
+
+## Context
+
+### Background
+
+360-review architecture finding (`a1542d17`, T2 `luciferase/360-review-2026-05-23-summary`): "lucien owns gRPC service clients (ghost+balancing) that should live in lucien-distributed." This is a clean-layering refactor, not a behavior change.
+
+It is sequenced with RDR-005 (gRPC TLS+auth): the auth wiring touches exactly these gRPC clients, so the auth model should land in a way that survives (or coincides with) the module move — ideally decide the split first, or land auth in `lucien` and move it as a unit.
+
+### Technical Environment
+
+- **Module**: `lucien` (source), new `lucien-distributed` (target), `grpc` (proto dependency), and downstream consumers (`simulation`, forest tests)
+- **Key packages to relocate**:
+  - `lucien/.../forest/ghost/grpc/` — `GhostServiceClient`, ghost service impl, channel mgmt
+  - `lucien/.../balancing/grpc/` — `BalanceCoordinatorClient`, balance service impl
+- **What stays in lucien**: the non-distributed ghost layer abstractions (`GhostLayer`, `GhostType`, ghost geometry) and balancing strategy interfaces — only the gRPC transport leaves.
+- **Dependency direction after split**: `lucien-distributed` → `lucien` + `grpc`; `lucien` loses its gRPC/netty deps.
+- **Related**: RDR-005 (auth on these exact clients); the forest ghost tests (`GhostIntegrationTest`, `GhostCommunicationIntegrationTest`) and Phase4* balancing tests will move or gain a test dependency on the new module.
+
+## Approach
+
+> To be completed in `/nx:rdr-research` + design. Initial candidate directions:
+
+1. **Draw the seam** — precisely classify each class in `forest/ghost/grpc` and `balancing/grpc` as "transport/RPC" (moves) vs "abstraction" (stays). Identify any back-references from core lucien into the grpc packages (those are the layering violations to sever).
+2. **Define `lucien-distributed`** — new Maven module, `lucien-distributed` → `lucien` + `grpc`; strip gRPC/netty/protobuf from `lucien`'s own deps once the move is complete.
+3. **Relocate + re-point** — move the gRPC packages, update `simulation` and any forest consumers to depend on `lucien-distributed`, migrate the relevant tests.
+4. **Sequence with RDR-005** — decide whether auth lands before the move (in lucien, moved as a unit) or after (in the new module). Avoid doing the auth wiring twice.
+5. **Verify** — `mvn dependency:tree -pl lucien` shows no grpc/netty after the split; full build + ghost/balancing integration tests green.
+
+## Open Questions
+
+- Are there compile-time back-references from `lucien` core into the `*/grpc/` packages that must be inverted first?
+- Module name: `lucien-distributed` vs `lucien-grpc` vs `lucien-ghost-transport`?
+- Do `simulation`'s distributed paths consume these directly, or only via forest APIs (affects how many poms change)?
+- RDR-005 ordering: auth-then-move, or move-then-auth?
+
+## Decision
+
+_Pending research + gate._
+
+## Consequences
+
+_Pending._

--- a/docs/rdr/RDR-008-decompose-abstractspatialindex.md
+++ b/docs/rdr/RDR-008-decompose-abstractspatialindex.md
@@ -1,0 +1,75 @@
+---
+title: "Decompose the AbstractSpatialIndex God-Class"
+id: RDR-008
+type: Architecture
+status: draft
+priority: medium
+author: hal.hildebrand
+reviewed-by: pending
+created: 2026-05-24
+related_issues: [Luciferase-x5i, RDR-002, RDR-003]
+---
+
+# RDR-008: Decompose the AbstractSpatialIndex God-Class
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+`AbstractSpatialIndex` (`lucien/src/main/java/.../AbstractSpatialIndex.java`) is **5,767 lines with 135 public methods**. It is the shared generic base for Octree, Tetree, Prism, and SFCArrayIndex, and it has accreted essentially every cross-cutting spatial-index concern into one type: entity lifecycle, k-NN search (SFC-pruning + expanding-radius variants), range queries, ray intersection, frustum/plane culling, collision detection, stream/leaf/level accessors, the KNN cache integration, locking strategy, bulk operations, neighbor traversal, and tree balancing hooks.
+
+A 5.7k-LOC / 135-method base class is hard to reason about, hard to test in isolation, and a magnet for the kind of latent bugs Tranches A–C fixed (lazy-stream-under-lock, kNN TOCTOU, containment-vs-intersection — all lived here or in close collaborators). Any change risks wide blast radius because everything is one class.
+
+The goal is to decompose it into cohesive collaborators **without breaking the generic `SpatialIndex<Key, ID, Content>` API contract** or the four existing subclasses (Octree/Tetree/Prism/SFCArrayIndex), which rely on its protected template methods.
+
+## Context
+
+### Background
+
+360-review architecture finding (`a1542d17`, T2 `luciferase/360-review-2026-05-23-summary`): "AbstractSpatialIndex is 5,750 LOC / 135 public methods (god class)." This is the largest single-file architectural debt in the codebase. It is explicitly RDR-scope and a likely multi-PR arc — not a single refactor commit.
+
+Tranches A–C touched this file repeatedly (stream materialization under lock, KNNCache lock collapse, kNN pruning, containment predicate) — evidence that its size concentrates risk. RDR-002 (12-DOP containment) and RDR-003 (FCC/RD indexing) both interact with its query surface, so the decomposition must preserve the seams those rely on.
+
+### Technical Environment
+
+- **Module**: `lucien`
+- **Key file**: `lucien/src/main/java/.../AbstractSpatialIndex.java` (5,767 LOC, 135 public methods)
+- **Subclasses bound to its protected template methods** (must not break):
+  - `octree/Octree.java`, `tetree/Tetree.java`, `prism/Prism.java`, `sfc/SFCArrayIndex.java`
+  - Each overrides `calculateSpatialIndex`, `isNodeContainedInVolume`, `shouldContinueKNNSearch`, `getNodeBounds`, `doesNodeIntersectVolume`, etc.
+- **Identifiable cohesive clusters** (candidate extraction boundaries):
+  - Entity lifecycle (insert/remove/update/move) + `EntityManager` collaboration
+  - k-NN search (SFC range-pruning + expanding-radius fallback + `KNNCache`)
+  - Region/range queries (`entitiesInRegion`, `spatialRangeQuery`, `getSpatialIndexRange`)
+  - Ray intersection / frustum / plane culling
+  - Collision detection entry points
+  - Stream accessors (`leafStream`/`levelStream`/`nodeStream`) + locking
+  - Tree balancing hooks
+- **Storage/concurrency**: single `ConcurrentSkipListMap`, `ReadWriteLock`, `spatialVersion` AtomicLong, `KNNCache` (per CLAUDE.md "Concurrent Architecture").
+
+## Approach
+
+> To be completed in `/nx:rdr-research` + design. This is expected to be a phased, multi-PR decomposition. Initial candidate directions:
+
+1. **Map the method surface** — bucket all 135 public + the protected template methods into the cohesive clusters above; identify shared state each cluster touches (spatialIndex map, lock, spatialVersion, entityManager, knnCache).
+2. **Pick a decomposition style** — Strategy/delegate objects (e.g. `KnnSearcher`, `RangeQueryEngine`, `RayIntersector`, `CollisionEngine`) holding references to the shared storage + lock, vs. mixin-style interfaces with default methods, vs. composition with a small `SpatialIndexCore` holding state and feature objects delegating to it. Must keep the public `SpatialIndex` contract and the subclass template-method hooks intact.
+3. **Preserve the subclass seam** — Octree/Tetree/Prism/SFCArrayIndex override protected hooks; the decomposition must route those hooks to the right collaborator without forcing subclass rewrites (or with a clearly-scoped, mechanical subclass update).
+4. **Phase it** — extract one cluster at a time behind green tests (e.g. k-NN first, since it is self-contained and was a recent bug site), each phase its own PR. Define the phase boundaries + the `/nx:phase-review-gate` checkpoints up front.
+5. **No behavior change** — this is a structural refactor; the full lucien suite (2400+ tests) must stay green at every phase. Performance parity verified via `-Pperformance` benchmarks.
+
+## Open Questions
+
+- Delegation/Strategy vs. interface-with-defaults vs. core+feature-objects — which best preserves the generic contract and minimizes subclass churn?
+- Can collaborators share the lock/version/map by reference safely, or does extraction force a concurrency rethink (the TOCTOU/lock work in Tranches B–C is relevant)?
+- Phase ordering: k-NN first (self-contained, recent bug site) or entity-lifecycle first (most foundational)?
+- How many phases / PRs, and what are the `/nx:phase-review-gate` boundaries?
+- Does RDR-003's future FCC query surface impose constraints on where the query seams should fall?
+
+## Decision
+
+_Pending research + gate._
+
+## Consequences
+
+_Pending._


### PR DESCRIPTION
## Summary

Scaffolds the five RDRs deferred from the 360-review remediation (PR #88), by the book — following the project RDR lifecycle (create → research → gate → accept → implement → close). Each is `status: draft` with a substantive problem statement, technical-environment context (file:line pointers), and an approach skeleton + open questions to drive the research phase. Registered in T2 `luciferase_rdr/RDR-00N` and linked to tracking beads.

| RDR | Type | Pri | Topic | Bead |
|-----|------|-----|-------|------|
| 004 | Security | high | Harden VoN SocketServer/Client unfiltered network deserialization | `Luciferase-irh` |
| 005 | Security | high | gRPC TLS + auth model (all `.usePlaintext()` today) | `Luciferase-va5` |
| 006 | Architecture | med | Break simulation→portal coupling (BubbleBounds → JavaFX) | `Luciferase-jvs` |
| 007 | Architecture | med | Extract lucien-distributed module (gRPC out of core) | `Luciferase-8cv` |
| 008 | Architecture | med | Decompose AbstractSpatialIndex (5,767 LOC / 135 methods) | `Luciferase-x5i` |

## Sequencing captured in the docs
- RDR-004 + 005 share the "what is the trust boundary / peer identity" question.
- RDR-005 + 007 both touch the ghost/balancing gRPC clients — auth should land in a way that survives the module move.
- RDR-006 unblocks relocating RDR-003's RD coordinate math out of the JavaFX module.
- RDR-008 is an explicitly phased, multi-PR arc with `/nx:phase-review-gate` boundaries.

## Status
These are **scaffolds** (the `create` step). Decision/Consequences sections are deliberately stubbed — they get filled in `/nx:rdr-research` → `/nx:rdr-gate` → `/nx:rdr-accept`. Docs-only change; no code, no CI risk beyond the documentation-checks workflow.