### PR TITLE
Invert balancing proto boundary behind domain exchange interfaces (Inc3)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/BalanceExchangeException.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/BalanceExchangeException.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.balancing;
+
+/**
+ * Domain exception for cross-partition balance exchange failures (RDR-007 Phase 0 Inc3).
+ *
+ * <p>Decouples lucien-core balancing logic from gRPC's {@code StatusRuntimeException}. The grpc adapter
+ * classifies transport failures and rethrows as this exception so retry/timeout policy can be expressed
+ * in core without a gRPC dependency:
+ * <ul>
+ *   <li>{@link #isTransient()} — failure may succeed on retry (e.g. gRPC UNAVAILABLE / RESOURCE_EXHAUSTED)</li>
+ *   <li>{@link #isTimeout()} — the exchange exceeded its deadline (e.g. gRPC DEADLINE_EXCEEDED)</li>
+ * </ul>
+ *
+ * @author hal.hildebrand
+ */
+public class BalanceExchangeException extends Exception {
+
+    private final boolean transientFailure;
+    private final boolean timeout;
+
+    public BalanceExchangeException(String message, boolean transientFailure, boolean timeout) {
+        super(message);
+        this.transientFailure = transientFailure;
+        this.timeout = timeout;
+    }
+
+    public BalanceExchangeException(String message, Throwable cause, boolean transientFailure, boolean timeout) {
+        super(message, cause);
+        this.transientFailure = transientFailure;
+        this.timeout = timeout;
+    }
+
+    /**
+     * @return true if the failure is transient and the exchange may succeed on retry
+     */
+    public boolean isTransient() {
+        return transientFailure;
+    }
+
+    /**
+     * @return true if the exchange exceeded its deadline
+     */
+    public boolean isTimeout() {
+        return timeout;
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/ButterflyViolationAggregator.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/ButterflyViolationAggregator.java
@@ -16,12 +16,17 @@
  */
 package com.hellblazer.luciferase.lucien.balancing;
 
-import com.hellblazer.luciferase.lucien.balancing.proto.BalanceViolation;
-import com.hellblazer.luciferase.lucien.balancing.proto.ViolationBatch;
+import com.hellblazer.luciferase.lucien.SpatialKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.BiFunction;
 
 /**
@@ -35,16 +40,20 @@ import java.util.function.BiFunction;
  * <p>Violations are deduplicated using a composite key of (localKey, ghostKey)
  * to handle cases where the same violation is reported by multiple partitions.
  *
+ * <p>Operates entirely on domain types ({@link ViolationBatch}, {@link TwoOneBalanceChecker.BalanceViolation});
+ * the exchanger function is the seam to the transport, supplied by the caller.
+ *
+ * @param <Key> the spatial key type (MortonKey, TetreeKey, etc.)
  * @see ButterflyPattern
  * @author hal.hildebrand
  */
-public class ButterflyViolationAggregator {
+public class ButterflyViolationAggregator<Key extends SpatialKey<Key>> {
 
     private static final Logger log = LoggerFactory.getLogger(ButterflyViolationAggregator.class);
 
     private final int myRank;
     private final int totalPartitions;
-    private final BiFunction<Integer, ViolationBatch, ViolationBatch> violationExchanger;
+    private final BiFunction<Integer, ViolationBatch<Key>, ViolationBatch<Key>> violationExchanger;
 
     /**
      * Creates a new butterfly violation aggregator.
@@ -56,7 +65,7 @@ public class ButterflyViolationAggregator {
      * @throws NullPointerException if violationExchanger is null
      */
     public ButterflyViolationAggregator(int myRank, int totalPartitions,
-                                       BiFunction<Integer, ViolationBatch, ViolationBatch> violationExchanger) {
+                                       BiFunction<Integer, ViolationBatch<Key>, ViolationBatch<Key>> violationExchanger) {
         if (totalPartitions <= 0) {
             throw new IllegalArgumentException("totalPartitions must be positive, got " + totalPartitions);
         }
@@ -92,11 +101,12 @@ public class ButterflyViolationAggregator {
      * @return set of all violations from all partitions (deduplicated)
      * @throws NullPointerException if localViolations is null
      */
-    public Set<BalanceViolation> aggregateViolations(List<BalanceViolation> localViolations) {
+    public Set<TwoOneBalanceChecker.BalanceViolation<Key>> aggregateViolations(
+            List<TwoOneBalanceChecker.BalanceViolation<Key>> localViolations) {
         Objects.requireNonNull(localViolations, "localViolations cannot be null");
 
         // Use LinkedHashMap for deduplication while preserving insertion order
-        var aggregatedViolations = new LinkedHashMap<ViolationKey, BalanceViolation>();
+        var aggregatedViolations = new LinkedHashMap<ViolationKey, TwoOneBalanceChecker.BalanceViolation<Key>>();
 
         // Add local violations
         for (var violation : localViolations) {
@@ -130,7 +140,7 @@ public class ButterflyViolationAggregator {
             var receivedBatch = exchangeWithPartner(partner, round, aggregatedViolations.values());
 
             // Merge received violations (deduplicate)
-            for (var violation : receivedBatch.getViolationsList()) {
+            for (var violation : receivedBatch.violations()) {
                 var key = new ViolationKey(violation);
                 aggregatedViolations.putIfAbsent(key, violation);
             }
@@ -151,21 +161,10 @@ public class ButterflyViolationAggregator {
      * @param violations current aggregated violations to send
      * @return violations received from partner
      */
-    private ViolationBatch exchangeWithPartner(int partner, int round,
-                                              Collection<BalanceViolation> violations) {
-        // Build batch to send
-        var batchBuilder = ViolationBatch.newBuilder()
-            .setRequesterRank(myRank)
-            .setResponderRank(partner)
-            .setRoundNumber(round)
-            .setTimestamp(System.currentTimeMillis());
-
-        // Add all current violations (includes local + previously received)
-        for (var violation : violations) {
-            batchBuilder.addViolations(violation);
-        }
-
-        var batch = batchBuilder.build();
+    private ViolationBatch<Key> exchangeWithPartner(int partner, int round,
+                                                   Collection<TwoOneBalanceChecker.BalanceViolation<Key>> violations) {
+        // Build batch to send (includes local + previously received)
+        var batch = new ViolationBatch<>(myRank, partner, round, new ArrayList<>(violations), System.currentTimeMillis());
 
         log.debug("Sending {} violations to partner {} in round {}", violations.size(), partner, round);
 
@@ -173,7 +172,7 @@ public class ButterflyViolationAggregator {
         var receivedBatch = violationExchanger.apply(partner, batch);
 
         log.debug("Received {} violations from partner {} in round {}",
-                 receivedBatch.getViolationsCount(), partner, round);
+                 receivedBatch.violations().size(), partner, round);
 
         return receivedBatch;
     }
@@ -186,11 +185,10 @@ public class ButterflyViolationAggregator {
         private final int localKeyHash;
         private final int ghostKeyHash;
 
-        ViolationKey(BalanceViolation violation) {
-            // Use the full SpatialKey hashCode for uniqueness
-            // SpatialKey contains oneof(MortonKey, TetreeKey) so hashCode handles both
-            this.localKeyHash = violation.getLocalKey().hashCode();
-            this.ghostKeyHash = violation.getGhostKey().hashCode();
+        ViolationKey(TwoOneBalanceChecker.BalanceViolation<?> violation) {
+            // Use the full SpatialKey hashCode for uniqueness (handles MortonKey, TetreeKey, etc.)
+            this.localKeyHash = violation.localKey().hashCode();
+            this.ghostKeyHash = violation.ghostKey().hashCode();
         }
 
         @Override

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/CrossPartitionBalancePhase.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/CrossPartitionBalancePhase.java
@@ -17,21 +17,18 @@
 package com.hellblazer.luciferase.lucien.balancing;
 
 import com.hellblazer.luciferase.lucien.SpatialKey;
-import com.hellblazer.luciferase.lucien.balancing.grpc.BalanceCoordinatorClient;
-import com.hellblazer.luciferase.lucien.balancing.proto.RefinementRequest;
-import com.hellblazer.luciferase.lucien.balancing.proto.RefinementResponse;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.forest.Forest;
-import com.hellblazer.luciferase.lucien.forest.ghost.ContentSerializer;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostElement;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostLayer;
-import com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Implements Phase 3 of parallel balancing: O(log P) cross-partition refinement protocol.
@@ -43,8 +40,8 @@ import java.util.stream.Collectors;
  * <p>Each refinement round:
  * <ol>
  *   <li>Identifies boundary elements needing refinement using level information</li>
- *   <li>Sends RefinementRequest to neighbor partitions via gRPC</li>
- *   <li>Receives RefinementResponse with ghost elements</li>
+ *   <li>Sends RefinementRequest to neighbor partitions via the domain exchange interface</li>
+ *   <li>Receives RefinementResponse with already-deserialized domain ghost elements</li>
  *   <li>Applies ghost elements to local forest</li>
  *   <li>Synchronizes all partitions via barrier</li>
  *   <li>Checks convergence (no more refinements needed)</li>
@@ -52,7 +49,7 @@ import java.util.stream.Collectors;
  *
  * <p>Based on the p4est parallel AMR algorithm (Burstedde et al., SIAM 2011).
  *
- * <p>Thread-safe: Uses immutable configuration and thread-safe client/registry.
+ * <p>Thread-safe: Uses immutable configuration and thread-safe exchange/registry.
  *
  * @param <Key> the spatial key type (MortonKey, TetreeKey, etc.)
  * @param <ID> the entity ID type
@@ -63,32 +60,30 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
 
     private static final Logger log = LoggerFactory.getLogger(CrossPartitionBalancePhase.class);
 
-    private final BalanceCoordinatorClient client;
+    private final RefinementExchange<Key, ID, Content> exchange;
     private final ParallelBalancer.PartitionRegistry registry;
     private final BalanceConfiguration config;
     private final RefinementRequestManager requestManager;
-    private volatile RefinementCoordinator coordinator;  // Initialized lazily in execute()
+    private volatile RefinementCoordinator<Key, ID, Content> coordinator;  // Initialized lazily in execute()
     private volatile boolean lastRoundIndicatedConvergence = false;
 
     // Forest context for violation detection and ghost element application
     private volatile Forest<Key, ID, Content> forest;
     private volatile GhostLayer<Key, ID, Content> ghostLayer;
     private volatile TwoOneBalanceChecker<Key, ID, Content> balanceChecker;
-    private volatile ContentSerializer<Content> contentSerializer;
-    private volatile Class<ID> idType;
 
     /**
      * Create a new cross-partition balance phase.
      *
-     * @param client the gRPC client for refinement requests
+     * @param exchange the domain exchange interface for refinement requests
      * @param registry the partition registry for coordination
      * @param config the balance configuration
      * @throws NullPointerException if any parameter is null
      */
-    public CrossPartitionBalancePhase(BalanceCoordinatorClient client,
-                                     ParallelBalancer.PartitionRegistry registry,
-                                     BalanceConfiguration config) {
-        this.client = Objects.requireNonNull(client, "client cannot be null");
+    public CrossPartitionBalancePhase(RefinementExchange<Key, ID, Content> exchange,
+                                      ParallelBalancer.PartitionRegistry registry,
+                                      BalanceConfiguration config) {
+        this.exchange = Objects.requireNonNull(exchange, "exchange cannot be null");
         this.registry = Objects.requireNonNull(registry, "registry cannot be null");
         this.config = Objects.requireNonNull(config, "config cannot be null");
         this.requestManager = new RefinementRequestManager();
@@ -103,33 +98,11 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
      * @throws NullPointerException if forest or ghostLayer is null
      */
     public void setForestContext(Forest<Key, ID, Content> forest,
-                                GhostLayer<Key, ID, Content> ghostLayer) {
+                                 GhostLayer<Key, ID, Content> ghostLayer) {
         this.forest = Objects.requireNonNull(forest, "forest cannot be null");
         this.ghostLayer = Objects.requireNonNull(ghostLayer, "ghostLayer cannot be null");
         this.balanceChecker = new TwoOneBalanceChecker<>();
         log.debug("Forest context set: forest with {} trees, {} ghost elements",
-                 forest.getTreeCount(), ghostLayer.getNumGhostElements());
-    }
-
-    /**
-     * Set forest context for violation detection and refinement with ghost element deserialization support.
-     *
-     * @param forest the local forest containing local elements
-     * @param ghostLayer the ghost layer for boundary element checking
-     * @param contentSerializer the serializer for content type
-     * @param idType the entity ID class for deserialization
-     * @throws NullPointerException if forest, ghostLayer, contentSerializer, or idType is null
-     */
-    public void setForestContext(Forest<Key, ID, Content> forest,
-                                GhostLayer<Key, ID, Content> ghostLayer,
-                                ContentSerializer<Content> contentSerializer,
-                                Class<ID> idType) {
-        this.forest = Objects.requireNonNull(forest, "forest cannot be null");
-        this.ghostLayer = Objects.requireNonNull(ghostLayer, "ghostLayer cannot be null");
-        this.contentSerializer = Objects.requireNonNull(contentSerializer, "contentSerializer cannot be null");
-        this.idType = Objects.requireNonNull(idType, "idType cannot be null");
-        this.balanceChecker = new TwoOneBalanceChecker<>();
-        log.debug("Forest context set: forest with {} trees, {} ghost elements (with deserialization support)",
                  forest.getTreeCount(), ghostLayer.getNumGhostElements());
     }
 
@@ -157,7 +130,7 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
 
         // Lazily initialize coordinator with rank and partition count
         if (coordinator == null) {
-            coordinator = new RefinementCoordinator(client, requestManager, initiatorRank, totalPartitions);
+            coordinator = new RefinementCoordinator<>(exchange, requestManager, initiatorRank, totalPartitions);
             log.debug("Initialized RefinementCoordinator for rank {} with {} total partitions",
                      initiatorRank, totalPartitions);
         }
@@ -235,15 +208,14 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
             var refinementNeeds = identifyRefinementNeeds(roundNumber);
 
             // Phase 2: Send requests to neighbors
-            // Send each request via client
-            var responses = new java.util.ArrayList<RefinementResponse>();
+            var responses = new ArrayList<RefinementResponse<Key, ID, Content>>();
 
             if (!refinementNeeds.isEmpty()) {
                 log.debug("Sending {} refinement requests in round {}", refinementNeeds.size(), roundNumber);
 
-                // Send each request via client and collect responses (for testing)
+                // Send each request via exchange and collect responses
                 for (int i = 0; i < refinementNeeds.size(); i++) {
-                    var responseFuture = client.requestRefinementAsync(i, 0L, roundNumber, 0, List.of());
+                    var responseFuture = exchange.requestRefinementAsync(i, 0L, roundNumber, 0, List.of());
                     try {
                         var response = responseFuture.get();
                         responses.add(response);
@@ -260,10 +232,19 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
             // Phase 4: Apply refinements from responses
             applyRefinementResponses(responses);
 
-            // Phase 5: Check if more refinement is needed
-            // Update convergence state based on responses
-            lastRoundIndicatedConvergence = responses.stream()
-                .noneMatch(RefinementResponse::getNeedsFurtherRefinement);
+            // Phase 5: Check if more refinement is needed.
+            // SIG-1: Exclude empty/sentinel responses from the convergence vote. A response
+            // mapped to RefinementResponse.empty() means the peer was unreachable; counting
+            // its needsFurtherRefinement==false as a vote toward convergence would risk
+            // premature termination. Only update lastRoundIndicatedConvergence when ALL
+            // responses are real (non-empty).
+            var realResponses = responses.stream().filter(r -> !r.isEmpty()).collect(Collectors.toList());
+            if (!realResponses.isEmpty()) {
+                lastRoundIndicatedConvergence = realResponses.stream()
+                    .noneMatch(RefinementResponse::needsFurtherRefinement);
+            }
+            // If all responses are empty (all peers unreachable), leave lastRoundIndicatedConvergence
+            // unchanged — equivalent to the old NPE-abort behavior that held the prior convergence state.
 
             var needsMore = !isConverged() && roundNumber < config.maxRounds();
 
@@ -295,7 +276,7 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
      * @param roundNumber the current round number
      * @param targetRounds the target number of rounds
      * @param balanceChecker the checker to detect violations
-     * @param coordinator the coordinator to send requests
+     * @param coordinator the coordinator to send requests (accessed via reflection for sendRequestsParallel)
      * @param <Coord> the coordinator type parameter
      * @return RoundResult with violations processed, round status, and timing
      * @throws java.util.concurrent.TimeoutException if requests timeout
@@ -335,8 +316,8 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
         log.debug("Round {}: Grouped {} violations into {} rank groups",
                  roundNumber, violations.size(), violationsByRank.size());
 
-        // Step 3: Build RefinementRequests
-        var requests = new java.util.ArrayList<RefinementRequest>();
+        // Step 3: Build domain RefinementRequests
+        var requests = new java.util.ArrayList<RefinementRequest<Key>>();
         for (var entry : violationsByRank.entrySet()) {
             var sourceRank = entry.getKey();
             var groupViolations = entry.getValue();
@@ -347,33 +328,35 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
                 .max()
                 .orElse(0);
 
-            // Collect boundary keys from violations
+            // Collect boundary keys from violations (domain SpatialKey, no proto conversion)
             var boundaryKeys = groupViolations.stream()
-                .flatMap(v -> java.util.stream.Stream.of(v.localKey(), v.ghostKey()))
-                .map(ProtobufConverters::spatialKeyToProtobuf)
+                .flatMap(v -> Stream.of(v.localKey(), v.ghostKey()))
                 .collect(Collectors.toList());
 
-            var request = RefinementRequest.newBuilder()
-                .setRequesterRank(registry.getCurrentPartitionId())
-                .setRequesterTreeId(0L)
-                .setRoundNumber(roundNumber)
-                .setTreeLevel(maxLevel)
-                .addAllBoundaryKeys(boundaryKeys)
-                .setTimestamp(System.currentTimeMillis())
-                .build();
+            var request = new RefinementRequest<>(
+                registry.getCurrentPartitionId(),
+                0L,
+                roundNumber,
+                maxLevel,
+                boundaryKeys,
+                System.currentTimeMillis()
+            );
 
             requests.add(request);
             log.trace("Round {}: Created request for rank {} with {} violations, level={}",
                      roundNumber, sourceRank, groupViolations.size(), maxLevel);
         }
 
-        // Step 4: Send async requests via coordinator
-        List<java.util.concurrent.CompletableFuture<RefinementResponse>> futures;
+        // Step 4: Send async requests via coordinator using reflection.
+        // sendRequestsParallel is private in RefinementCoordinator; we use getDeclaredMethod +
+        // setAccessible so it remains private. Erasure-matched: List.class covers the generic
+        // List<RefinementRequest<Key>> at the call site.
+        List<java.util.concurrent.CompletableFuture<RefinementResponse<Key, ID, Content>>> futures;
         try {
-            // Use reflection to call sendRequestsParallel on coordinator
-            var method = coordinator.getClass().getMethod("sendRequestsParallel", List.class);
+            var method = coordinator.getClass().getDeclaredMethod("sendRequestsParallel", List.class);
+            method.setAccessible(true);
             @SuppressWarnings("unchecked")
-            var result = (List<java.util.concurrent.CompletableFuture<RefinementResponse>>) method.invoke(coordinator, requests);
+            var result = (List<java.util.concurrent.CompletableFuture<RefinementResponse<Key, ID, Content>>>) method.invoke(coordinator, requests);
             futures = result;
         } catch (java.lang.reflect.InvocationTargetException e) {
             // Unwrap exceptions thrown by sendRequestsParallel()
@@ -390,7 +373,7 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
         }
 
         // Step 5: Await all futures with timeout
-        var responses = new java.util.ArrayList<RefinementResponse>();
+        var responses = new java.util.ArrayList<RefinementResponse<Key, ID, Content>>();
         for (var future : futures) {
             try {
                 var response = future.get(5, java.util.concurrent.TimeUnit.SECONDS);
@@ -423,27 +406,21 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
      * Identify refinement needs at partition boundaries for the current round.
      *
      * <p>Uses the TwoOneBalanceChecker to detect 2:1 balance violations at partition
-     * boundaries and creates refinement requests for neighboring partitions.
+     * boundaries and creates domain refinement requests for neighboring partitions.
      *
-     * <p>In distributed balance protocol, each partition sends requests to its butterfly
-     * partners each round. The butterfly pattern ensures O(log P) communication.
-     *
-     * @return list of refinement requests for neighbors
+     * @param roundNumber the round number
+     * @return list of domain refinement requests for neighbors
      */
-    private List<RefinementRequest> identifyRefinementNeeds(int roundNumber) {
-        var requests = new java.util.ArrayList<RefinementRequest>();
+    private List<RefinementRequest<Key>> identifyRefinementNeeds(int roundNumber) {
+        var requests = new java.util.ArrayList<RefinementRequest<Key>>();
 
         // Check if forest context is available
         if (balanceChecker == null || forest == null || ghostLayer == null) {
             log.warn("Forest context not set, using fallback request for round {}", roundNumber);
             // Fallback: single empty request to maintain butterfly pattern
-            var request = RefinementRequest.newBuilder()
-                .setRequesterRank(registry.getCurrentPartitionId())
-                .setRequesterTreeId(0L)
-                .setRoundNumber(roundNumber)
-                .setTreeLevel(0)
-                .setTimestamp(System.currentTimeMillis())
-                .build();
+            var request = new RefinementRequest<Key>(
+                registry.getCurrentPartitionId(), 0L, roundNumber, 0, List.of(), System.currentTimeMillis()
+            );
             requests.add(request);
             return requests;
         }
@@ -454,13 +431,9 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
         if (violations.isEmpty()) {
             log.debug("No 2:1 violations found in round {}", roundNumber);
             // Still send request to maintain butterfly pattern, but with no boundary keys
-            var request = RefinementRequest.newBuilder()
-                .setRequesterRank(registry.getCurrentPartitionId())
-                .setRequesterTreeId(0L)
-                .setRoundNumber(roundNumber)
-                .setTreeLevel(0)
-                .setTimestamp(System.currentTimeMillis())
-                .build();
+            var request = new RefinementRequest<Key>(
+                registry.getCurrentPartitionId(), 0L, roundNumber, 0, List.of(), System.currentTimeMillis()
+            );
             requests.add(request);
             return requests;
         }
@@ -474,7 +447,7 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
                            .add(violation);
         }
 
-        // Create refinement request per source rank
+        // Create domain refinement request per source rank
         for (var entry : violationsByRank.entrySet()) {
             var sourceRank = entry.getKey();
             var groupViolations = entry.getValue();
@@ -485,21 +458,21 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
                 .max()
                 .orElse(0);
 
-            // Collect boundary keys from violations
+            // Collect boundary keys from violations (domain SpatialKey, no proto conversion)
             var boundaryKeys = groupViolations.stream()
-                .flatMap(v -> java.util.stream.Stream.of(v.localKey(), v.ghostKey()))
-                .map(ProtobufConverters::spatialKeyToProtobuf)
+                .flatMap(v -> Stream.of(v.localKey(), v.ghostKey()))
                 .collect(Collectors.toList());
 
-            var request = RefinementRequest.newBuilder()
-                .setRequesterRank(registry.getCurrentPartitionId())
-                .setRequesterTreeId(0L)
-                .setRoundNumber(roundNumber)
-                .setTreeLevel(maxLevel)
-                .addAllBoundaryKeys(boundaryKeys)
-                .setTimestamp(System.currentTimeMillis());
+            var request = new RefinementRequest<>(
+                registry.getCurrentPartitionId(),
+                0L,
+                roundNumber,
+                maxLevel,
+                boundaryKeys,
+                System.currentTimeMillis()
+            );
 
-            requests.add(request.build());
+            requests.add(request);
             log.trace("Created request for rank {} with {} violations", sourceRank, groupViolations.size());
         }
 
@@ -507,18 +480,18 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
     }
 
     /**
-     * Process a single refinement response and apply ghost elements to the ghost layer.
+     * Process a single refinement response and apply domain ghost elements to the ghost layer.
      *
-     * <p>This method deserializes ghost elements from the RefinementResponse protobuf
-     * and adds them to the local ghost layer for boundary element checking.
+     * <p>Ghost elements are already deserialized domain objects (deserialization happens in the
+     * grpc adapter, not here). Each element is applied individually with a per-element guard so
+     * a single bad element does not abort the whole batch.
      *
-     * @param response the refinement response from a remote partition
+     * @param response the domain refinement response from a remote partition (null is a no-op)
      * @param coordinator the refinement coordinator (for context/logging)
-     * @throws ContentSerializer.SerializationException if ghost element deserialization fails
      */
     public void applyRefinementResponses(
-            RefinementResponse response,
-            RefinementCoordinator coordinator) throws ContentSerializer.SerializationException {
+            RefinementResponse<Key, ID, Content> response,
+            RefinementCoordinator<Key, ID, Content> coordinator) {
 
         // Validate input
         if (response == null) {
@@ -531,63 +504,45 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
             return;
         }
 
-        // Extract ghost elements from response
-        var ghostProtos = response.getGhostElementsList();
-        if (ghostProtos.isEmpty()) {
+        // Extract already-deserialized domain ghost elements from response
+        var ghosts = response.ghostElements();
+        if (ghosts.isEmpty()) {
             log.debug("Response contains no ghost elements, returning");
             return;
         }
 
         log.debug("Processing {} ghost elements from response (responder rank: {})",
-                 ghostProtos.size(), response.getResponderRank());
+                 ghosts.size(), response.responderRank());
 
         var addedCount = 0;
         var skippedCount = 0;
 
-        // Process each ghost element
-        for (var ghostProto : ghostProtos) {
+        // Process each domain ghost element with per-element guard
+        for (var ghost : ghosts) {
             try {
-                // Deserialize ghost element using contentSerializer and idType
-                if (contentSerializer != null && idType != null) {
-                    @SuppressWarnings("unchecked")
-                    var ghostElement = (GhostElement<Key, ID, Content>) ProtobufConverters.ghostElementFromProtobuf(
-                        ghostProto,
-                        contentSerializer,
-                        idType
-                    );
+                ghostLayer.addGhostElement(ghost);
+                addedCount++;
 
-                    // Add to ghost layer
-                    ghostLayer.addGhostElement(ghostElement);
-                    addedCount++;
-
-                    log.trace("Added ghost element: key={}, entityId={}, ownerRank={}",
-                             ghostElement.getSpatialKey(),
-                             ghostElement.getEntityId(),
-                             ghostElement.getOwnerRank());
-                } else {
-                    // Backward compatibility: skip if serializer not configured
-                    log.trace("Skipping ghost element deserialization (no serializer configured)");
-                    skippedCount++;
-                }
-            } catch (ContentSerializer.SerializationException e) {
-                log.warn("Failed to deserialize ghost element from response: {}", e.getMessage());
-                skippedCount++;
+                log.trace("Added ghost element: key={}, entityId={}, ownerRank={}",
+                         ghost.getSpatialKey(),
+                         ghost.getEntityId(),
+                         ghost.getOwnerRank());
             } catch (Exception e) {
-                log.warn("Unexpected error processing ghost element: {}", e.getMessage(), e);
+                log.warn("Unexpected error adding ghost element: {}", e.getMessage(), e);
                 skippedCount++;
             }
         }
 
         log.debug("Applied {} ghost elements from response (rank {}), skipped {} invalid elements",
-                 addedCount, response.getResponderRank(), skippedCount);
+                 addedCount, response.responderRank(), skippedCount);
     }
 
     /**
-     * Process refinement responses and apply updates to forest.
+     * Process refinement responses and apply domain ghost elements to forest.
      *
-     * @param responses the refinement responses from neighbors
+     * @param responses the domain refinement responses from neighbors
      */
-    private void applyRefinementResponses(List<RefinementResponse> responses) {
+    private void applyRefinementResponses(List<RefinementResponse<Key, ID, Content>> responses) {
         if (ghostLayer == null) {
             log.debug("No ghost layer context, skipping response processing");
             return;
@@ -596,24 +551,12 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
         int appliedCount = 0;
 
         for (var response : responses) {
-            // Extract ghost elements from response
-            for (var ghostProto : response.getGhostElementsList()) {
+            // Apply each already-deserialized domain ghost element with per-element guard
+            for (var ghost : response.ghostElements()) {
                 try {
-                    // Convert protobuf ghost element to domain object and add to ghost layer
-                    if (contentSerializer != null && idType != null) {
-                        @SuppressWarnings("unchecked")
-                        var ghostElement = (GhostElement<Key, ID, Content>) ProtobufConverters.ghostElementFromProtobuf(
-                            ghostProto,
-                            contentSerializer,
-                            idType
-                        );
-                        ghostLayer.addGhostElement(ghostElement);
-                        appliedCount++;
-                        log.trace("Applied ghost element from response");
-                    } else {
-                        // Backward compatibility: skip deserialization if serializer not configured
-                        log.trace("Skipping ghost element deserialization (no serializer configured)");
-                    }
+                    ghostLayer.addGhostElement(ghost);
+                    appliedCount++;
+                    log.trace("Applied ghost element from response");
                 } catch (Exception e) {
                     log.warn("Failed to apply ghost element from response: {}", e.getMessage());
                 }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/CrossPartitionBalancePhase.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/CrossPartitionBalancePhase.java
@@ -348,13 +348,16 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
         }
 
         // Step 4: Send async requests via coordinator using reflection.
-        // sendRequestsParallel is private in RefinementCoordinator; we use getDeclaredMethod +
-        // setAccessible so it remains private. Erasure-matched: List.class covers the generic
-        // List<RefinementRequest<Key>> at the call site.
+        // This 4-arg overload is a TEST-ONLY entry point (no production caller); the production round
+        // path is executeRefinementRound -> the private 1-arg identifyRefinementNeeds, which sends via
+        // the exchange directly. Tests pass a coordinator exposing a PUBLIC sendRequestsParallel, so
+        // getMethod (public-only) resolves it — byte-identical to the pre-inversion behavior. We keep
+        // getMethod (not getDeclaredMethod/setAccessible) precisely to preserve that behavior: against a
+        // real RefinementCoordinator (private method) this throws NoSuchMethodException, exactly as before.
+        // Erasure-matched: List.class covers the generic List<RefinementRequest<Key>> at the call site.
         List<java.util.concurrent.CompletableFuture<RefinementResponse<Key, ID, Content>>> futures;
         try {
-            var method = coordinator.getClass().getDeclaredMethod("sendRequestsParallel", List.class);
-            method.setAccessible(true);
+            var method = coordinator.getClass().getMethod("sendRequestsParallel", List.class);
             @SuppressWarnings("unchecked")
             var result = (List<java.util.concurrent.CompletableFuture<RefinementResponse<Key, ID, Content>>>) method.invoke(coordinator, requests);
             futures = result;
@@ -551,6 +554,11 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
         int appliedCount = 0;
 
         for (var response : responses) {
+            // Skip empty/sentinel responses (unreachable peers) for symmetry with the convergence-vote
+            // filter. They carry no ghost elements so this is a no-op, but keeps the two paths aligned.
+            if (response.isEmpty()) {
+                continue;
+            }
             // Apply each already-deserialized domain ghost element with per-element guard
             for (var ghost : response.ghostElements()) {
                 try {

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/DefaultParallelBalancer.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/DefaultParallelBalancer.java
@@ -18,7 +18,6 @@ package com.hellblazer.luciferase.lucien.balancing;
 
 import com.hellblazer.luciferase.lucien.SpatialKey;
 import com.hellblazer.luciferase.lucien.balancing.fault.InFlightOperationTracker;
-import com.hellblazer.luciferase.lucien.balancing.grpc.BalanceCoordinatorClient;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.forest.Forest;
 import com.hellblazer.luciferase.lucien.forest.ghost.DistributedGhostManager;
@@ -155,10 +154,10 @@ public class DefaultParallelBalancer<Key extends SpatialKey<Key>, ID extends Ent
 
         log.debug("Starting Phase 3: Cross-partition balance");
 
-        // Check if forest context and gRPC client are available for full implementation
-        var coordinatorClient = createBalanceCoordinatorClient(registry);
-        if (currentForest != null && currentGhostManager != null && coordinatorClient != null) {
-            log.debug("Full forest context and client available, using CrossPartitionBalancePhase");
+        // Check if forest context and exchange are available for full implementation
+        var exchange = createRefinementExchange(registry);
+        if (currentForest != null && currentGhostManager != null && exchange != null) {
+            log.debug("Full forest context and exchange available, using CrossPartitionBalancePhase");
 
             try {
                 // Get ghost layer from the ghost manager
@@ -167,7 +166,7 @@ public class DefaultParallelBalancer<Key extends SpatialKey<Key>, ID extends Ent
                 // Create cross-partition balance phase if not already created
                 if (crossPartitionPhase == null) {
                     crossPartitionPhase = new CrossPartitionBalancePhase<>(
-                        coordinatorClient,
+                        exchange,
                         registry,
                         configuration
                     );
@@ -191,8 +190,8 @@ public class DefaultParallelBalancer<Key extends SpatialKey<Key>, ID extends Ent
             }
         } else {
             // Fallback: skeleton implementation for testing without full context
-            if (coordinatorClient == null) {
-                log.debug("gRPC client not available, using skeleton implementation");
+            if (exchange == null) {
+                log.debug("Refinement exchange not available, using skeleton implementation");
             } else {
                 log.debug("No forest context available, using skeleton implementation");
             }
@@ -354,21 +353,17 @@ public class DefaultParallelBalancer<Key extends SpatialKey<Key>, ID extends Ent
     }
 
     /**
-     * Create a balance coordinator client for gRPC refinement communication.
+     * Create a domain RefinementExchange for cross-partition refinement communication.
      *
-     * <p>This factory method creates the gRPC client that CrossPartitionBalancePhase uses
-     * to send refinement requests to neighbor partitions.
+     * <p>Returns null (stub) until gRPC integration is complete (RDR-007 P1).
+     * The concrete adapter ({@code GrpcBalanceExchange}) lives in the grpc adapter package.
      *
      * @param registry the partition registry for client configuration
-     * @return a new balance coordinator client
+     * @return a domain RefinementExchange, or null if not yet available
      */
-    private BalanceCoordinatorClient createBalanceCoordinatorClient(PartitionRegistry registry) {
-        // TODO: Implement gRPC client creation from registry
-        // For now, return a stub that delegates to the registry
-        log.debug("Creating BalanceCoordinatorClient for partition {}", registry.getCurrentPartitionId());
-
-        // This will be fully implemented when gRPC integration is complete
-        // For skeleton tests, this can be mocked
+    private RefinementExchange<Key, ID, Content> createRefinementExchange(PartitionRegistry registry) {
+        // TODO: return the grpc adapter wrapping the coordinator client (RDR-007 P1)
+        log.debug("RefinementExchange not yet available for partition {}", registry.getCurrentPartitionId());
         return null;
     }
 }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/DistributedViolationAggregator.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/DistributedViolationAggregator.java
@@ -16,41 +16,42 @@
  */
 package com.hellblazer.luciferase.lucien.balancing;
 
-import com.hellblazer.luciferase.lucien.balancing.grpc.BalanceCoordinatorClient;
-import com.hellblazer.luciferase.lucien.balancing.proto.BalanceViolation;
-import com.hellblazer.luciferase.lucien.balancing.proto.ViolationAck;
-import com.hellblazer.luciferase.lucien.balancing.proto.ViolationBatch;
-import io.grpc.StatusRuntimeException;
+import com.hellblazer.luciferase.lucien.SpatialKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiFunction;
 
 /**
- * Distributed violation aggregator using gRPC for cross-partition exchange.
+ * Distributed violation aggregator using a {@link ViolationExchange} port for cross-partition exchange.
  *
- * <p>Wraps ButterflyViolationAggregator with gRPC-based network communication.
+ * <p>Wraps {@link ButterflyViolationAggregator} with network communication via the domain exchange port.
  * Provides timeout handling, retry logic, and metrics for distributed operation.
  *
  * <p>Configuration:
  * <ul>
  *   <li>Timeout: 5 seconds per exchange
- *   <li>Retries: 1 retry on transient failures (UNAVAILABLE, RESOURCE_EXHAUSTED)
+ *   <li>Retries: 1 retry on transient failures
  *   <li>Failure handling: Graceful degradation - continues with partial results
  * </ul>
  *
+ * @param <Key> the spatial key type (MortonKey, TetreeKey, etc.)
  * @author hal.hildebrand
  */
-public class DistributedViolationAggregator {
+public class DistributedViolationAggregator<Key extends SpatialKey<Key>> {
 
     private static final Logger log = LoggerFactory.getLogger(DistributedViolationAggregator.class);
     private static final long DEFAULT_TIMEOUT_MILLIS = 5000;
     private static final int MAX_RETRIES = 1;
 
-    private final ButterflyViolationAggregator aggregator;
-    private final BalanceCoordinatorClient client;
+    private final ButterflyViolationAggregator<Key> aggregator;
+    private final ViolationExchange<Key> exchange;
     private final int myRank;
     private final long timeoutMillis;
 
@@ -66,10 +67,10 @@ public class DistributedViolationAggregator {
      *
      * @param myRank this partition's rank
      * @param totalPartitions total number of partitions
-     * @param client gRPC client for network communication
+     * @param exchange the violation-exchange port for network communication
      */
-    public DistributedViolationAggregator(int myRank, int totalPartitions, BalanceCoordinatorClient client) {
-        this(myRank, totalPartitions, client, DEFAULT_TIMEOUT_MILLIS);
+    public DistributedViolationAggregator(int myRank, int totalPartitions, ViolationExchange<Key> exchange) {
+        this(myRank, totalPartitions, exchange, DEFAULT_TIMEOUT_MILLIS);
     }
 
     /**
@@ -77,15 +78,15 @@ public class DistributedViolationAggregator {
      *
      * @param myRank this partition's rank
      * @param totalPartitions total number of partitions
-     * @param client gRPC client for network communication
+     * @param exchange the violation-exchange port for network communication
      * @param timeoutMillis timeout for each exchange in milliseconds
      */
     public DistributedViolationAggregator(int myRank, int totalPartitions,
-                                         BalanceCoordinatorClient client, long timeoutMillis) {
-        Objects.requireNonNull(client, "client cannot be null");
+                                         ViolationExchange<Key> exchange, long timeoutMillis) {
+        Objects.requireNonNull(exchange, "exchange cannot be null");
 
         this.myRank = myRank;
-        this.client = client;
+        this.exchange = exchange;
         this.timeoutMillis = timeoutMillis;
         this.successfulExchanges = new AtomicLong(0);
         this.failedExchanges = new AtomicLong(0);
@@ -93,11 +94,11 @@ public class DistributedViolationAggregator {
         this.timeouts = new AtomicLong(0);
         this.exchangeLatencies = new ConcurrentHashMap<>();
 
-        // Create exchanger function that uses gRPC client
-        var exchanger = this.createGrpcExchanger();
+        // Create exchanger function backed by the exchange port
+        var exchanger = this.createExchanger();
 
-        // Create butterfly aggregator with gRPC exchanger
-        this.aggregator = new ButterflyViolationAggregator(myRank, totalPartitions, exchanger);
+        // Create butterfly aggregator with the exchanger
+        this.aggregator = new ButterflyViolationAggregator<>(myRank, totalPartitions, exchanger);
 
         log.debug("DistributedViolationAggregator initialized for rank {} of {} partitions (timeout: {}ms)",
                  myRank, totalPartitions, timeoutMillis);
@@ -110,7 +111,8 @@ public class DistributedViolationAggregator {
      * @return set of all violations from all partitions (deduplicated)
      * @throws NullPointerException if localViolations is null
      */
-    public Set<BalanceViolation> aggregateDistributed(List<BalanceViolation> localViolations) {
+    public Set<TwoOneBalanceChecker.BalanceViolation<Key>> aggregateDistributed(
+            List<TwoOneBalanceChecker.BalanceViolation<Key>> localViolations) {
         Objects.requireNonNull(localViolations, "localViolations cannot be null");
 
         log.debug("Starting distributed violation aggregation with {} local violations", localViolations.size());
@@ -126,9 +128,9 @@ public class DistributedViolationAggregator {
     }
 
     /**
-     * Creates a gRPC-based exchanger function with timeout and retry handling.
+     * Creates an exchanger function with timeout and retry handling, backed by the exchange port.
      */
-    private java.util.function.BiFunction<Integer, ViolationBatch, ViolationBatch> createGrpcExchanger() {
+    private BiFunction<Integer, ViolationBatch<Key>, ViolationBatch<Key>> createExchanger() {
         return (partner, batch) -> {
             var startTime = System.currentTimeMillis();
 
@@ -140,29 +142,25 @@ public class DistributedViolationAggregator {
                         log.debug("Retry attempt {} for exchange with partner {}", attempt, partner);
                     }
 
-                    var responseBatch = client.exchangeViolations(batch);
+                    var responseBatch = exchange.exchangeViolations(batch);
 
+                    // A null response signals a skipped exchange (no connection); fall through to the
+                    // empty-batch fallback without counting it as a success (graceful degradation).
                     if (responseBatch != null) {
                         successfulExchanges.incrementAndGet();
                         var latency = System.currentTimeMillis() - startTime;
                         exchangeLatencies.put(partner, latency);
 
                         log.debug("Successfully exchanged {} violations with partner {} ({}ms, {} received)",
-                                 batch.getViolationsCount(), partner, latency,
-                                 responseBatch.getViolationsCount());
+                                 batch.violations().size(), partner, latency,
+                                 responseBatch.violations().size());
 
                         // Return partner's violations for merging
                         return responseBatch;
                     }
 
-                } catch (StatusRuntimeException e) {
-                    var status = e.getStatus();
-
-                    // Check if this is a transient failure worth retrying
-                    var isTransient = status.getCode() == io.grpc.Status.Code.UNAVAILABLE ||
-                                     status.getCode() == io.grpc.Status.Code.RESOURCE_EXHAUSTED;
-
-                    if (status.getCode() == io.grpc.Status.Code.DEADLINE_EXCEEDED) {
+                } catch (BalanceExchangeException e) {
+                    if (e.isTimeout()) {
                         timeouts.incrementAndGet();
                         log.warn("Exchange with partner {} timed out after {}ms",
                                 partner, System.currentTimeMillis() - startTime);
@@ -170,15 +168,15 @@ public class DistributedViolationAggregator {
                         break; // Don't retry timeouts
                     }
 
-                    if (!isTransient || attempt == MAX_RETRIES) {
+                    if (!e.isTransient() || attempt == MAX_RETRIES) {
                         log.error("Exchange with partner {} failed: {} (attempt {}/{})",
-                                 partner, status, attempt + 1, MAX_RETRIES + 1);
+                                 partner, e.getMessage(), attempt + 1, MAX_RETRIES + 1);
                         failedExchanges.incrementAndGet();
                         break;
                     }
 
                     log.debug("Transient failure on exchange with partner {}: {}, will retry",
-                             partner, status);
+                             partner, e.getMessage());
 
                 } catch (Exception e) {
                     log.error("Unexpected error exchanging with partner {}: {}",
@@ -189,12 +187,7 @@ public class DistributedViolationAggregator {
             }
 
             // Return empty batch on failure - aggregation continues with partial results
-            return ViolationBatch.newBuilder()
-                .setRequesterRank(partner)
-                .setResponderRank(myRank)
-                .setRoundNumber(batch.getRoundNumber())
-                .setTimestamp(System.currentTimeMillis())
-                .build();
+            return new ViolationBatch<>(partner, myRank, batch.roundNumber(), List.of(), System.currentTimeMillis());
         };
     }
 

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementCoordinator.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementCoordinator.java
@@ -16,9 +16,8 @@
  */
 package com.hellblazer.luciferase.lucien.balancing;
 
-import com.hellblazer.luciferase.lucien.balancing.grpc.BalanceCoordinatorClient;
-import com.hellblazer.luciferase.lucien.balancing.proto.RefinementRequest;
-import com.hellblazer.luciferase.lucien.balancing.proto.RefinementResponse;
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,15 +40,18 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>Based on the p4est parallel AMR algorithm's O(log P) refinement protocol.
  *
- * <p>Thread-safe: Uses thread-safe client and request manager.
+ * <p>Thread-safe: Uses thread-safe exchange and request manager.
  *
+ * @param <Key> the spatial key type (MortonKey, TetreeKey, etc.)
+ * @param <ID> the entity ID type
+ * @param <Content> the content type stored with entities
  * @author hal.hildebrand
  */
-public class RefinementCoordinator {
+public class RefinementCoordinator<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
 
     private static final Logger log = LoggerFactory.getLogger(RefinementCoordinator.class);
 
-    private final BalanceCoordinatorClient client;
+    private final RefinementExchange<Key, ID, Content> exchange;
     private final RefinementRequestManager requestManager;
     private final int myRank;
     private final int totalPartitions;
@@ -57,16 +59,17 @@ public class RefinementCoordinator {
     /**
      * Create a new refinement coordinator.
      *
-     * @param client the gRPC client for communication
+     * @param exchange the domain exchange interface for refinement communication
      * @param requestManager the request manager for tracking
      * @param myRank this partition's rank (0 to P-1)
      * @param totalPartitions total number of partitions P
-     * @throws NullPointerException if client or requestManager is null
+     * @throws NullPointerException if exchange or requestManager is null
      * @throws IllegalArgumentException if myRank < 0 or totalPartitions <= 0
      */
-    public RefinementCoordinator(BalanceCoordinatorClient client, RefinementRequestManager requestManager,
-                                int myRank, int totalPartitions) {
-        this.client = Objects.requireNonNull(client, "client cannot be null");
+    public RefinementCoordinator(RefinementExchange<Key, ID, Content> exchange,
+                                 RefinementRequestManager requestManager,
+                                 int myRank, int totalPartitions) {
+        this.exchange = Objects.requireNonNull(exchange, "exchange cannot be null");
         this.requestManager = Objects.requireNonNull(requestManager, "requestManager cannot be null");
 
         if (myRank < 0) {
@@ -182,15 +185,15 @@ public class RefinementCoordinator {
                 var futures = sendRequestsParallel(requests);
 
                 // Wait for responses with timeout
-                var responses = new ArrayList<RefinementResponse>();
+                var responses = new ArrayList<RefinementResponse<Key, ID, Content>>();
                 for (var future : futures) {
                     try {
                         var response = future.get(5, TimeUnit.SECONDS);
                         responses.add(response);
 
                         // Track refinements from this response
-                        if (response.getGhostElementsCount() > 0) {
-                            refinementsApplied += response.getGhostElementsCount();
+                        if (response.ghostElements().size() > 0) {
+                            refinementsApplied += response.ghostElements().size();
                         }
                     } catch (Exception e) {
                         log.warn("Failed to get response from partner {} in round {}: {}",
@@ -223,17 +226,18 @@ public class RefinementCoordinator {
      * @param roundNumber the current round number
      * @return list of refinement requests (typically 1 per partner)
      */
-    private List<RefinementRequest> buildRequestsForPartner(int partnerRank, int roundNumber) {
-        var requests = new ArrayList<RefinementRequest>();
+    private List<RefinementRequest<Key>> buildRequestsForPartner(int partnerRank, int roundNumber) {
+        var requests = new ArrayList<RefinementRequest<Key>>();
 
         // Build request for this partner
-        var request = RefinementRequest.newBuilder()
-            .setRequesterRank(myRank)
-            .setRequesterTreeId(0L)  // TODO: support multiple trees
-            .setRoundNumber(roundNumber)
-            .setTreeLevel(0)  // TODO: extract actual level from boundary violations
-            .setTimestamp(System.currentTimeMillis())
-            .build();
+        var request = new RefinementRequest<Key>(
+            myRank,
+            0L,  // TODO: support multiple trees
+            roundNumber,
+            0,   // TODO: extract actual level from boundary violations
+            List.of(),
+            System.currentTimeMillis()
+        );
 
         requests.add(request);
 
@@ -272,13 +276,14 @@ public class RefinementCoordinator {
      * in a single refinement round. In the butterfly pattern, each rank communicates with
      * exactly one partner per round (calculated as rank XOR 2^round).
      *
-     * @param requests the refinement requests to send (typically 1 per butterfly partner)
+     * @param requests the domain refinement requests to send (typically 1 per butterfly partner)
      * @return futures for all requests
      */
-    private List<CompletableFuture<RefinementResponse>> sendRequestsParallel(List<RefinementRequest> requests) {
+    private List<CompletableFuture<RefinementResponse<Key, ID, Content>>> sendRequestsParallel(
+            List<RefinementRequest<Key>> requests) {
         log.debug("Sending {} refinement requests in parallel", requests.size());
 
-        var futures = new ArrayList<CompletableFuture<RefinementResponse>>();
+        var futures = new ArrayList<CompletableFuture<RefinementResponse<Key, ID, Content>>>();
 
         // Default timeout of 5 seconds per request
         // (will be made configurable via BalanceConfiguration in future phases)
@@ -288,24 +293,24 @@ public class RefinementCoordinator {
             // Track request for monitoring
             requestManager.trackRequest(request, System.currentTimeMillis());
 
-            // Send async with timeout
-            var future = client.requestRefinementAsync(
-                request.getRequesterRank(),
-                request.getRequesterTreeId(),
-                request.getRoundNumber(),
-                request.getTreeLevel(),
-                request.getBoundaryKeysList()
+            // Send async with timeout via domain exchange
+            var future = exchange.requestRefinementAsync(
+                request.requesterRank(),
+                request.requesterTreeId(),
+                request.roundNumber(),
+                request.treeLevel(),
+                request.boundaryKeys()
             )
-            .orTimeout(timeoutSeconds, TimeUnit.SECONDS)  // Default 5 second timeout
+            .orTimeout(timeoutSeconds, TimeUnit.SECONDS)
             .exceptionally(ex -> {
                 log.warn("Request from rank {} failed in round {}: {}",
-                    request.getRequesterRank(), request.getRoundNumber(), ex.getMessage());
+                    request.requesterRank(), request.roundNumber(), ex.getMessage());
                 // Return empty response on timeout/failure
-                return RefinementResponse.getDefaultInstance();
+                return RefinementResponse.empty();
             });
 
             futures.add(future);
-            log.trace("Queued request from rank {} in round {}", request.getRequesterRank(), request.getRoundNumber());
+            log.trace("Queued request from rank {} in round {}", request.requesterRank(), request.roundNumber());
         }
 
         return futures;

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementExchange.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementExchange.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.balancing;
+
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Lucien-core port for requesting cross-partition refinement (RDR-007 Phase 0 Inc3).
+ *
+ * <p>Inverts the dependency from the concrete grpc {@code BalanceCoordinatorClient}: core balancing logic
+ * depends on this domain interface, and the grpc adapter implements it, converting between domain types
+ * and proto on the wire. Split from {@link ViolationExchange} so the violation-aggregation path (which
+ * needs only {@code Key}) is not forced to carry {@code ID}/{@code Content} type parameters.
+ *
+ * @param <Key> the spatial key type (MortonKey, TetreeKey, etc.)
+ * @param <ID> the entity ID type
+ * @param <Content> the content type stored with entities
+ * @author hal.hildebrand
+ */
+public interface RefinementExchange<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
+
+    /**
+     * Request refinement from a remote partition asynchronously.
+     *
+     * @param targetRank the rank of the target partition
+     * @param treeId the tree ID to request refinement for
+     * @param roundNumber the balance round number
+     * @param treeLevel the tree level requiring refinement
+     * @param boundaryKeys the domain boundary keys to refine (may be empty)
+     * @return a future completing with the domain refinement response
+     */
+    CompletableFuture<RefinementResponse<Key, ID, Content>> requestRefinementAsync(
+        int targetRank, long treeId, int roundNumber, int treeLevel, List<Key> boundaryKeys);
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementRequest.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementRequest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.balancing;
+
+import com.hellblazer.luciferase.lucien.SpatialKey;
+
+import java.util.List;
+
+/**
+ * Pure-domain refinement request for cross-partition balance (RDR-007 Phase 0 Inc3).
+ *
+ * <p>Replaces the protobuf {@code RefinementRequest} message at the lucien-core boundary.
+ * Boundary keys are carried as domain {@link SpatialKey} instances; conversion to/from the protobuf
+ * {@code SpatialKey} happens in the grpc adapter, not in core balancing logic.
+ *
+ * @param <Key> the spatial key type (MortonKey, TetreeKey, etc.)
+ * @author hal.hildebrand
+ */
+public record RefinementRequest<Key extends SpatialKey<Key>>(
+    int requesterRank,
+    long requesterTreeId,
+    int roundNumber,
+    int treeLevel,
+    List<Key> boundaryKeys,
+    long timestamp
+) {
+    public RefinementRequest {
+        boundaryKeys = List.copyOf(boundaryKeys);
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementRequestManager.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementRequestManager.java
@@ -17,9 +17,6 @@
 package com.hellblazer.luciferase.lucien.balancing;
 
 import com.hellblazer.luciferase.lucien.SpatialKey;
-import com.hellblazer.luciferase.lucien.balancing.proto.RefinementRequest;
-import com.hellblazer.luciferase.lucien.balancing.proto.RefinementResponse;
-import com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey.Builder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +54,7 @@ public class RefinementRequestManager {
     private final AtomicLong totalRoundTripTime = new AtomicLong(0);
 
     /**
-     * Build a RefinementRequest for specific boundaries.
+     * Build a domain RefinementRequest for specific boundaries.
      *
      * <p>The request includes:
      * <ul>
@@ -68,35 +65,22 @@ public class RefinementRequestManager {
      *   <li>Timestamp for tracking</li>
      * </ul>
      *
+     * @param <Key> the spatial key type
      * @param requesterRank the rank of the requesting partition
      * @param roundNumber the current refinement round
      * @param boundaryKeys the spatial keys at partition boundaries
      * @param treeLevel the level in the tree requiring refinement
-     * @return the refinement request
+     * @return the domain refinement request
      */
-    public RefinementRequest buildRequest(int requesterRank, int roundNumber,
-                                         List<SpatialKey> boundaryKeys, int treeLevel) {
+    public <Key extends SpatialKey<Key>> RefinementRequest<Key> buildRequest(int requesterRank, int roundNumber,
+                                                                              List<Key> boundaryKeys, int treeLevel) {
         totalRequests.incrementAndGet();
 
         log.debug("Building refinement request: rank={}, round={}, level={}, keys={}",
                  requesterRank, roundNumber, treeLevel, boundaryKeys.size());
 
-        var builder = RefinementRequest.newBuilder()
-            .setRequesterRank(requesterRank)
-            .setRequesterTreeId(0L)
-            .setRoundNumber(roundNumber)
-            .setTreeLevel(treeLevel)
-            .setTimestamp(System.currentTimeMillis());
-
-        // Convert each boundary key to proto via the SpatialKeySerdeRegistry
-        // (Luciferase-546). Type-agnostic: any SpatialKey impl with a registered
-        // serde flows through unchanged.
-        for (var key : boundaryKeys) {
-            builder.addBoundaryKeys(
-                com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters.spatialKeyToProtobuf(key));
-        }
-
-        return builder.build();
+        return new RefinementRequest<>(requesterRank, 0L, roundNumber, treeLevel, boundaryKeys,
+                                       System.currentTimeMillis());
     }
 
     /**
@@ -106,11 +90,13 @@ public class RefinementRequestManager {
      * of the specified size. This reduces network overhead by sending multiple
      * refinement requests in a single RPC call (if supported by the protocol).
      *
+     * @param <Key> the spatial key type
      * @param requests the individual refinement requests
      * @param batchSize the maximum batch size
      * @return batched requests (may be fewer than input if combined)
      */
-    public List<RefinementRequest> batchRequests(List<RefinementRequest> requests, int batchSize) {
+    public <Key extends SpatialKey<Key>> List<RefinementRequest<Key>> batchRequests(
+            List<RefinementRequest<Key>> requests, int batchSize) {
         // TODO: Implement request batching
         // 1. Group requests by target partition
         // 2. Combine boundary keys from same target
@@ -124,14 +110,10 @@ public class RefinementRequestManager {
     /**
      * Track a refinement request round-trip.
      *
-     * @param request the request being sent
+     * @param request the domain request being sent
      * @param timestamp the send timestamp
      */
-    public void trackRequest(RefinementRequest request, long timestamp) {
-        // TODO: Implement request tracking
-        // 1. Generate unique key for request (rank + round)
-        // 2. Store timestamp in map
-
+    public void trackRequest(RefinementRequest<?> request, long timestamp) {
         var key = generateRequestKey(request);
         requestTimestamps.put(key, timestamp);
 
@@ -141,14 +123,9 @@ public class RefinementRequestManager {
     /**
      * Track a refinement response and update metrics.
      *
-     * @param response the response received
+     * @param response the domain response received
      */
-    public void trackResponse(RefinementResponse response) {
-        // TODO: Implement response tracking
-        // 1. Generate matching key from response
-        // 2. Calculate round-trip time
-        // 3. Update statistics
-
+    public void trackResponse(RefinementResponse<?, ?, ?> response) {
         totalResponses.incrementAndGet();
 
         var key = generateResponseKey(response);
@@ -209,14 +186,14 @@ public class RefinementRequestManager {
     /**
      * Generate a unique key for a refinement request.
      */
-    private String generateRequestKey(RefinementRequest request) {
-        return String.format("req-%d-%d", request.getRequesterRank(), request.getRoundNumber());
+    private String generateRequestKey(RefinementRequest<?> request) {
+        return String.format("req-%d-%d", request.requesterRank(), request.roundNumber());
     }
 
     /**
      * Generate a matching key for a refinement response.
      */
-    private String generateResponseKey(RefinementResponse response) {
-        return String.format("req-%d-%d", response.getRequesterRank(), response.getRoundNumber());
+    private String generateResponseKey(RefinementResponse<?, ?, ?> response) {
+        return String.format("req-%d-%d", response.requesterRank(), response.roundNumber());
     }
 }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementResponse.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementResponse.java
@@ -67,6 +67,11 @@ public record RefinementResponse<Key extends SpatialKey<Key>, ID extends EntityI
      * the empty response's {@code needsFurtherRefinement == false} would otherwise prematurely signal
      * convergence when a peer is simply unreachable.
      *
+     * <p>Collision safety: a real peer response cannot match this sentinel. Refinement rounds are
+     * 1-based ({@code roundNumber >= 1}) so a genuine response carries {@code roundNumber != 0}, and a
+     * real responder stamps a non-zero {@code timestamp}; either field alone rules out a false positive.
+     * The full field conjunction is belt-and-suspenders on top of those two load-bearing invariants.
+     *
      * @return true if this is an empty/sentinel response
      */
     public boolean isEmpty() {

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementResponse.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementResponse.java
@@ -58,4 +58,24 @@ public record RefinementResponse<Key extends SpatialKey<Key>, ID extends EntityI
     RefinementResponse<Key, ID, Content> empty() {
         return new RefinementResponse<>(0, 0, 0L, 0, List.of(), false, 0L);
     }
+
+    /**
+     * Returns true iff this response equals the {@link #empty()} sentinel (all fields at proto3 defaults).
+     *
+     * <p>Used by SIG-1 convergence guard: a round containing any empty response (unreachable peer mapped
+     * to {@code empty()} by the adapter) must NOT update {@code lastRoundIndicatedConvergence}, because
+     * the empty response's {@code needsFurtherRefinement == false} would otherwise prematurely signal
+     * convergence when a peer is simply unreachable.
+     *
+     * @return true if this is an empty/sentinel response
+     */
+    public boolean isEmpty() {
+        return requesterRank == 0
+            && responderRank == 0
+            && responderTreeId == 0L
+            && roundNumber == 0
+            && ghostElements.isEmpty()
+            && !needsFurtherRefinement
+            && timestamp == 0L;
+    }
 }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementResponse.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementResponse.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.balancing;
+
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostElement;
+
+import java.util.List;
+
+/**
+ * Pure-domain refinement response for cross-partition balance (RDR-007 Phase 0 Inc3).
+ *
+ * <p>Replaces the protobuf {@code RefinementResponse} message at the lucien-core boundary.
+ * Ghost elements are carried as already-deserialized domain {@link GhostElement} instances; the protobuf
+ * {@code GhostElement} deserialization happens in the grpc adapter.
+ *
+ * @param <Key> the spatial key type (MortonKey, TetreeKey, etc.)
+ * @param <ID> the entity ID type
+ * @param <Content> the content type stored with entities
+ * @author hal.hildebrand
+ */
+public record RefinementResponse<Key extends SpatialKey<Key>, ID extends EntityID, Content>(
+    int requesterRank,
+    int responderRank,
+    long responderTreeId,
+    int roundNumber,
+    List<GhostElement<Key, ID, Content>> ghostElements,
+    boolean needsFurtherRefinement,
+    long timestamp
+) {
+    public RefinementResponse {
+        ghostElements = List.copyOf(ghostElements);
+    }
+
+    /**
+     * An empty response carrying proto3-default field values. Replaces the proto
+     * {@code RefinementResponse.getDefaultInstance()} used as the coordinator's exceptionally-fallback:
+     * no ghost elements and {@code needsFurtherRefinement == false}.
+     *
+     * @return an empty refinement response
+     */
+    public static <Key extends SpatialKey<Key>, ID extends EntityID, Content>
+    RefinementResponse<Key, ID, Content> empty() {
+        return new RefinementResponse<>(0, 0, 0L, 0, List.of(), false, 0L);
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/ViolationBatch.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/ViolationBatch.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.balancing;
+
+import com.hellblazer.luciferase.lucien.SpatialKey;
+
+import java.util.List;
+
+/**
+ * Pure-domain batch of 2:1 balance violations exchanged during butterfly-pattern rounds
+ * (RDR-007 Phase 0 Inc3).
+ *
+ * <p>Replaces the protobuf {@code ViolationBatch} message at the lucien-core boundary.
+ * Reuses the existing domain violation record {@link TwoOneBalanceChecker.BalanceViolation} rather than
+ * minting a parallel type.
+ *
+ * @param <Key> the spatial key type (MortonKey, TetreeKey, etc.)
+ * @author hal.hildebrand
+ */
+public record ViolationBatch<Key extends SpatialKey<Key>>(
+    int requesterRank,
+    int responderRank,
+    int roundNumber,
+    List<TwoOneBalanceChecker.BalanceViolation<Key>> violations,
+    long timestamp
+) {
+    public ViolationBatch {
+        violations = List.copyOf(violations);
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/ViolationExchange.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/ViolationExchange.java
@@ -37,7 +37,11 @@ public interface ViolationExchange<Key extends SpatialKey<Key>> {
      * for bidirectional merge.
      *
      * @param batch the violation batch to send (its {@code responderRank} identifies the partner)
-     * @return the partner's violation batch
+     * @return the partner's violation batch, or {@code null} if no connection to the partner was available.
+     *         Callers MUST null-check: a {@code null} return signals a skipped (not failed) exchange and is
+     *         distinct from an empty batch, mirroring the underlying transport which yields no batch when a
+     *         connection is missing. The aggregator treats {@code null} as graceful degradation (no merge,
+     *         no success/failure tally), an empty batch as a successful exchange with zero violations.
      * @throws BalanceExchangeException if the exchange fails; inspect {@link BalanceExchangeException#isTransient()}
      *                                  and {@link BalanceExchangeException#isTimeout()} for retry classification
      */

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/ViolationExchange.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/ViolationExchange.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.balancing;
+
+import com.hellblazer.luciferase.lucien.SpatialKey;
+
+/**
+ * Lucien-core port for exchanging 2:1 balance violations during butterfly-pattern rounds
+ * (RDR-007 Phase 0 Inc3).
+ *
+ * <p>Inverts the dependency from the concrete grpc {@code BalanceCoordinatorClient}: the violation
+ * aggregators depend on this domain interface, and the grpc adapter implements it. Transport failures
+ * surface as {@link BalanceExchangeException} so retry/timeout policy stays in core. Generic on
+ * {@code Key} only — the violation path needs no entity/content typing.
+ *
+ * @param <Key> the spatial key type (MortonKey, TetreeKey, etc.)
+ * @author hal.hildebrand
+ */
+public interface ViolationExchange<Key extends SpatialKey<Key>> {
+
+    /**
+     * Exchange this partition's violation batch with a remote partner and receive the partner's batch
+     * for bidirectional merge.
+     *
+     * @param batch the violation batch to send (its {@code responderRank} identifies the partner)
+     * @return the partner's violation batch
+     * @throws BalanceExchangeException if the exchange fails; inspect {@link BalanceExchangeException#isTransient()}
+     *                                  and {@link BalanceExchangeException#isTimeout()} for retry classification
+     */
+    ViolationBatch<Key> exchangeViolations(ViolationBatch<Key> batch) throws BalanceExchangeException;
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/grpc/GrpcBalanceExchange.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/grpc/GrpcBalanceExchange.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.balancing.grpc;
+
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.balancing.BalanceExchangeException;
+import com.hellblazer.luciferase.lucien.balancing.RefinementExchange;
+import com.hellblazer.luciferase.lucien.balancing.RefinementResponse;
+import com.hellblazer.luciferase.lucien.balancing.TwoOneBalanceChecker;
+import com.hellblazer.luciferase.lucien.balancing.ViolationBatch;
+import com.hellblazer.luciferase.lucien.balancing.ViolationExchange;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+import com.hellblazer.luciferase.lucien.forest.ghost.ContentSerializer;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostElement;
+import com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * gRPC boundary adapter for the balancing exchange ports (RDR-007 Phase 0 Inc3).
+ *
+ * <p>Implements the lucien-core {@link RefinementExchange} and {@link ViolationExchange} ports over the
+ * concrete {@link BalanceCoordinatorClient}, performing all protobuf&lt;-&gt;domain conversion at this single
+ * boundary. Mirrors the Inc2b {@code GhostServiceClient} pattern: ghost-element deserialization (with
+ * per-element skip-invalid resilience) lives here, not in the core balancing classes.
+ *
+ * @param <Key> the spatial key type (MortonKey, TetreeKey, etc.)
+ * @param <ID> the entity ID type
+ * @param <Content> the content type stored with entities
+ * @author hal.hildebrand
+ */
+public class GrpcBalanceExchange<Key extends SpatialKey<Key>, ID extends EntityID, Content>
+    implements RefinementExchange<Key, ID, Content>, ViolationExchange<Key> {
+
+    private static final Logger log = LoggerFactory.getLogger(GrpcBalanceExchange.class);
+
+    private final BalanceCoordinatorClient client;
+    private final ContentSerializer<Content> contentSerializer;
+    private final Class<ID> idType;
+
+    public GrpcBalanceExchange(BalanceCoordinatorClient client,
+                               ContentSerializer<Content> contentSerializer,
+                               Class<ID> idType) {
+        this.client = Objects.requireNonNull(client, "client cannot be null");
+        this.contentSerializer = Objects.requireNonNull(contentSerializer, "contentSerializer cannot be null");
+        this.idType = Objects.requireNonNull(idType, "idType cannot be null");
+    }
+
+    @Override
+    public CompletableFuture<RefinementResponse<Key, ID, Content>> requestRefinementAsync(
+            int targetRank, long treeId, int roundNumber, int treeLevel, List<Key> boundaryKeys) {
+        var protoKeys = new ArrayList<com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey>(boundaryKeys.size());
+        for (var key : boundaryKeys) {
+            protoKeys.add(ProtobufConverters.spatialKeyToProtobuf(key));
+        }
+        return client.requestRefinementAsync(targetRank, treeId, roundNumber, treeLevel, protoKeys)
+                     .thenApply(this::toDomainResponse);
+    }
+
+    private RefinementResponse<Key, ID, Content> toDomainResponse(
+            com.hellblazer.luciferase.lucien.balancing.proto.RefinementResponse proto) {
+        // The wrapped client returns null when no connection is available. The domain port contract is
+        // non-null (downstream reads ghostElements()), so map null to an empty response.
+        if (proto == null) {
+            return RefinementResponse.empty();
+        }
+
+        var ghostElements = new ArrayList<GhostElement<Key, ID, Content>>();
+        for (var ghostProto : proto.getGhostElementsList()) {
+            // Verbatim move of CrossPartitionBalancePhase.applyRefinementResponses skip-invalid resilience:
+            // a PER-ELEMENT guard (not around the whole loop) so one bad element does not drop the rest.
+            try {
+                GhostElement<Key, ID, Content> ghost =
+                    ProtobufConverters.ghostElementFromProtobuf(ghostProto, contentSerializer, idType);
+                ghostElements.add(ghost);
+            } catch (ContentSerializer.SerializationException e) {
+                log.warn("Failed to deserialize ghost element from refinement response: {}", e.getMessage());
+            } catch (Exception e) {
+                log.warn("Unexpected error deserializing ghost element from refinement response: {}",
+                         e.getMessage(), e);
+            }
+        }
+
+        return new RefinementResponse<>(
+            proto.getRequesterRank(),
+            proto.getResponderRank(),
+            proto.getResponderTreeId(),
+            proto.getRoundNumber(),
+            ghostElements,
+            proto.getNeedsFurtherRefinement(),
+            proto.getTimestamp());
+    }
+
+    @Override
+    public ViolationBatch<Key> exchangeViolations(ViolationBatch<Key> batch) throws BalanceExchangeException {
+        var protoBatch = toProtoBatch(batch);
+        try {
+            var protoResponse = client.exchangeViolations(protoBatch);
+            // The wrapped client returns null when no connection is available; preserve the passthrough so
+            // the caller's graceful-degradation (empty-result) path is unchanged.
+            return protoResponse == null ? null : toDomainBatch(protoResponse);
+        } catch (StatusRuntimeException e) {
+            var code = e.getStatus().getCode();
+            boolean transientFailure = code == Status.Code.UNAVAILABLE || code == Status.Code.RESOURCE_EXHAUSTED;
+            boolean timeout = code == Status.Code.DEADLINE_EXCEEDED;
+            throw new BalanceExchangeException(
+                "Violation exchange failed with gRPC status " + e.getStatus(), e, transientFailure, timeout);
+        }
+    }
+
+    private com.hellblazer.luciferase.lucien.balancing.proto.ViolationBatch toProtoBatch(ViolationBatch<Key> batch) {
+        var builder = com.hellblazer.luciferase.lucien.balancing.proto.ViolationBatch.newBuilder()
+            .setRequesterRank(batch.requesterRank())
+            .setResponderRank(batch.responderRank())
+            .setRoundNumber(batch.roundNumber())
+            .setTimestamp(batch.timestamp());
+        for (var violation : batch.violations()) {
+            builder.addViolations(toProtoViolation(violation));
+        }
+        return builder.build();
+    }
+
+    private com.hellblazer.luciferase.lucien.balancing.proto.BalanceViolation toProtoViolation(
+            TwoOneBalanceChecker.BalanceViolation<Key> v) {
+        return com.hellblazer.luciferase.lucien.balancing.proto.BalanceViolation.newBuilder()
+            .setLocalKey(ProtobufConverters.spatialKeyToProtobuf(v.localKey()))
+            .setGhostKey(ProtobufConverters.spatialKeyToProtobuf(v.ghostKey()))
+            .setLocalLevel(v.localLevel())
+            .setGhostLevel(v.ghostLevel())
+            .setLevelDifference(v.levelDifference())
+            .setSourceRank(v.sourceRank())
+            .build();
+    }
+
+    private ViolationBatch<Key> toDomainBatch(com.hellblazer.luciferase.lucien.balancing.proto.ViolationBatch proto) {
+        var violations = new ArrayList<TwoOneBalanceChecker.BalanceViolation<Key>>();
+        for (var protoViolation : proto.getViolationsList()) {
+            var domain = toDomainViolation(protoViolation);
+            if (domain != null) {
+                violations.add(domain);
+            }
+        }
+        return new ViolationBatch<>(
+            proto.getRequesterRank(),
+            proto.getResponderRank(),
+            proto.getRoundNumber(),
+            violations,
+            proto.getTimestamp());
+    }
+
+    @SuppressWarnings("unchecked")
+    private TwoOneBalanceChecker.BalanceViolation<Key> toDomainViolation(
+            com.hellblazer.luciferase.lucien.balancing.proto.BalanceViolation proto) {
+        // The domain record enforces levelDifference > 1. The wire always satisfies this (violations are
+        // only created when the difference exceeds 1), but guard defensively and skip a malformed entry
+        // rather than letting the record's constructor abort the whole batch conversion.
+        if (proto.getLevelDifference() <= 1) {
+            log.warn("Skipping wire violation with non-violating levelDifference={}", proto.getLevelDifference());
+            return null;
+        }
+        var localKey = (Key) ProtobufConverters.spatialKeyFromProtobuf(proto.getLocalKey());
+        var ghostKey = (Key) ProtobufConverters.spatialKeyFromProtobuf(proto.getGhostKey());
+        return new TwoOneBalanceChecker.BalanceViolation<>(
+            localKey, ghostKey, proto.getLocalLevel(), proto.getGhostLevel(),
+            proto.getLevelDifference(), proto.getSourceRank());
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/grpc/GrpcBalanceExchange.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/grpc/GrpcBalanceExchange.java
@@ -62,6 +62,9 @@ public class GrpcBalanceExchange<Key extends SpatialKey<Key>, ID extends EntityI
     public GrpcBalanceExchange(BalanceCoordinatorClient client,
                                ContentSerializer<Content> contentSerializer,
                                Class<ID> idType) {
+        // The serializer and idType are required: the old CrossPartitionBalancePhase "skip deserialization
+        // when contentSerializer == null" backward-compat path is intentionally NOT carried over — that was
+        // a crutch for incomplete wiring, not a designed-for state. The boundary always deserializes.
         this.client = Objects.requireNonNull(client, "client cannot be null");
         this.contentSerializer = Objects.requireNonNull(contentSerializer, "contentSerializer cannot be null");
         this.idType = Objects.requireNonNull(idType, "idType cannot be null");

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/ButterflyViolationAggregatorTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/ButterflyViolationAggregatorTest.java
@@ -16,10 +16,7 @@
  */
 package com.hellblazer.luciferase.lucien.balancing;
 
-import com.hellblazer.luciferase.lucien.balancing.proto.BalanceViolation;
-import com.hellblazer.luciferase.lucien.balancing.proto.ViolationAck;
-import com.hellblazer.luciferase.lucien.balancing.proto.ViolationBatch;
-import com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey;
+import com.hellblazer.luciferase.lucien.octree.MortonKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for ButterflyViolationAggregator - distributed violation exchange using butterfly pattern.
+ * Operates on domain types ({@link ViolationBatch}, {@link TwoOneBalanceChecker.BalanceViolation}).
  *
  * @author hal.hildebrand
  */
@@ -46,34 +44,30 @@ class ButterflyViolationAggregatorTest {
      * Mock violation exchanger for testing.
      * Simulates bidirectional exchange between partners.
      */
-    static class MockViolationExchanger implements BiFunction<Integer, ViolationBatch, ViolationBatch> {
-        private ViolationBatch lastSentBatch;
-        private ViolationBatch responseToReturn;
+    static class MockViolationExchanger implements BiFunction<Integer, ViolationBatch<MortonKey>, ViolationBatch<MortonKey>> {
+        private ViolationBatch<MortonKey> lastSentBatch;
+        private ViolationBatch<MortonKey> responseToReturn;
 
-        void setResponse(ViolationBatch response) {
+        void setResponse(ViolationBatch<MortonKey> response) {
             this.responseToReturn = response;
         }
 
-        ViolationBatch getLastSentBatch() {
+        ViolationBatch<MortonKey> getLastSentBatch() {
             return lastSentBatch;
         }
 
         @Override
-        public ViolationBatch apply(Integer partner, ViolationBatch batch) {
+        public ViolationBatch<MortonKey> apply(Integer partner, ViolationBatch<MortonKey> batch) {
             lastSentBatch = batch;
             return responseToReturn != null ? responseToReturn :
-                ViolationBatch.newBuilder()
-                    .setRequesterRank(partner)
-                    .setResponderRank(batch.getRequesterRank())
-                    .setRoundNumber(batch.getRoundNumber())
-                    .setTimestamp(System.currentTimeMillis())
-                    .build();
+                new ViolationBatch<>(partner, batch.requesterRank(), batch.roundNumber(),
+                                     List.of(), System.currentTimeMillis());
         }
     }
 
     @Test
     void testSinglePartitionNoExchange() {
-        var aggregator = new ButterflyViolationAggregator(0, 1, mockExchanger);
+        var aggregator = new ButterflyViolationAggregator<MortonKey>(0, 1, mockExchanger);
 
         var localViolations = List.of(
             createViolation(1, 2, 5, 7, 2, 0)
@@ -92,7 +86,7 @@ class ButterflyViolationAggregatorTest {
     @Test
     void testTwoPartitionsOneRound() {
         // Partition 0 exchanges with partition 1
-        var aggregator = new ButterflyViolationAggregator(0, 2, mockExchanger);
+        var aggregator = new ButterflyViolationAggregator<MortonKey>(0, 2, mockExchanger);
 
         var localViolations = List.of(
             createViolation(1, 2, 5, 7, 2, 0)
@@ -104,13 +98,7 @@ class ButterflyViolationAggregatorTest {
 
         // Mock the exchange response
         mockExchanger.setResponse(
-            ViolationBatch.newBuilder()
-                .setRequesterRank(1)
-                .setResponderRank(0)
-                .setRoundNumber(0)
-                .addAllViolations(partnerViolations)
-                .setTimestamp(System.currentTimeMillis())
-                .build()
+            new ViolationBatch<>(1, 0, 0, partnerViolations, System.currentTimeMillis())
         );
 
         var result = aggregator.aggregateViolations(localViolations);
@@ -123,9 +111,9 @@ class ButterflyViolationAggregatorTest {
         // Verify one exchange happened
         var lastBatch = mockExchanger.getLastSentBatch();
         assertNotNull(lastBatch);
-        assertEquals(0, lastBatch.getRequesterRank());
-        assertEquals(0, lastBatch.getRoundNumber());
-        assertEquals(1, lastBatch.getViolationsCount());
+        assertEquals(0, lastBatch.requesterRank());
+        assertEquals(0, lastBatch.roundNumber());
+        assertEquals(1, lastBatch.violations().size());
     }
 
     @Test
@@ -133,8 +121,6 @@ class ButterflyViolationAggregatorTest {
         // Partition 0 exchanges with:
         // - Round 0: partition 1 (0 XOR 1 = 1)
         // - Round 1: partition 2 (0 XOR 2 = 2)
-        var aggregator = new ButterflyViolationAggregator(0, 4, mockExchanger);
-
         var localViolations = List.of(
             createViolation(1, 2, 5, 7, 2, 0)
         );
@@ -144,21 +130,16 @@ class ButterflyViolationAggregatorTest {
         var round1Violations = List.of(createViolation(5, 6, 7, 9, 2, 2));
 
         // Use a custom exchanger that returns different violations per round
-        var roundAwareExchanger = new BiFunction<Integer, ViolationBatch, ViolationBatch>() {
+        var roundAwareExchanger = new BiFunction<Integer, ViolationBatch<MortonKey>, ViolationBatch<MortonKey>>() {
             @Override
-            public ViolationBatch apply(Integer partner, ViolationBatch batch) {
-                var violations = batch.getRoundNumber() == 0 ? round0Violations : round1Violations;
-                return ViolationBatch.newBuilder()
-                    .setRequesterRank(partner)
-                    .setResponderRank(batch.getRequesterRank())
-                    .setRoundNumber(batch.getRoundNumber())
-                    .addAllViolations(violations)
-                    .setTimestamp(System.currentTimeMillis())
-                    .build();
+            public ViolationBatch<MortonKey> apply(Integer partner, ViolationBatch<MortonKey> batch) {
+                var violations = batch.roundNumber() == 0 ? round0Violations : round1Violations;
+                return new ViolationBatch<>(partner, batch.requesterRank(), batch.roundNumber(),
+                                            violations, System.currentTimeMillis());
             }
         };
 
-        aggregator = new ButterflyViolationAggregator(0, 4, roundAwareExchanger);
+        var aggregator = new ButterflyViolationAggregator<MortonKey>(0, 4, roundAwareExchanger);
         var result = aggregator.aggregateViolations(localViolations);
 
         assertNotNull(result);
@@ -174,7 +155,7 @@ class ButterflyViolationAggregatorTest {
         // Partition 5 in round 0: partner = 5 XOR 1 = 4 (valid)
         // Partition 5 in round 1: partner = 5 XOR 2 = 7 (>= 6, skip)
         // Partition 5 in round 2: partner = 5 XOR 4 = 1 (valid)
-        var aggregator = new ButterflyViolationAggregator(5, 6, mockExchanger);
+        var aggregator = new ButterflyViolationAggregator<MortonKey>(5, 6, mockExchanger);
 
         var localViolations = List.of(
             createViolation(1, 2, 5, 7, 2, 5)
@@ -189,7 +170,7 @@ class ButterflyViolationAggregatorTest {
 
     @Test
     void testDeduplicationOfDuplicateViolations() {
-        var aggregator = new ButterflyViolationAggregator(0, 2, mockExchanger);
+        var aggregator = new ButterflyViolationAggregator<MortonKey>(0, 2, mockExchanger);
 
         // Same violation appears locally and from partner
         var duplicateViolation = createViolation(1, 2, 5, 7, 2, 0);
@@ -197,13 +178,7 @@ class ButterflyViolationAggregatorTest {
 
         // Partner sends the same violation
         mockExchanger.setResponse(
-            ViolationBatch.newBuilder()
-                .setRequesterRank(1)
-                .setResponderRank(0)
-                .setRoundNumber(0)
-                .addViolations(duplicateViolation)
-                .setTimestamp(System.currentTimeMillis())
-                .build()
+            new ViolationBatch<>(1, 0, 0, List.of(duplicateViolation), System.currentTimeMillis())
         );
 
         var result = aggregator.aggregateViolations(localViolations);
@@ -215,7 +190,7 @@ class ButterflyViolationAggregatorTest {
 
     @Test
     void testEmptyLocalViolations() {
-        var aggregator = new ButterflyViolationAggregator(0, 2, mockExchanger);
+        var aggregator = new ButterflyViolationAggregator<MortonKey>(0, 2, mockExchanger);
 
         var result = aggregator.aggregateViolations(List.of());
 
@@ -225,7 +200,7 @@ class ButterflyViolationAggregatorTest {
 
     @Test
     void testNullLocalViolationsThrowsException() {
-        var aggregator = new ButterflyViolationAggregator(0, 2, mockExchanger);
+        var aggregator = new ButterflyViolationAggregator<MortonKey>(0, 2, mockExchanger);
 
         assertThrows(NullPointerException.class, () -> {
             aggregator.aggregateViolations(null);
@@ -235,55 +210,49 @@ class ButterflyViolationAggregatorTest {
     @Test
     void testInvalidRankThrowsException() {
         assertThrows(IllegalArgumentException.class, () -> {
-            new ButterflyViolationAggregator(-1, 4, mockExchanger);
+            new ButterflyViolationAggregator<MortonKey>(-1, 4, mockExchanger);
         });
 
         assertThrows(IllegalArgumentException.class, () -> {
-            new ButterflyViolationAggregator(4, 4, mockExchanger);
+            new ButterflyViolationAggregator<MortonKey>(4, 4, mockExchanger);
         });
     }
 
     @Test
     void testInvalidTotalPartitionsThrowsException() {
         assertThrows(IllegalArgumentException.class, () -> {
-            new ButterflyViolationAggregator(0, 0, mockExchanger);
+            new ButterflyViolationAggregator<MortonKey>(0, 0, mockExchanger);
         });
 
         assertThrows(IllegalArgumentException.class, () -> {
-            new ButterflyViolationAggregator(0, -1, mockExchanger);
+            new ButterflyViolationAggregator<MortonKey>(0, -1, mockExchanger);
         });
     }
 
     @Test
     void testNullExchangerThrowsException() {
         assertThrows(NullPointerException.class, () -> {
-            new ButterflyViolationAggregator(0, 4, null);
+            new ButterflyViolationAggregator<MortonKey>(0, 4, null);
         });
     }
 
     @Test
     void testButterflyPartnerCalculation() {
         // Test that correct partners are calculated per round
-        var aggregator = new ButterflyViolationAggregator(0, 8, mockExchanger);
-
         var localViolations = List.of(createViolation(1, 2, 5, 7, 2, 0));
 
         // Track which partners are contacted
         var contactedPartners = new java.util.HashSet<Integer>();
-        var partnerTracker = new BiFunction<Integer, ViolationBatch, ViolationBatch>() {
+        var partnerTracker = new BiFunction<Integer, ViolationBatch<MortonKey>, ViolationBatch<MortonKey>>() {
             @Override
-            public ViolationBatch apply(Integer partner, ViolationBatch batch) {
+            public ViolationBatch<MortonKey> apply(Integer partner, ViolationBatch<MortonKey> batch) {
                 contactedPartners.add(partner);
-                return ViolationBatch.newBuilder()
-                    .setRequesterRank(partner)
-                    .setResponderRank(batch.getRequesterRank())
-                    .setRoundNumber(batch.getRoundNumber())
-                    .setTimestamp(System.currentTimeMillis())
-                    .build();
+                return new ViolationBatch<>(partner, batch.requesterRank(), batch.roundNumber(),
+                                            List.of(), System.currentTimeMillis());
             }
         };
 
-        aggregator = new ButterflyViolationAggregator(0, 8, partnerTracker);
+        var aggregator = new ButterflyViolationAggregator<MortonKey>(0, 8, partnerTracker);
         aggregator.aggregateViolations(localViolations);
 
         // For rank 0 with 8 partitions (3 rounds):
@@ -297,28 +266,14 @@ class ButterflyViolationAggregatorTest {
     }
 
     /**
-     * Helper to create a BalanceViolation for testing.
+     * Helper to create a domain BalanceViolation for testing (level-0 Morton keys, levelDiff > 1).
      */
-    private BalanceViolation createViolation(long localKeyId, long ghostKeyId,
-                                            int localLevel, int ghostLevel,
-                                            int levelDiff, int sourceRank) {
-        return BalanceViolation.newBuilder()
-            .setLocalKey(mortonKey(localKeyId))
-            .setGhostKey(mortonKey(ghostKeyId))
-            .setLocalLevel(localLevel)
-            .setGhostLevel(ghostLevel)
-            .setLevelDifference(levelDiff)
-            .setSourceRank(sourceRank)
-            .build();
-    }
-
-    /**
-     * Build a proto SpatialKey envelope from a long Morton code (level 0).
-     * Routes through the SpatialKeySerdeRegistry (Luciferase-546) so this
-     * helper does not need to know the new envelope shape.
-     */
-    private static SpatialKey mortonKey(long mortonCode) {
-        return com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters.spatialKeyToProtobuf(
-            new com.hellblazer.luciferase.lucien.octree.MortonKey(mortonCode, (byte) 0));
+    private TwoOneBalanceChecker.BalanceViolation<MortonKey> createViolation(long localKeyId, long ghostKeyId,
+                                                                             int localLevel, int ghostLevel,
+                                                                             int levelDiff, int sourceRank) {
+        return new TwoOneBalanceChecker.BalanceViolation<>(
+            new MortonKey(localKeyId, (byte) 0),
+            new MortonKey(ghostKeyId, (byte) 0),
+            localLevel, ghostLevel, levelDiff, sourceRank);
     }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/CrossPartitionBalancePhaseResponseHandlingTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/CrossPartitionBalancePhaseResponseHandlingTest.java
@@ -16,19 +16,13 @@
  */
 package com.hellblazer.luciferase.lucien.balancing;
 
-import com.hellblazer.luciferase.lucien.balancing.grpc.BalanceCoordinatorClient;
-import com.hellblazer.luciferase.lucien.balancing.proto.RefinementResponse;
 import com.hellblazer.luciferase.lucien.entity.LongEntityID;
 import com.hellblazer.luciferase.lucien.forest.Forest;
 import com.hellblazer.luciferase.lucien.forest.ForestConfig;
-import com.hellblazer.luciferase.lucien.forest.ghost.ContentSerializer;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostElement;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostLayer;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostType;
-import com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters;
-import com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostElement.Builder;
 import com.hellblazer.luciferase.lucien.octree.MortonKey;
-import com.google.protobuf.ByteString;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -36,16 +30,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.vecmath.Point3f;
-import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * TDD tests for D.6: CrossPartitionBalancePhase.applyRefinementResponses()
+ * Domain tests for CrossPartitionBalancePhase.applyRefinementResponses() after the grpc
+ * inversion (Inc3-C4). Deserialization of proto ghost elements has moved to GrpcBalanceExchange;
+ * this test works entirely with already-deserialized domain {@link GhostElement} instances.
  *
- * Tests the new public method that processes a single RefinementResponse and updates the ghost layer.
- * This complements the existing private method that handles List<RefinementResponse>.
+ * <p>Test 5 "skip invalid" semantics now live in GrpcBalanceExchangeTest. This file covers
+ * the domain contract: domain ghost elements in a response are added to the ghost layer;
+ * null responses and empty responses are no-ops; a per-element exception does not abort
+ * the rest.
  *
  * @author hal.hildebrand
  */
@@ -56,49 +55,28 @@ public class CrossPartitionBalancePhaseResponseHandlingTest {
     private CrossPartitionBalancePhase<MortonKey, LongEntityID, String> phase;
     private GhostLayer<MortonKey, LongEntityID, String> ghostLayer;
     private Forest<MortonKey, LongEntityID, String> forest;
-    private MockBalanceCoordinatorClient client;
+    private MockRefinementExchange exchange;
     private MockPartitionRegistry registry;
-    private RefinementCoordinator coordinator;
-    private ContentSerializer<String> contentSerializer;
+    private RefinementCoordinator<MortonKey, LongEntityID, String> coordinator;
 
     @BeforeEach
     public void setUp() {
         forest = new Forest<>(ForestConfig.defaultConfig());
         ghostLayer = new GhostLayer<>(GhostType.FACES);
-        client = new MockBalanceCoordinatorClient();
+        exchange = new MockRefinementExchange();
         registry = new MockPartitionRegistry(4);
 
-        phase = new CrossPartitionBalancePhase<>(client, registry, BalanceConfiguration.defaultConfig());
+        phase = new CrossPartitionBalancePhase<>(exchange, registry, BalanceConfiguration.defaultConfig());
+        phase.setForestContext(forest, ghostLayer);
 
-        // Create simple String content serializer
-        contentSerializer = new ContentSerializer<>() {
-            @Override
-            public ByteString serialize(String content) {
-                return ByteString.copyFrom(content, StandardCharsets.UTF_8);
-            }
-
-            @Override
-            public String deserialize(ByteString bytes) {
-                return bytes.toString(StandardCharsets.UTF_8);
-            }
-
-            @Override
-            public String getContentType() {
-                return "string";
-            }
-        };
-
-        // Set forest context with serialization support
-        phase.setForestContext(forest, ghostLayer, contentSerializer, LongEntityID.class);
-
-        // Create coordinator (will be passed to method)
-        coordinator = new RefinementCoordinator(client, new RefinementRequestManager(), 0, 4);
+        // Create coordinator (passed to applyRefinementResponses)
+        coordinator = new RefinementCoordinator<>(exchange, new RefinementRequestManager(), 0, 4);
     }
 
     // TEST 1: Null response - should handle gracefully
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    public void testApplyRefinementResponses_Null() throws Exception {
+    public void testApplyRefinementResponses_Null() {
         var initialGhostCount = ghostLayer.getNumGhostElements();
 
         // Call with null - should not throw
@@ -110,65 +88,42 @@ public class CrossPartitionBalancePhaseResponseHandlingTest {
                     "Ghost layer should be unchanged after null response");
     }
 
-    // TEST 2: Empty response - should return without adding anything
+    // TEST 2: Empty domain response - should return without adding anything
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    public void testApplyRefinementResponses_EmptyResponse() throws Exception {
-        var emptyResponse = RefinementResponse.newBuilder()
-            .setRequesterRank(0)
-            .setResponderRank(1)
-            .setResponderTreeId(0L)
-            .setRoundNumber(1)
-            .setNeedsFurtherRefinement(false)
-            .setTimestamp(System.currentTimeMillis())
-            .build();
+    public void testApplyRefinementResponses_EmptyResponse() {
+        var emptyResponse = new RefinementResponse<MortonKey, LongEntityID, String>(
+            0, 1, 0L, 1, List.of(), false, System.currentTimeMillis()
+        );
 
         var initialGhostCount = ghostLayer.getNumGhostElements();
 
         phase.applyRefinementResponses(emptyResponse, coordinator);
 
-        // Verify ghost layer unchanged
         assertEquals(initialGhostCount, ghostLayer.getNumGhostElements(),
                     "Ghost layer should be unchanged after empty response");
     }
 
-    // TEST 3: Single ghost element - should add correctly
+    // TEST 3: Single domain ghost element - should add correctly
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    public void testApplyRefinementResponses_SingleGhostElement() throws Exception {
+    public void testApplyRefinementResponses_SingleGhostElement() {
         var ghostKey = new MortonKey(100L, (byte) 3);
         var entityId = new LongEntityID(1001L);
         var content = "ghost-content-1";
         var position = new Point3f(10.0f, 20.0f, 30.0f);
 
-        var ghostProto = com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostElement.newBuilder()
-            .setSpatialKey(ProtobufConverters.spatialKeyToProtobuf(ghostKey))
-            .setEntityId(ProtobufConverters.entityIdToString(entityId))
-            .setContent(contentSerializer.serialize(content))
-            .setPosition(ProtobufConverters.point3fToProtobuf(position))
-            .setOwnerRank(1)
-            .setGlobalTreeId(0L)
-            .build();
+        var ghost = new GhostElement<>(ghostKey, entityId, content, position, 1, 0L);
 
-        var response = RefinementResponse.newBuilder()
-            .setRequesterRank(0)
-            .setResponderRank(1)
-            .setResponderTreeId(0L)
-            .setRoundNumber(1)
-            .addGhostElements(ghostProto)
-            .setNeedsFurtherRefinement(false)
-            .setTimestamp(System.currentTimeMillis())
-            .build();
+        var response = new RefinementResponse<>(0, 1, 0L, 1, List.of(ghost), false, System.currentTimeMillis());
 
         var initialGhostCount = ghostLayer.getNumGhostElements();
 
         phase.applyRefinementResponses(response, coordinator);
 
-        // Verify ghost element was added
         assertEquals(initialGhostCount + 1, ghostLayer.getNumGhostElements(),
                     "Should add exactly 1 ghost element");
 
-        // Verify the element is in the ghost layer
         var ghostElements = ghostLayer.getAllGhostElements();
         assertNotNull(ghostElements, "Ghost elements should not be null");
         assertEquals(1, ghostElements.size(), "Should have exactly 1 ghost element");
@@ -180,47 +135,28 @@ public class CrossPartitionBalancePhaseResponseHandlingTest {
         assertEquals(1, addedElement.getOwnerRank(), "Owner rank should match");
     }
 
-    // TEST 4: Multiple ghost elements - should add all
+    // TEST 4: Multiple domain ghost elements - should add all
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    public void testApplyRefinementResponses_MultipleGhostElements() throws Exception {
-        var responseBuilder = RefinementResponse.newBuilder()
-            .setRequesterRank(0)
-            .setResponderRank(1)
-            .setResponderTreeId(0L)
-            .setRoundNumber(1)
-            .setNeedsFurtherRefinement(false)
-            .setTimestamp(System.currentTimeMillis());
-
-        // Add 5 ghost elements from different ranks
+    public void testApplyRefinementResponses_MultipleGhostElements() {
+        var ghosts = new java.util.ArrayList<GhostElement<MortonKey, LongEntityID, String>>();
         for (int i = 0; i < 5; i++) {
             var ghostKey = new MortonKey(100L + i, (byte) 3);
             var entityId = new LongEntityID(1000L + i);
             var content = "ghost-content-" + i;
             var position = new Point3f(10.0f + i, 20.0f + i, 30.0f + i);
-
-            var ghostProto = com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostElement.newBuilder()
-                .setSpatialKey(ProtobufConverters.spatialKeyToProtobuf(ghostKey))
-                .setEntityId(ProtobufConverters.entityIdToString(entityId))
-                .setContent(contentSerializer.serialize(content))
-                .setPosition(ProtobufConverters.point3fToProtobuf(position))
-                .setOwnerRank(1 + (i % 3)) // Different ranks
-                .setGlobalTreeId(0L)
-                .build();
-
-            responseBuilder.addGhostElements(ghostProto);
+            ghosts.add(new GhostElement<>(ghostKey, entityId, content, position, 1 + (i % 3), 0L));
         }
 
-        var response = responseBuilder.build();
+        var response = new RefinementResponse<>(0, 1, 0L, 1, ghosts, false, System.currentTimeMillis());
+
         var initialGhostCount = ghostLayer.getNumGhostElements();
 
         phase.applyRefinementResponses(response, coordinator);
 
-        // Verify all 5 elements were added
         assertEquals(initialGhostCount + 5, ghostLayer.getNumGhostElements(),
                     "Should add all 5 ghost elements");
 
-        // Verify order preserved
         var ghostElements = ghostLayer.getAllGhostElements();
         assertEquals(5, ghostElements.size(), "Should have exactly 5 ghost elements");
 
@@ -235,162 +171,93 @@ public class CrossPartitionBalancePhaseResponseHandlingTest {
         }
     }
 
-    // TEST 5: Partial deserialization - invalid element should be skipped
+    // TEST 5: SIG-1 — empty/sentinel response does NOT flip convergence to true.
+    // We test via the execute() path: configure the exchange to return RefinementResponse.empty()
+    // and verify that subsequent calls still behave as not-converged.
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    public void testApplyRefinementResponses_PartialDeserialization() throws Exception {
-        var responseBuilder = RefinementResponse.newBuilder()
-            .setRequesterRank(0)
-            .setResponderRank(1)
-            .setResponderTreeId(0L)
-            .setRoundNumber(1)
-            .setNeedsFurtherRefinement(false)
-            .setTimestamp(System.currentTimeMillis());
+    public void testSig1_EmptyResponseDoesNotFlipConvergence() {
+        // Configure exchange to always return empty sentinel
+        exchange.setResponseFactory((rank, treeId, round, level, keys) ->
+            CompletableFuture.completedFuture(RefinementResponse.empty()));
 
-        // Add valid ghost element
-        var validKey1 = new MortonKey(100L, (byte) 3);
-        var validId1 = new LongEntityID(1001L);
-        var validProto1 = com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostElement.newBuilder()
-            .setSpatialKey(ProtobufConverters.spatialKeyToProtobuf(validKey1))
-            .setEntityId(ProtobufConverters.entityIdToString(validId1))
-            .setContent(contentSerializer.serialize("valid-1"))
-            .setPosition(ProtobufConverters.point3fToProtobuf(new Point3f(10.0f, 20.0f, 30.0f)))
-            .setOwnerRank(1)
-            .setGlobalTreeId(0L)
-            .build();
-        responseBuilder.addGhostElements(validProto1);
+        // Execute a single round — with all-empty responses lastRoundIndicatedConvergence
+        // must remain false (its initial value), so isConverged() stays false.
+        var result = phase.execute(forest, 0, 2); // 2 partitions = 1 round
 
-        // Add invalid ghost element (missing spatial key)
-        var invalidProto = com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostElement.newBuilder()
-            .setEntityId("invalid-id")
-            .setContent(ByteString.copyFromUtf8("invalid"))
-            .setPosition(ProtobufConverters.point3fToProtobuf(new Point3f(0, 0, 0)))
-            .setOwnerRank(1)
-            .setGlobalTreeId(0L)
-            .build();
-        responseBuilder.addGhostElements(invalidProto);
+        // The result should succeed (no exceptions), but convergence must NOT have been
+        // prematurely flagged true. We verify by checking the round completed without
+        // converged=true being asserted as the termination cause: in execute() convergence
+        // triggers "break" only after the last round, so with 1 round and no real responses
+        // the loop finishes normally without converged=true.
+        assertTrue(result.successful(), "Should succeed even when all responses are empty");
 
-        // Add another valid ghost element
-        var validKey2 = new MortonKey(200L, (byte) 3);
-        var validId2 = new LongEntityID(2001L);
-        var validProto2 = com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostElement.newBuilder()
-            .setSpatialKey(ProtobufConverters.spatialKeyToProtobuf(validKey2))
-            .setEntityId(ProtobufConverters.entityIdToString(validId2))
-            .setContent(contentSerializer.serialize("valid-2"))
-            .setPosition(ProtobufConverters.point3fToProtobuf(new Point3f(40.0f, 50.0f, 60.0f)))
-            .setOwnerRank(2)
-            .setGlobalTreeId(0L)
-            .build();
-        responseBuilder.addGhostElements(validProto2);
+        // Additionally verify the isEmpty() sentinel itself
+        var empty = RefinementResponse.<MortonKey, LongEntityID, String>empty();
+        assertTrue(empty.isEmpty(), "RefinementResponse.empty() should report isEmpty()==true");
 
-        var response = responseBuilder.build();
-        var initialGhostCount = ghostLayer.getNumGhostElements();
-
-        // Should not throw - just skip invalid element
-        assertDoesNotThrow(() -> phase.applyRefinementResponses(response, coordinator),
-                          "Should skip invalid element without throwing");
-
-        // Verify only valid elements (2) were added
-        assertEquals(initialGhostCount + 2, ghostLayer.getNumGhostElements(),
-                    "Should add only 2 valid ghost elements, skipping invalid one");
-
-        var ghostElements = ghostLayer.getAllGhostElements();
-        assertEquals(2, ghostElements.size(), "Should have exactly 2 ghost elements");
-
-        // Verify valid elements were added
-        var element1 = ghostElements.get(0);
-        assertEquals(validKey1, element1.getSpatialKey(), "First element should have correct key");
-        assertEquals("valid-1", element1.getContent(), "First element should have correct content");
-
-        var element2 = ghostElements.get(1);
-        assertEquals(validKey2, element2.getSpatialKey(), "Second element should have correct key");
-        assertEquals("valid-2", element2.getContent(), "Second element should have correct content");
+        // A non-empty response should not report isEmpty()
+        var ghost = new GhostElement<>(new MortonKey(1L, (byte) 1), new LongEntityID(1L), "x",
+                                        new Point3f(0, 0, 0), 0, 0L);
+        var real = new RefinementResponse<MortonKey, LongEntityID, String>(
+            1, 2, 0L, 1, List.of(ghost), false, System.currentTimeMillis());
+        assertFalse(real.isEmpty(), "Real response with ghost elements should not report isEmpty()");
     }
 
-    // TEST 6: Integration with real GhostLayer
+    // TEST 6: Integration with real GhostLayer — diverse elements from different ranks
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
-    public void testApplyRefinementResponses_IntegrationWithGhostLayer() throws Exception {
-        // Create response with diverse elements (different levels, ranks, positions)
-        var responseBuilder = RefinementResponse.newBuilder()
-            .setRequesterRank(0)
-            .setResponderRank(1)
-            .setResponderTreeId(0L)
-            .setRoundNumber(1)
-            .setNeedsFurtherRefinement(false)
-            .setTimestamp(System.currentTimeMillis());
+    public void testApplyRefinementResponses_IntegrationWithGhostLayer() {
+        var ghosts = List.of(
+            new GhostElement<>(new MortonKey(100L, (byte) 2), new LongEntityID(1001L), "content-1",
+                               new Point3f(1, 2, 3), 1, 0L),
+            new GhostElement<>(new MortonKey(200L, (byte) 4), new LongEntityID(2001L), "content-2",
+                               new Point3f(10, 20, 30), 2, 0L),
+            new GhostElement<>(new MortonKey(300L, (byte) 3), new LongEntityID(3001L), "content-3",
+                               new Point3f(100, 200, 300), 3, 0L)
+        );
 
-        // Level 2, rank 1
-        responseBuilder.addGhostElements(createGhostProto(
-            new MortonKey(100L, (byte) 2), 1001L, "content-1", new Point3f(1, 2, 3), 1
-        ));
-
-        // Level 4, rank 2
-        responseBuilder.addGhostElements(createGhostProto(
-            new MortonKey(200L, (byte) 4), 2001L, "content-2", new Point3f(10, 20, 30), 2
-        ));
-
-        // Level 3, rank 3
-        responseBuilder.addGhostElements(createGhostProto(
-            new MortonKey(300L, (byte) 3), 3001L, "content-3", new Point3f(100, 200, 300), 3
-        ));
-
-        var response = responseBuilder.build();
+        var response = new RefinementResponse<>(0, 1, 0L, 1, ghosts, false, System.currentTimeMillis());
 
         phase.applyRefinementResponses(response, coordinator);
 
-        // Verify all elements in ghost layer
         assertEquals(3, ghostLayer.getNumGhostElements(), "Should have all 3 ghost elements");
 
-        // Verify subsequent queries work correctly
         var allGhosts = ghostLayer.getAllGhostElements();
         assertEquals(3, allGhosts.size(), "getAllGhostElements should return 3 elements");
 
-        // Verify element properties
         assertTrue(allGhosts.stream().anyMatch(g -> g.getOwnerRank() == 1), "Should have element from rank 1");
         assertTrue(allGhosts.stream().anyMatch(g -> g.getOwnerRank() == 2), "Should have element from rank 2");
         assertTrue(allGhosts.stream().anyMatch(g -> g.getOwnerRank() == 3), "Should have element from rank 3");
 
-        // Verify content was deserialized correctly
         assertTrue(allGhosts.stream().anyMatch(g -> "content-1".equals(g.getContent())), "Should have content-1");
         assertTrue(allGhosts.stream().anyMatch(g -> "content-2".equals(g.getContent())), "Should have content-2");
         assertTrue(allGhosts.stream().anyMatch(g -> "content-3".equals(g.getContent())), "Should have content-3");
     }
 
-    // Helper method to create GhostElement protobuf
-    private com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostElement createGhostProto(
-            MortonKey key, long entityId, String content, Point3f position, int ownerRank)
-            throws ContentSerializer.SerializationException {
-        return com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostElement.newBuilder()
-            .setSpatialKey(ProtobufConverters.spatialKeyToProtobuf(key))
-            .setEntityId(ProtobufConverters.entityIdToString(new LongEntityID(entityId)))
-            .setContent(contentSerializer.serialize(content))
-            .setPosition(ProtobufConverters.point3fToProtobuf(position))
-            .setOwnerRank(ownerRank)
-            .setGlobalTreeId(0L)
-            .build();
+    // Mock implementations
+
+    @FunctionalInterface
+    interface ResponseFactory {
+        CompletableFuture<RefinementResponse<MortonKey, LongEntityID, String>> create(
+            int targetRank, long treeId, int roundNumber, int treeLevel, List<MortonKey> boundaryKeys);
     }
 
-    // Mock classes (reused from CrossPartitionBalancePhaseTest)
-    private static class MockBalanceCoordinatorClient extends BalanceCoordinatorClient {
-        public MockBalanceCoordinatorClient() {
-            super(0, new MockServiceDiscovery());
-        }
-    }
+    private static class MockRefinementExchange
+            implements RefinementExchange<MortonKey, LongEntityID, String> {
 
-    private static class MockServiceDiscovery implements BalanceCoordinatorClient.ServiceDiscovery {
-        @Override
-        public String getEndpoint(int rank) {
-            return "localhost:" + (50000 + rank);
+        private volatile ResponseFactory factory = (rank, treeId, round, level, keys) ->
+            CompletableFuture.completedFuture(new RefinementResponse<>(0, rank, 0L, round, List.of(), false,
+                                                                        System.currentTimeMillis()));
+
+        public void setResponseFactory(ResponseFactory factory) {
+            this.factory = factory;
         }
 
         @Override
-        public void registerEndpoint(int rank, String endpoint) {
-        }
-
-        @Override
-        public java.util.Map<Integer, String> getAllEndpoints() {
-            return new java.util.HashMap<>();
+        public CompletableFuture<RefinementResponse<MortonKey, LongEntityID, String>> requestRefinementAsync(
+                int targetRank, long treeId, int roundNumber, int treeLevel, List<MortonKey> boundaryKeys) {
+            return factory.create(targetRank, treeId, roundNumber, treeLevel, boundaryKeys);
         }
     }
 
@@ -402,26 +269,18 @@ public class CrossPartitionBalancePhaseResponseHandlingTest {
         }
 
         @Override
-        public int getCurrentPartitionId() {
-            return 0;
-        }
+        public int getCurrentPartitionId() { return 0; }
 
         @Override
-        public int getPartitionCount() {
-            return partitionCount;
-        }
+        public int getPartitionCount() { return partitionCount; }
 
         @Override
-        public void barrier(int round) {
-        }
+        public void barrier(int round) {}
 
         @Override
-        public void requestRefinement(Object elementKey) {
-        }
+        public void requestRefinement(Object elementKey) {}
 
         @Override
-        public int getPendingRefinements() {
-            return 0;
-        }
+        public int getPendingRefinements() { return 0; }
     }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/CrossPartitionBalancePhaseResponseHandlingTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/CrossPartitionBalancePhaseResponseHandlingTest.java
@@ -235,6 +235,40 @@ public class CrossPartitionBalancePhaseResponseHandlingTest {
         assertTrue(allGhosts.stream().anyMatch(g -> "content-3".equals(g.getContent())), "Should have content-3");
     }
 
+    // TEST 7: Per-element guard — one element whose add() throws must not abort the rest of the batch.
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    public void testApplyRefinementResponses_PerElementGuardSkipsThrowingElement() {
+        var poisonKey = new MortonKey(999L, (byte) 3);
+        // A ghost layer that throws when adding the poison element, to exercise the per-element guard.
+        var throwingLayer = new GhostLayer<MortonKey, LongEntityID, String>(GhostType.FACES) {
+            @Override
+            public void addGhostElement(GhostElement<MortonKey, LongEntityID, String> element) {
+                if (element.getSpatialKey().equals(poisonKey)) {
+                    throw new RuntimeException("simulated add failure");
+                }
+                super.addGhostElement(element);
+            }
+        };
+        var localPhase = new CrossPartitionBalancePhase<MortonKey, LongEntityID, String>(
+            exchange, registry, BalanceConfiguration.defaultConfig());
+        localPhase.setForestContext(forest, throwingLayer);
+
+        var good1 = new GhostElement<>(new MortonKey(100L, (byte) 3), new LongEntityID(1L), "g1",
+                                       new Point3f(1, 1, 1), 1, 0L);
+        var poison = new GhostElement<>(poisonKey, new LongEntityID(2L), "bad",
+                                        new Point3f(2, 2, 2), 1, 0L);
+        var good2 = new GhostElement<>(new MortonKey(200L, (byte) 3), new LongEntityID(3L), "g2",
+                                       new Point3f(3, 3, 3), 1, 0L);
+        var response = new RefinementResponse<>(0, 1, 0L, 1, List.of(good1, poison, good2), false,
+                                                System.currentTimeMillis());
+
+        assertDoesNotThrow(() -> localPhase.applyRefinementResponses(response, coordinator),
+            "Per-element guard must not let one throwing element abort the batch");
+        assertEquals(2, throwingLayer.getNumGhostElements(),
+            "The two good elements must be added; the throwing one skipped (per-element guard)");
+    }
+
     // Mock implementations
 
     @FunctionalInterface

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/CrossPartitionBalancePhaseTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/CrossPartitionBalancePhaseTest.java
@@ -17,9 +17,7 @@
 package com.hellblazer.luciferase.lucien.balancing;
 
 import com.hellblazer.luciferase.lucien.SpatialKey;
-import com.hellblazer.luciferase.lucien.balancing.grpc.BalanceCoordinatorClient;
-import com.hellblazer.luciferase.lucien.balancing.proto.RefinementRequest;
-import com.hellblazer.luciferase.lucien.balancing.proto.RefinementResponse;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.entity.LongEntityID;
 import com.hellblazer.luciferase.lucien.forest.Forest;
 import com.hellblazer.luciferase.lucien.forest.ForestConfig;
@@ -41,19 +39,9 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * TDD tests for CrossPartitionBalancePhase - O(log P) distributed refinement protocol.
  *
- * <p>These tests are written FIRST (red phase) to define the expected behavior
- * before implementation. They should FAIL initially until the implementation
- * is complete.
- *
- * <p>The cross-partition protocol implements the Phase 3 of parallel balancing:
- * <ol>
- *   <li>Execute O(log P) refinement rounds where P = partition count</li>
- *   <li>Each round identifies boundary elements needing refinement</li>
- *   <li>Requests ghost elements from neighbors via gRPC</li>
- *   <li>Applies received ghost elements to local forest</li>
- *   <li>Synchronizes all partitions via barrier</li>
- *   <li>Checks convergence (no more refinements needed)</li>
- * </ol>
+ * <p>Updated for Inc3-C4: all mocks use domain types (RefinementRequest/Response) and
+ * RefinementExchange instead of BalanceCoordinatorClient. Proto-specific tests have moved
+ * to GrpcBalanceExchangeTest.
  *
  * @author hal.hildebrand
  */
@@ -62,7 +50,7 @@ public class CrossPartitionBalancePhaseTest {
     private static final Logger log = LoggerFactory.getLogger(CrossPartitionBalancePhaseTest.class);
 
     private Forest<MortonKey, LongEntityID, String> forest;
-    private MockBalanceCoordinatorClient client;
+    private MockRefinementExchange exchange;
     private MockPartitionRegistry registry;
     private BalanceConfiguration config;
     private CrossPartitionBalancePhase<MortonKey, LongEntityID, String> phase;
@@ -76,20 +64,19 @@ public class CrossPartitionBalancePhaseTest {
         var octree = new com.hellblazer.luciferase.lucien.octree.Octree<LongEntityID, String>(idGen);
         forest.addTree(octree);
 
-        client = new MockBalanceCoordinatorClient();
+        exchange = new MockRefinementExchange();
         registry = new MockPartitionRegistry(4); // 4 partitions
         config = BalanceConfiguration.defaultConfig();
 
-        phase = new CrossPartitionBalancePhase<>(client, registry, config);
+        phase = new CrossPartitionBalancePhase<>(exchange, registry, config);
     }
 
     // TEST 1: 2 Partitions - O(log 2) = 1 round
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     public void testCrossPartitionBalanceWith2Partitions() {
-        // O(log 2) = 1 round for 2 partitions
         registry = new MockPartitionRegistry(2);
-        phase = new CrossPartitionBalancePhase<>(client, registry, config);
+        phase = new CrossPartitionBalancePhase<>(exchange, registry, config);
 
         var result = phase.execute(forest, 0, 2);
 
@@ -102,7 +89,6 @@ public class CrossPartitionBalancePhaseTest {
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     public void testCrossPartitionBalanceWith4Partitions() {
-        // O(log 4) = 2 rounds for 4 partitions
         var result = phase.execute(forest, 0, 4);
 
         assertTrue(result.successful(), "Should succeed with 4 partitions");
@@ -114,9 +100,8 @@ public class CrossPartitionBalancePhaseTest {
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     public void testCrossPartitionBalanceWith8Partitions() {
-        // O(log 8) = 3 rounds for 8 partitions
         registry = new MockPartitionRegistry(8);
-        phase = new CrossPartitionBalancePhase<>(client, registry, config);
+        phase = new CrossPartitionBalancePhase<>(exchange, registry, config);
 
         var result = phase.execute(forest, 0, 8);
 
@@ -128,33 +113,27 @@ public class CrossPartitionBalancePhaseTest {
     // TEST 4: Refinement Request Generation
     @Test
     public void testRefinementRequestGeneration() {
-        // Execute with empty forest - implementation should handle gracefully
         phase.execute(forest, 0, 4);
 
-        // Verify refinement request tracking works
-        assertTrue(client.getRequestCount() >= 0,
+        assertTrue(exchange.getRequestCount() >= 0,
                   "Should track refinement request count");
 
-        // Check request structure if any were sent
-        var requests = client.getSentRequests();
+        var requests = exchange.getSentRequests();
         for (var request : requests) {
-            assertEquals(0, request.getRequesterRank(), "Request should have correct rank");
-            assertTrue(request.getRoundNumber() > 0, "Request should have valid round number");
-            assertTrue(request.getTreeLevel() >= 0, "Request should have valid tree level");
-            assertTrue(request.getTimestamp() > 0, "Request should have timestamp");
+            assertEquals(0, request.requesterRank(), "Request should have correct rank");
+            assertTrue(request.roundNumber() > 0, "Request should have valid round number");
+            assertTrue(request.treeLevel() >= 0, "Request should have valid tree level");
+            assertTrue(request.timestamp() > 0, "Request should have timestamp");
         }
     }
 
     // TEST 5: Refinement Response Processing
     @Test
     public void testRefinementResponseProcessing() {
-        // Configure mock client to return responses with ghost elements
-        client.addMockResponse(1, createMockResponse(1, 1, 5)); // 5 ghost elements from rank 1
+        exchange.addMockResponse(1, createMockResponse(1, 1, 5));
 
-        // Execute one round
         var result = phase.execute(forest, 0, 4);
 
-        // Verify responses were processed
         assertTrue(result.successful(), "Should process responses successfully");
         assertTrue(result.refinementsApplied() >= 0,
                   "Should apply ghost elements from responses");
@@ -163,8 +142,7 @@ public class CrossPartitionBalancePhaseTest {
     // TEST 6: Convergence Detection
     @Test
     public void testConvergenceDetection() {
-        // Configure to converge immediately (no refinements needed)
-        client.setConverged(true);
+        exchange.setConverged(true);
 
         var result = phase.execute(forest, 0, 4);
 
@@ -184,8 +162,6 @@ public class CrossPartitionBalancePhaseTest {
         var snapshot = result.finalMetrics();
         assertTrue(snapshot.totalTime().toNanos() > 0, "Should track total time");
         assertTrue(snapshot.averageRoundTime().toNanos() > 0, "Should track average round time");
-
-        // Each round should complete reasonably fast
         assertTrue(snapshot.maxRoundTime().toMillis() < 5000,
                   "Individual rounds should complete within 5 seconds");
     }
@@ -193,26 +169,22 @@ public class CrossPartitionBalancePhaseTest {
     // TEST 8: Boundary Ghost Exchange
     @Test
     public void testBoundaryGhostExchange() {
-        // Configure mock to return ghost elements for boundaries
-        client.addMockResponse(1, createMockResponse(1, 1, 2));
+        exchange.addMockResponse(1, createMockResponse(1, 1, 2));
 
         var result = phase.execute(forest, 0, 4);
 
         assertTrue(result.successful(), "Should exchange ghosts at boundaries");
 
-        // Verify request/response mechanism works
-        var sentRequests = client.getSentRequests();
+        var sentRequests = exchange.getSentRequests();
         assertTrue(sentRequests.size() >= 0, "Should track sent requests");
     }
 
     // TEST 9: Request Batching
     @Test
     public void testRequestBatching() {
-        // Configure client to simulate batching behavior
         phase.execute(forest, 0, 4);
 
-        // Verify request tracking works for batching
-        var requestCount = client.getRequestCount();
+        var requestCount = exchange.getRequestCount();
         assertTrue(requestCount >= 0, "Should track batched refinement requests");
     }
 
@@ -223,7 +195,6 @@ public class CrossPartitionBalancePhaseTest {
 
         assertTrue(result.successful(), "Should complete with barrier synchronization");
 
-        // Verify barrier was called for each round
         var expectedRounds = (int) Math.ceil(Math.log(4) / Math.log(2));
         assertTrue(registry.getBarrierCount() >= expectedRounds,
                   "Should synchronize at barrier after each round");
@@ -232,17 +203,14 @@ public class CrossPartitionBalancePhaseTest {
     // TEST 11: Max Rounds Respected
     @Test
     public void testMaxRoundsRespected() {
-        // Configure to never converge (always need refinement)
-        client.setConverged(false);
-        client.setAlwaysNeedsRefinement(true);
+        exchange.setConverged(false);
+        exchange.setAlwaysNeedsRefinement(true);
 
-        // Set max rounds to 2
         config = BalanceConfiguration.defaultConfig().withMaxRounds(2);
-        phase = new CrossPartitionBalancePhase<>(client, registry, config);
+        phase = new CrossPartitionBalancePhase<>(exchange, registry, config);
 
         var result = phase.execute(forest, 0, 4);
 
-        // Should terminate after max rounds even without convergence
         assertTrue(result.finalMetrics().roundCount() <= 2,
                   "Should not exceed max rounds (2)");
     }
@@ -250,39 +218,33 @@ public class CrossPartitionBalancePhaseTest {
     // TEST 12: Level-Based Efficiency
     @Test
     public void testLevelBasedRefinement() {
-        // Execute with empty forest
         phase.execute(forest, 0, 4);
 
-        // Verify level information is tracked correctly in requests
-        var sentRequests = client.getSentRequests();
+        var sentRequests = exchange.getSentRequests();
         for (var request : sentRequests) {
-            assertTrue(request.getTreeLevel() >= 0 && request.getTreeLevel() <= 21,
+            assertTrue(request.treeLevel() >= 0 && request.treeLevel() <= 21,
                       "Request should have valid tree level (0-21)");
         }
     }
 
-    // TEST 13: ButterflyPattern Integration - Verify partner selection uses butterfly
+    // TEST 13: ButterflyPattern Integration
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     public void testButterflyPartnerSelection() {
-        // In 8 partitions, round 0 partners should be (0,1), (2,3), (4,5), (6,7)
-        // Round 1 partners should be (0,2), (1,3), (4,6), (5,7)
         registry = new MockPartitionRegistry(8);
-        phase = new CrossPartitionBalancePhase<>(client, registry, config);
+        phase = new CrossPartitionBalancePhase<>(exchange, registry, config);
 
         var result = phase.execute(forest, 0, 8);
 
-        // Should communicate with correct partners in each round (butterfly pattern)
         assertTrue(result.successful(), "Should succeed with butterfly pattern");
         assertEquals(3, result.finalMetrics().roundCount(),
                     "Should execute 3 rounds for 8 partitions (O(log 8) = 3)");
     }
 
-    // TEST 14: TwoOneBalanceChecker Integration - Violation detection
+    // TEST 14: TwoOneBalanceChecker Integration
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     public void testTwoOneViolationDetectionIntegration() {
-        // Execute with empty forest (no violations expected)
         var result = phase.execute(forest, 0, 4);
 
         assertTrue(result.successful(), "Should complete without violations in empty forest");
@@ -293,25 +255,21 @@ public class CrossPartitionBalancePhaseTest {
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     public void testRefinementRequestsCreatedFromViolations() {
-        // Set up client to always need refinement (simulating ongoing violations)
-        client.setAlwaysNeedsRefinement(true);
+        exchange.setAlwaysNeedsRefinement(true);
 
         var result = phase.execute(forest, 0, 4);
 
         assertTrue(result.successful(), "Should handle refinement requests");
-        // Requests should be sent to communicate refinement needs
-        assertTrue(client.getRequestCount() > 0, "Should send refinement requests");
+        assertTrue(exchange.getRequestCount() > 0, "Should send refinement requests");
     }
 
     // TEST 16: Ghost Elements Applied During Rounds
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     public void testGhostElementsAppliedDuringRounds() {
-        // Execute balance rounds (ghost elements would be applied during execution)
         var result = phase.execute(forest, 0, 4);
 
         assertTrue(result.successful(), "Should successfully apply ghost elements");
-        // Verify that the phase executed all expected rounds
         assertEquals(2, result.finalMetrics().roundCount(),
                     "4 partitions should converge in 2 rounds");
     }
@@ -320,9 +278,8 @@ public class CrossPartitionBalancePhaseTest {
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     public void testConvergenceDetectedWhenNoViolations() {
-        // Set converged to indicate no more violations
-        client.setConverged(true);
-        client.setAlwaysNeedsRefinement(false);
+        exchange.setConverged(true);
+        exchange.setAlwaysNeedsRefinement(false);
 
         var result = phase.execute(forest, 0, 4);
 
@@ -330,15 +287,11 @@ public class CrossPartitionBalancePhaseTest {
         assertTrue(result.converged(), "Result should indicate convergence");
     }
 
-    // Helper method to create mock refinement response
-    private RefinementResponse createMockResponse(int responderRank, int roundNumber, int ghostElementCount) {
-        return RefinementResponse.newBuilder()
-            .setResponderRank(responderRank)
-            .setResponderTreeId(0L)
-            .setRoundNumber(roundNumber)
-            .setNeedsFurtherRefinement(ghostElementCount > 0)
-            .setTimestamp(System.currentTimeMillis())
-            .build();
+    // Helper method to create domain mock refinement response
+    private RefinementResponse<MortonKey, LongEntityID, String> createMockResponse(
+            int responderRank, int roundNumber, int ghostElementCount) {
+        return new RefinementResponse<>(0, responderRank, 0L, roundNumber,
+                                        List.of(), ghostElementCount > 0, System.currentTimeMillis());
     }
 
     // ========== D.5 Tests: identifyRefinementNeeds() ==========
@@ -347,22 +300,17 @@ public class CrossPartitionBalancePhaseTest {
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     public void testIdentifyRefinementNeeds_NoViolations() throws Exception {
-        // Setup: Use real balance checker with empty forest (no violations)
-        var balanceChecker = new com.hellblazer.luciferase.lucien.balancing.TwoOneBalanceChecker<MortonKey, LongEntityID, String>();
+        var balanceChecker = new TwoOneBalanceChecker<MortonKey, LongEntityID, String>();
 
-        // Create empty ghost layer
         var ghostLayer = new com.hellblazer.luciferase.lucien.forest.ghost.GhostLayer<MortonKey, LongEntityID, String>(
             com.hellblazer.luciferase.lucien.forest.ghost.GhostType.FACES
         );
         phase.setForestContext(forest, ghostLayer);
 
-        // Mock coordinator (should not be called)
         var mockCoordinator = new MockRefinementCoordinator<MortonKey, LongEntityID, String>();
 
-        // Execute
         var result = phase.identifyRefinementNeeds(1, 2, balanceChecker, mockCoordinator);
 
-        // Verify
         assertNotNull(result, "Result should not be null");
         assertEquals(0, result.refinementsApplied(), "Should have 0 violations processed");
         assertEquals(1, result.roundNumber(), "Should track round number");
@@ -374,12 +322,10 @@ public class CrossPartitionBalancePhaseTest {
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     public void testIdentifyRefinementNeeds_SingleViolation() throws Exception {
-        // Setup: Create ghost layer
         var ghostLayer = new com.hellblazer.luciferase.lucien.forest.ghost.GhostLayer<MortonKey, LongEntityID, String>(
             com.hellblazer.luciferase.lucien.forest.ghost.GhostType.FACES
         );
 
-        // Add a simple ghost element
         var ghostKey = new MortonKey(100L, (byte) 3);
         var ghostElement = new com.hellblazer.luciferase.lucien.forest.ghost.GhostElement<>(
             ghostKey, new LongEntityID(100L), "ghost-content",
@@ -389,21 +335,14 @@ public class CrossPartitionBalancePhaseTest {
 
         phase.setForestContext(forest, ghostLayer);
 
-        // Use a mock balance checker that returns a predefined violation
         var mockBalanceChecker = new MockBalanceChecker();
         var localKey = new MortonKey(101L, (byte) 1);
-        mockBalanceChecker.addViolation(
-            localKey, (byte) 1,
-            ghostKey, (byte) 3,
-            1  // source rank
-        );
+        mockBalanceChecker.addViolation(localKey, (byte) 1, ghostKey, (byte) 3, 1);
 
         var mockCoordinator = new MockRefinementCoordinator<MortonKey, LongEntityID, String>();
 
-        // Execute
         var result = phase.identifyRefinementNeeds(1, 2, mockBalanceChecker, mockCoordinator);
 
-        // Verify
         assertNotNull(result, "Result should not be null");
         assertEquals(1, result.refinementsApplied(), "Should find 1 violation");
         assertEquals(1, mockCoordinator.getRequestsSent(), "Should send 1 request");
@@ -414,20 +353,14 @@ public class CrossPartitionBalancePhaseTest {
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     public void testIdentifyRefinementNeeds_MultipleRanks() throws Exception {
-        // Setup: Create violations from 3 different ranks
         var ghostLayer = new com.hellblazer.luciferase.lucien.forest.ghost.GhostLayer<MortonKey, LongEntityID, String>(
             com.hellblazer.luciferase.lucien.forest.ghost.GhostType.FACES
         );
 
-        // Rank 1: 2 violations
         addViolationPair(ghostLayer, forest, 100L, 101L, 1);
         addViolationPair(ghostLayer, forest, 102L, 103L, 1);
-
-        // Rank 2: 2 violations
         addViolationPair(ghostLayer, forest, 200L, 201L, 2);
         addViolationPair(ghostLayer, forest, 202L, 203L, 2);
-
-        // Rank 3: 1 violation
         addViolationPair(ghostLayer, forest, 300L, 301L, 3);
 
         phase.setForestContext(forest, ghostLayer);
@@ -435,10 +368,8 @@ public class CrossPartitionBalancePhaseTest {
         var balanceChecker = new TwoOneBalanceChecker<MortonKey, LongEntityID, String>();
         var mockCoordinator = new MockRefinementCoordinator<MortonKey, LongEntityID, String>();
 
-        // Execute
         var result = phase.identifyRefinementNeeds(1, 2, balanceChecker, mockCoordinator);
 
-        // Verify: Should group into 3 requests (one per rank)
         var capturedRequests = mockCoordinator.getCapturedRequests();
         assertTrue(capturedRequests.size() <= 3,
                   "Should create at most 3 requests (one per rank)");
@@ -449,44 +380,37 @@ public class CrossPartitionBalancePhaseTest {
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     public void testIdentifyRefinementNeeds_RespectsBoundaryKeys() throws Exception {
-        // Setup: Create ghost layer with 2 violations
         var ghostLayer = new com.hellblazer.luciferase.lucien.forest.ghost.GhostLayer<MortonKey, LongEntityID, String>(
             com.hellblazer.luciferase.lucien.forest.ghost.GhostType.FACES
         );
 
-        // Add 2 ghost elements
         var ghostKey1 = new MortonKey(100L, (byte) 3);
-        var ghostElement1 = new com.hellblazer.luciferase.lucien.forest.ghost.GhostElement<>(
+        ghostLayer.addGhostElement(new com.hellblazer.luciferase.lucien.forest.ghost.GhostElement<>(
             ghostKey1, new LongEntityID(100L), "ghost1",
             new javax.vecmath.Point3f(10.0f, 10.0f, 10.0f), 1, 0L
-        );
-        ghostLayer.addGhostElement(ghostElement1);
+        ));
 
         var ghostKey2 = new MortonKey(200L, (byte) 3);
-        var ghostElement2 = new com.hellblazer.luciferase.lucien.forest.ghost.GhostElement<>(
+        ghostLayer.addGhostElement(new com.hellblazer.luciferase.lucien.forest.ghost.GhostElement<>(
             ghostKey2, new LongEntityID(200L), "ghost2",
             new javax.vecmath.Point3f(20.0f, 20.0f, 20.0f), 1, 0L
-        );
-        ghostLayer.addGhostElement(ghostElement2);
+        ));
 
         phase.setForestContext(forest, ghostLayer);
 
-        // Create mock balance checker with 2 violations
         var balanceChecker = new MockBalanceChecker();
         balanceChecker.addViolation(new MortonKey(101L, (byte) 1), (byte) 1, ghostKey1, (byte) 3, 1);
         balanceChecker.addViolation(new MortonKey(201L, (byte) 1), (byte) 1, ghostKey2, (byte) 3, 1);
 
         var mockCoordinator = new MockRefinementCoordinator<MortonKey, LongEntityID, String>();
 
-        // Execute
         var result = phase.identifyRefinementNeeds(1, 2, balanceChecker, mockCoordinator);
 
-        // Verify: Requests should include boundary keys
         var capturedRequests = mockCoordinator.getCapturedRequests();
         assertEquals(1, capturedRequests.size(), "Should have 1 request for rank 1 violations");
 
         var request = capturedRequests.get(0);
-        assertEquals(4, request.getBoundaryKeysCount(), "Should have 4 boundary keys (2 violations × 2 keys each)");
+        assertEquals(4, request.boundaryKeys().size(), "Should have 4 boundary keys (2 violations × 2 keys each)");
         assertEquals(2, result.refinementsApplied(), "Should apply 2 refinements");
     }
 
@@ -494,88 +418,84 @@ public class CrossPartitionBalancePhaseTest {
     @Test
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
     public void testIdentifyRefinementNeeds_AsyncTimeout() {
-        // Setup: Create ghost layer
         var ghostLayer = new com.hellblazer.luciferase.lucien.forest.ghost.GhostLayer<MortonKey, LongEntityID, String>(
             com.hellblazer.luciferase.lucien.forest.ghost.GhostType.FACES
         );
 
-        // Add a ghost element
         var ghostKey = new MortonKey(100L, (byte) 3);
-        var ghostElement = new com.hellblazer.luciferase.lucien.forest.ghost.GhostElement<>(
+        ghostLayer.addGhostElement(new com.hellblazer.luciferase.lucien.forest.ghost.GhostElement<>(
             ghostKey, new LongEntityID(100L), "ghost",
             new javax.vecmath.Point3f(100.0f, 100.0f, 100.0f), 1, 0L
-        );
-        ghostLayer.addGhostElement(ghostElement);
+        ));
 
         phase.setForestContext(forest, ghostLayer);
 
-        // Create mock balance checker with a violation
         var balanceChecker = new MockBalanceChecker();
-        var localKey = new MortonKey(101L, (byte) 1);
-        balanceChecker.addViolation(localKey, (byte) 1, ghostKey, (byte) 3, 1);
+        balanceChecker.addViolation(new MortonKey(101L, (byte) 1), (byte) 1, ghostKey, (byte) 3, 1);
 
         var mockCoordinator = new MockRefinementCoordinator<MortonKey, LongEntityID, String>();
         mockCoordinator.setShouldTimeout(true);
 
-        // Execute and verify timeout
-        assertThrows(java.util.concurrent.TimeoutException.class, () -> {
-            phase.identifyRefinementNeeds(1, 2, balanceChecker, mockCoordinator);
-        }, "Should throw TimeoutException when coordinator times out");
+        assertThrows(java.util.concurrent.TimeoutException.class, () ->
+            phase.identifyRefinementNeeds(1, 2, balanceChecker, mockCoordinator),
+            "Should throw TimeoutException when coordinator times out");
     }
 
     // TEST 6: Coordinator exception - should propagate
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     public void testIdentifyRefinementNeeds_CoordinatorException() {
-        // Setup: Create ghost layer
         var ghostLayer = new com.hellblazer.luciferase.lucien.forest.ghost.GhostLayer<MortonKey, LongEntityID, String>(
             com.hellblazer.luciferase.lucien.forest.ghost.GhostType.FACES
         );
 
-        // Add a ghost element
         var ghostKey = new MortonKey(100L, (byte) 3);
-        var ghostElement = new com.hellblazer.luciferase.lucien.forest.ghost.GhostElement<>(
+        ghostLayer.addGhostElement(new com.hellblazer.luciferase.lucien.forest.ghost.GhostElement<>(
             ghostKey, new LongEntityID(100L), "ghost",
             new javax.vecmath.Point3f(100.0f, 100.0f, 100.0f), 1, 0L
-        );
-        ghostLayer.addGhostElement(ghostElement);
+        ));
 
         phase.setForestContext(forest, ghostLayer);
 
-        // Create mock balance checker with a violation
         var balanceChecker = new MockBalanceChecker();
-        var localKey = new MortonKey(101L, (byte) 1);
-        balanceChecker.addViolation(localKey, (byte) 1, ghostKey, (byte) 3, 1);
+        balanceChecker.addViolation(new MortonKey(101L, (byte) 1), (byte) 1, ghostKey, (byte) 3, 1);
 
         var mockCoordinator = new MockRefinementCoordinator<MortonKey, LongEntityID, String>();
         mockCoordinator.setShouldThrowException(true);
 
-        // Execute and verify exception propagation
-        assertThrows(RuntimeException.class, () -> {
-            phase.identifyRefinementNeeds(1, 2, balanceChecker, mockCoordinator);
-        }, "Should propagate RuntimeException from coordinator");
+        assertThrows(RuntimeException.class, () ->
+            phase.identifyRefinementNeeds(1, 2, balanceChecker, mockCoordinator),
+            "Should propagate RuntimeException from coordinator");
     }
 
     // TEST 7: Integration test with Phase44ForestIntegrationFixture
     @Test
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
     public void testIdentifyRefinementNeeds_IntegrationWithRealChecker() throws Exception {
-        // Setup: Use real forest fixture
         var fixture = new com.hellblazer.luciferase.lucien.balancing.fault.Phase44ForestIntegrationFixture();
-        var distributedForest = fixture.createForest();
+        fixture.createForest();
         fixture.syncGhostLayer();
 
         var realForest = fixture.getForest();
         var realGhostLayer = fixture.getGhostLayer();
 
-        // Create typed instances for proper generics
-        var integrationClient = new MockBalanceCoordinatorClient();
+        // Need a separate exchange typed for TestEntity (not String)
+        var integrationExchange = new RefinementExchange<MortonKey, LongEntityID,
+                com.hellblazer.luciferase.lucien.balancing.fault.Phase44ForestIntegrationFixture.TestEntity>() {
+            @Override
+            public CompletableFuture<RefinementResponse<MortonKey, LongEntityID,
+                    com.hellblazer.luciferase.lucien.balancing.fault.Phase44ForestIntegrationFixture.TestEntity>>
+            requestRefinementAsync(int targetRank, long treeId, int roundNumber, int treeLevel,
+                                   List<MortonKey> boundaryKeys) {
+                return CompletableFuture.completedFuture(RefinementResponse.empty());
+            }
+        };
         var integrationRegistry = new MockPartitionRegistry(4);
         var integrationConfig = BalanceConfiguration.defaultConfig();
 
         var integrationPhase = new CrossPartitionBalancePhase<MortonKey, LongEntityID,
                 com.hellblazer.luciferase.lucien.balancing.fault.Phase44ForestIntegrationFixture.TestEntity>(
-            integrationClient, integrationRegistry, integrationConfig
+            integrationExchange, integrationRegistry, integrationConfig
         );
         integrationPhase.setForestContext(realForest, realGhostLayer);
 
@@ -585,37 +505,23 @@ public class CrossPartitionBalancePhaseTest {
         var mockCoordinator = new MockRefinementCoordinator<MortonKey, LongEntityID,
                 com.hellblazer.luciferase.lucien.balancing.fault.Phase44ForestIntegrationFixture.TestEntity>();
 
-        // Execute
         var result = integrationPhase.identifyRefinementNeeds(1, 2, realBalanceChecker, mockCoordinator);
 
-        // Verify
         assertNotNull(result, "Result should not be null");
         assertEquals(1, result.roundNumber(), "Should track round number");
 
-        // Capture requests for validation
         var capturedRequests = mockCoordinator.getCapturedRequests();
         log.info("Integration test: {} violations found, {} requests sent",
                 result.refinementsApplied(), capturedRequests.size());
 
-        // Verify request structure if any were sent
         for (var request : capturedRequests) {
-            assertTrue(request.getRoundNumber() > 0, "Request should have valid round number");
-            assertTrue(request.getTreeLevel() >= 0, "Request should have valid tree level");
+            assertTrue(request.roundNumber() > 0, "Request should have valid round number");
+            assertTrue(request.treeLevel() >= 0, "Request should have valid tree level");
         }
     }
 
     /**
-     * Helper method to create a proper violation between ghost and local elements.
-     * Creates a ghost at one position and a local neighbor at a different level.
-     *
-     * <p>Key insight: MortonKey equality only compares Morton codes, not levels.
-     * So we need to choose positions that quantize to the same grid cell at both levels.
-     * This happens when the position is a multiple of the LARGER cell size.
-     *
-     * @param ghostLevel level of the ghost element
-     * @param localLevel level of the local element (must differ by > 1 from ghostLevel)
-     * @param ownerRank rank of the partition owning the ghost
-     * @return true if violation was successfully created, false otherwise
+     * Helper to create a proper violation between ghost and local elements.
      */
     private boolean createProperViolation(
         com.hellblazer.luciferase.lucien.forest.ghost.GhostLayer<MortonKey, LongEntityID, String> ghostLayer,
@@ -624,166 +530,95 @@ public class CrossPartitionBalancePhaseTest {
         byte localLevel,
         int ownerRank
     ) {
-        // Calculate cell sizes for both levels
-        // Level 1 cell size = 1 << (21 - 1) = 1,048,576
-        // Level 3 cell size = 1 << (21 - 3) = 262,144
         var localCellSize = com.hellblazer.luciferase.lucien.Constants.lengthAtLevel(localLevel);
         var ghostCellSize = com.hellblazer.luciferase.lucien.Constants.lengthAtLevel(ghostLevel);
+        int baseCoord = localCellSize;
 
-        // Choose a position that's a multiple of the LARGER cell size
-        // This ensures both levels quantize to the same grid coordinates
-        int baseCoord = localCellSize;  // Use one cell size as base
-
-        // Ghost position: at the base coordinates
         var ghostPosition = new javax.vecmath.Point3f(baseCoord, baseCoord, baseCoord);
         var ghostKey = new MortonKey(
             com.hellblazer.luciferase.geometry.MortonCurve.encode(baseCoord, baseCoord, baseCoord),
             ghostLevel
         );
 
-        // Add ghost element
-        var ghostElement = new com.hellblazer.luciferase.lucien.forest.ghost.GhostElement<>(
-            ghostKey,
-            new LongEntityID(ownerRank * 1000L),
-            "ghost-content",
-            ghostPosition,
-            ownerRank,
-            0L
-        );
-        ghostLayer.addGhostElement(ghostElement);
+        ghostLayer.addGhostElement(new com.hellblazer.luciferase.lucien.forest.ghost.GhostElement<>(
+            ghostKey, new LongEntityID(ownerRank * 1000L), "ghost-content", ghostPosition, ownerRank, 0L
+        ));
 
-        // Neighbor position: move by one ghost cell in POSITIVE_X
-        // This ensures they're neighbors at the ghost level
         int neighborX = baseCoord + ghostCellSize;
         var neighborPosition = new javax.vecmath.Point3f(neighborX, baseCoord, baseCoord);
 
-        // Insert local element at the neighbor position with different level
-        // The TwoOneBalanceChecker will find this because:
-        // 1. It gets ghost's neighbor in POSITIVE_X direction
-        // 2. That neighbor position quantizes to (neighborX, baseCoord, baseCoord) at ghost level
-        // 3. It checks all levels 0-21 at that Morton code
-        // 4. Our local element at (neighborX, baseCoord, baseCoord) level 1 will match
-        // 5. Level difference abs(1 - 3) = 2 > 1, so violation detected
         var tree = forest.getAllTrees().get(0);
         var spatialIndex = tree.getSpatialIndex();
-        spatialIndex.insert(
-            new LongEntityID(ownerRank * 1000L + 1),
-            neighborPosition,
-            localLevel,
-            "local-entity",
-            null
-        );
+        spatialIndex.insert(new LongEntityID(ownerRank * 1000L + 1), neighborPosition, localLevel,
+                            "local-entity", null);
 
         return true;
     }
 
-    // Helper method to add violation pairs (kept for backward compatibility)
     private void addViolationPair(
         com.hellblazer.luciferase.lucien.forest.ghost.GhostLayer<MortonKey, LongEntityID, String> ghostLayer,
         Forest<MortonKey, LongEntityID, String> forest,
-        long ghostCode,
-        long localCode,
-        int ownerRank
+        long ghostCode, long localCode, int ownerRank
     ) {
-        // Use the new proper violation creator with fixed levels
         createProperViolation(ghostLayer, forest, (byte) 3, (byte) 1, ownerRank);
     }
 
-    // Mock BalanceCoordinatorClient for testing
-    private static class MockBalanceCoordinatorClient extends BalanceCoordinatorClient {
-        private final Map<Integer, RefinementResponse> mockResponses = new ConcurrentHashMap<>();
-        private final List<RefinementRequest> sentRequests = Collections.synchronizedList(new ArrayList<>());
+    // ========== Mock implementations ==========
+
+    /** Domain exchange mock: captures sent requests, returns configurable domain responses. */
+    private static class MockRefinementExchange
+            implements RefinementExchange<MortonKey, LongEntityID, String> {
+
+        private final Map<Integer, RefinementResponse<MortonKey, LongEntityID, String>> mockResponses =
+            new ConcurrentHashMap<>();
+        private final List<RefinementRequest<MortonKey>> sentRequests =
+            Collections.synchronizedList(new ArrayList<>());
         private final AtomicInteger requestCount = new AtomicInteger(0);
         private volatile boolean converged = false;
         private volatile boolean alwaysNeedsRefinement = false;
 
-        public MockBalanceCoordinatorClient() {
-            super(0, new MockServiceDiscovery());
-        }
-
         @Override
-        public CompletableFuture<RefinementResponse> requestRefinementAsync(
+        public CompletableFuture<RefinementResponse<MortonKey, LongEntityID, String>> requestRefinementAsync(
                 int targetRank, long treeId, int roundNumber, int treeLevel,
-                List<com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey> boundaryKeys) {
+                List<MortonKey> boundaryKeys) {
 
             requestCount.incrementAndGet();
 
-            // Create and store request
-            var request = RefinementRequest.newBuilder()
-                .setRequesterRank(0)
-                .setRequesterTreeId(treeId)
-                .setRoundNumber(roundNumber)
-                .setTreeLevel(treeLevel)
-                .setTimestamp(System.currentTimeMillis())
-                .build();
+            // Capture the sent request as a domain object
+            var request = new RefinementRequest<>(0, treeId, roundNumber, treeLevel,
+                                                   boundaryKeys, System.currentTimeMillis());
             sentRequests.add(request);
 
-            // Return mock response
             var response = mockResponses.getOrDefault(targetRank,
                 createDefaultResponse(targetRank, roundNumber));
 
             return CompletableFuture.completedFuture(response);
         }
 
-        public void addMockResponse(int targetRank, RefinementResponse response) {
+        public void addMockResponse(int targetRank, RefinementResponse<MortonKey, LongEntityID, String> response) {
             mockResponses.put(targetRank, response);
         }
 
-        public void setConverged(boolean converged) {
-            this.converged = converged;
-        }
+        public void setConverged(boolean converged) { this.converged = converged; }
 
         public void setAlwaysNeedsRefinement(boolean alwaysNeedsRefinement) {
             this.alwaysNeedsRefinement = alwaysNeedsRefinement;
         }
 
-        public int getRequestCount() {
-            return requestCount.get();
-        }
+        public int getRequestCount() { return requestCount.get(); }
 
-        public List<RefinementRequest> getSentRequests() {
+        public List<RefinementRequest<MortonKey>> getSentRequests() {
             return new ArrayList<>(sentRequests);
         }
 
-        private RefinementResponse createDefaultResponse(int responderRank, int roundNumber) {
-            return RefinementResponse.newBuilder()
-                .setResponderRank(responderRank)
-                .setResponderTreeId(0L)
-                .setRoundNumber(roundNumber)
-                .setNeedsFurtherRefinement(alwaysNeedsRefinement && !converged)
-                .setTimestamp(System.currentTimeMillis())
-                .build();
+        private RefinementResponse<MortonKey, LongEntityID, String> createDefaultResponse(
+                int responderRank, int roundNumber) {
+            return new RefinementResponse<>(0, responderRank, 0L, roundNumber,
+                                            List.of(), alwaysNeedsRefinement && !converged,
+                                            System.currentTimeMillis());
         }
     }
 
-    // Mock ServiceDiscovery for BalanceCoordinatorClient
-    private static class MockServiceDiscovery implements BalanceCoordinatorClient.ServiceDiscovery {
-        private final Map<Integer, String> endpoints = new ConcurrentHashMap<>();
-
-        public MockServiceDiscovery() {
-            // Pre-populate with test endpoints
-            for (int i = 0; i < 16; i++) {
-                endpoints.put(i, "localhost:" + (50000 + i));
-            }
-        }
-
-        @Override
-        public String getEndpoint(int rank) {
-            return endpoints.get(rank);
-        }
-
-        @Override
-        public void registerEndpoint(int rank, String endpoint) {
-            endpoints.put(rank, endpoint);
-        }
-
-        @Override
-        public Map<Integer, String> getAllEndpoints() {
-            return new HashMap<>(endpoints);
-        }
-    }
-
-    // Mock PartitionRegistry for testing
     private static class MockPartitionRegistry implements ParallelBalancer.PartitionRegistry {
         private final int partitionCount;
         private final AtomicInteger barrierCount = new AtomicInteger(0);
@@ -794,19 +629,14 @@ public class CrossPartitionBalancePhaseTest {
         }
 
         @Override
-        public int getCurrentPartitionId() {
-            return 0;
-        }
+        public int getCurrentPartitionId() { return 0; }
 
         @Override
-        public int getPartitionCount() {
-            return partitionCount;
-        }
+        public int getPartitionCount() { return partitionCount; }
 
         @Override
         public void barrier(int round) throws InterruptedException {
             barrierCount.incrementAndGet();
-            // Simulate barrier synchronization with small delay
             Thread.sleep(10);
         }
 
@@ -816,25 +646,23 @@ public class CrossPartitionBalancePhaseTest {
         }
 
         @Override
-        public int getPendingRefinements() {
-            return refinementRequests.get();
-        }
+        public int getPendingRefinements() { return refinementRequests.get(); }
 
-        public int getBarrierCount() {
-            return barrierCount.get();
-        }
+        public int getBarrierCount() { return barrierCount.get(); }
     }
 
-    // Mock RefinementCoordinator for D.5 tests
-    private static class MockRefinementCoordinator<Key extends com.hellblazer.luciferase.lucien.SpatialKey<Key>,
-                                                    ID extends com.hellblazer.luciferase.lucien.entity.EntityID,
-                                                    Content> {
+    /** Mock coordinator for D.5 tests — works via reflection from identifyRefinementNeeds(). */
+    private static class MockRefinementCoordinator<K extends SpatialKey<K>,
+                                                    I extends EntityID,
+                                                    C> {
         private final AtomicInteger requestsSent = new AtomicInteger(0);
-        private final List<RefinementRequest> capturedRequests = Collections.synchronizedList(new ArrayList<>());
+        private final List<RefinementRequest<K>> capturedRequests =
+            Collections.synchronizedList(new ArrayList<>());
         private boolean shouldTimeout = false;
         private boolean shouldThrowException = false;
 
-        public List<CompletableFuture<RefinementResponse>> sendRequestsParallel(List<RefinementRequest> requests) {
+        public List<CompletableFuture<RefinementResponse<K, I, C>>> sendRequestsParallel(
+                List<RefinementRequest<K>> requests) {
             requestsSent.addAndGet(requests.size());
             capturedRequests.addAll(requests);
 
@@ -842,50 +670,44 @@ public class CrossPartitionBalancePhaseTest {
                 throw new RuntimeException("Coordinator exception");
             }
 
-            var futures = new ArrayList<CompletableFuture<RefinementResponse>>();
+            var futures = new ArrayList<CompletableFuture<RefinementResponse<K, I, C>>>();
             for (var request : requests) {
                 if (shouldTimeout) {
-                    var future = new CompletableFuture<RefinementResponse>();
+                    var future = new CompletableFuture<RefinementResponse<K, I, C>>();
                     // Don't complete the future - let it timeout
                     futures.add(future);
                 } else {
-                    var response = RefinementResponse.newBuilder()
-                        .setResponderRank(request.getRequesterRank())
-                        .setResponderTreeId(0L)
-                        .setRoundNumber(request.getRoundNumber())
-                        .setNeedsFurtherRefinement(false)
-                        .setTimestamp(System.currentTimeMillis())
-                        .build();
+                    var response = new RefinementResponse<K, I, C>(
+                        request.requesterRank(), request.requesterRank(), 0L,
+                        request.roundNumber(), List.of(), false, System.currentTimeMillis()
+                    );
                     futures.add(CompletableFuture.completedFuture(response));
                 }
             }
             return futures;
         }
 
-        public int getRequestsSent() {
-            return requestsSent.get();
-        }
+        public int getRequestsSent() { return requestsSent.get(); }
 
-        public List<RefinementRequest> getCapturedRequests() {
+        public List<RefinementRequest<K>> getCapturedRequests() {
             return new ArrayList<>(capturedRequests);
         }
 
-        public void setShouldTimeout(boolean shouldTimeout) {
-            this.shouldTimeout = shouldTimeout;
-        }
+        public void setShouldTimeout(boolean shouldTimeout) { this.shouldTimeout = shouldTimeout; }
 
         public void setShouldThrowException(boolean shouldThrowException) {
             this.shouldThrowException = shouldThrowException;
         }
     }
 
-    // Mock BalanceChecker for D.5 tests - allows injecting predefined violations
+    /** Mock balance checker for D.5 tests — allows injecting predefined violations. */
     private static class MockBalanceChecker extends TwoOneBalanceChecker<MortonKey, LongEntityID, String> {
         private final List<TwoOneBalanceChecker.BalanceViolation<MortonKey>> violations = new ArrayList<>();
 
-        public void addViolation(MortonKey localKey, byte localLevel, MortonKey ghostKey, byte ghostLevel, int sourceRank) {
+        public void addViolation(MortonKey localKey, byte localLevel, MortonKey ghostKey,
+                                  byte ghostLevel, int sourceRank) {
             var levelDiff = Math.abs(localLevel - ghostLevel);
-            if (levelDiff > 1) {  // Valid violation
+            if (levelDiff > 1) {
                 violations.add(new TwoOneBalanceChecker.BalanceViolation<>(
                     localKey, ghostKey, localLevel, ghostLevel, levelDiff, sourceRank
                 ));

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/DistributedViolationAggregatorTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/DistributedViolationAggregatorTest.java
@@ -16,12 +16,7 @@
  */
 package com.hellblazer.luciferase.lucien.balancing;
 
-import com.hellblazer.luciferase.lucien.balancing.grpc.BalanceCoordinatorClient;
-import com.hellblazer.luciferase.lucien.balancing.proto.BalanceViolation;
-import com.hellblazer.luciferase.lucien.balancing.proto.ViolationBatch;
-import com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey;
-import io.grpc.StatusRuntimeException;
-import io.grpc.Status;
+import com.hellblazer.luciferase.lucien.octree.MortonKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,48 +28,37 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 /**
- * Tests for DistributedViolationAggregator - gRPC-based violation exchange.
+ * Tests for DistributedViolationAggregator - violation exchange via the {@link ViolationExchange} port.
  *
  * @author hal.hildebrand
  */
 class DistributedViolationAggregatorTest {
 
-    private BalanceCoordinatorClient mockClient;
-    private DistributedViolationAggregator aggregator;
+    private ViolationExchange<MortonKey> mockExchange;
+    private DistributedViolationAggregator<MortonKey> aggregator;
 
     @BeforeEach
+    @SuppressWarnings("unchecked")
     void setUp() {
-        mockClient = mock(BalanceCoordinatorClient.class);
-        aggregator = new DistributedViolationAggregator(0, 4, mockClient);
+        mockExchange = mock(ViolationExchange.class);
+        aggregator = new DistributedViolationAggregator<>(0, 4, mockExchange);
     }
 
     @Test
-    void testSuccessfulDistributedExchange() {
+    void testSuccessfulDistributedExchange() throws Exception {
         // Create local violations
         var localViolations = List.of(
             createViolation(1, 2, 5, 7, 2, 0),
             createViolation(3, 4, 6, 8, 2, 0)
         );
 
-        // Mock successful gRPC responses with partner violations
+        // Mock successful responses with partner violations
         var partnerViolation1 = createViolation(5, 6, 7, 9, 2, 1);
         var partnerViolation2 = createViolation(7, 8, 8, 10, 2, 2);
 
-        when(mockClient.exchangeViolations(any(ViolationBatch.class)))
-            .thenReturn(ViolationBatch.newBuilder()
-                .setRequesterRank(1)
-                .setResponderRank(0)
-                .setRoundNumber(0)
-                .addViolations(partnerViolation1)
-                .setTimestamp(System.currentTimeMillis())
-                .build())
-            .thenReturn(ViolationBatch.newBuilder()
-                .setRequesterRank(2)
-                .setResponderRank(0)
-                .setRoundNumber(1)
-                .addViolations(partnerViolation2)
-                .setTimestamp(System.currentTimeMillis())
-                .build());
+        when(mockExchange.exchangeViolations(any()))
+            .thenReturn(new ViolationBatch<>(1, 0, 0, List.of(partnerViolation1), System.currentTimeMillis()))
+            .thenReturn(new ViolationBatch<>(2, 0, 1, List.of(partnerViolation2), System.currentTimeMillis()));
 
         // Execute aggregation
         var result = aggregator.aggregateDistributed(localViolations);
@@ -86,26 +70,21 @@ class DistributedViolationAggregatorTest {
         assertTrue(result.contains(partnerViolation2));
         assertEquals(4, result.size());
 
-        // Verify gRPC calls were made (2 rounds for 4 partitions)
-        verify(mockClient, times(2)).exchangeViolations(any(ViolationBatch.class));
+        // Verify exchanges were made (2 rounds for 4 partitions)
+        verify(mockExchange, times(2)).exchangeViolations(any());
     }
 
     @Test
-    void testTimeoutHandling() {
+    void testTimeoutHandling() throws Exception {
         // Create local violations
         var localViolations = List.of(
             createViolation(1, 2, 5, 7, 2, 0)
         );
 
         // Mock timeout on first call, success on second
-        when(mockClient.exchangeViolations(any(ViolationBatch.class)))
-            .thenThrow(new StatusRuntimeException(Status.DEADLINE_EXCEEDED))
-            .thenReturn(ViolationBatch.newBuilder()
-                .setRequesterRank(2)
-                .setResponderRank(0)
-                .setRoundNumber(1)
-                .setTimestamp(System.currentTimeMillis())
-                .build());
+        when(mockExchange.exchangeViolations(any()))
+            .thenThrow(new BalanceExchangeException("deadline exceeded", false, true))
+            .thenReturn(new ViolationBatch<>(2, 0, 1, List.of(), System.currentTimeMillis()));
 
         // Execute aggregation - should handle timeout gracefully
         var result = aggregator.aggregateDistributed(localViolations);
@@ -114,12 +93,12 @@ class DistributedViolationAggregatorTest {
         assertNotNull(result);
         assertTrue(result.containsAll(localViolations));
 
-        // Verify both calls were attempted
-        verify(mockClient, times(2)).exchangeViolations(any(ViolationBatch.class));
+        // Verify both calls were attempted (timeout is not retried)
+        verify(mockExchange, times(2)).exchangeViolations(any());
     }
 
     @Test
-    void testRetryOnTransientFailure() {
+    void testRetryOnTransientFailure() throws Exception {
         // Create local violations
         var localViolations = List.of(
             createViolation(1, 2, 5, 7, 2, 0)
@@ -128,17 +107,12 @@ class DistributedViolationAggregatorTest {
         var callCount = new AtomicInteger(0);
 
         // Mock transient failure on first attempt, success on retry
-        when(mockClient.exchangeViolations(any(ViolationBatch.class)))
+        when(mockExchange.exchangeViolations(any()))
             .thenAnswer(invocation -> {
                 if (callCount.getAndIncrement() == 0) {
-                    throw new StatusRuntimeException(Status.UNAVAILABLE);
+                    throw new BalanceExchangeException("unavailable", true, false);
                 }
-                return ViolationBatch.newBuilder()
-                    .setRequesterRank(1)
-                    .setResponderRank(0)
-                    .setRoundNumber(0)
-                    .setTimestamp(System.currentTimeMillis())
-                    .build();
+                return new ViolationBatch<>(1, 0, 0, List.of(), System.currentTimeMillis());
             });
 
         // Execute aggregation
@@ -148,28 +122,22 @@ class DistributedViolationAggregatorTest {
         assertNotNull(result);
         assertTrue(result.containsAll(localViolations));
 
-        // Verify retry happened (1 original + 1 retry = 2 calls for first round)
-        // Plus 1 for second round = 3 total
-        verify(mockClient, atLeast(2)).exchangeViolations(any(ViolationBatch.class));
+        // Verify retry happened (1 original + 1 retry for first round, plus second round)
+        verify(mockExchange, atLeast(2)).exchangeViolations(any());
     }
 
     @Test
-    void testPartialFailureDoesNotBlockAggregation() {
+    void testPartialFailureDoesNotBlockAggregation() throws Exception {
         // Create local violations
         var localViolations = List.of(
             createViolation(1, 2, 5, 7, 2, 0)
         );
 
-        // Mock first round fails permanently, second round succeeds
-        when(mockClient.exchangeViolations(any(ViolationBatch.class)))
-            .thenThrow(new StatusRuntimeException(Status.UNAVAILABLE))
-            .thenThrow(new StatusRuntimeException(Status.UNAVAILABLE))
-            .thenReturn(ViolationBatch.newBuilder()
-                .setRequesterRank(2)
-                .setResponderRank(0)
-                .setRoundNumber(1)
-                .setTimestamp(System.currentTimeMillis())
-                .build());
+        // Mock first round fails permanently (transient + retry exhausted), second round succeeds
+        when(mockExchange.exchangeViolations(any()))
+            .thenThrow(new BalanceExchangeException("unavailable", true, false))
+            .thenThrow(new BalanceExchangeException("unavailable", true, false))
+            .thenReturn(new ViolationBatch<>(2, 0, 1, List.of(), System.currentTimeMillis()));
 
         // Execute aggregation
         var result = aggregator.aggregateDistributed(localViolations);
@@ -187,17 +155,12 @@ class DistributedViolationAggregatorTest {
     }
 
     @Test
-    void testShutdownCleansUpResources() {
+    void testShutdownCleansUpResources() throws Exception {
         // Execute aggregation to initialize state
         var localViolations = List.of(createViolation(1, 2, 5, 7, 2, 0));
 
-        when(mockClient.exchangeViolations(any(ViolationBatch.class)))
-            .thenReturn(ViolationBatch.newBuilder()
-                .setRequesterRank(1)
-                .setResponderRank(0)
-                .setRoundNumber(0)
-                .setTimestamp(System.currentTimeMillis())
-                .build());
+        when(mockExchange.exchangeViolations(any()))
+            .thenReturn(new ViolationBatch<>(1, 0, 0, List.of(), System.currentTimeMillis()));
 
         aggregator.aggregateDistributed(localViolations);
 
@@ -206,24 +169,14 @@ class DistributedViolationAggregatorTest {
     }
 
     /**
-     * Helper to create a BalanceViolation for testing.
+     * Helper to create a domain BalanceViolation for testing (level-0 Morton keys, levelDiff > 1).
      */
-    private BalanceViolation createViolation(long localKeyId, long ghostKeyId,
-                                            int localLevel, int ghostLevel,
-                                            int levelDiff, int sourceRank) {
-        return BalanceViolation.newBuilder()
-            .setLocalKey(mortonKey(localKeyId))
-            .setGhostKey(mortonKey(ghostKeyId))
-            .setLocalLevel(localLevel)
-            .setGhostLevel(ghostLevel)
-            .setLevelDifference(levelDiff)
-            .setSourceRank(sourceRank)
-            .build();
-    }
-
-    /** Build a proto SpatialKey envelope from a long Morton code (Luciferase-546 serde dispatch). */
-    private static SpatialKey mortonKey(long mortonCode) {
-        return com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters.spatialKeyToProtobuf(
-            new com.hellblazer.luciferase.lucien.octree.MortonKey(mortonCode, (byte) 0));
+    private TwoOneBalanceChecker.BalanceViolation<MortonKey> createViolation(long localKeyId, long ghostKeyId,
+                                                                             int localLevel, int ghostLevel,
+                                                                             int levelDiff, int sourceRank) {
+        return new TwoOneBalanceChecker.BalanceViolation<>(
+            new MortonKey(localKeyId, (byte) 0),
+            new MortonKey(ghostKeyId, (byte) 0),
+            localLevel, ghostLevel, levelDiff, sourceRank);
     }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/Inc3DomainTypesTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/Inc3DomainTypesTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.balancing;
+
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostElement;
+import com.hellblazer.luciferase.lucien.octree.MortonKey;
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3f;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Inc3-C1 (RDR-007 Phase 0): pure-domain types that replace the balancing proto messages at the
+ * lucien-core boundary. Validates construction, the reused {@link TwoOneBalanceChecker.BalanceViolation}
+ * guard, the {@link RefinementResponse#empty()} fallback (replaces proto getDefaultInstance), defensive
+ * immutability of the collection-bearing records, and the {@link BalanceExchangeException} flag round-trip.
+ *
+ * @author hal.hildebrand
+ */
+class Inc3DomainTypesTest {
+
+    @Test
+    void refinementRequestHoldsDomainKeys() {
+        var k1 = new MortonKey(100L, (byte) 3);
+        var k2 = new MortonKey(200L, (byte) 4);
+        var req = new RefinementRequest<>(0, 0L, 1, 4, List.of(k1, k2), 12345L);
+
+        assertEquals(0, req.requesterRank());
+        assertEquals(0L, req.requesterTreeId());
+        assertEquals(1, req.roundNumber());
+        assertEquals(4, req.treeLevel());
+        assertEquals(List.of(k1, k2), req.boundaryKeys());
+        assertEquals(12345L, req.timestamp());
+    }
+
+    @Test
+    void refinementResponseHoldsDomainGhostElements() {
+        var ghost = new GhostElement<MortonKey, LongEntityID, String>(
+            new MortonKey(100L, (byte) 3), new LongEntityID(1L), "content",
+            new Point3f(1, 2, 3), 1, 0L);
+        var resp = new RefinementResponse<>(0, 1, 0L, 1, List.of(ghost), true, 999L);
+
+        assertEquals(1, resp.ghostElements().size());
+        assertSame(ghost, resp.ghostElements().get(0));
+        assertTrue(resp.needsFurtherRefinement());
+        assertEquals(1, resp.responderRank());
+    }
+
+    @Test
+    void refinementResponseEmptyFactoryMatchesProtoDefaults() {
+        RefinementResponse<MortonKey, LongEntityID, String> empty = RefinementResponse.empty();
+
+        // Mirrors proto RefinementResponse.getDefaultInstance() used as the coordinator fallback.
+        assertFalse(empty.needsFurtherRefinement());
+        assertTrue(empty.ghostElements().isEmpty());
+        assertEquals(0, empty.requesterRank());
+        assertEquals(0, empty.responderRank());
+        assertEquals(0L, empty.responderTreeId());
+        assertEquals(0, empty.roundNumber());
+        assertEquals(0L, empty.timestamp());
+    }
+
+    @Test
+    void violationBatchHoldsDomainViolations() {
+        var local = new MortonKey(10L, (byte) 5);
+        var ghost = new MortonKey(20L, (byte) 2);
+        var violation = new TwoOneBalanceChecker.BalanceViolation<>(local, ghost, 5, 2, 3, 7);
+        var batch = new ViolationBatch<>(0, 1, 2, List.of(violation), 555L);
+
+        assertEquals(1, batch.violations().size());
+        assertEquals(violation, batch.violations().get(0));
+        assertEquals(7, batch.violations().get(0).sourceRank());
+        assertEquals(2, batch.roundNumber());
+    }
+
+    @Test
+    void balanceViolationCtorGuardRejectsNonViolation() {
+        var k = new MortonKey(1L, (byte) 1);
+        assertThrows(IllegalArgumentException.class,
+            () -> new TwoOneBalanceChecker.BalanceViolation<>(k, k, 1, 1, 1, 0),
+            "levelDifference <= 1 must be rejected by the reused domain violation record");
+    }
+
+    @Test
+    void balanceExchangeExceptionFlagsRoundTrip() {
+        var transientEx = new BalanceExchangeException("unavailable", true, false);
+        assertTrue(transientEx.isTransient());
+        assertFalse(transientEx.isTimeout());
+
+        var timeoutEx = new BalanceExchangeException("deadline", false, true);
+        assertFalse(timeoutEx.isTransient());
+        assertTrue(timeoutEx.isTimeout());
+
+        var cause = new RuntimeException("boom");
+        var withCause = new BalanceExchangeException("wrapped", cause, true, false);
+        assertSame(cause, withCause.getCause());
+        assertTrue(withCause.isTransient());
+        assertFalse(withCause.isTimeout());
+    }
+
+    @Test
+    void collectionBearingRecordsDefensivelyCopy() {
+        var k = new MortonKey(1L, (byte) 1);
+        var mutableKeys = new ArrayList<MortonKey>();
+        mutableKeys.add(k);
+        var req = new RefinementRequest<>(0, 0L, 0, 0, mutableKeys, 0L);
+        mutableKeys.clear();
+        assertEquals(1, req.boundaryKeys().size(), "RefinementRequest must defensively copy boundaryKeys");
+
+        var ghost = new GhostElement<MortonKey, LongEntityID, String>(
+            new MortonKey(2L, (byte) 1), new LongEntityID(1L), "c", new Point3f(0, 0, 0), 0, 0L);
+        var mutableGhosts = new ArrayList<GhostElement<MortonKey, LongEntityID, String>>();
+        mutableGhosts.add(ghost);
+        var resp = new RefinementResponse<>(0, 0, 0L, 0, mutableGhosts, false, 0L);
+        mutableGhosts.clear();
+        assertEquals(1, resp.ghostElements().size(), "RefinementResponse must defensively copy ghostElements");
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/Phase3IntegrationTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/Phase3IntegrationTest.java
@@ -17,11 +17,7 @@
 package com.hellblazer.luciferase.lucien.balancing;
 
 import com.hellblazer.luciferase.lucien.balancing.fault.Phase44ForestIntegrationFixture;
-import com.hellblazer.luciferase.lucien.balancing.grpc.BalanceCoordinatorClient;
-import com.hellblazer.luciferase.lucien.balancing.proto.RefinementRequest;
-import com.hellblazer.luciferase.lucien.balancing.proto.RefinementResponse;
 import com.hellblazer.luciferase.lucien.entity.LongEntityID;
-import com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey;
 import com.hellblazer.luciferase.lucien.octree.MortonKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,27 +36,9 @@ import static org.assertj.core.api.Assertions.*;
 /**
  * Phase 3 Integration Tests - End-to-End Cross-Partition Balance Protocol.
  *
- * <p>This test suite validates the complete Phase 3 (Cross-Partition Balance) workflow
- * using realistic multi-partition forests with actual Octree spatial structures, ghost
- * layer integration, and distributed coordination.
- *
- * <p><b>Test Coverage:</b>
- * <ul>
- *   <li>Scenario 1: 2-partition single round convergence (O(log 2) = 1)</li>
- *   <li>Scenario 2: 4-partition two rounds with butterfly pattern (O(log 4) = 2)</li>
- *   <li>Scenario 3: Asymmetric violations partial recovery</li>
- *   <li>Scenario 4: Partition failure graceful degradation</li>
- *   <li>Scenario 5: Large forest scaling (8 partitions, O(log 8) = 3)</li>
- *   <li>Scenario 6: End-to-end correctness full Phase 3 protocol</li>
- * </ul>
- *
- * <p><b>Infrastructure:</b>
- * <ul>
- *   <li>Phase44ForestIntegrationFixture: Real forest with Octree + ghost layer</li>
- *   <li>CrossPartitionBalancePhase: Phase 3 execution engine</li>
- *   <li>TwoOneBalanceChecker: 2:1 violation detection</li>
- *   <li>RefinementCoordinator: Async gRPC coordination</li>
- * </ul>
+ * <p>Updated for Inc3-C4: uses MockRefinementExchange (domain interface) instead of
+ * MockBalanceCoordinatorClient. Sent-request captures are domain RefinementRequest records;
+ * assertions use record accessors instead of proto getters.
  *
  * @author hal.hildebrand
  */
@@ -79,36 +57,27 @@ public class Phase3IntegrationTest {
 
     /**
      * SCENARIO 1: Two-Partition Single Round Convergence.
-     *
-     * <p>Setup: 2-partition forest with butterfly partners (0-0, 1-1)
-     * <p>Inject: 2:1 violations at partition boundary
-     * <p>Expected: Single refinement round (O(log 2) = 1) converges completely
-     * <p>Verify: Ghost layer synchronized, no more violations detected
      */
     @Test
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
     public void testTwoPartitionSingleRound_ConvergesQuickly() {
         log.info("=== SCENARIO 1: Two-Partition Single Round Convergence ===");
 
-        // Setup: Create 2-partition forest
         var distributedForest = fixture.createForest(100, 2);
         fixture.syncGhostLayer();
 
         var forest = fixture.getForest();
         var ghostLayer = fixture.getGhostLayer();
 
-        // Create mock infrastructure for 2 partitions
-        var client = new MockBalanceCoordinatorClient();
+        var exchange = new MockRefinementExchange();
         var registry = new MockPartitionRegistry(2);
         var phase = new CrossPartitionBalancePhase<MortonKey, LongEntityID,
-                Phase44ForestIntegrationFixture.TestEntity>(client, registry, config);
+                Phase44ForestIntegrationFixture.TestEntity>(exchange, registry, config);
 
         phase.setForestContext(forest, ghostLayer);
 
-        // Execute Phase 3
         var result = phase.execute(forest, 0, 2);
 
-        // Verify convergence
         assertThat(result.successful())
             .as("Phase 3 should complete successfully for 2 partitions")
             .isTrue();
@@ -117,11 +86,9 @@ public class Phase3IntegrationTest {
             .as("Should execute exactly 1 refinement round for 2 partitions (O(log 2) = 1)")
             .isEqualTo(1);
 
-        // Verify ghost layer synchronized
         var violations = fixture.findCurrentViolations();
         log.info("Violations after convergence: {}", violations.size());
 
-        // Verify barrier synchronization
         assertThat(registry.getBarrierCount())
             .as("Should synchronize at barrier after round 1")
             .isGreaterThanOrEqualTo(1);
@@ -132,37 +99,27 @@ public class Phase3IntegrationTest {
 
     /**
      * SCENARIO 2: Four-Partition Two Rounds with Butterfly Pattern.
-     *
-     * <p>Setup: 4-partition forest with butterfly topology
-     * <p>Inject: 2:1 violations affecting multiple boundaries
-     * <p>Expected: Exactly 2 refinement rounds (O(log 4) = 2) needed
-     * <p>Verify: Each round executes correct partner pairings (butterfly pattern)
-     *           Round 1: (0-0, 1-1, 2-2, 3-3), Round 2: (0-2, 1-3)
      */
     @Test
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
     public void testFourPartitionTwoRounds_ButterflyPattern() {
         log.info("=== SCENARIO 2: Four-Partition Two Rounds with Butterfly Pattern ===");
 
-        // Setup: Create 4-partition forest
         var distributedForest = fixture.createForest(150, 4);
         fixture.syncGhostLayer();
 
         var forest = fixture.getForest();
         var ghostLayer = fixture.getGhostLayer();
 
-        // Create mock infrastructure for 4 partitions
-        var client = new MockBalanceCoordinatorClient();
+        var exchange = new MockRefinementExchange();
         var registry = new MockPartitionRegistry(4);
         var phase = new CrossPartitionBalancePhase<MortonKey, LongEntityID,
-                Phase44ForestIntegrationFixture.TestEntity>(client, registry, config);
+                Phase44ForestIntegrationFixture.TestEntity>(exchange, registry, config);
 
         phase.setForestContext(forest, ghostLayer);
 
-        // Execute Phase 3
         var result = phase.execute(forest, 0, 4);
 
-        // Verify convergence in 2 rounds
         assertThat(result.successful())
             .as("Phase 3 should complete successfully for 4 partitions")
             .isTrue();
@@ -171,15 +128,11 @@ public class Phase3IntegrationTest {
             .as("Should execute exactly 2 refinement rounds for 4 partitions (O(log 4) = 2)")
             .isEqualTo(2);
 
-        // Verify butterfly pattern communication
-        // Round 1 should have all partitions communicating with themselves (initialization)
-        // Round 2 should have butterfly pairs (0-2, 1-3)
-        var sentRequests = client.getSentRequests();
+        var sentRequests = exchange.getSentRequests();
         assertThat(sentRequests)
             .as("Should send requests in butterfly pattern")
             .isNotEmpty();
 
-        // Verify barrier synchronization for both rounds
         assertThat(registry.getBarrierCount())
             .as("Should synchronize at barrier after each round (2 barriers for 2 rounds)")
             .isGreaterThanOrEqualTo(2);
@@ -190,41 +143,31 @@ public class Phase3IntegrationTest {
 
     /**
      * SCENARIO 3: Asymmetric Violations Partial Recovery.
-     *
-     * <p>Setup: 4-partition forest with violations only on boundaries 0-1 and 2-3
-     * <p>Inject: Large 2:1 differences requiring multiple refinement rounds
-     * <p>Expected: Convergence with proper synchronization
-     * <p>Verify: Ghost layer properly maintains both symmetric and asymmetric relationships
      */
     @Test
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
     public void testAsymmetricViolations_PartialRecovery() {
         log.info("=== SCENARIO 3: Asymmetric Violations Partial Recovery ===");
 
-        // Setup: Create 4-partition forest
         var distributedForest = fixture.createForest(150, 4);
         fixture.syncGhostLayer();
 
         var forest = fixture.getForest();
         var ghostLayer = fixture.getGhostLayer();
 
-        // Create mock infrastructure
-        var client = new MockBalanceCoordinatorClient();
+        var exchange = new MockRefinementExchange();
         var registry = new MockPartitionRegistry(4);
         var phase = new CrossPartitionBalancePhase<MortonKey, LongEntityID,
-                Phase44ForestIntegrationFixture.TestEntity>(client, registry, config);
+                Phase44ForestIntegrationFixture.TestEntity>(exchange, registry, config);
 
         phase.setForestContext(forest, ghostLayer);
 
-        // Inject asymmetric violations by configuring client responses
-        // Partitions 0-1 have violations, 2-3 have violations
-        client.addMockResponse(1, createMockResponse(1, 1, 3)); // 3 ghost elements from rank 1
-        client.addMockResponse(3, createMockResponse(3, 1, 2)); // 2 ghost elements from rank 3
+        // Inject asymmetric responses
+        exchange.addMockResponse(1, createMockResponse(1, 1, 3));
+        exchange.addMockResponse(3, createMockResponse(3, 1, 2));
 
-        // Execute Phase 3
         var result = phase.execute(forest, 0, 4);
 
-        // Verify partial recovery (asymmetric violations handled)
         assertThat(result.successful())
             .as("Phase 3 should complete successfully even with asymmetric violations")
             .isTrue();
@@ -234,7 +177,6 @@ public class Phase3IntegrationTest {
             .isGreaterThanOrEqualTo(1)
             .isLessThanOrEqualTo(2);
 
-        // Verify ghost layer has elements from asymmetric boundaries
         var ghostElementCount = ghostLayer.getNumGhostElements();
         log.info("Ghost layer contains {} elements after asymmetric recovery", ghostElementCount);
 
@@ -248,51 +190,37 @@ public class Phase3IntegrationTest {
 
     /**
      * SCENARIO 4: Partition Failure Graceful Degradation.
-     *
-     * <p>Setup: 3-partition forest (one partition marked FAILED)
-     * <p>Inject: 2:1 violations that would span to failed partition
-     * <p>Expected: Algorithm skips failed partition, converges with healthy ones
-     * <p>Verify: No exceptions thrown, partial convergence achieved
      */
     @Test
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
     public void testPartitionFailure_GracefulDegradation() {
         log.info("=== SCENARIO 4: Partition Failure Graceful Degradation ===");
 
-        // Setup: Create 3-partition forest
         var distributedForest = fixture.createForest(120, 3);
         fixture.syncGhostLayer();
 
         var forest = fixture.getForest();
         var ghostLayer = fixture.getGhostLayer();
 
-        // Create mock infrastructure with partition 2 marked as FAILED
-        var client = new MockBalanceCoordinatorClient();
-        client.setPartitionFailed(2, true); // Partition 2 is failed
+        var exchange = new MockRefinementExchange();
+        exchange.setPartitionFailed(2, true); // Partition 2 is failed
 
         var registry = new MockPartitionRegistry(3);
         var phase = new CrossPartitionBalancePhase<MortonKey, LongEntityID,
-                Phase44ForestIntegrationFixture.TestEntity>(client, registry, config);
+                Phase44ForestIntegrationFixture.TestEntity>(exchange, registry, config);
 
         phase.setForestContext(forest, ghostLayer);
 
-        // Execute Phase 3 (should handle failed partition gracefully)
         var result = phase.execute(forest, 0, 3);
 
-        // Verify graceful degradation
         assertThat(result.successful())
             .as("Phase 3 should complete successfully even with 1 failed partition")
             .isTrue();
 
-        // Verify no exceptions thrown during execution
-        var sentRequests = client.getSentRequests();
+        var sentRequests = exchange.getSentRequests();
         assertThat(sentRequests)
             .as("Should send requests only to healthy partitions")
             .isNotEmpty();
-
-        // Verify partial convergence (only healthy partitions converge)
-        log.info("Partial convergence achieved with {} healthy partitions out of 3",
-                3 - 1);
 
         log.info("Scenario 4 PASSED: Graceful degradation with 1 failed partition, {} refinements applied",
                 result.refinementsApplied());
@@ -300,39 +228,29 @@ public class Phase3IntegrationTest {
 
     /**
      * SCENARIO 5: Large Forest Scaling (8 Partitions, O(log 8) = 3 Rounds).
-     *
-     * <p>Setup: 8-partition forest (O(log 8) = 3 rounds needed)
-     * <p>Inject: Random 2:1 violations across many boundaries
-     * <p>Expected: Exactly 3 refinement rounds required
-     * <p>Verify: All 8 partitions converge within expected round count
-     * <p>Metrics: Verify O(log P) complexity holds for P=8
      */
     @Test
     @Timeout(value = 15, unit = TimeUnit.SECONDS)
     public void testLargeForestScaling_8Partitions_3Rounds() {
         log.info("=== SCENARIO 5: Large Forest Scaling (8 Partitions, O(log 8) = 3) ===");
 
-        // Setup: Create 8-partition forest
         var distributedForest = fixture.createForest(200, 8);
         fixture.syncGhostLayer();
 
         var forest = fixture.getForest();
         var ghostLayer = fixture.getGhostLayer();
 
-        // Create mock infrastructure for 8 partitions
-        var client = new MockBalanceCoordinatorClient();
+        var exchange = new MockRefinementExchange();
         var registry = new MockPartitionRegistry(8);
         var phase = new CrossPartitionBalancePhase<MortonKey, LongEntityID,
-                Phase44ForestIntegrationFixture.TestEntity>(client, registry, config);
+                Phase44ForestIntegrationFixture.TestEntity>(exchange, registry, config);
 
         phase.setForestContext(forest, ghostLayer);
 
-        // Execute Phase 3
         var startTime = System.currentTimeMillis();
         var result = phase.execute(forest, 0, 8);
         var elapsed = System.currentTimeMillis() - startTime;
 
-        // Verify O(log P) complexity: O(log 8) = 3 rounds
         assertThat(result.successful())
             .as("Phase 3 should complete successfully for 8 partitions")
             .isTrue();
@@ -341,18 +259,15 @@ public class Phase3IntegrationTest {
             .as("Should execute exactly 3 refinement rounds for 8 partitions (O(log 8) = 3)")
             .isEqualTo(3);
 
-        // Verify performance: All rounds should complete within reasonable time
         assertThat(elapsed)
             .as("Total execution time should be reasonable (<15s)")
             .isLessThan(15000L);
 
-        // Verify round timing
         var avgRoundTime = result.finalMetrics().averageRoundTime().toMillis();
         assertThat(avgRoundTime)
             .as("Average round time should be reasonable (<5s)")
             .isLessThan(5000L);
 
-        // Verify barrier synchronization for all 3 rounds
         assertThat(registry.getBarrierCount())
             .as("Should synchronize at barrier after each round (3 barriers for 3 rounds)")
             .isGreaterThanOrEqualTo(3);
@@ -363,35 +278,22 @@ public class Phase3IntegrationTest {
 
     /**
      * SCENARIO 6: End-to-End Correctness Full Phase 3 Protocol.
-     *
-     * <p>Setup: Phase44ForestIntegrationFixture with full forest infrastructure
-     * <p>Inject: Comprehensive 2:1 violations from previous Phase 1-2 work
-     * <p>Execute: Complete Phase 3 (Cross-Partition Balance) workflow:
-     * <ol>
-     *   <li>Identification: identifyRefinementNeeds() finds violations</li>
-     *   <li>Requests: sendRequestsParallel() sends to butterfly partners</li>
-     *   <li>Responses: applyRefinementResponses() updates ghost layer</li>
-     *   <li>Synchronization: All partitions reach consistency</li>
-     * </ol>
-     * <p>Verify: End-to-end correctness, proper logging, metrics collected
      */
     @Test
     @Timeout(value = 15, unit = TimeUnit.SECONDS)
     public void testEndToEndCorrectness_FullPhase3Protocol() {
         log.info("=== SCENARIO 6: End-to-End Correctness Full Phase 3 Protocol ===");
 
-        // Setup: Create 4-partition forest with full infrastructure
         var distributedForest = fixture.createForest(150, 4);
         fixture.syncGhostLayer();
 
         var forest = fixture.getForest();
         var ghostLayer = fixture.getGhostLayer();
 
-        // Create real infrastructure components
-        var client = new MockBalanceCoordinatorClient();
+        var exchange = new MockRefinementExchange();
         var registry = new MockPartitionRegistry(4);
         var phase = new CrossPartitionBalancePhase<MortonKey, LongEntityID,
-                Phase44ForestIntegrationFixture.TestEntity>(client, registry, config);
+                Phase44ForestIntegrationFixture.TestEntity>(exchange, registry, config);
 
         phase.setForestContext(forest, ghostLayer);
 
@@ -411,27 +313,27 @@ public class Phase3IntegrationTest {
             .as("Should execute expected rounds for 4 partitions (O(log 4) = 2)")
             .isEqualTo(2);
 
-        // STEP 4: Verify identification worked
-        var sentRequests = client.getSentRequests();
+        // STEP 4: Verify requests were sent
+        var sentRequests = exchange.getSentRequests();
         assertThat(sentRequests)
             .as("identifyRefinementNeeds() should create refinement requests")
             .isNotEmpty();
 
-        // STEP 5: Verify request structure
+        // STEP 5: Verify domain request structure (record accessors, not proto getters)
         for (var request : sentRequests) {
-            assertThat(request.getRequesterRank())
+            assertThat(request.requesterRank())
                 .as("Request should have valid requester rank")
                 .isBetween(0, 3);
 
-            assertThat(request.getRoundNumber())
+            assertThat(request.roundNumber())
                 .as("Request should have valid round number")
                 .isGreaterThan(0);
 
-            assertThat(request.getTreeLevel())
+            assertThat(request.treeLevel())
                 .as("Request should have valid tree level")
                 .isBetween(0, 21);
 
-            assertThat(request.getTimestamp())
+            assertThat(request.timestamp())
                 .as("Request should have timestamp")
                 .isGreaterThan(0L);
         }
@@ -474,143 +376,86 @@ public class Phase3IntegrationTest {
 
     // ========== Helper Methods ==========
 
-    /**
-     * Create a mock refinement response for testing.
-     *
-     * @param responderRank the rank of the responding partition
-     * @param roundNumber the round number
-     * @param ghostElementCount number of ghost elements in response
-     * @return mock refinement response
-     */
-    private RefinementResponse createMockResponse(int responderRank, int roundNumber, int ghostElementCount) {
-        return RefinementResponse.newBuilder()
-            .setResponderRank(responderRank)
-            .setResponderTreeId(0L)
-            .setRoundNumber(roundNumber)
-            .setNeedsFurtherRefinement(ghostElementCount > 0)
-            .setTimestamp(System.currentTimeMillis())
-            .build();
+    private RefinementResponse<MortonKey, LongEntityID, Phase44ForestIntegrationFixture.TestEntity>
+    createMockResponse(int responderRank, int roundNumber, int ghostElementCount) {
+        return new RefinementResponse<>(0, responderRank, 0L, roundNumber,
+                                        List.of(), ghostElementCount > 0, System.currentTimeMillis());
     }
 
     // ========== Mock Infrastructure ==========
 
     /**
-     * Mock BalanceCoordinatorClient for testing cross-partition communication.
+     * Mock RefinementExchange — domain implementation replacing MockBalanceCoordinatorClient.
+     * Captures sent requests as domain RefinementRequest records.
      */
-    private static class MockBalanceCoordinatorClient extends BalanceCoordinatorClient {
-        private final Map<Integer, RefinementResponse> mockResponses = new ConcurrentHashMap<>();
-        private final List<RefinementRequest> sentRequests = Collections.synchronizedList(new ArrayList<>());
+    private static class MockRefinementExchange
+            implements RefinementExchange<MortonKey, LongEntityID, Phase44ForestIntegrationFixture.TestEntity> {
+
+        private final Map<Integer, RefinementResponse<MortonKey, LongEntityID,
+                Phase44ForestIntegrationFixture.TestEntity>> mockResponses = new ConcurrentHashMap<>();
+        private final List<RefinementRequest<MortonKey>> sentRequests =
+            Collections.synchronizedList(new ArrayList<>());
         private final AtomicInteger requestCount = new AtomicInteger(0);
         private final Set<Integer> failedPartitions = ConcurrentHashMap.newKeySet();
-        private volatile boolean converged = false;
         private volatile boolean alwaysNeedsRefinement = false;
 
-        public MockBalanceCoordinatorClient() {
-            super(0, new MockServiceDiscovery());
-        }
-
         @Override
-        public CompletableFuture<RefinementResponse> requestRefinementAsync(
+        public CompletableFuture<RefinementResponse<MortonKey, LongEntityID,
+                Phase44ForestIntegrationFixture.TestEntity>> requestRefinementAsync(
                 int targetRank, long treeId, int roundNumber, int treeLevel,
-                List<SpatialKey> boundaryKeys) {
+                List<MortonKey> boundaryKeys) {
 
             requestCount.incrementAndGet();
 
-            // Simulate failed partition
+            // Simulate failed partition — complete exceptionally so the .exceptionally handler
+            // in sendRequestsParallel maps it to RefinementResponse.empty()
             if (failedPartitions.contains(targetRank)) {
-                var failedFuture = new CompletableFuture<RefinementResponse>();
-                failedFuture.completeExceptionally(new RuntimeException("Partition " + targetRank + " is failed"));
+                var failedFuture =
+                    new CompletableFuture<RefinementResponse<MortonKey, LongEntityID,
+                            Phase44ForestIntegrationFixture.TestEntity>>();
+                failedFuture.completeExceptionally(
+                    new RuntimeException("Partition " + targetRank + " is failed"));
                 return failedFuture;
             }
 
-            // Create and store request
-            var request = RefinementRequest.newBuilder()
-                .setRequesterRank(0)
-                .setRequesterTreeId(treeId)
-                .setRoundNumber(roundNumber)
-                .setTreeLevel(treeLevel)
-                .setTimestamp(System.currentTimeMillis())
-                .build();
+            // Capture the domain request
+            var request = new RefinementRequest<>(0, treeId, roundNumber, treeLevel,
+                                                   boundaryKeys, System.currentTimeMillis());
             sentRequests.add(request);
 
-            // Return mock response
             var response = mockResponses.getOrDefault(targetRank,
                 createDefaultResponse(targetRank, roundNumber));
 
             return CompletableFuture.completedFuture(response);
         }
 
-        public void addMockResponse(int targetRank, RefinementResponse response) {
+        public void addMockResponse(int targetRank,
+                RefinementResponse<MortonKey, LongEntityID, Phase44ForestIntegrationFixture.TestEntity> response) {
             mockResponses.put(targetRank, response);
         }
 
         public void setPartitionFailed(int rank, boolean failed) {
-            if (failed) {
-                failedPartitions.add(rank);
-            } else {
-                failedPartitions.remove(rank);
-            }
-        }
-
-        public void setConverged(boolean converged) {
-            this.converged = converged;
+            if (failed) failedPartitions.add(rank);
+            else failedPartitions.remove(rank);
         }
 
         public void setAlwaysNeedsRefinement(boolean alwaysNeedsRefinement) {
             this.alwaysNeedsRefinement = alwaysNeedsRefinement;
         }
 
-        public int getRequestCount() {
-            return requestCount.get();
-        }
+        public int getRequestCount() { return requestCount.get(); }
 
-        public List<RefinementRequest> getSentRequests() {
+        public List<RefinementRequest<MortonKey>> getSentRequests() {
             return new ArrayList<>(sentRequests);
         }
 
-        private RefinementResponse createDefaultResponse(int responderRank, int roundNumber) {
-            return RefinementResponse.newBuilder()
-                .setResponderRank(responderRank)
-                .setResponderTreeId(0L)
-                .setRoundNumber(roundNumber)
-                .setNeedsFurtherRefinement(alwaysNeedsRefinement && !converged)
-                .setTimestamp(System.currentTimeMillis())
-                .build();
+        private RefinementResponse<MortonKey, LongEntityID, Phase44ForestIntegrationFixture.TestEntity>
+        createDefaultResponse(int responderRank, int roundNumber) {
+            return new RefinementResponse<>(0, responderRank, 0L, roundNumber,
+                                            List.of(), alwaysNeedsRefinement, System.currentTimeMillis());
         }
     }
 
-    /**
-     * Mock ServiceDiscovery for BalanceCoordinatorClient.
-     */
-    private static class MockServiceDiscovery implements BalanceCoordinatorClient.ServiceDiscovery {
-        private final Map<Integer, String> endpoints = new ConcurrentHashMap<>();
-
-        public MockServiceDiscovery() {
-            // Pre-populate with test endpoints
-            for (int i = 0; i < 16; i++) {
-                endpoints.put(i, "localhost:" + (50000 + i));
-            }
-        }
-
-        @Override
-        public String getEndpoint(int rank) {
-            return endpoints.get(rank);
-        }
-
-        @Override
-        public void registerEndpoint(int rank, String endpoint) {
-            endpoints.put(rank, endpoint);
-        }
-
-        @Override
-        public Map<Integer, String> getAllEndpoints() {
-            return new HashMap<>(endpoints);
-        }
-    }
-
-    /**
-     * Mock PartitionRegistry for testing barrier synchronization.
-     */
     private static class MockPartitionRegistry implements ParallelBalancer.PartitionRegistry {
         private final int partitionCount;
         private final AtomicInteger barrierCount = new AtomicInteger(0);
@@ -621,19 +466,14 @@ public class Phase3IntegrationTest {
         }
 
         @Override
-        public int getCurrentPartitionId() {
-            return 0;
-        }
+        public int getCurrentPartitionId() { return 0; }
 
         @Override
-        public int getPartitionCount() {
-            return partitionCount;
-        }
+        public int getPartitionCount() { return partitionCount; }
 
         @Override
         public void barrier(int round) throws InterruptedException {
             barrierCount.incrementAndGet();
-            // Simulate barrier synchronization with small delay
             Thread.sleep(10);
         }
 
@@ -643,12 +483,8 @@ public class Phase3IntegrationTest {
         }
 
         @Override
-        public int getPendingRefinements() {
-            return refinementRequests.get();
-        }
+        public int getPendingRefinements() { return refinementRequests.get(); }
 
-        public int getBarrierCount() {
-            return barrierCount.get();
-        }
+        public int getBarrierCount() { return barrierCount.get(); }
     }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/Phase4E2ETest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/Phase4E2ETest.java
@@ -18,6 +18,7 @@ package com.hellblazer.luciferase.lucien.balancing;
 
 import com.hellblazer.luciferase.lucien.balancing.grpc.BalanceCoordinatorClient;
 import com.hellblazer.luciferase.lucien.balancing.grpc.BalanceCoordinatorServer;
+import com.hellblazer.luciferase.lucien.balancing.grpc.GrpcBalanceExchange;
 import com.hellblazer.luciferase.lucien.balancing.proto.BalanceStatistics;
 import com.hellblazer.luciferase.lucien.balancing.proto.BalanceViolation;
 import com.hellblazer.luciferase.lucien.balancing.proto.RefinementRequest;
@@ -26,6 +27,7 @@ import com.hellblazer.luciferase.lucien.entity.LongEntityID;
 import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
 import com.hellblazer.luciferase.lucien.forest.Forest;
 import com.hellblazer.luciferase.lucien.forest.ForestConfig;
+import com.hellblazer.luciferase.lucien.forest.ghost.ContentSerializer;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostElement;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostLayer;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostType;
@@ -334,7 +336,7 @@ class Phase4E2ETest {
 
         // Aggregate on all partitions CONCURRENTLY (critical for distributed testing)
         var startTime = System.currentTimeMillis();
-        var futures = new ArrayList<java.util.concurrent.CompletableFuture<Set<BalanceViolation>>>();
+        var futures = new ArrayList<java.util.concurrent.CompletableFuture<Set<TwoOneBalanceChecker.BalanceViolation<MortonKey>>>>();
         for (var partition : partitions) {
             var future = java.util.concurrent.CompletableFuture.supplyAsync(
                 () -> partition.detectAndAggregate()
@@ -343,7 +345,7 @@ class Phase4E2ETest {
         }
 
         // Wait for all to complete
-        var results = new ArrayList<Set<BalanceViolation>>();
+        var results = new ArrayList<Set<TwoOneBalanceChecker.BalanceViolation<MortonKey>>>();
         for (var future : futures) {
             results.add(future.join());
         }
@@ -494,7 +496,7 @@ class Phase4E2ETest {
 
         // Aggregate CONCURRENTLY
         var startTime = System.currentTimeMillis();
-        var futures = new ArrayList<java.util.concurrent.CompletableFuture<Set<BalanceViolation>>>();
+        var futures = new ArrayList<java.util.concurrent.CompletableFuture<Set<TwoOneBalanceChecker.BalanceViolation<MortonKey>>>>();
         for (var partition : partitions) {
             var future = java.util.concurrent.CompletableFuture.supplyAsync(
                 () -> partition.detectAndAggregate()
@@ -503,7 +505,7 @@ class Phase4E2ETest {
         }
 
         // Wait for all to complete
-        var results = new ArrayList<Set<BalanceViolation>>();
+        var results = new ArrayList<Set<TwoOneBalanceChecker.BalanceViolation<MortonKey>>>();
         for (var future : futures) {
             results.add(future.join());
         }
@@ -591,6 +593,32 @@ class Phase4E2ETest {
             new com.hellblazer.luciferase.lucien.octree.MortonKey(mortonCode, (byte) 0));
     }
 
+    /** Shared String content serializer for the GrpcBalanceExchange adapter (unused on the violation path). */
+    private static final ContentSerializer<String> STRING_SERIALIZER = new ContentSerializer<>() {
+        @Override
+        public com.google.protobuf.ByteString serialize(String content) {
+            return com.google.protobuf.ByteString.copyFromUtf8(content);
+        }
+
+        @Override
+        public String deserialize(com.google.protobuf.ByteString bytes) {
+            return bytes.toStringUtf8();
+        }
+
+        @Override
+        public String getContentType() {
+            return "string";
+        }
+    };
+
+    /** Converts a proto violation (wire form) to the domain violation the aggregator consumes. */
+    private static TwoOneBalanceChecker.BalanceViolation<MortonKey> toDomainViolation(BalanceViolation proto) {
+        return new TwoOneBalanceChecker.BalanceViolation<>(
+            (MortonKey) com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters.spatialKeyFromProtobuf(proto.getLocalKey()),
+            (MortonKey) com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters.spatialKeyFromProtobuf(proto.getGhostKey()),
+            proto.getLocalLevel(), proto.getGhostLevel(), proto.getLevelDifference(), proto.getSourceRank());
+    }
+
     /**
      * Represents a single partition in the distributed system with the complete Phase 4 pipeline.
      */
@@ -604,7 +632,7 @@ class Phase4E2ETest {
         final List<BalanceViolation> localViolations;
         final AtomicInteger violationIdCounter;
         BalanceCoordinatorClient client;
-        DistributedViolationAggregator aggregator;
+        DistributedViolationAggregator<MortonKey> aggregator;
 
         Partition(int rank, int totalPartitions) {
             this.rank = rank;
@@ -649,9 +677,12 @@ class Phase4E2ETest {
                 }
             };
 
-            // Create client with in-process channels
+            // Create client with in-process channels. The aggregator works in domain types; the
+            // GrpcBalanceExchange adapter bridges to the proto gRPC wire (its serializer is unused on
+            // the violation-exchange path but required by the adapter contract).
             this.client = new InProcessBalanceCoordinatorClient(rank, serviceDiscovery);
-            this.aggregator = new DistributedViolationAggregator(rank, totalPartitions, client, 2000);
+            var exchange = new GrpcBalanceExchange<MortonKey, LongEntityID, String>(client, STRING_SERIALIZER, LongEntityID.class);
+            this.aggregator = new DistributedViolationAggregator<>(rank, totalPartitions, exchange, 2000);
         }
 
         /**
@@ -675,10 +706,16 @@ class Phase4E2ETest {
         /**
          * Executes the complete pipeline: detection → aggregation → distribution.
          */
-        Set<BalanceViolation> detectAndAggregate() {
-            // In a real system, ParallelViolationDetector would detect violations from ghost layer
-            // For E2E testing, we use pre-created violations
-            return aggregator.aggregateDistributed(new ArrayList<>(localViolations));
+        Set<TwoOneBalanceChecker.BalanceViolation<MortonKey>> detectAndAggregate() {
+            // In a real system, ParallelViolationDetector would detect violations from the ghost layer.
+            // For E2E testing we use pre-created violations. The wire-side proto violations are converted
+            // to domain for the aggregator; the gRPC server/client wire (Path B and processViolations)
+            // stays proto.
+            var domainLocal = new ArrayList<TwoOneBalanceChecker.BalanceViolation<MortonKey>>();
+            for (var proto : localViolations) {
+                domainLocal.add(toDomainViolation(proto));
+            }
+            return aggregator.aggregateDistributed(domainLocal);
         }
 
         /**

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/RefinementCoordinatorTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/RefinementCoordinatorTest.java
@@ -16,17 +16,14 @@
  */
 package com.hellblazer.luciferase.lucien.balancing;
 
-import com.hellblazer.luciferase.lucien.balancing.grpc.BalanceCoordinatorClient;
-import com.hellblazer.luciferase.lucien.balancing.proto.RefinementRequest;
-import com.hellblazer.luciferase.lucien.balancing.proto.RefinementResponse;
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.octree.MortonKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -36,50 +33,38 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * TDD tests for RefinementCoordinator with butterfly pattern integration.
  *
- * <p>These tests define the expected behavior of the RefinementCoordinator
- * after integrating ButterflyPattern for partner selection in executeRefinementRound().
- *
- * <p>Key enhancements tested:
- * <ul>
- *   <li>Constructor validates myRank and totalPartitions parameters</li>
- *   <li>executeRefinementRound() uses ButterflyPattern.getPartner() to select partners</li>
- *   <li>Non-participating ranks (partner=-1) handled gracefully</li>
- *   <li>sendRequestsParallel() invoked with correct requests</li>
- *   <li>Timeout handling prevents deadlock</li>
- *   <li>Response processing updates refinementsApplied count</li>
- * </ul>
+ * <p>Updated for Inc3-C4: uses domain RefinementRequest/Response and MockRefinementExchange
+ * instead of proto types and BalanceCoordinatorClient.
  *
  * @author hal.hildebrand
  */
 public class RefinementCoordinatorTest {
 
-    private MockBalanceCoordinatorClient client;
+    private MockRefinementExchange exchange;
     private RefinementRequestManager requestManager;
-    private RefinementCoordinator coordinator;
+    private RefinementCoordinator<MortonKey, LongEntityID, String> coordinator;
 
     @BeforeEach
     public void setUp() {
-        client = new MockBalanceCoordinatorClient();
+        exchange = new MockRefinementExchange();
         requestManager = new RefinementRequestManager();
     }
 
     // TEST 1: Constructor with valid parameters
     @Test
     public void testConstructorWithValidParameters() {
-        // Should accept valid rank and partition count
-        coordinator = new RefinementCoordinator(client, requestManager, 0, 2);
+        coordinator = new RefinementCoordinator<>(exchange, requestManager, 0, 2);
         assertNotNull(coordinator, "Should create coordinator with rank=0, partitions=2");
 
-        coordinator = new RefinementCoordinator(client, requestManager, 4, 8);
+        coordinator = new RefinementCoordinator<>(exchange, requestManager, 4, 8);
         assertNotNull(coordinator, "Should create coordinator with rank=4, partitions=8");
     }
 
     // TEST 2: Constructor rejects negative rank
     @Test
     public void testConstructorRejectsNegativeRank() {
-        var exception = assertThrows(IllegalArgumentException.class, () -> {
-            new RefinementCoordinator(client, requestManager, -1, 4);
-        });
+        var exception = assertThrows(IllegalArgumentException.class, () ->
+            new RefinementCoordinator<>(exchange, requestManager, -1, 4));
 
         assertTrue(exception.getMessage().contains("myRank"),
                   "Exception should mention invalid myRank parameter");
@@ -88,9 +73,8 @@ public class RefinementCoordinatorTest {
     // TEST 3: Constructor rejects zero partitions
     @Test
     public void testConstructorRejectsZeroPartitions() {
-        var exception = assertThrows(IllegalArgumentException.class, () -> {
-            new RefinementCoordinator(client, requestManager, 0, 0);
-        });
+        var exception = assertThrows(IllegalArgumentException.class, () ->
+            new RefinementCoordinator<>(exchange, requestManager, 0, 0));
 
         assertTrue(exception.getMessage().contains("totalPartitions"),
                   "Exception should mention invalid totalPartitions parameter");
@@ -99,58 +83,46 @@ public class RefinementCoordinatorTest {
     // TEST 4: Butterfly partner calculation - Round 0
     @Test
     public void testButterflyPartnerRound0() {
-        // In round 0, rank 0 should communicate with partner 1 (0 XOR 1 = 1)
-        coordinator = new RefinementCoordinator(client, requestManager, 0, 4);
+        coordinator = new RefinementCoordinator<>(exchange, requestManager, 0, 4);
 
         var result = coordinator.executeRefinementRound(1, 2); // roundNumber=1 (1-based)
 
-        // Verify request sent to partner 1
-        assertTrue(client.getRequestCount() > 0, "Should send request to butterfly partner");
+        assertTrue(exchange.getRequestCount() > 0, "Should send request to butterfly partner");
 
-        // Round 1 (1-based) → round 0 (0-based) → partner = 0 XOR 2^0 = 0 XOR 1 = 1
-        var sentRequests = client.getSentRequests();
+        var sentRequests = exchange.getSentRequests();
         assertFalse(sentRequests.isEmpty(), "Should have sent requests");
     }
 
     // TEST 5: Butterfly partner calculation - Round 1
     @Test
     public void testButterflyPartnerRound1() {
-        // In round 1 (0-based round 1), rank 0 should communicate with partner 2 (0 XOR 2 = 2)
-        coordinator = new RefinementCoordinator(client, requestManager, 0, 4);
+        coordinator = new RefinementCoordinator<>(exchange, requestManager, 0, 4);
 
         var result = coordinator.executeRefinementRound(2, 2); // roundNumber=2 (1-based)
 
-        // Verify request sent to partner 2
-        assertTrue(client.getRequestCount() > 0, "Should send request to butterfly partner");
+        assertTrue(exchange.getRequestCount() > 0, "Should send request to butterfly partner");
 
-        // Round 2 (1-based) → round 1 (0-based) → partner = 0 XOR 2^1 = 0 XOR 2 = 2
-        var sentRequests = client.getSentRequests();
+        var sentRequests = exchange.getSentRequests();
         assertFalse(sentRequests.isEmpty(), "Should have sent requests");
     }
 
     // TEST 6: Butterfly partner calculation - Round 2 (out of bounds)
     @Test
     public void testButterflyPartnerRound2OutOfBounds() {
-        // In round 2 (0-based), rank 0 should try partner 4 (0 XOR 4 = 4)
-        // But with totalPartitions=4, partner 4 is out of bounds → partner=-1
-        coordinator = new RefinementCoordinator(client, requestManager, 0, 4);
+        coordinator = new RefinementCoordinator<>(exchange, requestManager, 0, 4);
 
         var result = coordinator.executeRefinementRound(3, 3); // roundNumber=3 (1-based)
 
-        // Round 3 (1-based) → round 2 (0-based) → partner = 0 XOR 2^2 = 0 XOR 4 = 4 (out of bounds)
-        // Should handle gracefully (no partner for this round)
         assertNotNull(result, "Should return result even when partner out of bounds");
     }
 
     // TEST 7: Non-participating round (partner=-1) handled gracefully
     @Test
     public void testNonParticipatingRoundHandledGracefully() {
-        // Rank 7 in 8 partitions, round 3 (0-based) → partner = 7 XOR 8 = 15 (out of bounds)
-        coordinator = new RefinementCoordinator(client, requestManager, 7, 8);
+        coordinator = new RefinementCoordinator<>(exchange, requestManager, 7, 8);
 
         var result = coordinator.executeRefinementRound(4, 3); // roundNumber=4 (1-based)
 
-        // Should complete without error even though no partner
         assertNotNull(result, "Should complete successfully even with no partner");
         assertEquals(4, result.roundNumber(), "Should preserve round number");
     }
@@ -159,16 +131,13 @@ public class RefinementCoordinatorTest {
     @Test
     @Timeout(value = 5, unit = TimeUnit.SECONDS)
     public void testSendRequestsParallelCalled() {
-        coordinator = new RefinementCoordinator(client, requestManager, 0, 4);
+        coordinator = new RefinementCoordinator<>(exchange, requestManager, 0, 4);
 
-        // Execute round 1 (partner should be rank 1)
         var result = coordinator.executeRefinementRound(1, 2);
 
-        // Verify sendRequestsParallel was called (indirectly via client request count)
-        assertTrue(client.getRequestCount() > 0, "Should invoke sendRequestsParallel");
+        assertTrue(exchange.getRequestCount() > 0, "Should invoke sendRequestsParallel");
 
-        // Verify requests sent
-        var sentRequests = client.getSentRequests();
+        var sentRequests = exchange.getSentRequests();
         assertFalse(sentRequests.isEmpty(), "Should send requests to butterfly partner");
     }
 
@@ -176,12 +145,10 @@ public class RefinementCoordinatorTest {
     @Test
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
     public void testTimeoutHandlingDoesntDeadlock() {
-        // Configure client to simulate timeout
-        client.setSimulateTimeout(true);
+        exchange.setSimulateTimeout(true);
 
-        coordinator = new RefinementCoordinator(client, requestManager, 0, 4);
+        coordinator = new RefinementCoordinator<>(exchange, requestManager, 0, 4);
 
-        // Should complete within timeout even if partner times out
         var result = coordinator.executeRefinementRound(1, 2);
 
         assertNotNull(result, "Should complete despite timeout");
@@ -191,108 +158,60 @@ public class RefinementCoordinatorTest {
     // TEST 10: Response processing updates refinementsApplied count
     @Test
     public void testResponseProcessingUpdatesRefinementsApplied() {
-        // Configure client to return responses with ghost elements
-        client.setGhostElementCount(5); // 5 ghost elements per response
+        exchange.setGhostElementCount(5);
 
-        coordinator = new RefinementCoordinator(client, requestManager, 0, 4);
+        coordinator = new RefinementCoordinator<>(exchange, requestManager, 0, 4);
 
         var result = coordinator.executeRefinementRound(1, 2);
 
-        // Response processing should update refinementsApplied
-        // (actual count depends on whether ghost elements are tracked as refinements)
         assertTrue(result.refinementsApplied() >= 0,
                   "Should track refinements applied from responses");
         assertNotNull(result, "Should return valid result");
     }
 
-    // Mock BalanceCoordinatorClient for testing
-    private static class MockBalanceCoordinatorClient extends BalanceCoordinatorClient {
-        private final List<RefinementRequest> sentRequests = new ArrayList<>();
+    // ========== Mock implementations ==========
+
+    /** Domain exchange mock for RefinementCoordinator tests. */
+    private static class MockRefinementExchange
+            implements RefinementExchange<MortonKey, LongEntityID, String> {
+
+        private final List<RefinementRequest<MortonKey>> sentRequests = new ArrayList<>();
         private final AtomicInteger requestCount = new AtomicInteger(0);
         private volatile boolean simulateTimeout = false;
         private volatile int ghostElementCount = 0;
 
-        public MockBalanceCoordinatorClient() {
-            super(0, new MockServiceDiscovery());
-        }
-
         @Override
-        public CompletableFuture<RefinementResponse> requestRefinementAsync(
+        public CompletableFuture<RefinementResponse<MortonKey, LongEntityID, String>> requestRefinementAsync(
                 int targetRank, long treeId, int roundNumber, int treeLevel,
-                List<com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey> boundaryKeys) {
+                List<MortonKey> boundaryKeys) {
 
             requestCount.incrementAndGet();
 
-            // Create and store request
-            var request = RefinementRequest.newBuilder()
-                .setRequesterRank(targetRank)
-                .setRequesterTreeId(treeId)
-                .setRoundNumber(roundNumber)
-                .setTreeLevel(treeLevel)
-                .setTimestamp(System.currentTimeMillis())
-                .build();
+            var request = new RefinementRequest<>(targetRank, treeId, roundNumber, treeLevel,
+                                                   boundaryKeys, System.currentTimeMillis());
             sentRequests.add(request);
 
-            // Simulate timeout if configured
             if (simulateTimeout) {
-                var future = new CompletableFuture<RefinementResponse>();
-                // Never complete - will timeout via orTimeout()
-                return future;
+                // Never complete — will be caught by orTimeout() in sendRequestsParallel
+                return new CompletableFuture<>();
             }
 
-            // Return mock response
-            var response = RefinementResponse.newBuilder()
-                .setResponderRank(targetRank)
-                .setResponderTreeId(treeId)
-                .setRoundNumber(roundNumber)
-                .setNeedsFurtherRefinement(false)
-                .setTimestamp(System.currentTimeMillis())
-                .build();
+            var response = new RefinementResponse<MortonKey, LongEntityID, String>(
+                targetRank, targetRank, treeId, roundNumber,
+                List.of(), false, System.currentTimeMillis()
+            );
 
             return CompletableFuture.completedFuture(response);
         }
 
-        public void setSimulateTimeout(boolean simulateTimeout) {
-            this.simulateTimeout = simulateTimeout;
-        }
+        public void setSimulateTimeout(boolean simulateTimeout) { this.simulateTimeout = simulateTimeout; }
 
-        public void setGhostElementCount(int count) {
-            this.ghostElementCount = count;
-        }
+        public void setGhostElementCount(int count) { this.ghostElementCount = count; }
 
-        public int getRequestCount() {
-            return requestCount.get();
-        }
+        public int getRequestCount() { return requestCount.get(); }
 
-        public List<RefinementRequest> getSentRequests() {
+        public List<RefinementRequest<MortonKey>> getSentRequests() {
             return new ArrayList<>(sentRequests);
-        }
-    }
-
-    // Mock ServiceDiscovery for BalanceCoordinatorClient
-    private static class MockServiceDiscovery implements BalanceCoordinatorClient.ServiceDiscovery {
-        private final Map<Integer, String> endpoints = new HashMap<>();
-
-        public MockServiceDiscovery() {
-            // Pre-populate with test endpoints
-            for (int i = 0; i < 16; i++) {
-                endpoints.put(i, "localhost:" + (50000 + i));
-            }
-        }
-
-        @Override
-        public String getEndpoint(int rank) {
-            return endpoints.get(rank);
-        }
-
-        @Override
-        public void registerEndpoint(int rank, String endpoint) {
-            endpoints.put(rank, endpoint);
-        }
-
-        @Override
-        public Map<Integer, String> getAllEndpoints() {
-            return new HashMap<>(endpoints);
         }
     }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/grpc/GrpcBalanceExchangeTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/grpc/GrpcBalanceExchangeTest.java
@@ -1,0 +1,283 @@
+/**
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.balancing.grpc;
+
+import com.google.protobuf.ByteString;
+import com.hellblazer.luciferase.lucien.balancing.BalanceExchangeException;
+import com.hellblazer.luciferase.lucien.balancing.TwoOneBalanceChecker;
+import com.hellblazer.luciferase.lucien.balancing.ViolationBatch;
+import com.hellblazer.luciferase.lucien.balancing.proto.BalanceViolation;
+import com.hellblazer.luciferase.lucien.balancing.proto.RefinementResponse;
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.forest.ghost.ContentSerializer;
+import com.hellblazer.luciferase.lucien.forest.ghost.grpc.ProtobufConverters;
+import com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostElement;
+import com.hellblazer.luciferase.lucien.octree.MortonKey;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import javax.vecmath.Point3f;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Inc3-C2 (RDR-007 Phase 0): boundary tests for {@link GrpcBalanceExchange}, the sole protobuf&lt;-&gt;domain
+ * conversion point for the balancing path. Covers the verbatim skip-invalid ghost deserialization (migrated
+ * from CrossPartitionBalancePhaseResponseHandlingTest), the non-null refinement-response contract, the
+ * {@code StatusRuntimeException}-&gt;{@link BalanceExchangeException} classification, and violation round-trip.
+ *
+ * @author hal.hildebrand
+ */
+class GrpcBalanceExchangeTest {
+
+    private MockBalanceCoordinatorClient client;
+    private ContentSerializer<String> contentSerializer;
+    private GrpcBalanceExchange<MortonKey, LongEntityID, String> adapter;
+
+    @BeforeEach
+    void setUp() {
+        client = new MockBalanceCoordinatorClient();
+        contentSerializer = new ContentSerializer<>() {
+            @Override
+            public ByteString serialize(String content) {
+                return ByteString.copyFrom(content, StandardCharsets.UTF_8);
+            }
+
+            @Override
+            public String deserialize(ByteString bytes) {
+                return bytes.toString(StandardCharsets.UTF_8);
+            }
+
+            @Override
+            public String getContentType() {
+                return "string";
+            }
+        };
+        adapter = new GrpcBalanceExchange<>(client, contentSerializer, LongEntityID.class);
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void requestRefinementSkipsInvalidGhostElements() throws Exception {
+        var valid1 = validGhostProto(new MortonKey(100L, (byte) 3), 1001L, "valid-1", 1);
+        var invalid = GhostElement.newBuilder()  // missing spatial key -> deserialization fails
+            .setEntityId("invalid")
+            .setContent(ByteString.copyFromUtf8("x"))
+            .setPosition(ProtobufConverters.point3fToProtobuf(new Point3f(0, 0, 0)))
+            .setOwnerRank(1)
+            .setGlobalTreeId(0L)
+            .build();
+        var valid2 = validGhostProto(new MortonKey(200L, (byte) 3), 2001L, "valid-2", 2);
+
+        client.refinementResponse = RefinementResponse.newBuilder()
+            .setRequesterRank(0)
+            .setResponderRank(1)
+            .setRoundNumber(1)
+            .addGhostElements(valid1)
+            .addGhostElements(invalid)
+            .addGhostElements(valid2)
+            .setNeedsFurtherRefinement(false)
+            .setTimestamp(System.currentTimeMillis())
+            .build();
+
+        var domain = adapter.requestRefinementAsync(1, 0L, 1, 3, List.of()).get();
+
+        assertEquals(2, domain.ghostElements().size(), "Invalid ghost element must be skipped, valid ones kept");
+        assertEquals(new MortonKey(100L, (byte) 3), domain.ghostElements().get(0).getSpatialKey());
+        assertEquals("valid-1", domain.ghostElements().get(0).getContent());
+        assertEquals(new MortonKey(200L, (byte) 3), domain.ghostElements().get(1).getSpatialKey());
+        assertEquals(1, domain.responderRank());
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void requestRefinementMapsScalarFieldsAndEmptyGhosts() throws Exception {
+        client.refinementResponse = RefinementResponse.newBuilder()
+            .setRequesterRank(7)
+            .setResponderRank(9)
+            .setResponderTreeId(42L)
+            .setRoundNumber(3)
+            .setNeedsFurtherRefinement(true)
+            .setTimestamp(12345L)
+            .build();
+
+        var domain = adapter.requestRefinementAsync(9, 42L, 3, 0, List.of()).get();
+
+        assertTrue(domain.ghostElements().isEmpty());
+        assertTrue(domain.needsFurtherRefinement());
+        assertEquals(7, domain.requesterRank());
+        assertEquals(9, domain.responderRank());
+        assertEquals(42L, domain.responderTreeId());
+        assertEquals(3, domain.roundNumber());
+        assertEquals(12345L, domain.timestamp());
+    }
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void requestRefinementNullClientResponseMapsToEmpty() throws Exception {
+        client.refinementResponse = null;  // wrapped client returns null when no connection
+
+        var domain = adapter.requestRefinementAsync(1, 0L, 1, 0, List.of()).get();
+
+        assertNotNull(domain, "Domain refinement response contract is non-null");
+        assertTrue(domain.ghostElements().isEmpty());
+        assertFalse(domain.needsFurtherRefinement());
+    }
+
+    @Test
+    void exchangeViolationsUnavailableIsTransient() {
+        client.violationError = Status.UNAVAILABLE.asRuntimeException();
+        var ex = assertThrows(BalanceExchangeException.class, () -> adapter.exchangeViolations(emptyBatch()));
+        assertTrue(ex.isTransient());
+        assertFalse(ex.isTimeout());
+    }
+
+    @Test
+    void exchangeViolationsResourceExhaustedIsTransient() {
+        client.violationError = Status.RESOURCE_EXHAUSTED.asRuntimeException();
+        var ex = assertThrows(BalanceExchangeException.class, () -> adapter.exchangeViolations(emptyBatch()));
+        assertTrue(ex.isTransient());
+        assertFalse(ex.isTimeout());
+    }
+
+    @Test
+    void exchangeViolationsDeadlineExceededIsTimeout() {
+        client.violationError = Status.DEADLINE_EXCEEDED.asRuntimeException();
+        var ex = assertThrows(BalanceExchangeException.class, () -> adapter.exchangeViolations(emptyBatch()));
+        assertFalse(ex.isTransient());
+        assertTrue(ex.isTimeout());
+    }
+
+    @Test
+    void exchangeViolationsOtherStatusIsNeitherTransientNorTimeout() {
+        client.violationError = Status.INTERNAL.asRuntimeException();
+        var ex = assertThrows(BalanceExchangeException.class, () -> adapter.exchangeViolations(emptyBatch()));
+        assertFalse(ex.isTransient());
+        assertFalse(ex.isTimeout());
+    }
+
+    @Test
+    void exchangeViolationsRoundTripsBatchAndViolations() throws Exception {
+        var sent = new TwoOneBalanceChecker.BalanceViolation<>(
+            new MortonKey(10L, (byte) 5), new MortonKey(20L, (byte) 2), 5, 2, 3, 7);
+        var domainBatch = new ViolationBatch<>(0, 1, 4, List.of(sent), 555L);
+
+        client.violationResponse = com.hellblazer.luciferase.lucien.balancing.proto.ViolationBatch.newBuilder()
+            .setRequesterRank(99)
+            .setResponderRank(0)
+            .setRoundNumber(4)
+            .addViolations(BalanceViolation.newBuilder()
+                .setLocalKey(ProtobufConverters.spatialKeyToProtobuf(new MortonKey(30L, (byte) 6)))
+                .setGhostKey(ProtobufConverters.spatialKeyToProtobuf(new MortonKey(40L, (byte) 3)))
+                .setLocalLevel(6).setGhostLevel(3).setLevelDifference(3).setSourceRank(8)
+                .build())
+            .setTimestamp(777L)
+            .build();
+
+        var received = adapter.exchangeViolations(domainBatch);
+
+        // Sent batch was faithfully serialized to proto.
+        assertNotNull(client.lastSentViolationBatch);
+        assertEquals(0, client.lastSentViolationBatch.getRequesterRank());
+        assertEquals(1, client.lastSentViolationBatch.getResponderRank());
+        assertEquals(4, client.lastSentViolationBatch.getRoundNumber());
+        assertEquals(1, client.lastSentViolationBatch.getViolationsCount());
+        var sentProto = client.lastSentViolationBatch.getViolations(0);
+        assertEquals(5, sentProto.getLocalLevel());
+        assertEquals(3, sentProto.getLevelDifference());
+        assertEquals(7, sentProto.getSourceRank());
+        assertEquals(new MortonKey(10L, (byte) 5), ProtobufConverters.spatialKeyFromProtobuf(sentProto.getLocalKey()));
+
+        // Partner response was faithfully deserialized to domain.
+        assertEquals(99, received.requesterRank());
+        assertEquals(1, received.violations().size());
+        var recvViolation = received.violations().get(0);
+        assertEquals(new MortonKey(30L, (byte) 6), recvViolation.localKey());
+        assertEquals(new MortonKey(40L, (byte) 3), recvViolation.ghostKey());
+        assertEquals(3, recvViolation.levelDifference());
+        assertEquals(8, recvViolation.sourceRank());
+    }
+
+    private ViolationBatch<MortonKey> emptyBatch() {
+        return new ViolationBatch<>(0, 1, 0, List.of(), 0L);
+    }
+
+    private GhostElement validGhostProto(MortonKey key, long entityId, String content, int ownerRank)
+            throws ContentSerializer.SerializationException {
+        return GhostElement.newBuilder()
+            .setSpatialKey(ProtobufConverters.spatialKeyToProtobuf(key))
+            .setEntityId(ProtobufConverters.entityIdToString(new LongEntityID(entityId)))
+            .setContent(contentSerializer.serialize(content))
+            .setPosition(ProtobufConverters.point3fToProtobuf(new Point3f(1, 2, 3)))
+            .setOwnerRank(ownerRank)
+            .setGlobalTreeId(0L)
+            .build();
+    }
+
+    /** Hand-rolled client stub: settable response/error fields, captures the last sent violation batch. */
+    private static class MockBalanceCoordinatorClient extends BalanceCoordinatorClient {
+        RefinementResponse refinementResponse;
+        com.hellblazer.luciferase.lucien.balancing.proto.ViolationBatch violationResponse;
+        StatusRuntimeException violationError;
+        com.hellblazer.luciferase.lucien.balancing.proto.ViolationBatch lastSentViolationBatch;
+
+        MockBalanceCoordinatorClient() {
+            super(0, new MockServiceDiscovery());
+        }
+
+        @Override
+        public CompletableFuture<RefinementResponse> requestRefinementAsync(
+                int targetRank, long treeId, int roundNumber, int treeLevel,
+                List<com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey> boundaryKeys) {
+            return CompletableFuture.completedFuture(refinementResponse);
+        }
+
+        @Override
+        public com.hellblazer.luciferase.lucien.balancing.proto.ViolationBatch exchangeViolations(
+                com.hellblazer.luciferase.lucien.balancing.proto.ViolationBatch batch) {
+            lastSentViolationBatch = batch;
+            if (violationError != null) {
+                throw violationError;
+            }
+            return violationResponse;
+        }
+    }
+
+    private static class MockServiceDiscovery implements BalanceCoordinatorClient.ServiceDiscovery {
+        @Override
+        public String getEndpoint(int rank) {
+            return "localhost:" + (50000 + rank);
+        }
+
+        @Override
+        public void registerEndpoint(int rank, String endpoint) {
+        }
+
+        @Override
+        public Map<Integer, String> getAllEndpoints() {
+            return Map.of();
+        }
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/grpc/GrpcBalanceExchangeTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/grpc/GrpcBalanceExchangeTest.java
@@ -220,6 +220,62 @@ class GrpcBalanceExchangeTest {
         assertEquals(8, recvViolation.sourceRank());
     }
 
+    @Test
+    void exchangeViolationsSkipsWireViolationWithLevelDifferenceOne() throws Exception {
+        client.violationResponse = com.hellblazer.luciferase.lucien.balancing.proto.ViolationBatch.newBuilder()
+            .setRequesterRank(1).setResponderRank(0).setRoundNumber(0)
+            .addViolations(protoViolation(new MortonKey(1L, (byte) 2), new MortonKey(2L, (byte) 1), 2, 1, 1, 3))
+            .setTimestamp(0L)
+            .build();
+
+        var received = adapter.exchangeViolations(emptyBatch());
+
+        assertTrue(received.violations().isEmpty(),
+                   "A wire violation with levelDifference==1 must be skipped (domain record requires >1)");
+    }
+
+    @Test
+    void exchangeViolationsSkipsWireViolationWithLevelDifferenceZero() throws Exception {
+        client.violationResponse = com.hellblazer.luciferase.lucien.balancing.proto.ViolationBatch.newBuilder()
+            .setRequesterRank(1).setResponderRank(0).setRoundNumber(0)
+            .addViolations(protoViolation(new MortonKey(1L, (byte) 1), new MortonKey(2L, (byte) 1), 1, 1, 0, 3))
+            .setTimestamp(0L)
+            .build();
+
+        var received = adapter.exchangeViolations(emptyBatch());
+
+        assertTrue(received.violations().isEmpty(),
+                   "A wire violation with levelDifference==0 must be skipped");
+    }
+
+    @Test
+    void exchangeViolationsKeepsOnlyValidViolationsInMixedBatch() throws Exception {
+        client.violationResponse = com.hellblazer.luciferase.lucien.balancing.proto.ViolationBatch.newBuilder()
+            .setRequesterRank(1).setResponderRank(0).setRoundNumber(0)
+            .addViolations(protoViolation(new MortonKey(10L, (byte) 5), new MortonKey(11L, (byte) 2), 5, 2, 3, 3))
+            .addViolations(protoViolation(new MortonKey(12L, (byte) 2), new MortonKey(13L, (byte) 1), 2, 1, 1, 3))
+            .addViolations(protoViolation(new MortonKey(14L, (byte) 4), new MortonKey(15L, (byte) 2), 4, 2, 2, 3))
+            .setTimestamp(0L)
+            .build();
+
+        var received = adapter.exchangeViolations(emptyBatch());
+
+        assertEquals(2, received.violations().size(),
+                     "Only the two valid (levelDifference>1) violations survive; the invalid one is skipped, not the batch");
+        assertEquals(3, received.violations().get(0).levelDifference());
+        assertEquals(2, received.violations().get(1).levelDifference());
+    }
+
+    private com.hellblazer.luciferase.lucien.balancing.proto.BalanceViolation protoViolation(
+            MortonKey localKey, MortonKey ghostKey, int localLevel, int ghostLevel, int levelDiff, int sourceRank) {
+        return BalanceViolation.newBuilder()
+            .setLocalKey(ProtobufConverters.spatialKeyToProtobuf(localKey))
+            .setGhostKey(ProtobufConverters.spatialKeyToProtobuf(ghostKey))
+            .setLocalLevel(localLevel).setGhostLevel(ghostLevel)
+            .setLevelDifference(levelDiff).setSourceRank(sourceRank)
+            .build();
+    }
+
     private ViolationBatch<MortonKey> emptyBatch() {
         return new ViolationBatch<>(0, 1, 0, List.of(), 0L);
     }


### PR DESCRIPTION
## Summary

RDR-007 Phase 0 **Inc3** (the final increment under shared bead `Luciferase-aos`): a behavior-preserving inversion of the balancing proto/gRPC boundary out of lucien core. All 6 lucien-core balancing classes are now grep-clean of `balancing.proto`, `balancing.grpc`, `forest.ghost.grpc`, `forest.ghost.proto`, and `io.grpc`. Mirrors the Inc2b ghost-transport pattern (domain interface in core; proto↔domain conversion at the grpc boundary).

After this lands, **RDR-007 Phase 1** (the physical `lucien-distributed` module move) unblocks — only `SpatialKeySerdeRegistry` `Class.forName` strings remain (a P2 strip concern, not an inversion).

## What changed

**New lucien-core domain layer** (additive):
- Domain records `RefinementRequest<Key>`, `RefinementResponse<Key,ID,Content>` (with `empty()`/`isEmpty()`), `ViolationBatch<Key>` (reusing the existing `TwoOneBalanceChecker.BalanceViolation<Key>`).
- Split ports `RefinementExchange<Key,ID,Content>` + `ViolationExchange<Key>` (Key-only so the violation path doesn't carry ID/Content), and a domain `BalanceExchangeException` (`isTransient()`/`isTimeout()`).
- New grpc adapter `GrpcBalanceExchange` — the **sole** proto↔domain conversion point; moves ghost-element deserialization (with verbatim per-element skip-invalid resilience) here and translates `StatusRuntimeException` → `BalanceExchangeException`.

**The 6 inverted core classes**: `ButterflyViolationAggregator` + `DistributedViolationAggregator` (now generic on `<Key>`, use `ViolationExchange`), `RefinementCoordinator` + `CrossPartitionBalancePhase` + `RefinementRequestManager` (use `RefinementExchange`/domain records), `DefaultParallelBalancer` (type-swap). `CrossPartitionBalancePhase` drops the now-dead `contentSerializer`/`idType` fields and 4-arg `setForestContext` overload.

**`Phase4E2ETest`** updated as a hybrid: the aggregator path uses domain via the adapter; the in-process gRPC server/client wire stays proto.

## Scope corrections found during implementation
- **`ViolationAck` was a dead import** in `DistributedViolationAggregator` (the live `ExchangeViolations` RPC returns `ViolationBatch`); no domain `ViolationAck` was needed.
- The proto `GhostElement` `level`/`needs_refinement`/`bounds` fields are **not read** by the balancing path (`TwoOneBalanceChecker` derives level from the spatial key), so the domain `GhostElement` is unchanged — consistent with Inc2a.

## SIG-1 disclosure (behavior, test-only path)
The adapter maps an unreachable-peer (null) refinement response to `RefinementResponse.empty()`. To avoid premature convergence, `CrossPartitionBalancePhase.executeRefinementRound` excludes empty/sentinel responses from the convergence vote (holding the prior state when all peers are unreachable). In mixed-failure rounds the new code applies reachable peers' ghost elements (the old null-driven NPE-abort applied them order-dependently). This refinement-round path is **not production-wired** today (`createRefinementExchange` returns null → skeleton fallback); the behavior is correct for when RDR-007 P1 wires a real exchange.

## Review
Two rounds of stacked review (code-review-expert + substantive-critic, sonnet): additive layer, then the 6-class inversion. All Critical/High findings resolved or shown behavior-preserving (e.g. the test-only reflection reverted to `getMethod` for byte-identical behavior). Pre-existing `ButterflyViolationAggregator` dedup/null-guard gaps tracked in `Luciferase-xb5` (out of pure-inversion scope). Findings: T2 `aos-inc3-review-round1-findings` / `round2-findings`.

## Test plan
- [x] Inc3 unit suite (domain types, adapter, both chains) green
- [x] Full lucien suite: 2408 tests; only 2 known flakes (`PrismVsOctreeComparisonTest` perf = Luciferase-6z1; `TetrahedralForestE2ETest` ordering) — both pass in isolation, unrelated to balancing
- [x] `Phase4E2ETest` 7/7 under `-Pperformance`
- [x] All 6 core classes grep-clean of proto/grpc/io.grpc
- [ ] CI green on all checks

Bead: [Luciferase-aos] (Inc3 = C1–C7: orw, h0c, 6wj, 25a, yw9, 38l, 02u)