### PR TITLE
RDR-007 P1 prep: ServiceLoader serde registry + de-grpc fixtures

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialKeySerdeRegistry.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialKeySerdeRegistry.java
@@ -6,6 +6,7 @@
 package com.hellblazer.luciferase.lucien;
 
 import java.util.Objects;
+import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -14,13 +15,13 @@ import java.util.concurrent.ConcurrentMap;
  * strings and {@link SpatialKey} implementation classes to their serdes
  * (Luciferase-546).
  * <p>
- * <b>Built-in registrations.</b> The two ship-with-lucien serde classes
- * ({@code MortonKeySerde}, {@code TetreeKeySerde} in
- * {@code com.hellblazer.luciferase.lucien.forest.ghost.grpc}) register
- * themselves via class-initialisers on this registry. They are eagerly
- * triggered from this class's static initialiser so that any consumer that
- * touches the registry sees the built-ins without having to load each serde
- * class by name first.
+ * <b>Built-in registrations.</b> Serde providers are discovered via the
+ * {@link java.util.ServiceLoader} SPI ({@code META-INF/services/} the
+ * {@link SpatialKeySerde} service) from this class's static initialiser. The
+ * built-in {@code MortonKeySerde} / {@code TetreeKeySerde} ship as providers in
+ * the module that owns the gRPC/proto transport. When no providers are on the
+ * classpath the registry is simply empty — the spatial index works standalone;
+ * serdes are only needed for distributed ghost exchange.
  * <p>
  * <b>Extension registrations.</b> Other modules and tests can register
  * additional serdes by calling {@link #register(SpatialKeySerde)} once at
@@ -44,16 +45,11 @@ public final class SpatialKeySerdeRegistry {
     private static final ConcurrentMap<Class<?>, SpatialKeySerde<?>>   BY_KEY_CLASS = new ConcurrentHashMap<>();
 
     static {
-        // Trigger built-in serde class-init so their self-registration runs
-        // before any consumer queries the registry.
-        try {
-            Class.forName(
-                "com.hellblazer.luciferase.lucien.forest.ghost.grpc.MortonKeySerde");
-            Class.forName(
-                "com.hellblazer.luciferase.lucien.forest.ghost.grpc.TetreeKeySerde");
-        } catch (ClassNotFoundException e) {
-            throw new ExceptionInInitializerError("Built-in SpatialKeySerde class not on classpath: " + e.getMessage());
-        }
+        // Discover SpatialKeySerde providers via the ServiceLoader SPI. Built-ins ship as
+        // providers in the module owning the gRPC/proto transport (lucien-distributed after
+        // RDR-007 P1). Zero providers is a valid state — the registry stays empty and the
+        // spatial index works standalone (no ExceptionInInitializerError on absence).
+        ServiceLoader.load(SpatialKeySerde.class).forEach(SpatialKeySerdeRegistry::register);
     }
 
     private SpatialKeySerdeRegistry() {

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/MortonKeySerde.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/MortonKeySerde.java
@@ -7,7 +7,6 @@ package com.hellblazer.luciferase.lucien.forest.ghost.grpc;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hellblazer.luciferase.lucien.SpatialKeySerde;
-import com.hellblazer.luciferase.lucien.SpatialKeySerdeRegistry;
 import com.hellblazer.luciferase.lucien.octree.MortonKey;
 
 /**
@@ -16,21 +15,22 @@ import com.hellblazer.luciferase.lucien.octree.MortonKey;
  * Wire format: the existing {@code ghost.proto MortonKey} message
  * (morton_code + level) marshalled to bytes. Discriminator: {@code "morton"}.
  * <p>
- * Registers itself with {@link SpatialKeySerdeRegistry} via class-init; the
- * registry triggers this class-init from its own static initialiser.
+ * Discovered via {@link java.util.ServiceLoader} (declared in
+ * {@code META-INF/services/com.hellblazer.luciferase.lucien.SpatialKeySerde}) and
+ * registered by {@code SpatialKeySerdeRegistry} from its static initialiser.
  *
  * @author hal.hildebrand
  */
 public final class MortonKeySerde implements SpatialKeySerde<MortonKey> {
 
-    public static final  String          TYPE_ID  = "morton";
-    public static final  MortonKeySerde  INSTANCE = new MortonKeySerde();
+    public static final String TYPE_ID = "morton";
 
-    static {
-        SpatialKeySerdeRegistry.register(INSTANCE);
-    }
-
-    private MortonKeySerde() {
+    /**
+     * Public no-arg constructor required by {@link java.util.ServiceLoader} on the classpath
+     * (the {@code META-INF/services} mechanism instantiates each provider via its no-arg
+     * constructor). The serde is stateless.
+     */
+    public MortonKeySerde() {
     }
 
     @Override

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/TetreeKeySerde.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/TetreeKeySerde.java
@@ -7,7 +7,6 @@ package com.hellblazer.luciferase.lucien.forest.ghost.grpc;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hellblazer.luciferase.lucien.SpatialKeySerde;
-import com.hellblazer.luciferase.lucien.SpatialKeySerdeRegistry;
 import com.hellblazer.luciferase.lucien.tetree.CompactTetreeKey;
 import com.hellblazer.luciferase.lucien.tetree.ExtendedTetreeKey;
 import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
@@ -28,24 +27,28 @@ import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
  * for callers that have round-tripped existing payloads.
  * <p>
  * Registered against the {@link TetreeKey} abstract base; the
- * {@link SpatialKeySerdeRegistry} walks the class hierarchy at lookup time so
+ * {@code SpatialKeySerdeRegistry} walks the class hierarchy at lookup time so
  * both compact and extended runtime instances route to this serde.
+ * <p>
+ * Discovered via {@link java.util.ServiceLoader} (declared in
+ * {@code META-INF/services/com.hellblazer.luciferase.lucien.SpatialKeySerde}) and
+ * registered by {@code SpatialKeySerdeRegistry} from its static initialiser.
  *
  * @author hal.hildebrand
  */
 public final class TetreeKeySerde implements SpatialKeySerde<TetreeKey<?>> {
 
-    public static final  String          TYPE_ID  = "tetree";
-    public static final  TetreeKeySerde  INSTANCE = new TetreeKeySerde();
+    public static final String TYPE_ID = "tetree";
 
     /** Inclusive level boundary below which {@link CompactTetreeKey} is the natural concrete type. */
-    private static final int             COMPACT_LEVEL_MAX = 10;
+    private static final int COMPACT_LEVEL_MAX = 10;
 
-    static {
-        SpatialKeySerdeRegistry.register(INSTANCE);
-    }
-
-    private TetreeKeySerde() {
+    /**
+     * Public no-arg constructor required by {@link java.util.ServiceLoader} on the classpath
+     * (the {@code META-INF/services} mechanism instantiates each provider via its no-arg
+     * constructor). The serde is stateless.
+     */
+    public TetreeKeySerde() {
     }
 
     @Override

--- a/lucien/src/main/resources/META-INF/services/com.hellblazer.luciferase.lucien.SpatialKeySerde
+++ b/lucien/src/main/resources/META-INF/services/com.hellblazer.luciferase.lucien.SpatialKeySerde
@@ -1,0 +1,2 @@
+com.hellblazer.luciferase.lucien.forest.ghost.grpc.MortonKeySerde
+com.hellblazer.luciferase.lucien.forest.ghost.grpc.TetreeKeySerde

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/SpatialKeySerdeRegistryTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/SpatialKeySerdeRegistryTest.java
@@ -142,6 +142,18 @@ public class SpatialKeySerdeRegistryTest {
                      () -> SpatialKeySerdeRegistry.register(conflict));
     }
 
+    @Test
+    void serviceLoaderDiscoversBuiltInSerdes() {
+        // The registry's static initializer discovers providers via ServiceLoader
+        // (META-INF/services/...SpatialKeySerde) and registers the instances it creates.
+        var morton = SpatialKeySerdeRegistry.forTypeId("morton");
+        var tetree = SpatialKeySerdeRegistry.forTypeId("tetree");
+        assertInstanceOf(MortonKeySerde.class, morton, "ServiceLoader must register the built-in MortonKeySerde");
+        assertInstanceOf(TetreeKeySerde.class, tetree, "ServiceLoader must register the built-in TetreeKeySerde");
+        assertEquals("morton", morton.typeId());
+        assertEquals("tetree", tetree.typeId());
+    }
+
     // ============================================================
     // Test fixtures: a minimal SpatialKey + its serde
     // ============================================================

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/DefaultParallelBalancerPhase1Test.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/DefaultParallelBalancerPhase1Test.java
@@ -505,8 +505,14 @@ public class DefaultParallelBalancerPhase1Test {
         private static com.hellblazer.luciferase.lucien.forest.ghost.GhostChannel<MortonKey, LongEntityID, String> createMockGhostChannel() {
             // De-grpc'd (RDR-007 P1-prep): mock the GhostChannel interface (was GrpcGhostChannel),
             // so this fixture keeps its dependency when GrpcGhostChannel moves to lucien-distributed.
-            return (com.hellblazer.luciferase.lucien.forest.ghost.GhostChannel<MortonKey, LongEntityID, String>)
+            // Stub flushToTarget so DistributedGhostManager.createDistributedGhostLayer()'s
+            // unconditional flushToTarget(...).join() does not NPE on a null mock return.
+            var channel = (com.hellblazer.luciferase.lucien.forest.ghost.GhostChannel<MortonKey, LongEntityID, String>)
                 mock(com.hellblazer.luciferase.lucien.forest.ghost.GhostChannel.class);
+            when(channel.flushToTarget(org.mockito.ArgumentMatchers.anyInt()))
+                .thenReturn(java.util.concurrent.CompletableFuture.<Void>completedFuture(null));
+            when(channel.getTotalPendingCount()).thenReturn(0);
+            return channel;
         }
 
         @SuppressWarnings("unchecked")

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/DefaultParallelBalancerPhase1Test.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/DefaultParallelBalancerPhase1Test.java
@@ -502,10 +502,11 @@ public class DefaultParallelBalancerPhase1Test {
         }
 
         @SuppressWarnings("unchecked")
-        private static com.hellblazer.luciferase.lucien.forest.ghost.GrpcGhostChannel<MortonKey, LongEntityID, String> createMockGhostChannel() {
-            // Use Mockito to create a mock that satisfies the non-null requirement
-            return (com.hellblazer.luciferase.lucien.forest.ghost.GrpcGhostChannel<MortonKey, LongEntityID, String>)
-                mock(com.hellblazer.luciferase.lucien.forest.ghost.GrpcGhostChannel.class);
+        private static com.hellblazer.luciferase.lucien.forest.ghost.GhostChannel<MortonKey, LongEntityID, String> createMockGhostChannel() {
+            // De-grpc'd (RDR-007 P1-prep): mock the GhostChannel interface (was GrpcGhostChannel),
+            // so this fixture keeps its dependency when GrpcGhostChannel moves to lucien-distributed.
+            return (com.hellblazer.luciferase.lucien.forest.ghost.GhostChannel<MortonKey, LongEntityID, String>)
+                mock(com.hellblazer.luciferase.lucien.forest.ghost.GhostChannel.class);
         }
 
         @SuppressWarnings("unchecked")

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/ParallelBalancerTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/ParallelBalancerTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * TDD tests for ParallelBalancer interface and implementations.
@@ -348,17 +349,17 @@ public class ParallelBalancerTest {
         }
 
         @SuppressWarnings("unchecked")
-        private static com.hellblazer.luciferase.lucien.forest.ghost.GrpcGhostChannel<MortonKey, LongEntityID, String> createMockGhostChannel() {
-            // Use Mockito to create a mock GhostCommunicationManager
-            var mockCommManager = mock(com.hellblazer.luciferase.lucien.forest.ghost.grpc.GhostCommunicationManager.class);
-
-            // Create GrpcGhostChannel with the mock
-            return new com.hellblazer.luciferase.lucien.forest.ghost.GrpcGhostChannel<MortonKey, LongEntityID, String>(
-                mockCommManager,
-                0,    // currentRank
-                0L,   // treeId
-                com.hellblazer.luciferase.lucien.forest.ghost.GhostType.NONE
-            );
+        private static com.hellblazer.luciferase.lucien.forest.ghost.GhostChannel<MortonKey, LongEntityID, String> createMockGhostChannel() {
+            // De-grpc'd (RDR-007 P1-prep): mock the GhostChannel interface instead of building a
+            // concrete GrpcGhostChannel, so this fixture keeps its dependency when GrpcGhostChannel
+            // moves to lucien-distributed. Getters stubbed to the prior concrete values
+            // (rank 0, treeId 0L, GhostType.NONE) so DistributedGhostManager construction is identical.
+            var channel = (com.hellblazer.luciferase.lucien.forest.ghost.GhostChannel<MortonKey, LongEntityID, String>)
+                mock(com.hellblazer.luciferase.lucien.forest.ghost.GhostChannel.class);
+            when(channel.getCurrentRank()).thenReturn(0);
+            when(channel.getTreeId()).thenReturn(0L);
+            when(channel.getGhostType()).thenReturn(com.hellblazer.luciferase.lucien.forest.ghost.GhostType.NONE);
+            return channel;
         }
 
         private static com.hellblazer.luciferase.lucien.forest.ghost.GhostBoundaryDetector<MortonKey, LongEntityID, String> createMockGhostBoundaryDetector() {

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/ParallelBalancerTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/ParallelBalancerTest.java
@@ -359,6 +359,11 @@ public class ParallelBalancerTest {
             when(channel.getCurrentRank()).thenReturn(0);
             when(channel.getTreeId()).thenReturn(0L);
             when(channel.getGhostType()).thenReturn(com.hellblazer.luciferase.lucien.forest.ghost.GhostType.NONE);
+            // DistributedGhostManager.createDistributedGhostLayer() calls flushToTarget(...).join()
+            // unconditionally; stub it so the mock channel does not NPE on a null future.
+            when(channel.flushToTarget(org.mockito.ArgumentMatchers.anyInt()))
+                .thenReturn(java.util.concurrent.CompletableFuture.<Void>completedFuture(null));
+            when(channel.getTotalPendingCount()).thenReturn(0);
             return channel;
         }
 

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/Phase44ForestIntegrationFixture.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/Phase44ForestIntegrationFixture.java
@@ -27,7 +27,7 @@ import com.hellblazer.luciferase.lucien.forest.ForestConfig;
 import com.hellblazer.luciferase.lucien.forest.ghost.DistributedGhostManager;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostBoundaryDetector;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostLayer;
-import com.hellblazer.luciferase.lucien.forest.ghost.GrpcGhostChannel;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostChannel;
 import com.hellblazer.luciferase.lucien.octree.MortonKey;
 import com.hellblazer.luciferase.lucien.octree.Octree;
 import org.slf4j.Logger;
@@ -397,24 +397,24 @@ public class Phase44ForestIntegrationFixture {
     }
 
     /**
-     * Create a mock GrpcGhostChannel for testing (no network communication).
+     * Create a mock GhostChannel for testing (no network communication).
+     *
+     * <p>De-grpc'd (RDR-007 P1-prep): mocks the {@link GhostChannel} interface instead of building a
+     * concrete GrpcGhostChannel, so this shared fixture keeps its dependency when GrpcGhostChannel
+     * moves to lucien-distributed. Getters are stubbed to the prior concrete values (rank 0, treeId 1L,
+     * GhostType.FACES) so DistributedGhostManager construction is behavior-identical.
      */
     @SuppressWarnings("unchecked")
-    private GrpcGhostChannel<MortonKey, LongEntityID, TestEntity> createMockGhostChannel(
+    private GhostChannel<MortonKey, LongEntityID, TestEntity> createMockGhostChannel(
         Octree<LongEntityID, TestEntity> octree
     ) {
-        // Use Mockito to create a minimal mock GhostCommunicationManager
-        // The mock doesn't need to implement any methods for basic testing
-        var mockCommManager = org.mockito.Mockito.mock(
-            com.hellblazer.luciferase.lucien.forest.ghost.grpc.GhostCommunicationManager.class
-        );
-
-        return new GrpcGhostChannel<>(
-            mockCommManager,  // Mock GhostCommunicationManager
-            0,                // currentRank
-            1L,               // treeId
-            com.hellblazer.luciferase.lucien.forest.ghost.GhostType.FACES
-        );
+        var channel = (GhostChannel<MortonKey, LongEntityID, TestEntity>)
+            org.mockito.Mockito.mock(GhostChannel.class);
+        org.mockito.Mockito.when(channel.getCurrentRank()).thenReturn(0);
+        org.mockito.Mockito.when(channel.getTreeId()).thenReturn(1L);
+        org.mockito.Mockito.when(channel.getGhostType()).thenReturn(
+            com.hellblazer.luciferase.lucien.forest.ghost.GhostType.FACES);
+        return channel;
     }
 
     /**

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/Phase44ForestIntegrationFixture.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/Phase44ForestIntegrationFixture.java
@@ -414,6 +414,11 @@ public class Phase44ForestIntegrationFixture {
         org.mockito.Mockito.when(channel.getTreeId()).thenReturn(1L);
         org.mockito.Mockito.when(channel.getGhostType()).thenReturn(
             com.hellblazer.luciferase.lucien.forest.ghost.GhostType.FACES);
+        // DistributedGhostManager.createDistributedGhostLayer() calls flushToTarget(...).join()
+        // unconditionally; stub it so the mock channel does not NPE on a null future.
+        org.mockito.Mockito.when(channel.flushToTarget(org.mockito.ArgumentMatchers.anyInt()))
+            .thenReturn(java.util.concurrent.CompletableFuture.<Void>completedFuture(null));
+        org.mockito.Mockito.when(channel.getTotalPendingCount()).thenReturn(0);
         return channel;
     }
 


### PR DESCRIPTION
## Summary

PR-A of the RDR-007 Phase 1 `lucien-distributed` extraction — **prep only**. lucien stays green with grpc still on the classpath; the structural module move + class relocation lands in PR-B. Two independent changes:

**A1 — ServiceLoader-ize `SpatialKeySerdeRegistry` ([Luciferase-48l])**
Replaces the `Class.forName(...MortonKeySerde/TetreeKeySerde)` static block (which threw `ExceptionInInitializerError` when the serde classes were absent) with `ServiceLoader.load(SpatialKeySerde.class)`. The registry now degrades to an empty registry gracefully — the spatial index works standalone; serdes are only needed for distributed ghost exchange. This is what lets PR-B strip the serdes out to `lucien-distributed`.

Classpath `ServiceLoader` (no `module-info`) instantiates providers via a **public no-arg constructor** — the `provider()` static-method form is modulepath-only. So `MortonKeySerde`/`TetreeKeySerde` drop the private-ctor + `INSTANCE` singleton + self-registering `static{}` in favor of a public no-arg ctor; `ServiceLoader.forEach(register)` is the single registration path. Added `META-INF/services/…SpatialKeySerde` (moves to `lucien-distributed` in PR-B).

**A2 — de-grpc shared test fixtures ([Luciferase-xt7])**
`ParallelBalancerTest`, `DefaultParallelBalancerPhase1Test`, and `Phase44ForestIntegrationFixture` built/mocked the concrete `GrpcGhostChannel` (which moves in PR-B). Swapped to `mock(GhostChannel.class)` (Inc1's lucien-core interface) so the fixtures keep their dependency and stay in lucien with their consumers (`CrossPartitionBalancePhaseTest`, `Phase3IntegrationTest`, `TwoOneBalanceCheckerTest`, `Phase44…ValidationTest`). Getters (`getCurrentRank`/`getTreeId`/`getGhostType`) stubbed to the prior concrete values; `flushToTarget`/`getTotalPendingCount` stubbed (review hardening — `DistributedGhostManager` calls `flushToTarget(...).join()` unconditionally).

## Review
Stacked review (code-review-expert + substantive-critic, sonnet). The `flushToTarget` latent-NPE trap was hardened in all three fixtures. The critic's META-INF/services migration trap (the file must move, not stay, in PR-B) is tracked on the PR-B bead. Findings in T2 `rdr007-pra-review-findings`.

## Test plan
- [x] `SpatialKeySerdeRegistryTest` 9/9 (incl. new ServiceLoader-discovery test)
- [x] All de-grpc'd fixtures' consumers green (ParallelBalancerTest, DefaultParallelBalancerPhase1Test, CrossPartitionBalancePhaseTest, Phase3IntegrationTest, TwoOneBalanceCheckerTest, Phase44…ValidationTest)
- [x] Full lucien suite green modulo known perf flakes (TetreeLocateMethodTest, PrismVsTetreeComparisonTest = Luciferase-6z1), both pass in isolation
- [ ] CI green

Bead: RDR-007 tracker [Luciferase-8cv] (PR-A = A1 48l, A2 xt7, gate 3yf). PR-B follows.