### PR TITLE
Invert ghost transport behind GhostExchange interface (Inc2b) [Luciferase-aos]

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/ElementGhostManager.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/ElementGhostManager.java
@@ -61,9 +61,9 @@ public class ElementGhostManager<Key extends SpatialKey<Key>, ID extends EntityI
     // Owner information for distributed support (placeholder for now)
     private final Map<Key, Integer> elementOwners;
     
-    // gRPC client for fetching remote ghost data (optional for distributed environments)
-    private final com.hellblazer.luciferase.lucien.forest.ghost.grpc.GhostServiceClient ghostServiceClient;
-    
+    // Ghost exchange for fetching remote ghost data (optional for distributed environments)
+    private final GhostExchange<Key, ID, Content> ghostExchange;
+
     // Tree ID for distributed ghost requests
     private final long treeId;
     
@@ -81,20 +81,20 @@ public class ElementGhostManager<Key extends SpatialKey<Key>, ID extends EntityI
     }
     
     /**
-     * Create an element ghost manager with gRPC support.
-     * 
+     * Create an element ghost manager with ghost exchange support.
+     *
      * @param spatialIndex the spatial index
      * @param neighborDetector the neighbor detector for this index type
      * @param ghostType the type of ghosts to create
-     * @param ghostServiceClient gRPC client for remote ghost data fetching (null for local-only operation)
+     * @param ghostExchange ghost exchange for remote ghost data fetching (null for local-only operation)
      * @param treeId tree identifier for distributed ghost requests
      */
     public ElementGhostManager(AbstractSpatialIndex<Key, ID, Content> spatialIndex,
                               NeighborDetector<Key> neighborDetector,
                               GhostType ghostType,
-                              com.hellblazer.luciferase.lucien.forest.ghost.grpc.GhostServiceClient ghostServiceClient,
+                              GhostExchange<Key, ID, Content> ghostExchange,
                               long treeId) {
-        this(spatialIndex, neighborDetector, ghostType, GhostAlgorithm.CONSERVATIVE, ghostServiceClient, treeId);
+        this(spatialIndex, neighborDetector, ghostType, GhostAlgorithm.CONSERVATIVE, ghostExchange, treeId);
     }
     
     /**
@@ -114,19 +114,19 @@ public class ElementGhostManager<Key extends SpatialKey<Key>, ID extends EntityI
     
     /**
      * Create an element ghost manager with full configuration.
-     * 
+     *
      * @param spatialIndex the spatial index
      * @param neighborDetector the neighbor detector for this index type
      * @param ghostType the type of ghosts to create
      * @param ghostAlgorithm the ghost creation algorithm to use
-     * @param ghostServiceClient gRPC client for remote ghost data fetching (null for local-only operation)
+     * @param ghostExchange ghost exchange for remote ghost data fetching (null for local-only operation)
      * @param treeId tree identifier for distributed ghost requests
      */
     public ElementGhostManager(AbstractSpatialIndex<Key, ID, Content> spatialIndex,
                               NeighborDetector<Key> neighborDetector,
                               GhostType ghostType,
                               GhostAlgorithm ghostAlgorithm,
-                              com.hellblazer.luciferase.lucien.forest.ghost.grpc.GhostServiceClient ghostServiceClient,
+                              GhostExchange<Key, ID, Content> ghostExchange,
                               long treeId) {
         this.spatialIndex = Objects.requireNonNull(spatialIndex);
         this.neighborDetector = Objects.requireNonNull(neighborDetector);
@@ -135,7 +135,7 @@ public class ElementGhostManager<Key extends SpatialKey<Key>, ID extends EntityI
         this.boundaryElements = new ConcurrentSkipListSet<>();
         this.processedElements = ConcurrentHashMap.newKeySet();
         this.elementOwners = new ConcurrentHashMap<>();
-        this.ghostServiceClient = ghostServiceClient;
+        this.ghostExchange = ghostExchange;
         this.treeId = treeId;
     }
     
@@ -370,38 +370,33 @@ public class ElementGhostManager<Key extends SpatialKey<Key>, ID extends EntityI
     
     private void createGhostElement(Key neighborKey, int ownerRank) {
         // Create a ghost element for this non-local neighbor
-        
-        if (ghostServiceClient != null && treeId != 0L) {
-            // Use gRPC to fetch real ghost data from remote process
+
+        if (ghostExchange != null && treeId != 0L) {
+            // Use ghost exchange to fetch domain ghost elements from remote process
             try {
-                var ghostBatch = ghostServiceClient.requestGhosts(
-                    ownerRank, 
-                    treeId, 
-                    ghostLayer.getGhostType(), 
-                    List.of(neighborKey)
-                );
-                
-                if (ghostBatch != null) {
-                    // Process the received ghost elements
-                    for (var ghostElementProto : ghostBatch.getElementsList()) {
-                        processReceivedGhostElement(ghostElementProto);
+                var elements = ghostExchange.requestGhostElements(ownerRank, treeId, ghostLayer.getGhostType(),
+                                                                  List.of(neighborKey));
+
+                if (elements != null) {
+                    for (var e : elements) {
+                        ghostLayer.addGhostElement(e);
                     }
-                    log.debug("Successfully fetched ghost element for neighbor key: {} from owner: {}", 
+                    log.debug("Successfully fetched ghost element for neighbor key: {} from owner: {}",
                              neighborKey, ownerRank);
                 } else {
-                    log.warn("Failed to fetch ghost element for neighbor key: {} from owner: {}", 
+                    log.warn("Failed to fetch ghost element for neighbor key: {} from owner: {}",
                             neighborKey, ownerRank);
                 }
-                
+
             } catch (Exception e) {
-                log.error("Error fetching ghost element for neighbor key: {} from owner: {}: {}", 
+                log.error("Error fetching ghost element for neighbor key: {} from owner: {}: {}",
                          neighborKey, ownerRank, e.getMessage(), e);
             }
         } else {
             // Local-only mode: create a placeholder ghost element for testing
-            log.debug("Creating placeholder ghost element for neighbor key: {} from owner: {} (no gRPC client)", 
+            log.debug("Creating placeholder ghost element for neighbor key: {} from owner: {} (no gRPC client)",
                      neighborKey, ownerRank);
-            
+
             // Create a minimal ghost element with synthetic data
             createPlaceholderGhostElement(neighborKey, ownerRank);
         }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/ElementGhostManager.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/ElementGhostManager.java
@@ -403,47 +403,6 @@ public class ElementGhostManager<Key extends SpatialKey<Key>, ID extends EntityI
     }
     
     /**
-     * Process a ghost element received from a remote process via gRPC.
-     */
-    private void processReceivedGhostElement(com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostElement ghostElementProto) {
-        try {
-            // Convert protobuf ghost element to local representation
-            var spatialKey = com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters.spatialKeyFromProtobuf(ghostElementProto.getSpatialKey());
-            
-            // Convert protobuf position to javax.vecmath.Point3f
-            var protoPos = ghostElementProto.getPosition();
-            var position = new Point3f(protoPos.getX(), protoPos.getY(), protoPos.getZ());
-            
-            // For now, we create placeholder ID and Content since we can't deserialize them generically
-            // In a real implementation, these would be properly deserialized from protobuf
-            @SuppressWarnings("unchecked")
-            ID placeholderEntityId = (ID) new com.hellblazer.luciferase.lucien.entity.UUIDEntityID(java.util.UUID.fromString(ghostElementProto.getEntityId()));
-            
-            @SuppressWarnings("unchecked") 
-            Content placeholderContent = (Content) ghostElementProto.getContent().toByteArray();
-            
-            // Create a proper ghost element with the received data
-            var ghostElement = new GhostElement<Key, ID, Content>(
-                (Key) spatialKey,
-                placeholderEntityId,
-                placeholderContent,
-                position,
-                ghostElementProto.getOwnerRank(),
-                treeId
-            );
-            
-            // Add to ghost layer
-            ghostLayer.addGhostElement(ghostElement);
-            
-            log.trace("Processed ghost element with key: {} from rank: {}", 
-                     spatialKey, ghostElementProto.getOwnerRank());
-                     
-        } catch (Exception e) {
-            log.error("Error processing received ghost element: {}", e.getMessage(), e);
-        }
-    }
-    
-    /**
      * Create a placeholder ghost element for local testing without gRPC.
      */
     private void createPlaceholderGhostElement(Key neighborKey, int ownerRank) {

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/ElementGhostManager.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/ElementGhostManager.java
@@ -379,7 +379,12 @@ public class ElementGhostManager<Key extends SpatialKey<Key>, ID extends EntityI
 
                 if (elements != null) {
                     for (var e : elements) {
-                        ghostLayer.addGhostElement(e);
+                        // Guard each add so one bad element doesn't abort the rest of the batch.
+                        try {
+                            ghostLayer.addGhostElement(e);
+                        } catch (Exception addEx) {
+                            log.error("Error processing received ghost element: {}", addEx.getMessage(), addEx);
+                        }
                     }
                     log.debug("Successfully fetched ghost element for neighbor key: {} from owner: {}",
                              neighborKey, ownerRank);

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/GhostBoundaryDetector.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/GhostBoundaryDetector.java
@@ -84,10 +84,7 @@ public class GhostBoundaryDetector<Key extends SpatialKey<Key>, ID extends Entit
     // Owner information for distributed support
     private final Map<Key, Integer> elementOwners;
 
-    // gRPC client for fetching remote ghost data (optional for distributed environments)
-    private final com.hellblazer.luciferase.lucien.forest.ghost.grpc.GhostServiceClient ghostServiceClient;
-
-    // Tree ID for distributed ghost requests
+    // Tree ID for distributed ghost requests (candidate-dead-field; flagged for follow-up review B6)
     private final long treeId;
 
     // ========================================
@@ -211,7 +208,7 @@ public class GhostBoundaryDetector<Key extends SpatialKey<Key>, ID extends Entit
                                  NeighborDetector<Key> neighborDetector,
                                  GhostType ghostType,
                                  GhostAlgorithm ghostAlgorithm) {
-        this(spatialIndex, neighborDetector, ghostType, ghostAlgorithm, null, null, 0L, 0f);
+        this(spatialIndex, neighborDetector, ghostType, ghostAlgorithm, null, 0L, 0f);
     }
 
     /**
@@ -221,7 +218,7 @@ public class GhostBoundaryDetector<Key extends SpatialKey<Key>, ID extends Entit
      * @param defaultGhostZoneWidth the default ghost zone width
      */
     public GhostBoundaryDetector(Forest<Key, ID, Content> forest, float defaultGhostZoneWidth) {
-        this(null, null, GhostType.FACES, GhostAlgorithm.CONSERVATIVE, forest, null, 0L, defaultGhostZoneWidth);
+        this(null, null, GhostType.FACES, GhostAlgorithm.CONSERVATIVE, forest, 0L, defaultGhostZoneWidth);
     }
 
     /**
@@ -232,7 +229,6 @@ public class GhostBoundaryDetector<Key extends SpatialKey<Key>, ID extends Entit
      * @param ghostType the type of ghosts to create
      * @param ghostAlgorithm the ghost creation algorithm
      * @param forest the forest (null for single-tree mode)
-     * @param ghostServiceClient gRPC client for remote ghost data (null for local-only)
      * @param treeId tree identifier for distributed ghost requests
      * @param defaultGhostZoneWidth default ghost zone width for forest mode
      */
@@ -241,7 +237,6 @@ public class GhostBoundaryDetector<Key extends SpatialKey<Key>, ID extends Entit
                                  GhostType ghostType,
                                  GhostAlgorithm ghostAlgorithm,
                                  Forest<Key, ID, Content> forest,
-                                 com.hellblazer.luciferase.lucien.forest.ghost.grpc.GhostServiceClient ghostServiceClient,
                                  long treeId,
                                  float defaultGhostZoneWidth) {
         // Element-level fields
@@ -252,7 +247,6 @@ public class GhostBoundaryDetector<Key extends SpatialKey<Key>, ID extends Entit
         this.boundaryElements = ConcurrentHashMap.newKeySet();
         this.processedElements = ConcurrentHashMap.newKeySet();
         this.elementOwners = new ConcurrentHashMap<>();
-        this.ghostServiceClient = ghostServiceClient;
         this.treeId = treeId;
 
         // Tree-level fields

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/GhostExchange.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/GhostExchange.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.hellblazer.luciferase.lucien.forest.ghost;
+
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+
+import java.util.List;
+
+/**
+ * Transport-agnostic interface for synchronous ghost-element requests between distributed processes.
+ *
+ * <p>lucien core ({@link ElementGhostManager}) depends on this interface rather than on a concrete
+ * gRPC transport, so the gRPC implementation ({@link com.hellblazer.luciferase.lucien.forest.ghost.grpc.GhostServiceClient})
+ * can be moved out of the core module without touching core code.
+ *
+ * <p>Returns domain {@link GhostElement} objects rather than proto types, keeping the core module
+ * free of protobuf dependencies. Mirrors the pattern established by {@link GhostChannel} for
+ * batched push-style ghost exchange.
+ *
+ * @param <Key>     the type of spatial key
+ * @param <ID>      the type of entity identifier
+ * @param <Content> the type of content stored in entities
+ *
+ * @author Hal Hildebrand
+ */
+public interface GhostExchange<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
+
+    /**
+     * Synchronously request ghost elements from a remote process.
+     *
+     * @param targetRank   the rank of the target process
+     * @param treeId       the tree ID to request ghosts for
+     * @param ghostType    the type of ghosts to request
+     * @param boundaryKeys specific boundary keys to request
+     * @return list of ghost elements, or {@code null} if the request fails
+     */
+    List<GhostElement<Key, ID, Content>> requestGhostElements(
+            int targetRank, long treeId, GhostType ghostType, List<Key> boundaryKeys);
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostServiceClient.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostServiceClient.java
@@ -19,10 +19,17 @@ package com.hellblazer.luciferase.lucien.forest.ghost.grpc;
 
 import com.hellblazer.luciferase.lucien.SpatialKey;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
+import com.hellblazer.luciferase.lucien.entity.UUIDEntityID;
 import com.hellblazer.luciferase.lucien.forest.ghost.ContentSerializer;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostElement;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostExchange;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostType;
 import com.hellblazer.luciferase.lucien.forest.ghost.ServiceDiscovery;
 import com.hellblazer.luciferase.lucien.forest.ghost.proto.*;
+
+import javax.vecmath.Point3f;
+import java.util.ArrayList;
+import java.util.UUID;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Status;
@@ -55,7 +62,8 @@ import java.util.function.Consumer;
  * 
  * @author Hal Hildebrand
  */
-public class GhostServiceClient<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
+public class GhostServiceClient<Key extends SpatialKey<Key>, ID extends EntityID, Content>
+        implements GhostExchange<Key, ID, Content> {
     
     private static final Logger log = LoggerFactory.getLogger(GhostServiceClient.class);
     
@@ -161,15 +169,61 @@ public class GhostServiceClient<Key extends SpatialKey<Key>, ID extends EntityID
     }
     
     /**
+     * Requests ghost elements from a remote process, returning domain objects.
+     *
+     * <p>This is the {@link GhostExchange} implementation. It calls the proto-returning
+     * {@link #requestGhosts} internally and converts each element verbatim — preserving the
+     * same stub conversion logic that lived in {@code ElementGhostManager.processReceivedGhostElement}
+     * before Inc2b. Per-element try/catch is preserved: one malformed proto logs and continues,
+     * it does NOT abort the whole batch.
+     *
+     * @param targetRank   the rank of the target process
+     * @param treeId       the tree ID to request ghosts for (threaded verbatim into each GhostElement)
+     * @param ghostType    the type of ghosts to request
+     * @param boundaryKeys specific boundary keys to request
+     * @return list of domain ghost elements, or {@code null} if the batch request fails
+     */
+    @Override
+    public List<GhostElement<Key, ID, Content>> requestGhostElements(
+            int targetRank, long treeId, GhostType ghostType, List<Key> boundaryKeys) {
+        var batch = requestGhosts(targetRank, treeId, ghostType, boundaryKeys);
+        if (batch == null) {
+            // Preserve old null-batch path so caller's "Failed to fetch" log fires identically.
+            return null;
+        }
+        var elements = new ArrayList<GhostElement<Key, ID, Content>>();
+        for (var proto : batch.getElementsList()) {
+            // PER-ELEMENT try/catch is LOAD-BEARING: verbatim relocation of the guard that
+            // was in ElementGhostManager.processReceivedGhostElement. One malformed proto
+            // must NOT abort the whole batch — log and continue.
+            try {
+                var spatialKey = ProtobufConverters.spatialKeyFromProtobuf(proto.getSpatialKey());
+                var p = proto.getPosition();
+                var position = new Point3f(p.getX(), p.getY(), p.getZ());
+                @SuppressWarnings("unchecked")
+                ID id = (ID) new UUIDEntityID(UUID.fromString(proto.getEntityId()));
+                @SuppressWarnings("unchecked")
+                Content content = (Content) proto.getContent().toByteArray();
+                elements.add(new GhostElement<>(
+                        (Key) spatialKey, id, content, position,
+                        proto.getOwnerRank(), treeId)); // treeId: PASSED arg, not client state
+            } catch (Exception e) {
+                log.error("Error processing received ghost element: {}", e.getMessage(), e);
+            }
+        }
+        return elements;
+    }
+
+    /**
      * Requests ghost elements asynchronously using virtual threads.
-     * 
+     *
      * @param targetRank the rank of the target process
      * @param treeId the tree ID to request ghosts for
      * @param ghostType the type of ghosts to request
      * @param boundaryKeys specific boundary keys to request (optional)
      * @return CompletableFuture with the ghost batch response
      */
-    public CompletableFuture<GhostBatch> requestGhostsAsync(int targetRank, long treeId, 
+    public CompletableFuture<GhostBatch> requestGhostsAsync(int targetRank, long treeId,
                                                            com.hellblazer.luciferase.lucien.forest.ghost.GhostType ghostType, List<Key> boundaryKeys) {
         return CompletableFuture.supplyAsync(() -> 
             requestGhosts(targetRank, treeId, ghostType, boundaryKeys), virtualExecutor);


### PR DESCRIPTION
## Summary

RDR-007 Phase 0, increment **Inc2b** (under shared bead `Luciferase-aos`), the second half of the ghost-domain inversion (follows Inc2a #97). Severs lucien-core `ElementGhostManager` + `GhostBoundaryDetector` from the concrete grpc `GhostServiceClient` behind a new core interface. Pure behavior-preserving inversion.

**Result:** `ElementGhostManager.java` and `GhostBoundaryDetector.java` are now grep-clean of `forest.ghost.grpc`/`forest.ghost.proto`/`io.grpc`. With Inc2a, the whole ghost-domain group is inverted; only balancing (Inc3) and the `SpatialKeySerdeRegistry` `Class.forName` strings (RDR-007 P2) remain for P0.

## Changes
- **New `GhostExchange<Key,ID,Content>`** (lucien-core `forest.ghost`): one method, `List<GhostElement<Key,ID,Content>> requestGhostElements(int, long, GhostType, List<Key>)`. Returns domain elements, no proto.
- **`GhostServiceClient` implements `GhostExchange`** — `requestGhostElements` delegates to the existing proto `requestGhosts` (kept; live caller `GhostCommunicationManager`) and converts each element. The proto→domain conversion (formerly `ElementGhostManager.processReceivedGhostElement`) is relocated **verbatim** (per-element try/catch preserved; `treeId` threaded from the passed arg).
- **`ElementGhostManager`**: field/ctor `GhostServiceClient` → `GhostExchange`; `createGhostElement` iterates returned domain elements; `processReceivedGhostElement` deleted; local-only placeholder path untouched.
- **`GhostBoundaryDetector`**: the `ghostServiceClient` field was dead (write-only) — deleted along with the unused 8-arg ctor param (zero external callers; two internal `this(...)` delegations updated).

## Review note (resilience guard)
The substantive-critic flagged that moving `addGhostElement` into the outer try/catch changed per-element resilience (a mid-batch throw would abort the remainder vs. the old skip-and-continue). Fixed in `b6282a73` by restoring a per-element guard, so behavior is byte-identical.

## Deferred (own bead)
`Luciferase-5of`: replace the relocated stub (hardcoded `UUIDEntityID` + raw-bytes content) with real deserialization via `ProtobufConverters.ghostElementFromProtobuf` + a round-trip test. Deliberately kept out of this pure inversion. (`GhostBoundaryDetector.treeId` is also dead — flagged for a follow-up, out of this increment's authorized scope.)

## Test plan
- [x] `mvn -pl lucien -am test` → 2389 run, only the known Prism perf flake `Luciferase-6z1` (orthogonal)
- [x] Grep gate clean on the 2 core files
- [x] Stacked review (code-review-expert + substantive-critic, sonnet): 0 critical, 0 high; 1 significant resolved