### PR TITLE
fix: GrpcGhostChannel queue/flush race (3ko) + ButterflyViolationAggregator dedup (xb5)

### DIFF
--- a/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GrpcGhostChannel.java
+++ b/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GrpcGhostChannel.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * gRPC-based ghost channel adapter for distributed ghost communication.
@@ -73,7 +74,10 @@ public class GrpcGhostChannel<Key extends SpatialKey<Key>, ID extends EntityID, 
     private final GhostType ghostType;
 
     // Batching infrastructure
-    private final Map<Integer, List<GhostElement<Key, ID, Content>>> queuedGhosts;
+    // Per-target queues. ConcurrentLinkedQueue is thread-safe for concurrent add/poll, and
+    // flushToTarget drains via poll() (never removing the map entry), so a queueGhost racing a
+    // concurrent flush of the same target can never NPE or lose an element (Luciferase-3ko).
+    private final Map<Integer, Queue<GhostElement<Key, ID, Content>>> queuedGhosts;
     private final int batchSize;
 
     /**
@@ -129,10 +133,14 @@ public class GrpcGhostChannel<Key extends SpatialKey<Key>, ID extends EntityID, 
             return;
         }
 
-        queuedGhosts.computeIfAbsent(targetRank, k -> new ArrayList<>()).add(ghostElement);
+        // Capture the queue reference rather than re-getting it: a concurrent flushToTarget must
+        // not be able to null out the local 'queue' between the add and the size check.
+        var queue = queuedGhosts.computeIfAbsent(targetRank, k -> new ConcurrentLinkedQueue<>());
+        queue.add(ghostElement);
 
-        // Auto-flush if batch size reached
-        var queue = queuedGhosts.get(targetRank);
+        // Auto-flush when the batch fills. Advisory/best-effort: ConcurrentLinkedQueue.size() is O(n) and
+        // not atomic with add(), so the queue may transiently exceed batchSize under concurrent producers
+        // -- acceptable for a batched best-effort ghost channel (batchSize is small, ~100 by default).
         if (queue.size() >= batchSize) {
             flushToTarget(targetRank);
         }
@@ -204,12 +212,23 @@ public class GrpcGhostChannel<Key extends SpatialKey<Key>, ID extends EntityID, 
      */
     @Override
     public CompletableFuture<Void> flushToTarget(int targetRank) {
-        var queue = queuedGhosts.remove(targetRank);
-        if (queue == null || queue.isEmpty()) {
+        // Drain via poll() instead of remove()-then-read: the entry stays in the map, so a
+        // concurrent queueGhost.add() to the same target is never orphaned — it either lands in
+        // this batch (polled) or remains for the next flush. ConcurrentLinkedQueue makes the
+        // concurrent add/poll safe (no ConcurrentModificationException). (Luciferase-3ko)
+        var queue = queuedGhosts.get(targetRank);
+        if (queue == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+        var batch = new ArrayList<GhostElement<Key, ID, Content>>();
+        for (GhostElement<Key, ID, Content> element; (element = queue.poll()) != null; ) {
+            batch.add(element);
+        }
+        if (batch.isEmpty()) {
             return CompletableFuture.completedFuture(null);
         }
 
-        return sendBatch(targetRank, queue);
+        return sendBatch(targetRank, batch);
     }
 
     /**
@@ -231,7 +250,7 @@ public class GrpcGhostChannel<Key extends SpatialKey<Key>, ID extends EntityID, 
     @Override
     public int getTotalPendingCount() {
         return queuedGhosts.values().stream()
-                          .mapToInt(List::size)
+                          .mapToInt(Queue::size)
                           .sum();
     }
 

--- a/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GrpcGhostChannelConcurrencyTest.java
+++ b/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GrpcGhostChannelConcurrencyTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.forest.ghost.grpc;
+
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostElement;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostType;
+import com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostBatch;
+import com.hellblazer.luciferase.lucien.octree.MortonKey;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.vecmath.Point3f;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Concurrency regression for {@link GrpcGhostChannel} queue/flush (Luciferase-3ko). The pre-fix code
+ * (a) re-{@code get()} the queue after {@code computeIfAbsent().add()} — NPE when a concurrent
+ * {@code flushToTarget} {@code remove()}d the entry in between; and (b) stored a plain {@code ArrayList}
+ * that a concurrent flush drained while a queuer was still adding (CME / lost elements). The fix uses a
+ * per-target {@link java.util.concurrent.ConcurrentLinkedQueue}, captures the queue reference, and drains
+ * via {@code poll()} without removing the map entry. This test hammers concurrent queue + flush of the
+ * same target and asserts no exception and zero element loss.
+ *
+ * @author hal.hildebrand
+ */
+class GrpcGhostChannelConcurrencyTest {
+
+    private static final Point3f POS = new Point3f(1, 2, 3);
+
+    @SuppressWarnings("unchecked")
+    private static GhostCommunicationManager<MortonKey, LongEntityID, String> mockManager() {
+        var mgr = (GhostCommunicationManager<MortonKey, LongEntityID, String>) mock(GhostCommunicationManager.class);
+        when(mgr.requestGhostsAsync(anyInt(), anyLong(), any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(GhostBatch.getDefaultInstance()));
+        return mgr;
+    }
+
+    private static GhostElement<MortonKey, LongEntityID, String> ghost(long id) {
+        return new GhostElement<>(new MortonKey(id, (byte) 5), new LongEntityID(id), "g" + id, POS, 1, 7L);
+    }
+
+    @Test
+    void flushToTargetSendsEveryQueuedGhostExactlyOnce() {
+        var mgr = mockManager();
+        // huge batch size so queueGhost never auto-flushes; we flush explicitly
+        var channel = new GrpcGhostChannel<>(mgr, 0, 7L, GhostType.FACES, Integer.MAX_VALUE);
+        for (long i = 0; i < 50; i++) {
+            channel.queueGhost(1, ghost(i));
+        }
+        assertEquals(50, channel.getPendingCount(1));
+
+        channel.flushToTarget(1).join();
+        assertEquals(0, channel.getTotalPendingCount(), "queue drained after flush");
+        assertEquals(50, totalGhostsSent(mgr), "every queued ghost sent exactly once");
+    }
+
+    @Test
+    void concurrentQueueAndFlushLosesNoGhostsAndNeverThrows() throws Exception {
+        var mgr = mockManager();
+        var channel = new GrpcGhostChannel<>(mgr, 0, 7L, GhostType.FACES, Integer.MAX_VALUE);
+
+        int queuers = 8;
+        int perQueuer = 500;
+        int target = 1;
+        var pool = Executors.newFixedThreadPool(queuers + 1);
+        var start = new CountDownLatch(1);
+        var queuersDone = new CountDownLatch(queuers);
+        var flusherStop = new AtomicBoolean(false);
+
+        // queuers: each adds `perQueuer` ghosts to the same target concurrently
+        for (int q = 0; q < queuers; q++) {
+            final long base = (long) q * perQueuer;
+            pool.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < perQueuer; i++) {
+                        channel.queueGhost(target, ghost(base + i));
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    queuersDone.countDown();
+                }
+            });
+        }
+        // flusher: continuously drains the same target while queuers are adding
+        var flusher = pool.submit(() -> {
+            try {
+                start.await();
+                while (!flusherStop.get()) {
+                    channel.flushToTarget(target).join();
+                    Thread.onSpinWait();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        start.countDown();
+        assertTrue(queuersDone.await(30, TimeUnit.SECONDS), "queuers finished");
+        flusherStop.set(true);
+        flusher.get(10, TimeUnit.SECONDS);   // surfaces any exception thrown on the flusher thread
+        channel.flush().join();              // final drain of whatever the flusher left
+        pool.shutdownNow();
+
+        assertEquals(0, channel.getTotalPendingCount(), "nothing left queued after final flush");
+        assertEquals(queuers * perQueuer, totalGhostsSent(mgr),
+                     "every concurrently-queued ghost was sent exactly once (no NPE, no CME, no loss)");
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static int totalGhostsSent(GhostCommunicationManager<MortonKey, LongEntityID, String> mgr) {
+        ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+        verify(mgr, atLeastOnce()).requestGhostsAsync(eq(1), anyLong(), any(), captor.capture());
+        return captor.getAllValues().stream().mapToInt(List::size).sum();
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/ButterflyViolationAggregator.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/ButterflyViolationAggregator.java
@@ -171,6 +171,15 @@ public class ButterflyViolationAggregator<Key extends SpatialKey<Key>> {
         // Exchange with partner using the provided exchanger function
         var receivedBatch = violationExchanger.apply(partner, batch);
 
+        // The BiFunction contract permits a null return. DistributedViolationAggregator's exchanger
+        // never returns null, but guard defensively so an alternative/future exchanger cannot NPE the
+        // aggregation; treat null as "no violations received from this partner" (Luciferase-xb5).
+        if (receivedBatch == null) {
+            log.warn("Violation exchanger returned null for partner {} in round {}; treating as empty batch",
+                     partner, round);
+            return new ViolationBatch<>(myRank, partner, round, List.of(), System.currentTimeMillis());
+        }
+
         log.debug("Received {} violations from partner {} in round {}",
                  receivedBatch.violations().size(), partner, round);
 
@@ -181,27 +190,29 @@ public class ButterflyViolationAggregator<Key extends SpatialKey<Key>> {
      * Composite key for violation deduplication.
      * Uses localKey and ghostKey to uniquely identify violations.
      */
-    private static class ViolationKey {
-        private final int localKeyHash;
-        private final int ghostKeyHash;
+    private static final class ViolationKey {
+        // Store the actual spatial keys, not just their hashCodes: two distinct violations whose
+        // keys merely collide on hashCode must NOT be deduplicated into one (which would silently
+        // drop a real violation). equals/hashCode delegate to the keys' own equals/hashCode, so
+        // a hash collision is resolved by a true key comparison (Luciferase-xb5).
+        private final Object localKey;
+        private final Object ghostKey;
 
         ViolationKey(TwoOneBalanceChecker.BalanceViolation<?> violation) {
-            // Use the full SpatialKey hashCode for uniqueness (handles MortonKey, TetreeKey, etc.)
-            this.localKeyHash = violation.localKey().hashCode();
-            this.ghostKeyHash = violation.ghostKey().hashCode();
+            this.localKey = violation.localKey();
+            this.ghostKey = violation.ghostKey();
         }
 
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            var that = (ViolationKey) o;
-            return localKeyHash == that.localKeyHash && ghostKeyHash == that.ghostKeyHash;
+            if (!(o instanceof ViolationKey that)) return false;
+            return Objects.equals(localKey, that.localKey) && Objects.equals(ghostKey, that.ghostKey);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(localKeyHash, ghostKeyHash);
+            return Objects.hash(localKey, ghostKey);
         }
     }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/ButterflyViolationAggregatorDedupTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/ButterflyViolationAggregatorDedupTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.balancing;
+
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.balancing.TwoOneBalanceChecker.BalanceViolation;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Deduplication + robustness regression for {@link ButterflyViolationAggregator} (Luciferase-xb5).
+ * The pre-fix {@code ViolationKey} deduplicated by {@code (localKey.hashCode(), ghostKey.hashCode())}
+ * and compared only those ints, so two distinct violations whose keys merely collide on hashCode were
+ * falsely merged — silently dropping a real violation. The fix stores the actual keys and delegates
+ * equals/hashCode to them. Separately, {@code exchangeWithPartner} now guards a null exchanger result.
+ *
+ * @author hal.hildebrand
+ */
+class ButterflyViolationAggregatorDedupTest {
+
+    /** A SpatialKey whose instances all share one hashCode but are equal only by id — forces a collision. */
+    static final class CollidingKey implements SpatialKey<CollidingKey> {
+        final int id;
+
+        CollidingKey(int id) {
+            this.id = id;
+        }
+
+        @Override
+        public int hashCode() {
+            return 42; // every instance collides
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof CollidingKey c && c.id == id;
+        }
+
+        @Override
+        public int compareTo(CollidingKey o) {
+            return Integer.compare(id, o.id);
+        }
+
+        @Override
+        public byte getLevel() {
+            return 0;
+        }
+
+        @Override
+        public CollidingKey parent() {
+            return this;
+        }
+
+        @Override
+        public CollidingKey root() {
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return "CK" + id;
+        }
+    }
+
+    private static BalanceViolation<CollidingKey> violation(int localId, int ghostId) {
+        return new BalanceViolation<>(new CollidingKey(localId), new CollidingKey(ghostId), 0, 3, 3, 0);
+    }
+
+    @Test
+    void hashCodeCollidingButDistinctViolationsAreNotDeduplicated() {
+        // single partition -> pure local dedup, no exchange
+        var agg = new ButterflyViolationAggregator<CollidingKey>(0, 1, (partner, batch) -> batch);
+
+        // two genuinely distinct violations; all four keys share hashCode 42 but none are equal
+        var v1 = violation(1, 2);
+        var v2 = violation(3, 4);
+
+        var result = agg.aggregateViolations(List.of(v1, v2));
+
+        assertEquals(2, result.size(),
+                     "distinct violations whose keys collide on hashCode must NOT be deduplicated");
+        assertTrue(result.contains(v1) && result.contains(v2), "both distinct violations retained");
+    }
+
+    @Test
+    void genuinelyEqualViolationsAreStillDeduplicated() {
+        var agg = new ButterflyViolationAggregator<CollidingKey>(0, 1, (partner, batch) -> batch);
+
+        var result = agg.aggregateViolations(List.of(violation(1, 2), violation(1, 2)));
+
+        assertEquals(1, result.size(), "equal violations (same keys) still collapse to one");
+    }
+
+    @Test
+    void nullExchangeResultIsTreatedAsEmptyAndDoesNotThrow() {
+        // two partitions -> one butterfly round with a partner; exchanger returns null
+        var agg = new ButterflyViolationAggregator<CollidingKey>(0, 2, (partner, batch) -> null);
+
+        var local = violation(5, 6);
+        var result = assertDoesNotThrow(() -> agg.aggregateViolations(List.of(local)),
+                                        "a null exchange result must not NPE the aggregation");
+        assertTrue(result.contains(local), "local violation survives a null partner exchange");
+    }
+}


### PR DESCRIPTION
## Summary

Two pre-existing correctness defects (both surfaced by RDR-007 review; neither introduced by it). TDD failing-test-first + stacked review (code-review-expert + substantive-critic, Sonnet) → **0 critical / 0 significant**, both approved.

### `Luciferase-3ko` — GrpcGhostChannel.queueGhost TOCTOU race
`queueGhost` re-`get()` the queue after `computeIfAbsent().add()` → NPE if a concurrent `flushToTarget` `remove()`d the entry between; and the plain `ArrayList` was drained by a concurrent flush while a queuer was still adding (CME / lost elements).

**Fix:** per-target `ConcurrentLinkedQueue`; capture the queue reference from `computeIfAbsent` (no re-get → no NPE); `flushToTarget` drains via `poll()` **without** removing the map entry → a concurrent `add` is never orphaned (lands in this batch or the next). Map entries are bounded by cluster size (one per target rank). `GrpcGhostChannelConcurrencyTest` (2): exact-once flush + 8-thread concurrent queue/flush asserting zero loss.

### `Luciferase-xb5` — ButterflyViolationAggregator false dedup
`ViolationKey` deduplicated by `(localKey.hashCode(), ghostKey.hashCode())` comparing only those ints, so two distinct violations whose keys collide on hashCode were merged — silently dropping a real violation.

**Fix:** store the actual keys and delegate `equals`/`hashCode` to them. Plus a null-guard on the exchanger result (`BiFunction` permits null; treat as empty — defense-in-depth, the production exchanger never returns null). `ButterflyViolationAggregatorDedupTest` (3): collision-not-deduped, equal-still-deduped, null-exchange-no-NPE.

## Test plan
- [x] `mvn -pl lucien-distributed -Dtest=GrpcGhostChannelConcurrencyTest` → 2/2
- [x] `mvn -pl lucien -Dtest=ButterflyViolationAggregatorDedupTest` → 3/3
- [x] stacked review: 0 critical / 0 significant
- [ ] CI green