### PR TITLE
Close RDR-007: lucien-distributed extraction complete

### DIFF
--- a/docs/rdr/RDR-007-extract-lucien-distributed-module.md
+++ b/docs/rdr/RDR-007-extract-lucien-distributed-module.md
@@ -2,12 +2,14 @@
 title: "Extract a lucien-distributed Module (gRPC Clients out of lucien)"
 id: RDR-007
 type: Architecture
-status: accepted
+status: closed
+outcome: implemented
 priority: medium
 author: hal.hildebrand
 reviewed-by: self
 created: 2026-05-24
 accepted_date: 2026-05-25
+closed_date: 2026-05-26
 related_issues: [Luciferase-8cv, RDR-005, RDR-008, Luciferase-aos]
 ---
 
@@ -99,3 +101,16 @@ Module name: `lucien-distributed`. **Sequencing:** move-then-auth — RDR-005's 
 - **Positive:** `lucien` becomes a true non-distributed spatial-index core (no gRPC/netty/protobuf compile deps); distributed concerns layer cleanly above it; the dependency inversion also unblocks RDR-008's god-class decomposition.
 - **Cost / risk:** Phase 0 is the hard part — the proto-type and `StatusRuntimeException` leaks mean inversion is more than a file move; under-enumerating back-references would leave `lucien` still depending on `grpc`. Mitigated by the shared `Luciferase-aos` interface contract defined before Phase 1.
 - **Sequencing:** coordinate Phase 0 with RDR-008 via `Luciferase-aos`; do not begin Phase 1 until the interface contract is settled.
+
+## Outcome
+
+**Closed 2026-05-26 — implemented.** All three phases landed; `lucien` is now a non-distributed spatial-index core and the gRPC transport lives in `lucien-distributed`.
+
+- **Phase 0 (dependency inversion)** — bead `Luciferase-aos`, increments Inc1–Inc3 (PRs #96–#99). Introduced lucien-resident interfaces over the gRPC collaborators (`GhostChannel`/`ServiceDiscovery`, `GhostExchange`, the split `RefinementExchange`/`ViolationExchange`), replaced the balancing-boundary proto message types (`RefinementRequest`/`RefinementResponse`/`BalanceViolation`/`ViolationBatch`) with domain records, and resolved the `io.grpc.StatusRuntimeException` leak by wrapping it in a domain `BalanceExchangeException`. All ghost + balancing core classes became grep-clean of grpc/proto.
+- **Phase 1 + Phase 2** — PR-A #100 (ServiceLoader-ize `SpatialKeySerdeRegistry` + de-grpc the shared test fixtures to the `GhostChannel` interface) then PR-B #101 (create `lucien-distributed`; move the 11 transport classes + 7 integration tests + the `META-INF/services` serde file; strip grpc/netty/grpc-proto-module from `lucien`). `lucien-distributed` → `lucien` + `grpc` + `grpc-netty-shaded`; 34 tests green via ServiceLoader serde discovery.
+
+**Verification:** `mvn dependency:tree -pl lucien` shows no `grpc-netty-shaded`, `grpc-testing`, or the `grpc` proto-module; full reactor (10 modules) builds green. `simulation/pom.xml` unchanged, as predicted.
+
+**Refinement vs the original plan:** `lucien` legitimately retains a direct `protobuf-java` dependency — `ContentSerializer`'s public API uses `com.google.protobuf.ByteString`. RDR-007 extracted the gRPC **transport** (clients/netty/proto-generated-message-types); proto serialization in core is accepted. `io.grpc:grpc-api` also remains transitively via `common` (RDR-005 auth helpers, pre-existing).
+
+**Follow-ups (tracked, out of scope):** migrate `ContentSerializer` off `ByteString` to drop `protobuf-java` from `lucien`; a pre-existing `GrpcGhostChannel.queueGhost` TOCTOU race; and RDR-005 per-client mTLS wiring (the MOVE-THEN-AUTH step, now unblocked). Post-mortem: `post-mortem/007-extract-lucien-distributed-module.md`.

--- a/docs/rdr/post-mortem/007-extract-lucien-distributed-module.md
+++ b/docs/rdr/post-mortem/007-extract-lucien-distributed-module.md
@@ -1,0 +1,34 @@
+# Post-Mortem: RDR-007 — Extract a lucien-distributed Module
+
+**Closed:** 2026-05-26 — implemented
+**Outcome:** `lucien` is now a non-distributed spatial-index core; the gRPC transport lives in a new `lucien-distributed` module.
+
+## What shipped
+
+| Phase | Work | PRs |
+|-------|------|-----|
+| P0 — dependency inversion | lucien-resident interfaces over the gRPC collaborators (`GhostChannel`/`ServiceDiscovery`, `GhostExchange`, split `RefinementExchange`/`ViolationExchange`); balancing-boundary proto messages → domain records; `io.grpc.StatusRuntimeException` → domain `BalanceExchangeException`. All ghost + balancing core classes grep-clean of grpc/proto. | #96 (Inc1), #97 (Inc2a), #98 (Inc2b), #99 (Inc3) |
+| P1+P2 — module move | PR-A: ServiceLoader-ize `SpatialKeySerdeRegistry` + de-grpc shared test fixtures to the `GhostChannel` interface. PR-B: create `lucien-distributed`; move 11 transport classes + 7 integration tests + the `META-INF/services` serde file; strip grpc/netty/grpc-proto-module from `lucien`. | #100 (PR-A), #101 (PR-B) |
+
+Final state: `mvn dependency:tree -pl lucien` shows no `grpc-netty-shaded`/`grpc-testing`/`grpc` proto-module; `lucien-distributed` 34 tests green (serde discovery via ServiceLoader); full reactor (10 modules) green; `simulation/pom.xml` untouched as predicted.
+
+## What went well
+
+- **Research front-loaded the hard part.** The pre-accept analysis correctly identified that this was *not* a clean leaf-move — 8+ compile-time back-references from `lucien` core into the grpc packages forced a dependency-inversion phase (P0) before any physical move. That framing held.
+- **Incremental, behavior-preserving increments.** P0 split into Inc1/Inc2a/Inc2b/Inc3, each a small, independently-reviewed, behavior-preserving inversion with the full lucien suite green at every step. The two-PR split of P1/P2 (prep-then-move) kept each PR green despite the module-wide compile coupling.
+- **Stacked review caught real issues before merge** at every increment (per `feedback_review-stacking`): a per-element resilience regression (Inc2b), the SIG-1 convergence-vote change (Inc3), the `flushToTarget` mock NPE trap and the test-jar coupling (PR-A/PR-B).
+
+## Lessons / what was tricky
+
+1. **Classpath `ServiceLoader` needs a public no-arg constructor.** The serdes used a private-ctor `INSTANCE` singleton with static self-registration. The Java-9 `provider()` static-method form only works on the *modulepath*; on the classpath (this project — only `dyada-java` has `module-info`), `ServiceLoader` instantiates via the public no-arg ctor and throws `ServiceConfigurationError` otherwise. Fix: drop the singleton, public ctor, registry's `ServiceLoader.forEach(register)` as the single registration path.
+2. **A `META-INF/services` file must move *with* its providers.** A services file left behind in `lucien` naming the (now-moved) serde classes makes `ServiceLoader` hit `ClassNotFoundException` and *silently skip* the provider — an empty registry with no compile error. Caught in PR-A review, tracked, and verified-relocated in PR-B.
+3. **"Extract gRPC" conflated transport with serialization coupling.** `lucien` could not become fully proto-free: `ContentSerializer`'s public API uses `com.google.protobuf.ByteString`, consumed by `AbstractSpatialIndex`. The RDR extracted the *transport* (clients/netty/proto-generated-message-types) and accepts proto serialization in core; `lucien` retains a direct `protobuf-java` dep. The audit (F1) surfaced this; the cleaner `ByteString`→`byte[]` migration is a tracked follow-up.
+4. **Module-wide test compilation couples "independent" beads.** Inverting a class signature broke tests in the same module that couldn't be split out, so increments that looked independent (e.g. C3 violation chain vs C6 `Phase4E2ETest`) were compile-coupled and had to land together.
+5. **Trust-but-verify on subagent output paid off repeatedly.** A reviewer's CRITICAL "9 tests will NPE" was empirically false (tests green); a reviewer's `@Override`-missing finding was a false positive; the "dead reflection path" concern dissolved once the actual caller was checked. The empirical suite + reading the real source settled each.
+
+## Follow-ups (tracked, out of RDR-007 scope)
+
+- Migrate `ContentSerializer` off `ByteString` (→ `byte[]` or a lucien-native container) to drop `protobuf-java` from `lucien` entirely. (P3)
+- Pre-existing `GrpcGhostChannel.queueGhost` TOCTOU race on the auto-flush path. (P3 bug)
+- `io.grpc:grpc-api` remains transitive in `lucien` via `common` (RDR-005 `GrpcAuth` helpers) — a common-module concern, not lucien's transport.
+- **RDR-005 per-client mTLS wiring** — the MOVE-THEN-AUTH step, now unblocked.


### PR DESCRIPTION
Marks RDR-007 (Extract a lucien-distributed Module) **closed / implemented** now that all phases have merged to main:

- **Phase 0** (dependency inversion) — #96, #97, #98, #99 (bead Luciferase-aos)
- **Phase 1 + P2** (module move + strip) — #100 (PR-A prep), #101 (PR-B move)

Doc-only change: flips the RDR status frontmatter (`accepted` → `closed`, `outcome: implemented`, `closed_date`), adds an `## Outcome` section, and adds `post-mortem/007-extract-lucien-distributed-module.md`.

Outcome: `lucien` is grpc-transport-free (`dependency:tree` shows no grpc-netty/grpc-testing/grpc-proto-module); the gRPC transport lives in `lucien-distributed`. `lucien` retains `protobuf-java` for `ContentSerializer`'s `ByteString` (transport-only extraction). Follow-ups tracked: `ContentSerializer` ByteString→byte[], a pre-existing `GrpcGhostChannel.queueGhost` race, and RDR-005 per-client mTLS (now unblocked).

Tracker `Luciferase-8cv` already closed.

## Test plan
- [x] Doc-only (no code change); full reactor already green on #101
- [ ] CI green