### PR TITLE
Harden VoN socket-transport deserialization + bind (RDR-004 Direction A)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/MessageConverter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/MessageConverter.java
@@ -171,10 +171,12 @@ public class MessageConverter {
     // ==================== JoinResponse Conversion ====================
 
     private static TransportVonMessage joinResponseToTransport(Message.JoinResponse msg) {
-        // Convert neighbor set to transport format
+        // Convert neighbor set to transport format. Collect into a concrete ArrayList: Stream.toList()
+        // returns an ImmutableCollections type that is not on the VoN deserialization allow-list
+        // (RDR-004), so it would be rejected on the receiving side.
         var transportNeighbors = msg.neighbors().stream()
             .map(TransportNeighborInfo::from)
-            .toList();
+            .collect(java.util.stream.Collectors.toCollection(ArrayList::new));
 
         return new TransportVonMessage(
             "JoinResponse",

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/transport/SocketClient.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/transport/SocketClient.java
@@ -105,6 +105,7 @@ public class SocketClient {
      */
     private void receiveMessages() {
         try (var inStream = new ObjectInputStream(socket.getInputStream())) {
+            inStream.setObjectInputFilter(VonTransportFilter.create());  // RDR-004: reject non-wire types
             while (connected) {
                 var message = (TransportVonMessage) inStream.readObject();
                 log.debug("Received message type={} from {}", message.type(), remoteAddress.toUrl());

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/transport/SocketConnectionManager.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/transport/SocketConnectionManager.java
@@ -22,6 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -174,15 +176,22 @@ public class SocketConnectionManager implements ConnectionManager {
     }
 
     /**
-     * Check if a hostname is a loopback address.
+     * Check if a hostname resolves to a loopback address.
      * <p>
-     * Used for Inc 6 scope enforcement. Accepts IPv4 (127.0.0.1),
-     * IPv6 (::1), and DNS name (localhost).
+     * RDR-004: enforces Inc 6 loopback-only scope on the <em>resolved</em> address rather than a
+     * string match, so a name that resolves off-loopback no longer passes. Removing this restriction
+     * for Inc 7+ remote-host support is gated on the VoN deserialization hardening landing first
+     * (bead Luciferase-ah3). An unresolvable host is treated as non-loopback (rejected).
      *
      * @param hostname Hostname to check
-     * @return true if hostname is 127.0.0.1, ::1, or localhost
+     * @return true if {@code hostname} resolves to a loopback address
      */
     private boolean isLoopback(String hostname) {
-        return hostname.equals("127.0.0.1") || hostname.equals("::1") || hostname.equals("localhost");
+        try {
+            return InetAddress.getByName(hostname).isLoopbackAddress();
+        } catch (UnknownHostException e) {
+            log.warn("Cannot resolve host '{}' for loopback check; treating as non-loopback", hostname);
+            return false;
+        }
     }
 }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/transport/SocketServer.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/transport/SocketServer.java
@@ -95,6 +95,15 @@ public class SocketServer {
      */
     public void start() throws IOException {
         var addr = InetAddress.getByName(bindAddress.hostname());
+        // RDR-004: enforce loopback-only binding on the resolved address. SocketServer otherwise
+        // performs zero loopback check, so direct instantiation is ungated. Removing this restriction
+        // (Inc 7+ remote-host support) is gated on the VoN deserialization hardening landing first
+        // (bead Luciferase-ah3) — see ProcessAddress javadoc.
+        if (!addr.isLoopbackAddress()) {
+            throw new IllegalArgumentException(
+                "SocketServer may bind only to a loopback address (Inc 6 scope; Inc 7+ gated on Luciferase-ah3). Got: "
+                + bindAddress.hostname() + " -> " + addr.getHostAddress());
+        }
         this.serverSocket = new ServerSocket(bindAddress.port(), 50, addr);
         this.running = true;
 
@@ -132,6 +141,7 @@ public class SocketServer {
      */
     private void handleClient(Socket clientSocket) {
         try (var stream = new ObjectInputStream(clientSocket.getInputStream())) {
+            stream.setObjectInputFilter(VonTransportFilter.create());  // RDR-004: reject non-wire types
             while (running) {
                 var message = (TransportVonMessage) stream.readObject();
                 log.debug("Received message type={} from {}", message.type(), clientSocket.getRemoteSocketAddress());

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/transport/VonTransportFilter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/transport/VonTransportFilter.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.von.transport;
+
+import java.io.ObjectInputFilter;
+
+/**
+ * Deserialization allow-list for the VoN socket transport (RDR-004, Direction A).
+ * <p>
+ * The VoN transport reads Java-serialized {@code TransportVonMessage} objects directly off a network
+ * socket. Unfiltered {@code ObjectInputStream.readObject()} on untrusted network input is the canonical
+ * Java deserialization RCE vector: a gadget chain executes during deserialization, before the
+ * {@code (TransportVonMessage)} cast is reached. This filter restricts deserialization to the concrete
+ * types actually on the wire and rejects everything else.
+ * <p>
+ * Unlike the file-input allow-lists added in Tranche D-1, this network-path filter deliberately
+ * <em>omits</em> the broad {@code java.util.*} wildcard: that wildcard admits gadget-bearing collections
+ * ({@code PriorityQueue}, {@code TreeMap}, {@code LinkedList}) that appear in published ysoserial chains.
+ * The actual wire payload is records of {@code String}/{@code float}/{@code double}/{@code long}/{@code Long}
+ * plus {@code List} fields whose concrete type is {@code java.util.ArrayList}; there is no
+ * {@code javax.vecmath} or JavaFX type on the wire (the {@code Point3f}/{@code Point3D} in the transport
+ * records are conversion-only, never serialized).
+ *
+ * @author hal.hildebrand
+ */
+final class VonTransportFilter {
+
+    /**
+     * Allow-list pattern for {@link ObjectInputFilter.Config#createFilter(String)}. Concrete wire types
+     * only; the trailing {@code !*} rejects everything not explicitly named.
+     */
+    static final String PATTERN =
+        "com.hellblazer.luciferase.simulation.von.TransportVonMessage;"
+        + "com.hellblazer.luciferase.simulation.von.TransportGhostData;"
+        + "com.hellblazer.luciferase.simulation.von.TransportNeighborInfo;"
+        + "java.util.ArrayList;"
+        + "java.util.Collections$UnmodifiableList;"
+        + "java.util.Arrays$ArrayList;"
+        + "java.lang.*;"
+        + "java.time.*;"
+        + "java.math.*;"
+        + "!*";
+
+    private VonTransportFilter() {
+    }
+
+    /**
+     * @return a fresh {@link ObjectInputFilter} enforcing the VoN wire allow-list
+     */
+    static ObjectInputFilter create() {
+        return ObjectInputFilter.Config.createFilter(PATTERN);
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/transport/VonDeserializationHardeningTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/transport/VonDeserializationHardeningTest.java
@@ -23,6 +23,7 @@ import com.hellblazer.luciferase.simulation.von.TransportGhostData;
 import com.hellblazer.luciferase.simulation.von.TransportNeighborInfo;
 import com.hellblazer.luciferase.simulation.von.TransportVonMessage;
 import javafx.geometry.Point3D;
+import javax.vecmath.Point3f;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -115,30 +116,47 @@ class VonDeserializationHardeningTest {
     }
 
     /**
-     * Exercises the real producer path: {@link MessageConverter#toTransport} serializes a JoinResponse's
-     * neighbor list onto the wire. The prior implementation used {@code Stream.toList()}, which emits an
-     * {@code ImmutableCollections} type that is NOT on the allow-list — so a legitimate JoinResponse with
-     * neighbors would be rejected by the filter. This guards that regression end-to-end (it would fail
-     * against the unfixed converter).
+     * Producer↔filter contract guard. The filter is only correct if every {@link MessageConverter}
+     * producer emits allow-listed concrete types onto the wire. That coupling is implicit: a JoinResponse
+     * regression already occurred when the neighbor list was built with {@code Stream.toList()} (an
+     * {@code ImmutableCollections} type not on the allow-list), which would have silently dropped every
+     * JoinResponse carrying neighbors. This test drives <em>every</em> {@code Message} subtype through the
+     * real {@code toTransport} → serialize → filtered-deserialize path, so the same class of regression on
+     * any message type (e.g. a future collection-typed field) fails CI rather than production traffic.
      */
     @Test
-    void filterAcceptsJoinResponseFromConverter() throws IOException {
-        var neighbors = Set.of(
-            new Message.NeighborInfo(UUID.randomUUID(), new Point3D(1, 2, 3), null),
-            new Message.NeighborInfo(UUID.randomUUID(), new Point3D(4, 5, 6), null),
-            new Message.NeighborInfo(UUID.randomUUID(), new Point3D(7, 8, 9), null));
-        var wire = MessageConverter.toTransport(new Message.JoinResponse(UUID.randomUUID(), neighbors, 123L));
+    void filterAcceptsEveryConverterProducedMessageType() throws IOException {
+        var ghost = new Message.TransportGhost("e1", new Point3f(1, 2, 3), "java.lang.String", "v", "tree-1", 1L, 2L, 3L);
+        var neighbor = new Message.NeighborInfo(UUID.randomUUID(), new Point3D(1, 2, 3), null);
+        List<Message> messages = List.of(
+            new Message.JoinRequest(UUID.randomUUID(), new Point3D(1, 2, 3), null, 1L),
+            new Message.JoinResponse(UUID.randomUUID(), Set.of(neighbor), 2L),
+            new Message.Move(UUID.randomUUID(), new Point3D(4, 5, 6), null, 3L),
+            new Message.Leave(UUID.randomUUID(), 4L),
+            new Message.GhostSync(UUID.randomUUID(), List.of(ghost), 9L, 5L),
+            new Message.Ack(UUID.randomUUID(), UUID.randomUUID(), 6L),
+            new Message.Query(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "position", 7L),
+            new Message.QueryResponse(UUID.randomUUID(), UUID.randomUUID(), "{}", 8L));
 
-        var bytes = serialize(wire);
-        var decoded = assertDoesNotThrow(() -> deserializeFiltered(bytes),
-                                         "A JoinResponse produced by MessageConverter must pass the filter");
-        assertEquals(wire, decoded, "Converter-produced JoinResponse must round-trip through the filter");
+        for (var message : messages) {
+            var wire = MessageConverter.toTransport(message);
+            var bytes = serialize(wire);
+            var decoded = assertDoesNotThrow(() -> deserializeFiltered(bytes),
+                () -> message.getClass().getSimpleName() + " produced by MessageConverter must pass the filter");
+            assertEquals(wire, decoded,
+                () -> message.getClass().getSimpleName() + " must round-trip through the filter unchanged");
+        }
     }
 
     /**
      * {@link SocketServer#start()} must reject a non-loopback bind address (RDR-004 bind hardening).
      * {@code 8.8.8.8} is an IPv4 literal — {@code getByName} resolves it without a DNS lookup — so the
      * guard fires deterministically before {@code new ServerSocket(...)} is reached.
+     * <p>
+     * <b>Inc 7+ enforcement artifact (Luciferase-ah3).</b> This test is the CI tripwire that keeps the
+     * loopback restriction from being silently deleted: removing the guard in {@code SocketServer.start()}
+     * (or in {@code SocketConnectionManager.isLoopback()}) fails here. Do not relax or delete it without
+     * landing the deserialization hardening that {@code Luciferase-ah3} gates.
      */
     @Test
     void socketServerRejectsNonLoopbackBind() {

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/transport/VonDeserializationHardeningTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/transport/VonDeserializationHardeningTest.java
@@ -17,9 +17,12 @@
 
 package com.hellblazer.luciferase.simulation.von.transport;
 
+import com.hellblazer.luciferase.simulation.von.Message;
+import com.hellblazer.luciferase.simulation.von.MessageConverter;
 import com.hellblazer.luciferase.simulation.von.TransportGhostData;
 import com.hellblazer.luciferase.simulation.von.TransportNeighborInfo;
 import com.hellblazer.luciferase.simulation.von.TransportVonMessage;
+import javafx.geometry.Point3D;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -32,6 +35,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -107,6 +112,27 @@ class VonDeserializationHardeningTest {
                                          "A legitimate TransportVonMessage must pass the filter");
 
         assertEquals(original, decoded, "Round-tripped message must equal the original");
+    }
+
+    /**
+     * Exercises the real producer path: {@link MessageConverter#toTransport} serializes a JoinResponse's
+     * neighbor list onto the wire. The prior implementation used {@code Stream.toList()}, which emits an
+     * {@code ImmutableCollections} type that is NOT on the allow-list — so a legitimate JoinResponse with
+     * neighbors would be rejected by the filter. This guards that regression end-to-end (it would fail
+     * against the unfixed converter).
+     */
+    @Test
+    void filterAcceptsJoinResponseFromConverter() throws IOException {
+        var neighbors = Set.of(
+            new Message.NeighborInfo(UUID.randomUUID(), new Point3D(1, 2, 3), null),
+            new Message.NeighborInfo(UUID.randomUUID(), new Point3D(4, 5, 6), null),
+            new Message.NeighborInfo(UUID.randomUUID(), new Point3D(7, 8, 9), null));
+        var wire = MessageConverter.toTransport(new Message.JoinResponse(UUID.randomUUID(), neighbors, 123L));
+
+        var bytes = serialize(wire);
+        var decoded = assertDoesNotThrow(() -> deserializeFiltered(bytes),
+                                         "A JoinResponse produced by MessageConverter must pass the filter");
+        assertEquals(wire, decoded, "Converter-produced JoinResponse must round-trip through the filter");
     }
 
     /**

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/transport/VonDeserializationHardeningTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/transport/VonDeserializationHardeningTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.von.transport;
+
+import com.hellblazer.luciferase.simulation.von.TransportGhostData;
+import com.hellblazer.luciferase.simulation.von.TransportNeighborInfo;
+import com.hellblazer.luciferase.simulation.von.TransportVonMessage;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InvalidClassException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.PriorityQueue;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RDR-004 Direction A: network-deserialization hardening on the VoN socket transport.
+ * <p>
+ * Verifies (1) the {@link VonTransportFilter} allow-list rejects gadget-bearing collections such as
+ * {@link PriorityQueue} while accepting the concrete {@link TransportVonMessage} wire payload, and
+ * (2) {@link SocketServer} refuses to bind to a non-loopback address.
+ *
+ * @author hal.hildebrand
+ */
+class VonDeserializationHardeningTest {
+
+    private static byte[] serialize(Serializable object) throws IOException {
+        var baos = new ByteArrayOutputStream();
+        try (var oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(object);
+        }
+        return baos.toByteArray();
+    }
+
+    private static Object deserializeFiltered(byte[] bytes) throws IOException, ClassNotFoundException {
+        try (var ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            ois.setObjectInputFilter(VonTransportFilter.create());
+            return ois.readObject();
+        }
+    }
+
+    /**
+     * The canonical gadget surface: a {@link PriorityQueue} (admitted by a broad {@code java.util.*}
+     * wildcard) must be rejected by the narrowed allow-list before any of its contents deserialize.
+     */
+    @Test
+    void filterRejectsPriorityQueue() throws IOException {
+        var bytes = serialize(new PriorityQueue<>(List.of("a", "b", "c")));
+        assertThrows(InvalidClassException.class, () -> deserializeFiltered(bytes),
+                     "PriorityQueue must be rejected by the VoN deserialization filter");
+    }
+
+    /**
+     * A second gadget-bearing collection ({@code java.util.HashMap}) is likewise rejected — confirms the
+     * allow-list is not merely excluding one named type.
+     */
+    @Test
+    void filterRejectsHashMap() throws IOException {
+        var map = new java.util.HashMap<String, String>();
+        map.put("k", "v");
+        var bytes = serialize(map);
+        assertThrows(InvalidClassException.class, () -> deserializeFiltered(bytes),
+                     "HashMap must be rejected by the VoN deserialization filter");
+    }
+
+    /**
+     * The legitimate wire payload — a fully populated {@link TransportVonMessage} carrying
+     * {@code ArrayList}s of ghost and neighbor records — must round-trip through the filter unharmed.
+     */
+    @Test
+    void filterAcceptsTransportVonMessageRoundTrip() throws IOException, ClassNotFoundException {
+        var ghosts = new ArrayList<>(List.of(
+            new TransportGhostData("e1", 1f, 2f, 3f, "java.lang.String", "payload", "tree-1", 1L, 2L, 3L)));
+        var neighbors = new ArrayList<>(List.of(
+            new TransportNeighborInfo("n1", 10.0, 20.0, 30.0)));
+        var original = new TransportVonMessage(
+            "GHOST_SYNC", "src-bubble", "tgt-bubble", 1f, 2f, 3f, "entity-1", 42L,
+            ghosts, 7L, neighbors, "query-1");
+
+        var bytes = serialize(original);
+        var decoded = assertDoesNotThrow(() -> deserializeFiltered(bytes),
+                                         "A legitimate TransportVonMessage must pass the filter");
+
+        assertEquals(original, decoded, "Round-tripped message must equal the original");
+    }
+
+    /**
+     * {@link SocketServer#start()} must reject a non-loopback bind address (RDR-004 bind hardening).
+     * {@code 8.8.8.8} is an IPv4 literal — {@code getByName} resolves it without a DNS lookup — so the
+     * guard fires deterministically before {@code new ServerSocket(...)} is reached.
+     */
+    @Test
+    void socketServerRejectsNonLoopbackBind() {
+        var server = new SocketServer(new ProcessAddress("p1", "8.8.8.8", 0), msg -> {});
+        var ex = assertThrows(IllegalArgumentException.class, server::start,
+                              "SocketServer must reject a non-loopback bind address");
+        assertTrue(ex.getMessage().contains("loopback"),
+                   "Error should mention the loopback requirement: " + ex.getMessage());
+    }
+
+    /**
+     * {@link SocketServer#start()} must still accept a loopback bind address.
+     */
+    @Test
+    void socketServerAcceptsLoopbackBind() throws IOException {
+        var server = new SocketServer(ProcessAddress.localhost("p1", 0), msg -> {});
+        try {
+            assertDoesNotThrow(server::start, "SocketServer must accept a loopback bind address");
+            assertTrue(server.isRunning(), "Server should be running after a successful loopback bind");
+        } finally {
+            server.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements **RDR-004 Direction A** (the immediate, independent, defense-in-depth layer locked at accept) for the VoN socket transport. Closes the unfiltered network-deserialization RCE surface and tightens loopback enforcement.

- **Narrowed `ObjectInputFilter` allow-list** (`VonTransportFilter`) on both network deser sites — `SocketServer.handleClient` (`:134`) and `SocketClient.receiveMessages` (`:107-109`). Names only the concrete wire types (`TransportVonMessage`/`TransportGhostData`/`TransportNeighborInfo` + `java.util.ArrayList` + `java.lang`/`time`/`math`) and rejects the rest via trailing `!*`. Deliberately **omits the broad `java.util.*` wildcard** used on the D-1 file sites — that wildcard admits gadget-bearing collections (`PriorityQueue`, `TreeMap`, `LinkedList`) found in published ysoserial chains.
- **Bind hardening at both enforcement points:** `SocketServer.start()` now asserts the resolved bind address `isLoopbackAddress()` before opening the `ServerSocket` (previously *no* guard); `SocketConnectionManager.isLoopback()` resolves the host and checks `isLoopbackAddress()` instead of string-equality, so a name resolving off-loopback no longer passes.

Direction B (protobuf wire format) and removal of the loopback restriction (Inc 7+) remain gated on **`Luciferase-ah3`**, referenced in code at both guard sites.

## RDR / bead

- RDR: `docs/rdr/RDR-004-von-socketserver-deserialization-hardening.md` (status: accepted)
- Bead: `[Luciferase-irh]`
- Gate: `[Luciferase-ah3]` (Inc 7+ loopback removal stays blocked until this lands)

## Test plan

- [x] `filterRejectsPriorityQueue` — the mandated gadget-rejection assertion
- [x] `filterRejectsHashMap` — second gadget type rejected
- [x] `filterAcceptsTransportVonMessageRoundTrip` — full payload (ghost + neighbor `ArrayList`s) round-trips
- [x] `socketServerRejectsNonLoopbackBind` / `socketServerAcceptsLoopbackBind`
- [x] Full `von/transport` suite green (66 tests, incl. all 16 `SocketConnectionManagerTest` loopback cases — no regression from the `isLoopbackAddress()` switch)

> Note: the `Validate Documentation` check is red repo-wide (pre-existing broken links, tracked `Luciferase-8gk`) and non-blocking. The `test-batch-3` flake (`Luciferase-jar`) may need a rerun.