### PR TITLE
docs(rdr): research findings for RDR-004 + RDR-005 (security pair)

### DIFF
--- a/docs/rdr/RDR-004-von-socketserver-deserialization-hardening.md
+++ b/docs/rdr/RDR-004-von-socketserver-deserialization-hardening.md
@@ -46,7 +46,7 @@ The 360-review pass (2026-05-23, T2 `luciferase/360-review-2026-05-23-summary`) 
 
 ## Approach
 
-> To be completed in `/nx:rdr-research` + design. Initial candidate directions:
+> Candidate directions below; resolved by research (see [Research Findings](#research-findings)) into the layered recommendation that follows.
 
 1. **Threat-model the VoN socket** — determine the actual trust boundary: loopback-only dev, cluster-internal (mutually authenticated peers via Fireflies view), or untrusted. The answer gates how much hardening is warranted.
 2. **Option A — ObjectInputFilter allow-list** (minimum): restrict to `TransportVonMessage` + the JDK/vecmath types it transitively carries, mirroring the D-1 file-site pattern. Cheap, reversible, but Java serialization remains the format.
@@ -54,11 +54,29 @@ The 360-review pass (2026-05-23, T2 `luciferase/360-review-2026-05-23-summary`) 
 4. **Option C — bind/peer-identity constraint**: combine a filter with a loopback or Fireflies-view-authenticated bind so only known peers can connect (overlaps RDR-005's auth model).
 5. Decide single direction; sequence against RDR-005 (shared auth/transport concerns).
 
+### Recommended direction (pending gate)
+
+Research showed the three options are not mutually exclusive — they are **layers on different time horizons**:
+
+- **Now — Direction A, unconditionally (defense-in-depth).** Add an `ObjectInputFilter` allow-list at the inbound site (`SocketServer.java:134`) and the response site (`SocketClient.java:107-109`), reusing the D-1 pattern verbatim. Independently, harden the bind guard: replace the string-equality loopback check (`SocketConnectionManager.java:95-99`) with `InetAddress.isLoopbackAddress()`, and enforce it inside `SocketServer` itself (the only current guard lives in the manager and is bypassable by direct instantiation). Cheap, reversible, lands this RDR.
+- **Reject Direction C as the primary fix.** The Fireflies view exposes no per-peer cryptographic identity wired into the transport (only a view-epoch `Digest`); a bespoke socket→member authorization gate is high-cost net-new integration and duplicates RDR-005's auth model. The peer-identity/auth question belongs to **RDR-005**, not a one-off gate here.
+- **Direction B is the structural endgame, sequenced with RDR-005, and a hard gate on "Inc 7+".** `TransportVonMessage` is a flat struct that maps trivially to protobuf, the `grpc` module already covers the overlapping ghost types, and transport latency is dominated by the 300 ms Fireflies view-stability ACK (protobuf overhead is irrelevant). Replacing Java serialization eliminates the gadget surface rather than filtering it. **Critical constraint:** B (or at minimum the Direction-A filter, retained) MUST land before the planned "Inc 7+" work removes the loopback restriction — that is the moment the latent vuln becomes network-reachable.
+
+## Research Findings
+
+> Code investigation 2026-05-25 (`codebase-deep-analyzer`). Full detail in T2 `luciferase_rdr/004-research-1`.
+
+1. **Trust boundary — loopback-only today, but weakly and temporarily.** Bind is `new ServerSocket(port, 50, addr)` at `SocketServer.java:97-98`; loopback is enforced only in `SocketConnectionManager.java:95-99` via **string equality** (`=="127.0.0.1"/"::1"/"localhost"`, `:185-186`) — not `InetAddress.isLoopbackAddress()`, so `127.0.0.2` or an off-loopback DNS name passes. `SocketServer` has no bind guard of its own. `ProcessAddress.java:27-29`: "In Inc 6, only localhost supported. In Inc 7+, remote hosts will be allowed." → the RCE surface is **latent now, network-reachable once Inc 7+ ships.**
+2. **Fireflies gives no usable peer identity.** `FirefliesMembershipView.getCurrentViewId()` (`:83-85`) returns a view-epoch `Digest` (proves a view exists, not who is connecting). The `accept()` loop (`SocketServer.java:107-109`) has no auth gate. Delos `Member` carries a certificate (Delos uses mTLS internally) but nothing maps an inbound socket to a `Member`. Direction C requires net-new integration.
+3. **D-1 filter pattern is directly reusable.** Four sites from PR #88: `render` `ESVODeserializer.java:81-84`, `ESVTDeserializer.java:282-285`, `SparseVoxelIOUtils.java:208-211` (parameterized), `portal` `CollisionEventRecorder.java:285-291`. Shape: `createFilter("<FQTYPE>;java.util.*;java.lang.*;java.time.*;java.math.*;javax.vecmath.*;!*")`. For VoN, allow `TransportVonMessage` + `TransportGhostData` + `TransportNeighborInfo` + `javax.vecmath.*` + JDK + `!*`.
+4. **protobuf migration is feasible.** `TransportVonMessage.java:48-63` is flat (String ids, decomposed `float posX/Y/Z`, `long timestamp`, `Long bucket`, `List<TransportGhostData>`, `List<TransportNeighborInfo>`) — no `Object` fields, no polymorphism. `grpc/.../lucien/ghost.proto` already defines `Point3f`/`EntityBounds`/`SpatialKey`/`GhostElement`/`GhostBatch`, overlapping the GhostSync payload. Latency floor is the 300 ms Fireflies ACK (`SocketTransport.java:198-199`); protobuf cost is sub-µs.
+5. **Bind constraint = the same loopback finding.** Confirms the separate MEDIUM `network-bind` finding: no interface restriction enforced in `SocketServer`, no security TODO present.
+
 ## Open Questions
 
-- Is the VoN socket ever exposed beyond loopback / a trusted cluster subnet in any deployment?
-- Should VoN transport migrate to gRPC entirely (converging with RDR-005), making this moot?
-- Does the Fireflies view already give us a peer-identity primitive we can gate `accept()` on?
+- ~~Is the VoN socket ever exposed beyond loopback / a trusted cluster subnet in any deployment?~~ **Resolved:** Not today (loopback-only, `SocketConnectionManager.java:95-99`), but `ProcessAddress.java:27-29` schedules remote-host exposure for "Inc 7+". The loopback guard is a bypassable string check, not enforced in `SocketServer`.
+- ~~Should VoN transport migrate to gRPC entirely (converging with RDR-005), making this moot?~~ **Resolved (recommended):** Yes, as the structural endgame (Direction B) — `TransportVonMessage` is flat and protobuf-mappable, `grpc` already covers the overlapping ghost types, and latency is dominated by the Fireflies ACK. Sequenced with RDR-005, gated on Inc 7+.
+- ~~Does the Fireflies view already give us a peer-identity primitive we can gate `accept()` on?~~ **Resolved:** No — only a view-epoch `Digest`, no per-peer cryptographic identity wired into the transport. A peer-identity gate is net-new work that belongs to RDR-005's auth model.
 
 ## Decision
 

--- a/docs/rdr/RDR-005-grpc-tls-auth-model.md
+++ b/docs/rdr/RDR-005-grpc-tls-auth-model.md
@@ -48,7 +48,7 @@ The project already has a membership/identity substrate: **Fireflies** (Delos) p
 
 ## Approach
 
-> To be completed in `/nx:rdr-research` + design. Initial candidate directions:
+> Candidate directions below; resolved by research (see [Research Findings](#research-findings)) into the recommendation that follows.
 
 1. **Inventory the gRPC surface** — enumerate every server/client builder and RPC, and which run cross-process vs in-process (`InProcessServerBuilder` test usages should stay plaintext).
 2. **Auth model decision** — primary candidates:
@@ -59,12 +59,36 @@ The project already has a membership/identity substrate: **Fireflies** (Delos) p
 4. **In-process / test carve-out** — keep `InProcessServerBuilder` and CI plaintext for tests without weakening production (profile/config gate, not code-branch on an env var).
 5. **Sequencing with RDR-007** — land the auth wiring so the lucien→lucien-distributed module split doesn't have to redo it.
 
+### Recommended direction (pending gate)
+
+**Two-layer model: mTLS using Delos member certificates at the transport layer + a Fireflies-view `ServerInterceptor` for authorization.** Reject the token/bearer option — it requires a net-new issuer and rotation infrastructure for *weaker* peer binding, when the project already ships a certificate-backed identity substrate.
+
+- **Transport layer (mTLS).** Build `TlsServerCredentials` / `TlsChannelCredentials` from the local member's `CertificateWithPrivateKey` (Delos), requiring client certificates. **There is no shared CA**, so trust is *not* CA-pinning: use a permissive member-cert validator at the TLS layer (accept structurally valid member certs) and do the real trust decision at the interceptor.
+- **Authorization layer (`FirefliesAuthInterceptor`).** Extract the peer cert from `Grpc.TRANSPORT_ATTR_SSL_SESSION`, map it to a member id via the existing static bridge `Member.getMemberIdentifier(X509Certificate)` → `Digest`, and reject the call unless that id is in the *current* Fireflies view (`FirefliesMembershipView.getMembers()`). Peer identity = cluster member, exactly the binding the problem statement requires.
+- **Test carve-out (no env-var branch).** Add an optional `ChannelCredentials` / `ServerCredentials` constructor parameter to each client/manager, defaulting to `InsecureChannelCredentials.create()` / `InsecureServerCredentials.create()`. In-process balancing tests are unaffected; only `CommitteeP2PIntegrationTest` (a real Netty test) needs the cred gate.
+- **Placement (RDR-007-proof).** Put the shared `GrpcCredentialFactory` + `FirefliesAuthInterceptor` in the **`common`** module (already transitive to both `lucien` and `simulation`) and land them **before** RDR-007 moves the ghost/balancing clients to `lucien-distributed`, so the auth wiring is carried across once rather than redone.
+- **Convergence with RDR-004.** If VoN transport migrates to gRPC (RDR-004 Direction B), it inherits this exact mTLS + interceptor model — **one peer-identity mechanism across both the VoN data path and the control plane.** Strong reason to pair RDR-004-B and RDR-005.
+
+> **Pre-implementation spike required** before locking the Decision: (a) prove the cert-reachability workaround — thread the `ControlledIdentifierMember` from the `View` construction site to the credential factory, since `View.Node` does not expose it publicly; (b) prove the no-CA TLS validator that accepts any structurally-valid member cert and defers trust to the interceptor. Credential **rotation** is also open (Delos provisions certs on demand with caller-chosen validity and no auto-rotation hook).
+
+## Research Findings
+
+> Code + dependency investigation 2026-05-25 (`codebase-deep-analyzer`, Delos inspected via Serena `search_deps`). Full detail in T2 `luciferase_rdr/005-research-1`.
+
+1. **gRPC surface is entirely cross-process in production.** Servers: `GhostCommunicationManager.java:107` (`ServerBuilder.forPort`), `GrpcBubbleNetworkChannel.java:84` (`NettyServerBuilder.forPort`). Clients (all `.usePlaintext()`): `GhostServiceClient.java:378`, `BalanceCoordinatorClient.java:460`, `GrpcBubbleNetworkChannel.java:348`. `BalanceCoordinatorServer` has no production builder (test-only in-process). All production builders need real credentials.
+2. **Delos cert + private key exist but aren't reachable through `View.Node`'s public API.** `ControlledIdentifierMember.getCertificateWithPrivateKey(Instant, Duration, SignatureAlgorithm)` → `CertificateWithPrivateKey.getX509Certificate()` / `getPrivateKey()`, but `View.Node.wrapped` (the `ControlledIdentifierMember`) is private with no getter. Workaround without a Delos change: retain the `ControlledIdentifierMember` reference at `View` construction and feed it to a credential factory. **No shared CA** — certs are provisioned on demand via KERI/KERL; trust must be "cert DN UID → member id in view," not CA pinning.
+3. **View-based authorization is feasible and the bridge already exists.** `FirefliesMembershipView.getMembers()` (`:62`) yields the member set (`Member.getId()` → `Digest`); the static `Member.getMemberIdentifier(X509Certificate)` extracts a `Digest` from the cert's X500 DN UID. A `ServerInterceptor` ties them together once mTLS supplies a peer cert. Not yet implemented anywhere.
+4. **Test carve-out is clean.** In-process balancing tests (`BalanceCoordinatorIntegrationTest.java:60-68`, `Phase4E2ETest.java:561-565`) need zero change; only `CommitteeP2PIntegrationTest.java:75,93` (real Netty) needs the cred gate. An optional credentials constructor param defaulting to insecure gates production vs test without an env-var code branch.
+5. **RDR-007 split is known.** `GhostServiceClient`, `GhostCommunicationManager`, `BalanceCoordinatorClient`, `BalanceCoordinatorServer` move to `lucien-distributed`; `GrpcBubbleNetworkChannel` and `CommitteeServiceImpl` stay in `simulation`. Shared auth helpers belong in `common` to survive the move.
+
 ## Open Questions
 
-- Can Delos/Fireflies member certificates be used directly as gRPC `TlsChannelCredentials` / `TlsServerCredentials`?
-- Is there a deployment where these services are reachable outside a trusted subnet (raising urgency)?
-- Should the bubble network channel (simulation) and the ghost/balancing channels (lucien) share one credential mechanism, or do they have different trust boundaries?
-- How do tests run without real certs — in-process transport, a dev credential, or a test profile?
+- ~~Can Delos/Fireflies member certificates be used directly as gRPC `TlsChannelCredentials` / `TlsServerCredentials`?~~ **Resolved (with a caveat):** Yes — `ControlledIdentifierMember.getCertificateWithPrivateKey(...)` yields an `X509Certificate` + `PrivateKey`. Caveat: it isn't reachable through `View.Node`'s public API (private `wrapped` field), so the reference must be threaded from the `View` construction site. Spike to confirm.
+- ~~Is there a deployment where these services are reachable outside a trusted subnet (raising urgency)?~~ **Partially resolved:** Not yet found in code, but the control plane is unauthenticated *regardless* of subnet — any process reaching the port can call ghost/balance RPCs. Urgency is intrinsic, not deployment-gated. (Mirrors RDR-004's "Inc 7+" exposure trajectory.)
+- ~~Should the bubble network channel (simulation) and the ghost/balancing channels (lucien) share one credential mechanism, or do they have different trust boundaries?~~ **Resolved:** Share one mechanism — all are cross-process cluster RPCs whose peers are Fireflies members. Shared helpers (`GrpcCredentialFactory` + `FirefliesAuthInterceptor`) live in `common`.
+- ~~How do tests run without real certs — in-process transport, a dev credential, or a test profile?~~ **Resolved:** Optional credentials constructor param defaulting to `Insecure*Credentials.create()`. In-process tests unaffected; only `CommitteeP2PIntegrationTest` (real Netty) needs the gate. No env-var branch.
+
+**New open question from research:** Credential **rotation** — Delos provisions certs on demand with caller-chosen validity and exposes no auto-rotation hook. The rotation strategy (validity window, re-provision trigger, channel rebuild on rotation) must be settled before implementation.
 
 ## Decision
 


### PR DESCRIPTION
## Summary

Records the **research phase** for the two Security/high RDRs scaffolded in #90. Both are now backed by file:line-grounded codebase investigation, a recommended direction (pending gate), and resolved open questions. RDRs remain `status: draft` — gate/accept not yet run.

### RDR-004 — VoN socket deserialization hardening
- **Trust boundary:** loopback-only today, but enforced by a *bypassable string-equality check* in `SocketConnectionManager` (not in `SocketServer`), explicitly scheduled for removal in "Inc 7+" → latent RCE becomes network-reachable on the roadmap.
- **Fireflies:** no per-peer cryptographic identity wired into the transport (only a view-epoch `Digest`).
- **Prior art:** the D-1 `ObjectInputFilter` allow-list (4 sites from #88) is directly reusable.
- **Wire format:** `TransportVonMessage` is flat → trivially protobuf-mappable; latency dominated by the 300 ms Fireflies ACK.
- **Recommendation (layered):** Direction A filter + bind hardening **now** (defense-in-depth); Direction B protobuf endgame **sequenced with RDR-005, gated on Inc 7+**; reject a bespoke peer-identity gate (belongs to RDR-005).

### RDR-005 — gRPC TLS + auth model
- **Surface:** all production builders are cross-process and need credentials.
- **Pivotal finding:** Delos member cert+key exist but are **not reachable through `View.Node`'s public API** (private `ControlledIdentifierMember`); must be threaded from the `View` construction site. **No shared CA** — trust is "cert DN UID resolves to a member in the current view," not CA pinning.
- **Authz bridge already exists:** `Member.getMemberIdentifier(X509Certificate)` + `FirefliesMembershipView.getMembers()`.
- **Recommendation:** mTLS via Delos certs + a `FirefliesAuthInterceptor`; shared helpers in `common` **before** the RDR-007 split; **converges with RDR-004 Direction B** (one peer-identity mechanism across data path + control plane). Pre-implementation spike + credential-rotation strategy flagged as open.

Findings recorded in T2 `luciferase_rdr/004-research-1` and `005-research-1`.

## Test plan
- [ ] Docs-only change; no code or tests affected.
- [ ] `Validate Documentation` check may show pre-existing red (repo-wide broken relative links, tracked in `Luciferase-8gk`); the RDR files themselves contain no markdown links and introduce no new dead links.