### PR TITLE
Invert AbstractSpatialIndex ghost-transport gRPC deps behind interfaces [Luciferase-aos]

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
@@ -5172,15 +5172,19 @@ implements SpatialIndex<Key, ID, Content> {
     // ========================================
     
     /**
-     * Sets up distributed ghost management with the provided communication manager.
+     * Sets up distributed ghost management with the provided ghost channel.
      *
-     * @param communicationManager the gRPC communication manager
-     * @param contentSerializer the content serializer
-     * @param entityIdClass the entity ID class for deserialization
+     * <p>{@code contentSerializer} and {@code entityIdClass} are not read by the current
+     * implementation; they are retained for API stability and prospective deserialization
+     * wiring when the gRPC clients move to a distributed module (RDR-007 Phase 1).
+     *
+     * @param ghostChannel the pre-built ghost channel for batched cross-process transmission
+     * @param contentSerializer the content serializer (currently unused; see note above)
+     * @param entityIdClass the entity ID class for deserialization (currently unused; see note above)
      * @param currentRank the rank of this process
      * @param treeId the tree identifier
      */
-    public void setupDistributedGhosts(com.hellblazer.luciferase.lucien.forest.ghost.grpc.GhostCommunicationManager<Key, ID, Content> communicationManager,
+    public void setupDistributedGhosts(GhostChannel<Key, ID, Content> ghostChannel,
                                       ContentSerializer<Content> contentSerializer,
                                       Class<ID> entityIdClass,
                                       int currentRank,
@@ -5191,10 +5195,6 @@ implements SpatialIndex<Key, ID, Content> {
                 log.warn("Cannot setup distributed ghosts - local ghost manager not initialized");
                 return;
             }
-
-            // Create ghost channel wrapping the communication manager
-            var ghostChannel = new com.hellblazer.luciferase.lucien.forest.ghost.GrpcGhostChannel<>(
-                communicationManager, currentRank, treeId, getGhostType());
 
             this.distributedGhostManager = new DistributedGhostManager<>(
                 this, ghostChannel, ghostBoundaryDetector);
@@ -5211,7 +5211,7 @@ implements SpatialIndex<Key, ID, Content> {
      *
      * @param serviceDiscovery the service discovery to find other processes
      */
-    public void initializeDistributedGhosts(com.hellblazer.luciferase.lucien.forest.ghost.grpc.GhostServiceClient.ServiceDiscovery serviceDiscovery) {
+    public void initializeDistributedGhosts(ServiceDiscovery serviceDiscovery) {
         if (distributedGhostManager != null) {
             distributedGhostManager.initialize(serviceDiscovery);
         } else {

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/DistributedGhostManager.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/DistributedGhostManager.java
@@ -21,8 +21,6 @@ import com.hellblazer.luciferase.lucien.SpatialKey;
 import com.hellblazer.luciferase.lucien.AbstractSpatialIndex;
 import com.hellblazer.luciferase.lucien.balancing.fault.GhostSyncCallback;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
-import com.hellblazer.luciferase.lucien.forest.ghost.grpc.GhostCommunicationManager;
-import com.hellblazer.luciferase.lucien.forest.ghost.grpc.SimpleServiceDiscovery;
 import com.hellblazer.luciferase.lucien.neighbor.NeighborDetector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,11 +37,11 @@ import java.util.stream.Collectors;
  * Manages distributed ghost layers across multiple processes.
  *
  * <p>This class coordinates ghost element creation, synchronization, and updates
- * between distributed spatial index processes. It uses {@link GrpcGhostChannel}
+ * between distributed spatial index processes. It uses {@link GhostChannel}
  * for batched communication and integrates with the local ghost boundary detection.
  *
  * <p>Simplified from original implementation by delegating communication to
- * {@link GrpcGhostChannel}, reducing LOC from 430 to ~320.
+ * {@link GhostChannel}, reducing LOC from 430 to ~320.
  *
  * @param <Key> the type of spatial key used by the spatial index
  * @param <ID> the type of entity identifier
@@ -56,7 +54,7 @@ public class DistributedGhostManager<Key extends SpatialKey<Key>, ID extends Ent
     private static final Logger log = LoggerFactory.getLogger(DistributedGhostManager.class);
 
     private final AbstractSpatialIndex<Key, ID, Content> spatialIndex;
-    private final GrpcGhostChannel<Key, ID, Content> ghostChannel;
+    private final GhostChannel<Key, ID, Content> ghostChannel;
     private final GhostBoundaryDetector<Key, ID, Content> localGhostManager;
 
     // Configuration
@@ -83,7 +81,7 @@ public class DistributedGhostManager<Key extends SpatialKey<Key>, ID extends Ent
      * @param localGhostManager the local ghost manager
      */
     public DistributedGhostManager(AbstractSpatialIndex<Key, ID, Content> spatialIndex,
-                                  GrpcGhostChannel<Key, ID, Content> ghostChannel,
+                                  GhostChannel<Key, ID, Content> ghostChannel,
                                   GhostBoundaryDetector<Key, ID, Content> localGhostManager) {
         this.spatialIndex = Objects.requireNonNull(spatialIndex);
         this.ghostChannel = Objects.requireNonNull(ghostChannel);
@@ -112,7 +110,7 @@ public class DistributedGhostManager<Key extends SpatialKey<Key>, ID extends Ent
      *
      * @param serviceDiscovery the service discovery to find other processes
      */
-    public void initialize(com.hellblazer.luciferase.lucien.forest.ghost.grpc.GhostServiceClient.ServiceDiscovery serviceDiscovery) {
+    public void initialize(ServiceDiscovery serviceDiscovery) {
         log.info("Initializing distributed ghost layer for rank {}", currentRank);
 
         // Discover other processes

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/GhostChannel.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/GhostChannel.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.lucien.forest.ghost;
+
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Transport-agnostic channel for batched ghost-element exchange between distributed processes.
+ *
+ * <p>lucien core ({@link com.hellblazer.luciferase.lucien.AbstractSpatialIndex} and
+ * {@link DistributedGhostManager}) depends on this interface rather than on a concrete gRPC
+ * transport, so the gRPC implementation ({@link GrpcGhostChannel}) can be moved out of the
+ * core module without touching core.
+ *
+ * @param <Key>     the type of spatial key
+ * @param <ID>      the type of entity identifier
+ * @param <Content> the type of content stored in entities
+ *
+ * @author Hal Hildebrand
+ */
+public interface GhostChannel<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
+
+    /**
+     * Queue a ghost element for batched transmission to a target process.
+     *
+     * @param targetRank the rank of the target process
+     * @param element    the ghost element to send
+     */
+    void queueGhost(int targetRank, GhostElement<Key, ID, Content> element);
+
+    /**
+     * Flush queued ghosts to a specific target process.
+     *
+     * @param targetRank the rank of the target process
+     * @return a future that completes when the flush finishes
+     */
+    CompletableFuture<Void> flushToTarget(int targetRank);
+
+    /**
+     * @return the total number of queued ghosts across all targets
+     */
+    int getTotalPendingCount();
+
+    /**
+     * Clear all queued ghosts without sending them.
+     */
+    void clear();
+
+    /**
+     * @return the rank of this process
+     */
+    int getCurrentRank();
+
+    /**
+     * @return the tree identifier this channel is bound to
+     */
+    long getTreeId();
+
+    /**
+     * @return the type of ghosts this channel transmits
+     */
+    GhostType getGhostType();
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/GrpcGhostChannel.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/GrpcGhostChannel.java
@@ -20,7 +20,6 @@ package com.hellblazer.luciferase.lucien.forest.ghost;
 import com.hellblazer.luciferase.lucien.SpatialKey;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.forest.ghost.grpc.GhostCommunicationManager;
-import com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostBatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +60,8 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @author Hal Hildebrand
  */
-public class GrpcGhostChannel<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
+public class GrpcGhostChannel<Key extends SpatialKey<Key>, ID extends EntityID, Content>
+    implements GhostChannel<Key, ID, Content> {
 
     private static final Logger log = LoggerFactory.getLogger(GrpcGhostChannel.class);
 
@@ -120,6 +120,7 @@ public class GrpcGhostChannel<Key extends SpatialKey<Key>, ID extends EntityID, 
      * @param targetRank the rank of the target process
      * @param ghostElement the ghost element to send
      */
+    @Override
     public void queueGhost(int targetRank, GhostElement<Key, ID, Content> ghostElement) {
         if (targetRank == currentRank) {
             log.debug("Skipping ghost queue for self (rank {})", currentRank);
@@ -199,6 +200,7 @@ public class GrpcGhostChannel<Key extends SpatialKey<Key>, ID extends EntityID, 
      * @param targetRank the rank of the target process
      * @return CompletableFuture that completes when flush finishes
      */
+    @Override
     public CompletableFuture<Void> flushToTarget(int targetRank) {
         var queue = queuedGhosts.remove(targetRank);
         if (queue == null || queue.isEmpty()) {
@@ -224,6 +226,7 @@ public class GrpcGhostChannel<Key extends SpatialKey<Key>, ID extends EntityID, 
      *
      * @return the total number of queued ghosts
      */
+    @Override
     public int getTotalPendingCount() {
         return queuedGhosts.values().stream()
                           .mapToInt(List::size)
@@ -242,6 +245,7 @@ public class GrpcGhostChannel<Key extends SpatialKey<Key>, ID extends EntityID, 
     /**
      * Clear all queued ghosts without sending them.
      */
+    @Override
     public void clear() {
         queuedGhosts.clear();
         log.debug("Cleared all queued ghosts");
@@ -252,6 +256,7 @@ public class GrpcGhostChannel<Key extends SpatialKey<Key>, ID extends EntityID, 
      *
      * @return the current process rank
      */
+    @Override
     public int getCurrentRank() {
         return currentRank;
     }
@@ -261,6 +266,7 @@ public class GrpcGhostChannel<Key extends SpatialKey<Key>, ID extends EntityID, 
      *
      * @return the tree identifier
      */
+    @Override
     public long getTreeId() {
         return treeId;
     }
@@ -270,6 +276,7 @@ public class GrpcGhostChannel<Key extends SpatialKey<Key>, ID extends EntityID, 
      *
      * @return the ghost type
      */
+    @Override
     public GhostType getGhostType() {
         return ghostType;
     }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/ServiceDiscovery.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/ServiceDiscovery.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.lucien.forest.ghost;
+
+import java.util.Map;
+
+/**
+ * Rank-to-endpoint discovery for distributed ghost communication.
+ *
+ * <p>Promoted to a top-level lucien-core interface (formerly nested in the gRPC-package
+ * {@code GhostServiceClient}) so core consumers can reference it without depending on the
+ * gRPC transport package.
+ *
+ * @author Hal Hildebrand
+ */
+public interface ServiceDiscovery {
+
+    /**
+     * @param rank the process rank
+     * @return the gRPC endpoint registered for the given rank, or {@code null} if unknown
+     */
+    String getEndpoint(int rank);
+
+    /**
+     * Register the endpoint for a process rank.
+     *
+     * @param rank     the process rank
+     * @param endpoint the endpoint to associate with the rank
+     */
+    void registerEndpoint(int rank, String endpoint);
+
+    /**
+     * @return an immutable view of all known rank-to-endpoint mappings
+     */
+    Map<Integer, String> getAllEndpoints();
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostCommunicationManager.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostCommunicationManager.java
@@ -22,6 +22,7 @@ import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.forest.ghost.ContentSerializer;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostElement;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostLayer;
+import com.hellblazer.luciferase.lucien.forest.ghost.ServiceDiscovery;
 import com.hellblazer.luciferase.lucien.forest.ghost.proto.*;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -65,7 +66,7 @@ public class GhostCommunicationManager<Key extends SpatialKey<Key>, ID extends E
     private final Server server;
     private final GhostExchangeServiceImpl<Key, ID, Content> serviceImpl;
     private final GhostServiceClient<Key, ID, Content> client;
-    private final GhostServiceClient.ServiceDiscovery serviceDiscovery;
+    private final ServiceDiscovery serviceDiscovery;
     
     // Ghost layer management
     private final Map<Long, GhostLayer<Key, ID, Content>> ghostLayers;
@@ -86,7 +87,7 @@ public class GhostCommunicationManager<Key extends SpatialKey<Key>, ID extends E
                                    int port,
                                    ContentSerializer<Content> contentSerializer,
                                    Class<ID> entityIdClass,
-                                   GhostServiceClient.ServiceDiscovery serviceDiscovery) {
+                                   ServiceDiscovery serviceDiscovery) {
         this.currentRank = currentRank;
         this.bindAddress = bindAddress;
         this.port = port;
@@ -385,7 +386,7 @@ public class GhostCommunicationManager<Key extends SpatialKey<Key>, ID extends E
      * 
      * @return the service discovery
      */
-    public GhostServiceClient.ServiceDiscovery getServiceDiscovery() {
+    public ServiceDiscovery getServiceDiscovery() {
         return serviceDiscovery;
     }
     

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostServiceClient.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostServiceClient.java
@@ -21,6 +21,7 @@ import com.hellblazer.luciferase.lucien.SpatialKey;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.forest.ghost.ContentSerializer;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostElement;
+import com.hellblazer.luciferase.lucien.forest.ghost.ServiceDiscovery;
 import com.hellblazer.luciferase.lucien.forest.ghost.proto.*;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -460,34 +461,5 @@ public class GhostServiceClient<Key extends SpatialKey<Key>, ID extends EntityID
             case EDGES -> com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostType.EDGES;
             case VERTICES -> com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostType.VERTICES;
         };
-    }
-    
-    /**
-     * Interface for service discovery mechanism.
-     */
-    public interface ServiceDiscovery {
-        
-        /**
-         * Gets the gRPC endpoint for a specific process rank.
-         * 
-         * @param rank the process rank
-         * @return the endpoint (host:port), or null if not found
-         */
-        String getEndpoint(int rank);
-        
-        /**
-         * Registers this process's endpoint.
-         * 
-         * @param rank the process rank
-         * @param endpoint the endpoint (host:port)
-         */
-        void registerEndpoint(int rank, String endpoint);
-        
-        /**
-         * Gets all known endpoints.
-         * 
-         * @return map of rank to endpoint
-         */
-        Map<Integer, String> getAllEndpoints();
     }
 }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/SimpleServiceDiscovery.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/SimpleServiceDiscovery.java
@@ -17,6 +17,7 @@
 
 package com.hellblazer.luciferase.lucien.forest.ghost.grpc;
 
+import com.hellblazer.luciferase.lucien.forest.ghost.ServiceDiscovery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +34,7 @@ import java.util.Objects;
  * 
  * @author Hal Hildebrand
  */
-public class SimpleServiceDiscovery implements GhostServiceClient.ServiceDiscovery {
+public class SimpleServiceDiscovery implements ServiceDiscovery {
     
     private static final Logger log = LoggerFactory.getLogger(SimpleServiceDiscovery.class);
     


### PR DESCRIPTION
## Summary

RDR-007 **Phase 0**, ghost-transport portion (Increment 1 of the shared gRPC dependency inversion owned by `Luciferase-aos`). Introduces two lucien-core interfaces so the central god-class seam stops referencing the gRPC/proto packages:

- **`forest.ghost.GhostChannel<Key,ID,Content>`** — the exact 7-method batched-transmission surface `DistributedGhostManager` consumes (`queueGhost`, `flushToTarget`, `getTotalPendingCount`, `clear`, `getCurrentRank`, `getTreeId`, `getGhostType`). `GrpcGhostChannel` now `implements` it.
- **`forest.ghost.ServiceDiscovery`** — promoted from the grpc-package `GhostServiceClient.ServiceDiscovery` nested interface; `SimpleServiceDiscovery` and `GhostCommunicationManager` re-point to it.

`AbstractSpatialIndex.setupDistributedGhosts` now accepts a **pre-built `GhostChannel`** (caller constructs the concrete gRPC channel) instead of building a `GrpcGhostChannel` from a `GhostCommunicationManager`. After this change, **`AbstractSpatialIndex.java` and `DistributedGhostManager.java` contain zero compile-time references** to `forest.ghost.grpc`, proto-generated types, or `io.grpc.*` (grep-verified). No behavior change.

## Scope (read before approving)

This is **only** the `AbstractSpatialIndex` / `DistributedGhostManager` seam — **not** all of RDR-007 P0. The bead `Luciferase-aos` stays **open**. Remaining P0 inversions that still block the Phase 1 module move (full inventory in T2 `luciferase/aos-p0-remaining-scope.md`):
- Residual ghost-domain proto leakage: `GhostBoundaryDetector`, `ElementGhostManager`, `GhostElement`, `GhostLayer`, `MortonKey`, `SpatialKeySerdeRegistry`.
- Balancing proto boundary: `CrossPartitionBalancePhase`, `DistributedViolationAggregator` (+`io.grpc.StatusRuntimeException` leak), `RefinementCoordinator`, `DefaultParallelBalancer`, `ButterflyViolationAggregator`, `RefinementRequestManager`.

Deliberately **deferred** (enabled by this PR, tracked, non-behavioral): migrating test mocks from concrete `GrpcGhostChannel` to the `GhostChannel` interface; a `ghostType`/rank/treeId consistency guard on `setupDistributedGhosts` (add when real callers land in P1). `BalanceCoordinatorClient` keeps its own nested `ServiceDiscovery` for now (Inc2 may unify).

Notes: `contentSerializer`/`entityIdClass` params on `setupDistributedGhosts` are now unused (they were already unused pre-PR) — retained per design for API stability, documented in the javadoc.

## Review

Stacked **code-review-expert** + **substantive-critic** (sonnet), 0 critical. Remediated: `@Override` on the 7 implementing methods, trailing-newline/whitespace cleanup, javadoc note on the retained params. The critic's "scope-claim accuracy" finding is reflected in the Scope section above and the T2 inventory.

## Test plan

- [x] `mvn -pl lucien test-compile` — green (main + test)
- [x] `mvn -pl lucien test` — 2387/2389 pass; the 2 failures are `PrismVsOctree/TetreeComparisonTest.testRangeQueryPerformanceComparison` (absolute <5ms wall-clock assertions — load flakes, unrelated to this diff)
- [x] Ghost + distributed subset (`*Ghost*`, `DistributedForestImplTest`) — 69/69 green
- [x] Structural assertion: `AbstractSpatialIndex.java` + `DistributedGhostManager.java` grep-clean of `forest.ghost.grpc` / `.proto.` / `io.grpc`