### PR TITLE
docs(rdr): research findings for RDR-006/007/008 (architecture trio)

### DIFF
--- a/docs/rdr/RDR-006-break-simulation-portal-coupling.md
+++ b/docs/rdr/RDR-006-break-simulation-portal-coupling.md
@@ -43,7 +43,7 @@ This RDR overlaps the Clock-package-rename concern (`Luciferase-7n1`): both are 
 
 ## Approach
 
-> To be completed in `/nx:rdr-research` + design. Initial candidate directions:
+> Candidate directions below; resolved by research (see [Research Findings](#research-findings)) into the recommendation that follows.
 
 1. **Isolate the UI-free geometry** — determine the exact subset of `Tetrahedral`/`RDG`/`RDGCS` that is pure RD coordinate math (no `javafx.*` references) vs. what is genuinely visualization (mesh/scene-graph helpers).
 2. **Pick the new home** — `common` (already a leaf-ish dependency), `lucien` (spatial-index module, natural for spatial math), or a new small `geometry`/`rd-geom` module. Must NOT depend on JavaFX.
@@ -52,12 +52,36 @@ This RDR overlaps the Clock-package-rename concern (`Luciferase-7n1`): both are 
 5. **Add coverage** for the extracted RD math (currently zero per `portal-rdfcc-quality`).
 6. Consider folding the Clock package rename (`Luciferase-7n1`) into the same "domain primitives in the right module" pass.
 
+### Recommended direction (pending gate)
+
+Extract the **UI-free RD math kernel** — `toRDG` plus the `vecmath`-only methods (`euclideanNorm`, `l1`, `cross`, `dot`, `rotateVectorCC`, the connected-neighbor helpers) — into a non-JavaFX home, leaving the scene-graph/mesh layer (`construct`, `positionTransform`, the `Point3D`-typed `toCartesian` overloads) in `portal`.
+
+- **`common` is disqualified.** Research found `common` *already declares* `javafx-graphics`, so landing the math there does not remove JavaFX from the headless classpath — it would defeat the purpose. (This is a separate smell: `common` is not the clean leaf the module name implies — a follow-up worth filing.)
+- **Home — `lucien` vs a new `geometry`/`rd-geom` module (the real tradeoff).** `lucien` is the minimal-change option (no new module; `simulation` already depends on it; `portal` already depends on it; RDR-003's FCC work wants this math reachable from `lucien` anyway). The counter-pull: **RDR-008 is actively trying to *shrink* `lucien`**, so growing it with RD math is in tension. A small `vecmath`-only `geometry` module that both `lucien` and `portal` depend on is the purer single-responsibility answer at the cost of one new module. **Decision deferred to the gate**; both are viable and neither creates a dependency cycle (`portal → lucien → common` already holds).
+- **API ripple.** The two `toCartesian` overloads return `javafx.geometry.Point3D`. The kernel's version must return `Point3f`/`Tuple3f`; this propagates to `BubbleBounds.toCartesian` and `BubbleBounds.centroid` (both currently `Point3D`). `portal` keeps a JavaFX-typed rendering layer (subclass or thin wrapper) over the extracted math.
+- **Consumers are minimal.** `BubbleBounds` is the *only* non-portal compile consumer; `RDGridViewer` (portal) is the only other. So the blast radius is two files plus the extraction.
+- **Coverage.** Three RD-math tests already exist in `portal` (`RDFCCMathCoverageTest`, `PortalCleanupBatchTest`, `RDGeometrySmokeTest`) — the RDR's "zero coverage" was inaccurate for `portal`. Port these to the new home with the extraction.
+- **Fold in the Clock rename** (`Luciferase-7n1`) as a second "domain primitive in the right module" move in the same pass.
+- **Verify** `mvn dependency:tree -pl simulation` shows no `javafx-*` afterward.
+
+## Research Findings
+
+> Investigation 2026-05-25 (`codebase-deep-analyzer`). Full detail in T2 `luciferase_rdr/006-research-1`.
+
+1. **The JavaFX pull-in is structural via inheritance.** `Tetrahedral` (`:38`) `extends RDGCS extends Grid`, and `Grid.java:1-18` imports `javafx.scene.*` / `javafx.geometry.Point3D` heavily. `Tetrahedral` itself imports `javafx.geometry.Point3D` (`:17`) but only in its two `toCartesian` overloads (`:157`, `:163`); the rest (`toRDG:181` + the vecmath methods) is JavaFX-free.
+2. **`BubbleBounds` is the sole non-portal consumer.** Imports `portal.Tetrahedral` (`:7`) and `javafx.geometry.Point3D` (`:8`); constructs `Tetrahedral` at `:49,65,130,201`, calls `toRDG` (`:68,134,213`) and `toCartesian` (`:223`). The only other reference anywhere is `RDGridViewer` (portal). No consumers in `lucien`/`common`/`grpc`/`sentry`/`render`/`dyada-java`.
+3. **`common` carries JavaFX.** `common/pom.xml:19` declares `javafx-graphics`; `lucien` has no direct JavaFX. The dependency chain `portal → lucien → common` already exists, so placing the math in `lucien` (or a new vecmath-only module) removes JavaFX from the headless path with no cycle; placing it in `common` does not.
+4. **Portal needs no new dependency** post-extraction (already depends on `lucien`/`common`); it retains a `Point3D`-typed rendering layer. RD-math test coverage already exists in `portal` (3 files).
+5. **Clock mismatch confirmed.** `common/.../simulation/distributed/integration/Clock.java:18` is physically in `common` but package-named for `simulation`; its own javadoc (`:26`) says the placement is deliberate (avoids a `lucien`↔`simulation` cycle) — only the package label is wrong. Foldable into this pass.
+
 ## Open Questions
 
-- Is `Tetrahedral` cleanly separable, or is the RD math entangled with JavaFX `Point3D`/`Transform` types that would need swapping to `vecmath`?
-- New dedicated module vs. landing in `common`/`lucien` — what does the dependency graph prefer?
-- Does `portal` then depend on the new module (re-import the math) or keep its own copy for rendering?
-- Scope: bundle `Luciferase-7n1` (Clock rename) here, or keep separate?
+- ~~Is `Tetrahedral` cleanly separable, or is the RD math entangled with JavaFX `Point3D`/`Transform` types that would need swapping to `vecmath`?~~ **Resolved:** Mostly separable — `toRDG` + the vecmath methods are JavaFX-free; only the two `toCartesian(...)→Point3D` overloads are entangled and need a return-type swap to `Point3f`. The inheritance chain (`Tetrahedral→RDGCS→Grid`) is what drags JavaFX, so the kernel must be lifted *out* of that hierarchy.
+- ~~New dedicated module vs. landing in `common`/`lucien` — what does the dependency graph prefer?~~ **Resolved (narrowed):** `common` is out (it already pulls `javafx-graphics`). Choice is `lucien` (minimal change) vs a new vecmath-only `geometry` module (purer, but `lucien` is being shrunk by RDR-008). Final pick deferred to gate.
+- ~~Does `portal` then depend on the new module (re-import the math) or keep its own copy for rendering?~~ **Resolved:** `portal` re-depends (it already depends on `lucien`/`common`) and keeps a thin `Point3D`-typed rendering layer over the extracted kernel.
+- ~~Scope: bundle `Luciferase-7n1` (Clock rename) here, or keep separate?~~ **Resolved (recommended):** Bundle — same "domain primitive in the right module" pass.
+
+**New follow-up from research:** `common` declaring `javafx-graphics` undermines it as a leaf module — worth a separate cleanup item.
 
 ## Decision
 

--- a/docs/rdr/RDR-007-extract-lucien-distributed-module.md
+++ b/docs/rdr/RDR-007-extract-lucien-distributed-module.md
@@ -46,7 +46,7 @@ It is sequenced with RDR-005 (gRPC TLS+auth): the auth wiring touches exactly th
 
 ## Approach
 
-> To be completed in `/nx:rdr-research` + design. Initial candidate directions:
+> Candidate directions below; resolved by research (see [Research Findings](#research-findings)) into the phased recommendation that follows.
 
 1. **Draw the seam** — precisely classify each class in `forest/ghost/grpc` and `balancing/grpc` as "transport/RPC" (moves) vs "abstraction" (stays). Identify any back-references from core lucien into the grpc packages (those are the layering violations to sever).
 2. **Define `lucien-distributed`** — new Maven module, `lucien-distributed` → `lucien` + `grpc`; strip gRPC/netty/protobuf from `lucien`'s own deps once the move is complete.
@@ -54,12 +54,32 @@ It is sequenced with RDR-005 (gRPC TLS+auth): the auth wiring touches exactly th
 4. **Sequence with RDR-005** — decide whether auth lands before the move (in lucien, moved as a unit) or after (in the new module). Avoid doing the auth wiring twice.
 5. **Verify** — `mvn dependency:tree -pl lucien` shows no grpc/netty after the split; full build + ghost/balancing integration tests green.
 
+### Recommended direction (pending gate)
+
+**This is not a clean leaf-move — research found 8+ compile-time back-references from `lucien` core *into* the gRPC packages, so a dependency-inversion phase must precede the physical move.** Phased:
+
+- **Phase 0 — dependency inversion (the hard part).** Introduce `lucien`-resident interfaces for the gRPC collaborators that core `lucien` references (`GhostCommunicationManager`, `GhostServiceClient.ServiceDiscovery`, `GrpcGhostChannel`, `BalanceCoordinatorClient`), and **replace the protobuf message types at the balancing boundary** (`RefinementRequest`/`RefinementResponse`/`BalanceViolation` used directly by `CrossPartitionBalancePhase` and `DistributedViolationAggregator`) with domain objects — that proto-type leak is what forces `lucien` to keep the `grpc` compile dependency. Sever the `AbstractSpatialIndex` references at `:5183` / `:5195-5196` / `:5214`. **This same extraction is RDR-008 Phase 2 (the distributed-ghost cluster) — do it once, coordinated.**
+- **Phase 1 — create `lucien-distributed`** (`lucien` + `grpc` + `grpc-netty-shaded`); move the 9 transport classes from `forest/ghost/grpc` + `balancing/grpc`, plus the `GrpcGhostChannel` impl.
+- **Phase 2 — re-point + strip.** Update consumers (all in `lucien/src/test` — **`simulation`'s production code does not consume these**, so its pom is unchanged), migrate/test-scope the ghost & balancing integration tests, and remove `grpc`/`netty` from `lucien`'s deps. Verify `mvn dependency:tree -pl lucien` shows no grpc/netty.
+- **Module name:** `lucien-distributed` (matches the 360-review finding) over the narrower `lucien-grpc`.
+- **RDR-005 sequencing:** the shared auth helpers (`GrpcCredentialFactory`, `FirefliesAuthInterceptor`) have no `lucien` dependency → land them in `common` independently, any time. Do the **module move (this RDR) before wiring per-client credentials (RDR-005)** so the `.usePlaintext()`→credentials change lands once, in the permanent home.
+
+## Research Findings
+
+> Investigation 2026-05-25 (`codebase-deep-analyzer`, building on `005-research-1`). Full detail in T2 `luciferase_rdr/007-research-1`.
+
+1. **The seam is clean at the package level: 9 grpc-subpackage classes move.** `forest/ghost/grpc/` (7: `GhostCommunicationManager`, `GhostExchangeServiceImpl`, `GhostServiceClient`, `MortonKeySerde`, `TetreeKeySerde`, `ProtobufConverters`, `SimpleServiceDiscovery`) and `balancing/grpc/` (2: `BalanceCoordinatorClient`, `BalanceCoordinatorServer`). Abstractions (`GhostLayer`, `GhostType`, `GhostElement`, etc.) sit in parent packages with zero grpc imports — they stay. `GrpcGhostChannel` (in `forest/ghost/`, not the subpackage) is borderline and moves with the bundle.
+2. **But there are 8+ back-references from `lucien` core into the grpc packages (the real blocker).** Most notably `AbstractSpatialIndex` itself: `:5183` `setupDistributedGhosts(GhostCommunicationManager,…)`, `:5195-5196` `new GrpcGhostChannel<>(…)`, `:5214` `initializeDistributedGhosts(GhostServiceClient.ServiceDiscovery)`. Also `GhostBoundaryDetector`, `ElementGhostManager`, `DistributedGhostManager`, and balancing-parent classes (`RefinementCoordinator`, `CrossPartitionBalancePhase`, `DistributedViolationAggregator`, `DefaultParallelBalancer`). `CrossPartitionBalancePhase` is the worst — it imports the client *and* `ProtobufConverters` *and* proto message types directly.
+3. **`simulation` does not consume these in production** (only `GhostZoneManager`, a stay-class, via tests). Every grpc consumer is in `lucien/src/test`. So only `lucien/pom.xml`, the new `lucien-distributed/pom.xml`, and root `pom.xml` change — **`simulation/pom.xml` is untouched.**
+4. **`lucien` cannot drop the `grpc` compile dep until the proto-type leak is fixed.** `lucien/pom.xml:36-38` compile-depends on the `grpc` module for proto stubs; `grpc-netty-shaded`/`grpc-testing` are test-scope only. After Phase 0 inverts the proto types at the balancing boundary, `lucien` retains just `common`/`h2-mvstore`/`guava`/`slf4j`; `lucien-distributed` takes `lucien`+`grpc`+`grpc-netty-shaded`.
+5. **Cross-RDR coordination:** Phase 0's `AbstractSpatialIndex` inversion is identical to RDR-008's Phase 2 distributed-ghost extraction. Sequence RDR-007 Phase 0 with / before RDR-008 Phase 2.
+
 ## Open Questions
 
-- Are there compile-time back-references from `lucien` core into the `*/grpc/` packages that must be inverted first?
-- Module name: `lucien-distributed` vs `lucien-grpc` vs `lucien-ghost-transport`?
-- Do `simulation`'s distributed paths consume these directly, or only via forest APIs (affects how many poms change)?
-- RDR-005 ordering: auth-then-move, or move-then-auth?
+- ~~Are there compile-time back-references from `lucien` core into the `*/grpc/` packages that must be inverted first?~~ **Resolved — yes, 8+.** Including `AbstractSpatialIndex` (`:5183/:5195-5196/:5214`), the ghost managers, and the balancing-parent classes. Dependency inversion (Phase 0) is mandatory before any physical move. The proto-type leak in `CrossPartitionBalancePhase`/`DistributedViolationAggregator` is what pins `lucien`'s `grpc` compile dep.
+- ~~Module name: `lucien-distributed` vs `lucien-grpc` vs `lucien-ghost-transport`?~~ **Resolved:** `lucien-distributed` (matches the 360-review finding; broader than just gRPC transport).
+- ~~Do `simulation`'s distributed paths consume these directly, or only via forest APIs (affects how many poms change)?~~ **Resolved:** Not at all in production — every consumer is in `lucien/src/test`. `simulation/pom.xml` is unchanged; only `lucien`, new `lucien-distributed`, and root poms change.
+- ~~RDR-005 ordering: auth-then-move, or move-then-auth?~~ **Resolved:** Move-then-auth. Common auth helpers land in `common` independently; per-client credential wiring (RDR-005) happens after the move, in the permanent home.
 
 ## Decision
 

--- a/docs/rdr/RDR-008-decompose-abstractspatialindex.md
+++ b/docs/rdr/RDR-008-decompose-abstractspatialindex.md
@@ -50,21 +50,48 @@ Tranches A–C touched this file repeatedly (stream materialization under lock, 
 
 ## Approach
 
-> To be completed in `/nx:rdr-research` + design. This is expected to be a phased, multi-PR decomposition. Initial candidate directions:
+> Candidate directions below; resolved by research (see [Research Findings](#research-findings)) into the phased recommendation that follows. This is a phased, multi-PR decomposition.
 
 1. **Map the method surface** — bucket all 135 public + the protected template methods into the cohesive clusters above; identify shared state each cluster touches (spatialIndex map, lock, spatialVersion, entityManager, knnCache).
 2. **Pick a decomposition style** — Strategy/delegate objects (e.g. `KnnSearcher`, `RangeQueryEngine`, `RayIntersector`, `CollisionEngine`) holding references to the shared storage + lock, vs. mixin-style interfaces with default methods, vs. composition with a small `SpatialIndexCore` holding state and feature objects delegating to it. Must keep the public `SpatialIndex` contract and the subclass template-method hooks intact.
 3. **Preserve the subclass seam** — Octree/Tetree/Prism/SFCArrayIndex override protected hooks; the decomposition must route those hooks to the right collaborator without forcing subclass rewrites (or with a clearly-scoped, mechanical subclass update).
-4. **Phase it** — extract one cluster at a time behind green tests (e.g. k-NN first, since it is self-contained and was a recent bug site), each phase its own PR. Define the phase boundaries + the `/nx:phase-review-gate` checkpoints up front.
+4. **Phase it** — extract one cluster at a time behind green tests (e.g. k-NN first, since it is self-contained and was a recent bug site), each phase its own PR. Define the phase boundaries + the `/conexus:phase-review-gate` checkpoints up front.
 5. **No behavior change** — this is a structural refactor; the full lucien suite (2400+ tests) must stay green at every phase. Performance parity verified via `-Pperformance` benchmarks.
+
+### Recommended direction (pending gate)
+
+Adopt **decomposition style (iii): core + feature-objects**, because research showed it minimizes subclass churn — the subclasses keep overriding the same protected hooks and never learn that collaborators exist.
+
+- **Structure.** Extract a `SpatialIndexCore` holding the six-field shared nucleus (`spatialIndex`, `lock`, `spatialVersion`, `knnCache`, `entityManager`, `entityCache`). `AbstractSpatialIndex` becomes a thin **façade** that implements a `SpatialGeometry<Key>` callback interface (the ~21 protected template hooks stay on the façade, so Octree/Tetree/Prism/SFCArrayIndex are **unchanged**) and delegates to feature objects, each holding `SpatialIndexCore` + the `SpatialGeometry<Key>` callback: `DsocController`, `GhostCoordinator`, `KnnSearcher`, a frustum/plane/ray culler, `CollisionEngine`, `EntityLifecycleManager`. The public `SpatialIndex<Key,ID,Content>` contract is untouched. Concurrency lives in one auditable place (`SpatialIndexCore`).
+- **Keep region/range queries and stream accessors *in the façade*** — they are tightly bound to the `spatialIndex`+`lock` nucleus and read as core responsibilities, not collaborators.
+- **Phase ordering** (each its own PR, behind a `/conexus:phase-review-gate`, full lucien suite green + `-Pperformance` parity at every step):
+  1. **DSOC (cluster k)** — cleanest first cut: 10+ dedicated private fields, **zero template hooks**, touches only the lock. No cross-RDR dependency.
+  2. **Distributed-ghost (cluster i)** — **dual-purpose: this is also RDR-007 Phase 0.** Prerequisite: RDR-007's interface inversion (the `:5183-5214` gRPC FQN types must hide behind an interface before extraction). Sequence RDR-007 first.
+  3. **k-NN + KNNCache (cluster b)** — moderate hooks (`shouldContinueKNNSearch`, `estimateNodeDistance`, `calculateSpatialIndex`); recent bug site (Tranches B–C, RDR-003).
+  4. **Frustum + plane + ray (clusters d+e bundled)** — shared traversal hooks, high internal cohesion.
+  5. **Collision (cluster f)** — self-contained once 1–4 are out.
+  6. **Entity lifecycle (cluster a)** — broadest shared-state footprint (7 fields incl. `knnCache`/`spatialVersion`), most disruptive, deliberately last.
+- **Scope correction:** the file is **~195 methods across 11 clusters**, not 135/7 — the RDR's count undershot, and the **DSOC** and **distributed-ghost** clusters are first-class extraction targets the original list omitted.
+
+## Research Findings
+
+> Investigation 2026-05-25 (`codebase-deep-analyzer`). Full detail in T2 `luciferase_rdr/008-research-1`.
+
+1. **~195 methods, 11 cohesive clusters.** Largest: entity lifecycle (~48), collision (~26), frustum/plane (~22), balancing/subdivision (~22), **distributed-ghost (~22)**, core/config (~20), region/range (~20); plus k-NN (~13), **DSOC (~13)**, stream accessors (~11), ray (~9).
+2. **Two-field nucleus + a coupling pair.** `spatialIndex` (`ConcurrentNavigableMap`, `:99`) and `lock` (`ReentrantReadWriteLock`, `:101`) are touched by every cluster; `spatialVersion` (`:137`) + `knnCache` (`:138`) couple entity-lifecycle to k-NN. Other state is cluster-dedicated (DSOC `:116-119`, ghost `:150-155`, balancing `:103,145-147`). Stream accessors **materialize under the read lock** (`.collect(...).stream()`) — the prior lazy-stream-after-unlock hazard is already fixed.
+3. **~21 protected template hooks; each serves exactly one cluster, no hook-splitting needed.** All four subclasses override the core ~15 (`calculateSpatialIndex`, `shouldContinueKNNSearch`, `getNodeBounds`, `doesNodeIntersectVolume`, `doesRayIntersectNode`, frustum/plane variants, …). This is the seam any decomposition must route.
+4. **Style (iii) wins on subclass churn.** A feature object (`KnnSearcher`) must call subclass-overridden hooks (`shouldContinueKNNSearch` at `:4320`, `calculateSpatialIndex` at `:1428` + 8 sites) — passed as a `SpatialGeometry<Key>` callback. Style (iii) (and the architecturally-equivalent delegate-with-`this` style (i)) keeps subclasses unchanged; mixin-with-defaults (ii) is worst (needs 6+ field accessors on the public interface).
+5. **Cleanest first extraction = DSOC** (dedicated state, zero hooks). **Distributed-ghost is the highest-leverage** because it discharges RDR-007's `AbstractSpatialIndex` blocker simultaneously — but only after RDR-007's interface inversion.
 
 ## Open Questions
 
-- Delegation/Strategy vs. interface-with-defaults vs. core+feature-objects — which best preserves the generic contract and minimizes subclass churn?
-- Can collaborators share the lock/version/map by reference safely, or does extraction force a concurrency rethink (the TOCTOU/lock work in Tranches B–C is relevant)?
-- Phase ordering: k-NN first (self-contained, recent bug site) or entity-lifecycle first (most foundational)?
-- How many phases / PRs, and what are the `/nx:phase-review-gate` boundaries?
-- Does RDR-003's future FCC query surface impose constraints on where the query seams should fall?
+- ~~Delegation/Strategy vs. interface-with-defaults vs. core+feature-objects — which best preserves the generic contract and minimizes subclass churn?~~ **Resolved (recommended):** core+feature-objects (style iii); subclasses stay unchanged because the façade keeps the `SpatialGeometry<Key>` hooks. Mixin-with-defaults rejected (leaks field accessors onto the public interface).
+- ~~Can collaborators share the lock/version/map by reference safely, or does extraction force a concurrency rethink?~~ **Resolved:** Share by reference via `SpatialIndexCore`; the nucleus is two fields (`spatialIndex`+`lock`) plus the `spatialVersion`/`knnCache` coupling. The lazy-stream-under-lock hazard is already fixed (stream accessors materialize inside the lock), so no concurrency rethink is forced — and centralizing the nucleus makes correctness auditable in one place.
+- ~~Phase ordering: k-NN first or entity-lifecycle first?~~ **Resolved:** Neither — **DSOC first** (zero hooks, dedicated state), then distributed-ghost (dual-purpose with RDR-007), then k-NN; entity-lifecycle **last** (broadest shared state).
+- ~~How many phases / PRs, and what are the `/conexus:phase-review-gate` boundaries?~~ **Resolved (proposed):** 6 phases (DSOC → distributed-ghost → k-NN → frustum/plane/ray → collision → entity-lifecycle), a gate at each.
+- ~~Does RDR-003's future FCC query surface impose constraints on where the query seams should fall?~~ **Partially open:** region/range + stream accessors are recommended to stay in the façade (core); whether RDR-003's FCC query work needs a dedicated query collaborator should be revisited when RDR-003 implementation resumes.
+
+**New cross-RDR constraint from research:** Phase 2 (distributed-ghost extraction) is identical to RDR-007's Phase 0 dependency inversion of `AbstractSpatialIndex` (`:5183-5214`). These must be sequenced together (RDR-007 first / jointly) and executed once.
 
 ## Decision
 


### PR DESCRIPTION
## Summary

Records the **research phase** for the three Architecture/medium RDRs scaffolded in #90. Each is now backed by file:line-grounded investigation, a recommended direction (pending gate), and resolved open questions. RDRs remain `status: draft`.

### RDR-006 — break simulation→portal coupling
- `Tetrahedral extends RDGCS extends Grid`; **`Grid` is the JavaFX carrier**. The `toRDG` + vecmath kernel is extractable; only the two `toCartesian(...)→Point3D` overloads are entangled (need a `Point3f` swap that ripples to `BubbleBounds.toCartesian`/`centroid`).
- **`common` is disqualified as the new home** — it already declares `javafx-graphics`. Home is `lucien` (minimal change) vs a new vecmath-only module (tension: RDR-008 is *shrinking* `lucien`).
- `BubbleBounds` is the sole non-portal consumer. Fold in the Clock package rename (`Luciferase-7n1`).

### RDR-007 — extract lucien-distributed
- **Not a clean leaf-move:** 8+ back-references from `lucien` core into the gRPC packages — including `AbstractSpatialIndex` (`:5183`/`:5195-5196`/`:5214`) — require a dependency-inversion phase first. The proto-type leak in `CrossPartitionBalancePhase`/`DistributedViolationAggregator` pins `lucien`'s `grpc` compile dep.
- `simulation` production code does not consume these (its pom is unchanged). Recommend **move-then-auth** ordering vs RDR-005.

### RDR-008 — decompose AbstractSpatialIndex
- **~195 methods / 11 clusters** (the scaffold's 135/7 undershot; DSOC + distributed-ghost clusters were omitted).
- Recommend **core+feature-objects** style (façade keeps the `SpatialGeometry<Key>` hooks → subclasses unchanged). 6-phase order: **DSOC first** (zero hooks) → distributed-ghost → k-NN → frustum/plane/ray → collision → entity-lifecycle last.

### Cross-RDR coordination
**RDR-008 Phase 2 (distributed-ghost extraction) == RDR-007 Phase 0 (`AbstractSpatialIndex` gRPC inversion)** — the same work; sequence together.

Findings in T2 `luciferase_rdr/006-research-1`, `007-research-1`, `008-research-1`.

## Test plan
- [ ] Docs-only; no code or tests affected.
- [ ] `Validate Documentation` may show pre-existing red (repo-wide broken relative links, tracked in `Luciferase-8gk`); these RDR files add no markdown links.