### PR TITLE
Wire per-client gRPC credentials in lucien-distributed (RDR-005)

### DIFF
--- a/lucien-distributed/pom.xml
+++ b/lucien-distributed/pom.xml
@@ -19,6 +19,11 @@
             <artifactId>lucien</artifactId>
         </dependency>
         <dependency>
+            <!-- gRPC auth mechanism: GrpcCredentialFactory / PeerVerifier / PeerAuthInterceptor (RDR-005) -->
+            <groupId>${project.groupId}</groupId>
+            <artifactId>common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>grpc</artifactId>
         </dependency>

--- a/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/balancing/grpc/BalanceCoordinatorClient.java
+++ b/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/balancing/grpc/BalanceCoordinatorClient.java
@@ -480,6 +480,8 @@ public class BalanceCoordinatorClient {
 
             log.debug("Creating channel to rank {} at {}", rank, endpoint);
             // RDR-005: credentials default to insecure (plaintext); mTLS is injected by the caller.
+            // endpoint is a host:port target — Grpc.newChannelBuilder resolves it as
+            // ManagedChannelBuilder.forTarget did (default name resolver).
             return Grpc.newChannelBuilder(endpoint, channelCredentials)
                 .keepAliveTime(30, TimeUnit.SECONDS)
                 .keepAliveTimeout(5, TimeUnit.SECONDS)

--- a/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/balancing/grpc/BalanceCoordinatorClient.java
+++ b/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/balancing/grpc/BalanceCoordinatorClient.java
@@ -17,10 +17,12 @@
 
 package com.hellblazer.luciferase.lucien.balancing.grpc;
 
+import com.hellblazer.luciferase.common.grpc.GrpcCredentialFactory;
 import com.hellblazer.luciferase.lucien.balancing.proto.*;
 import com.hellblazer.luciferase.lucien.forest.ghost.proto.SpatialKey;
+import io.grpc.ChannelCredentials;
+import io.grpc.Grpc;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
@@ -58,6 +60,7 @@ public class BalanceCoordinatorClient {
     private final ServiceDiscovery serviceDiscovery;
     private final int batchSize;
     private final long batchTimeoutMillis;
+    private final ChannelCredentials channelCredentials;
 
     // Virtual thread executor for concurrent operations
     private final ExecutorService virtualExecutor;
@@ -95,10 +98,29 @@ public class BalanceCoordinatorClient {
      */
     public BalanceCoordinatorClient(int currentRank, ServiceDiscovery serviceDiscovery,
                                    int batchSize, long batchTimeoutMillis) {
+        this(currentRank, serviceDiscovery, batchSize, batchTimeoutMillis,
+             GrpcCredentialFactory.insecureChannel());
+    }
+
+    /**
+     * Creates a new balance coordinator client with explicit outbound channel credentials (RDR-005).
+     *
+     * @param currentRank the rank of this process
+     * @param serviceDiscovery service discovery mechanism
+     * @param batchSize maximum batch size
+     * @param batchTimeoutMillis maximum time to wait before sending partial batch
+     * @param channelCredentials transport credentials for outbound channels —
+     *        {@code GrpcCredentialFactory.insecureChannel()} for plaintext (in-process/test) or
+     *        {@code GrpcCredentialFactory.mtlsChannel(...)} for mTLS
+     */
+    public BalanceCoordinatorClient(int currentRank, ServiceDiscovery serviceDiscovery,
+                                   int batchSize, long batchTimeoutMillis,
+                                   ChannelCredentials channelCredentials) {
         this.currentRank = currentRank;
         this.serviceDiscovery = serviceDiscovery;
         this.batchSize = batchSize;
         this.batchTimeoutMillis = batchTimeoutMillis;
+        this.channelCredentials = channelCredentials;
         this.channels = new ConcurrentHashMap<>();
         this.blockingStubs = new ConcurrentHashMap<>();
         this.asyncStubs = new ConcurrentHashMap<>();
@@ -457,8 +479,8 @@ public class BalanceCoordinatorClient {
             }
 
             log.debug("Creating channel to rank {} at {}", rank, endpoint);
-            return ManagedChannelBuilder.forTarget(endpoint)
-                .usePlaintext() // For development - use TLS in production
+            // RDR-005: credentials default to insecure (plaintext); mTLS is injected by the caller.
+            return Grpc.newChannelBuilder(endpoint, channelCredentials)
                 .keepAliveTime(30, TimeUnit.SECONDS)
                 .keepAliveTimeout(5, TimeUnit.SECONDS)
                 .keepAliveWithoutCalls(true)

--- a/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostCommunicationManager.java
+++ b/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostCommunicationManager.java
@@ -133,9 +133,12 @@ public class GhostCommunicationManager<Key extends SpatialKey<Key>, ID extends E
         this.serviceImpl = new GhostExchangeServiceImpl<>(
             ghostLayerProvider, contentSerializer, entityIdClass);
 
-        // Create gRPC server (RDR-005: insecure by default; mTLS creds + the verifying
-        // PeerAuthInterceptor are injected together via ServerAuth, so trust-any TLS creds can never
-        // be installed without the interceptor that actually authenticates the peer).
+        // Create gRPC server (RDR-005: insecure by default). When a ServerAuth is supplied, its
+        // (trust-any) mTLS credentials and a PeerAuthInterceptor are installed together, so bare creds
+        // cannot be passed without *an* interceptor. The interceptor's PeerVerifier must be a real
+        // cryptographic verifier (the deferred FirefliesPeerVerifier) for the server to actually
+        // authenticate peers — prefer GrpcCredentialFactory.serverAuth(key, cert, verifier) over
+        // hand-rolling a ServerAuth, which could pair trust-any creds with a non-verifying interceptor.
         var serverCredentials = serverAuth == null
             ? GrpcCredentialFactory.insecureServer() : serverAuth.credentials();
         var serverBuilder = Grpc.newServerBuilderForPort(port, serverCredentials);

--- a/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostCommunicationManager.java
+++ b/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostCommunicationManager.java
@@ -17,6 +17,7 @@
 
 package com.hellblazer.luciferase.lucien.forest.ghost.grpc;
 
+import com.hellblazer.luciferase.common.grpc.GrpcCredentialFactory;
 import com.hellblazer.luciferase.lucien.SpatialKey;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.forest.ghost.ContentSerializer;
@@ -24,8 +25,9 @@ import com.hellblazer.luciferase.lucien.forest.ghost.GhostElement;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostLayer;
 import com.hellblazer.luciferase.lucien.forest.ghost.ServiceDiscovery;
 import com.hellblazer.luciferase.lucien.forest.ghost.proto.*;
+import io.grpc.ChannelCredentials;
+import io.grpc.Grpc;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,6 +90,33 @@ public class GhostCommunicationManager<Key extends SpatialKey<Key>, ID extends E
                                    ContentSerializer<Content> contentSerializer,
                                    Class<ID> entityIdClass,
                                    ServiceDiscovery serviceDiscovery) {
+        this(currentRank, bindAddress, port, contentSerializer, entityIdClass, serviceDiscovery,
+             null, GrpcCredentialFactory.insecureChannel());
+    }
+
+    /**
+     * Creates a new ghost communication manager with explicit transport credentials (RDR-005).
+     *
+     * @param currentRank the rank of this process
+     * @param bindAddress the address to bind the server to
+     * @param port the port to bind the server to
+     * @param contentSerializer serializer for content objects
+     * @param entityIdClass class for entity ID deserialization
+     * @param serviceDiscovery service discovery mechanism
+     * @param serverAuth server transport credentials + the matching {@code PeerAuthInterceptor} as one
+     *        unit (from {@code GrpcCredentialFactory.serverAuth(...)}); {@code null} for an insecure
+     *        (plaintext, no auth) server suitable for in-process/test use
+     * @param channelCredentials outbound channel credentials for the embedded client —
+     *        {@code GrpcCredentialFactory.insecureChannel()} or {@code .mtlsChannel(...)}
+     */
+    public GhostCommunicationManager(int currentRank,
+                                   String bindAddress,
+                                   int port,
+                                   ContentSerializer<Content> contentSerializer,
+                                   Class<ID> entityIdClass,
+                                   ServiceDiscovery serviceDiscovery,
+                                   GrpcCredentialFactory.ServerAuth serverAuth,
+                                   ChannelCredentials channelCredentials) {
         this.currentRank = currentRank;
         this.bindAddress = bindAddress;
         this.port = port;
@@ -96,24 +125,31 @@ public class GhostCommunicationManager<Key extends SpatialKey<Key>, ID extends E
         this.serviceDiscovery = serviceDiscovery;
         this.ghostLayers = new ConcurrentHashMap<>();
         this.running = new AtomicBoolean(false);
-        
+
         // Create ghost layer provider
         var ghostLayerProvider = new GhostLayerProviderImpl();
-        
+
         // Create service implementation
         this.serviceImpl = new GhostExchangeServiceImpl<>(
             ghostLayerProvider, contentSerializer, entityIdClass);
-        
-        // Create gRPC server
-        this.server = ServerBuilder.forPort(port)
-            .addService(serviceImpl)
-            .build();
-        
-        // Create client
+
+        // Create gRPC server (RDR-005: insecure by default; mTLS creds + the verifying
+        // PeerAuthInterceptor are injected together via ServerAuth, so trust-any TLS creds can never
+        // be installed without the interceptor that actually authenticates the peer).
+        var serverCredentials = serverAuth == null
+            ? GrpcCredentialFactory.insecureServer() : serverAuth.credentials();
+        var serverBuilder = Grpc.newServerBuilderForPort(port, serverCredentials);
+        serverBuilder.addService(serviceImpl);
+        if (serverAuth != null) {
+            serverBuilder.intercept(serverAuth.interceptor());
+        }
+        this.server = serverBuilder.build();
+
+        // Create client with the outbound channel credentials
         this.client = new GhostServiceClient<>(
-            currentRank, contentSerializer, entityIdClass, serviceDiscovery);
-        
-        log.info("GhostCommunicationManager created for rank {} on {}:{}", 
+            currentRank, contentSerializer, entityIdClass, serviceDiscovery, channelCredentials);
+
+        log.info("GhostCommunicationManager created for rank {} on {}:{}",
                 currentRank, bindAddress, port);
     }
     

--- a/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostServiceClient.java
+++ b/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostServiceClient.java
@@ -455,6 +455,8 @@ public class GhostServiceClient<Key extends SpatialKey<Key>, ID extends EntityID
             
             log.debug("Creating channel to rank {} at {}", rank, endpoint);
             // RDR-005: credentials default to insecure (plaintext); mTLS is injected by the caller.
+            // endpoint is a host:port target — Grpc.newChannelBuilder resolves it as
+            // ManagedChannelBuilder.forTarget did (default name resolver).
             return Grpc.newChannelBuilder(endpoint, channelCredentials)
                 .keepAliveTime(30, TimeUnit.SECONDS)
                 .keepAliveTimeout(5, TimeUnit.SECONDS)

--- a/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostServiceClient.java
+++ b/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostServiceClient.java
@@ -17,6 +17,7 @@
 
 package com.hellblazer.luciferase.lucien.forest.ghost.grpc;
 
+import com.hellblazer.luciferase.common.grpc.GrpcCredentialFactory;
 import com.hellblazer.luciferase.lucien.SpatialKey;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.entity.UUIDEntityID;
@@ -30,8 +31,9 @@ import com.hellblazer.luciferase.lucien.forest.ghost.proto.*;
 import javax.vecmath.Point3f;
 import java.util.ArrayList;
 import java.util.UUID;
+import io.grpc.ChannelCredentials;
+import io.grpc.Grpc;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
@@ -77,7 +79,8 @@ public class GhostServiceClient<Key extends SpatialKey<Key>, ID extends EntityID
     private final ContentSerializer<Content> contentSerializer;
     private final Class<ID> entityIdClass;
     private final ServiceDiscovery serviceDiscovery;
-    
+    private final ChannelCredentials channelCredentials;
+
     // Virtual thread executor for concurrent operations
     private final ExecutorService virtualExecutor;
     
@@ -102,10 +105,31 @@ public class GhostServiceClient<Key extends SpatialKey<Key>, ID extends EntityID
                              ContentSerializer<Content> contentSerializer,
                              Class<ID> entityIdClass,
                              ServiceDiscovery serviceDiscovery) {
+        this(currentRank, contentSerializer, entityIdClass, serviceDiscovery,
+             GrpcCredentialFactory.insecureChannel());
+    }
+
+    /**
+     * Creates a new ghost service client with explicit outbound channel credentials (RDR-005).
+     *
+     * @param currentRank the rank of this process
+     * @param contentSerializer serializer for content objects
+     * @param entityIdClass class for entity ID deserialization
+     * @param serviceDiscovery service discovery mechanism
+     * @param channelCredentials transport credentials for outbound channels —
+     *        {@code GrpcCredentialFactory.insecureChannel()} for plaintext (in-process/test) or
+     *        {@code GrpcCredentialFactory.mtlsChannel(...)} for mTLS
+     */
+    public GhostServiceClient(int currentRank,
+                             ContentSerializer<Content> contentSerializer,
+                             Class<ID> entityIdClass,
+                             ServiceDiscovery serviceDiscovery,
+                             ChannelCredentials channelCredentials) {
         this.currentRank = currentRank;
         this.contentSerializer = contentSerializer;
         this.entityIdClass = entityIdClass;
         this.serviceDiscovery = serviceDiscovery;
+        this.channelCredentials = channelCredentials;
         this.channels = new ConcurrentHashMap<>();
         this.blockingStubs = new ConcurrentHashMap<>();
         this.asyncStubs = new ConcurrentHashMap<>();
@@ -430,8 +454,8 @@ public class GhostServiceClient<Key extends SpatialKey<Key>, ID extends EntityID
             }
             
             log.debug("Creating channel to rank {} at {}", rank, endpoint);
-            return ManagedChannelBuilder.forTarget(endpoint)
-                .usePlaintext() // For development - use TLS in production
+            // RDR-005: credentials default to insecure (plaintext); mTLS is injected by the caller.
+            return Grpc.newChannelBuilder(endpoint, channelCredentials)
                 .keepAliveTime(30, TimeUnit.SECONDS)
                 .keepAliveTimeout(5, TimeUnit.SECONDS)
                 .keepAliveWithoutCalls(true)

--- a/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/distributed/CredentialPlumbingTest.java
+++ b/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/distributed/CredentialPlumbingTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.distributed;
+
+import com.google.protobuf.ByteString;
+import com.hellblazer.luciferase.common.grpc.GrpcCredentialFactory;
+import com.hellblazer.luciferase.common.grpc.PeerAuthInterceptor;
+import com.hellblazer.luciferase.lucien.balancing.grpc.BalanceCoordinatorClient;
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.forest.ghost.ContentSerializer;
+import com.hellblazer.luciferase.lucien.forest.ghost.ServiceDiscovery;
+import com.hellblazer.luciferase.lucien.forest.ghost.grpc.GhostCommunicationManager;
+import com.hellblazer.luciferase.lucien.forest.ghost.grpc.GhostServiceClient;
+import com.hellblazer.luciferase.lucien.octree.MortonKey;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * RDR-005 per-client credential plumbing (move-then-auth): the lucien-distributed gRPC clients and the
+ * communication manager accept injectable transport credentials and route them to the channel/server
+ * builders. These tests assert the WIRING — construction via the new credential-accepting constructors
+ * succeeds (i.e. {@code Grpc.newChannelBuilder(...)} / {@code Grpc.newServerBuilderForPort(...).build()}
+ * run with the supplied credentials). The factory's actual mTLS correctness and forged-cert behavior are
+ * covered by {@code common}'s GrpcAuthTest; the insecure default path is covered by the existing
+ * integration tests. Real mTLS activation (FirefliesPeerVerifier + the load-bearing forged-cert spike)
+ * is deferred RDR-005 work.
+ *
+ * @author hal.hildebrand
+ */
+class CredentialPlumbingTest {
+
+    private static final ContentSerializer<String> SERIALIZER = new ContentSerializer<>() {
+        @Override
+        public ByteString serialize(String content) {
+            return ByteString.copyFrom(content, StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public String deserialize(ByteString bytes) {
+            return bytes.toString(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public String getContentType() {
+            return "string";
+        }
+    };
+
+    private static final ServiceDiscovery GHOST_DISCOVERY = new ServiceDiscovery() {
+        @Override
+        public String getEndpoint(int rank) {
+            return "localhost:" + (50000 + rank);
+        }
+
+        @Override
+        public void registerEndpoint(int rank, String endpoint) {
+        }
+
+        @Override
+        public Map<Integer, String> getAllEndpoints() {
+            return Map.of();
+        }
+    };
+
+    private static final BalanceCoordinatorClient.ServiceDiscovery BALANCE_DISCOVERY =
+        new BalanceCoordinatorClient.ServiceDiscovery() {
+            @Override
+            public String getEndpoint(int rank) {
+                return "localhost:" + (50000 + rank);
+            }
+
+            @Override
+            public void registerEndpoint(int rank, String endpoint) {
+            }
+
+            @Override
+            public Map<Integer, String> getAllEndpoints() {
+                return Map.of();
+            }
+        };
+
+    @Test
+    void ghostServiceClientAcceptsExplicitChannelCredentials() {
+        var client = new GhostServiceClient<MortonKey, LongEntityID, String>(
+            0, SERIALIZER, LongEntityID.class, GHOST_DISCOVERY, GrpcCredentialFactory.insecureChannel());
+        try {
+            assertNotNull(client);
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    void balanceCoordinatorClientAcceptsExplicitChannelCredentials() {
+        var client = new BalanceCoordinatorClient(
+            0, BALANCE_DISCOVERY, 10, 100L, GrpcCredentialFactory.insecureChannel());
+        try {
+            assertNotNull(client);
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    void ghostCommunicationManagerInsecureServerPathBuilds() {
+        // serverAuth == null -> insecure server (today's behavior) built via Grpc.newServerBuilderForPort.
+        var mgr = new GhostCommunicationManager<MortonKey, LongEntityID, String>(
+            0, "localhost", 0, SERIALIZER, LongEntityID.class, GHOST_DISCOVERY,
+            null, GrpcCredentialFactory.insecureChannel());
+        try {
+            assertNotNull(mgr);
+        } finally {
+            mgr.shutdown();
+        }
+    }
+
+    @Test
+    void ghostCommunicationManagerServerAuthWiresInterceptor() {
+        // Verifies the serverAuth branch installs the PeerAuthInterceptor on the server builder. Uses
+        // insecure creds + an accept-all verifier purely to exercise the .intercept(...) wiring path;
+        // real mTLS + cryptographic verification (FirefliesPeerVerifier) is the deferred RDR-005 work.
+        var serverAuth = new GrpcCredentialFactory.ServerAuth(
+            GrpcCredentialFactory.insecureServer(),
+            new PeerAuthInterceptor(cert -> Optional.of("test-member")));
+        var mgr = new GhostCommunicationManager<MortonKey, LongEntityID, String>(
+            0, "localhost", 0, SERIALIZER, LongEntityID.class, GHOST_DISCOVERY,
+            serverAuth, GrpcCredentialFactory.insecureChannel());
+        try {
+            assertNotNull(mgr);
+        } finally {
+            mgr.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

RDR-005 **move-then-auth** deliverable, unblocked by the RDR-007 module move (#101). Makes the production gRPC transports in `lucien-distributed` **credential-pluggable**, defaulting to **insecure** so behavior is unchanged and mTLS stays **inactive** until the `FirefliesPeerVerifier` + the RDR's load-bearing forged-cert spike land (explicitly deferred). Uses the common helpers from #95.

- **`GhostServiceClient` / `BalanceCoordinatorClient`** — optional `ChannelCredentials` constructor (default `GrpcCredentialFactory.insecureChannel()`); channel built via `Grpc.newChannelBuilder(endpoint, creds)` instead of `forTarget(...).usePlaintext()` (keepalive preserved).
- **`GhostCommunicationManager`** — optional `GrpcCredentialFactory.ServerAuth` bundle (mTLS creds + matching `PeerAuthInterceptor`), `null` → insecure server (no interceptor); plus an outbound `ChannelCredentials` for the embedded client. The **bundle** ensures server creds are always installed *with* an interceptor (prefer `serverAuth(key, cert, verifier)` over hand-rolling).
- Existing constructors **delegate** to the new ones with insecure defaults → all callers, subclasses (`InProcessBalanceCoordinatorClient`, `MockBalanceCoordinatorClient`), and integration tests unchanged. Added `common` as a direct dependency (already transitive via lucien).

## Security framing
No false security: defaults are genuine plaintext (same as before `usePlaintext()`); this PR is a no-op security-wise until a caller injects real credentials. The client-side `mtlsChannel` has no server-identity check (per the factory's documented caveat) — symmetric client verification is part of the deferred `FirefliesPeerVerifier` work.

## Review
Stacked review (code-review-expert + substantive-critic, sonnet), 0 Critical. Softened an overstated ServerAuth invariant comment; added the `host:port` endpoint-resolution note. Declined `@Deprecated` on the insecure-default ctors (insecure is the intentional in-process/test default).

## Out of scope (deferred — va5 item 1)
`FirefliesPeerVerifier` + the load-bearing forged-cert-rejection spike; threading the Delos member cert from the `View` construction; caller-side activation; `simulation`'s `GrpcBubbleNetworkChannel`.

## Test plan
- [x] `CredentialPlumbingTest` (4) — credential constructors wired
- [x] lucien-distributed 38 tests green (insecure default path = existing integration tests)
- [x] Full reactor (10 modules) assembles
- [ ] CI green

Bead: RDR-005 tracker [Luciferase-va5]; impl bead [Luciferase-4gn]. mTLS activation remains tracked.