### PR TITLE
refactor: ContentSerializer ByteString → byte[]; drop protobuf-java from lucien (uxx)

### DIFF
--- a/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/ProtobufConverters.java
+++ b/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/ProtobufConverters.java
@@ -179,7 +179,7 @@ public final class ProtobufConverters {
         var builder = com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostElement.newBuilder()
             .setSpatialKey(spatialKeyToProtobuf(element.getSpatialKey()))
             .setEntityId(entityIdToString(element.getEntityId()))
-            .setContent(contentSerializer.serialize(element.getContent()))
+            .setContent(ByteString.copyFrom(contentSerializer.serialize(element.getContent())))
             .setPosition(point3fToProtobuf(element.getPosition()))
             .setOwnerRank(element.getOwnerRank())
             .setGlobalTreeId(element.getGlobalTreeId())
@@ -211,7 +211,7 @@ public final class ProtobufConverters {
 
         var spatialKey = (K) spatialKeyFromProtobuf(proto.getSpatialKey());
         var entityId = createEntityId(proto.getEntityId(), entityIdClass);
-        var content = contentSerializer.deserialize(proto.getContent());
+        var content = contentSerializer.deserialize(proto.getContent().toByteArray());
         var position = point3fFromProtobuf(proto.getPosition());
 
         return new GhostElement<>(spatialKey, entityId, content, position,

--- a/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/balancing/Phase4E2ETest.java
+++ b/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/balancing/Phase4E2ETest.java
@@ -596,13 +596,13 @@ class Phase4E2ETest {
     /** Shared String content serializer for the GrpcBalanceExchange adapter (unused on the violation path). */
     private static final ContentSerializer<String> STRING_SERIALIZER = new ContentSerializer<>() {
         @Override
-        public com.google.protobuf.ByteString serialize(String content) {
-            return com.google.protobuf.ByteString.copyFromUtf8(content);
+        public byte[] serialize(String content) {
+            return content.getBytes(java.nio.charset.StandardCharsets.UTF_8);
         }
 
         @Override
-        public String deserialize(com.google.protobuf.ByteString bytes) {
-            return bytes.toStringUtf8();
+        public String deserialize(byte[] bytes) {
+            return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
         }
 
         @Override

--- a/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/balancing/grpc/GrpcBalanceExchangeTest.java
+++ b/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/balancing/grpc/GrpcBalanceExchangeTest.java
@@ -61,13 +61,13 @@ class GrpcBalanceExchangeTest {
         client = new MockBalanceCoordinatorClient();
         contentSerializer = new ContentSerializer<>() {
             @Override
-            public ByteString serialize(String content) {
-                return ByteString.copyFrom(content, StandardCharsets.UTF_8);
+            public byte[] serialize(String content) {
+                return content.getBytes(StandardCharsets.UTF_8);
             }
 
             @Override
-            public String deserialize(ByteString bytes) {
-                return bytes.toString(StandardCharsets.UTF_8);
+            public String deserialize(byte[] bytes) {
+                return new String(bytes, StandardCharsets.UTF_8);
             }
 
             @Override
@@ -285,7 +285,7 @@ class GrpcBalanceExchangeTest {
         return GhostElement.newBuilder()
             .setSpatialKey(ProtobufConverters.spatialKeyToProtobuf(key))
             .setEntityId(ProtobufConverters.entityIdToString(new LongEntityID(entityId)))
-            .setContent(contentSerializer.serialize(content))
+            .setContent(ByteString.copyFrom(contentSerializer.serialize(content)))
             .setPosition(ProtobufConverters.point3fToProtobuf(new Point3f(1, 2, 3)))
             .setOwnerRank(ownerRank)
             .setGlobalTreeId(0L)

--- a/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/distributed/CredentialPlumbingTest.java
+++ b/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/distributed/CredentialPlumbingTest.java
@@ -16,7 +16,6 @@
  */
 package com.hellblazer.luciferase.lucien.distributed;
 
-import com.google.protobuf.ByteString;
 import com.hellblazer.luciferase.common.grpc.GrpcCredentialFactory;
 import com.hellblazer.luciferase.common.grpc.PeerAuthInterceptor;
 import com.hellblazer.luciferase.lucien.balancing.grpc.BalanceCoordinatorClient;
@@ -50,13 +49,13 @@ class CredentialPlumbingTest {
 
     private static final ContentSerializer<String> SERIALIZER = new ContentSerializer<>() {
         @Override
-        public ByteString serialize(String content) {
-            return ByteString.copyFrom(content, StandardCharsets.UTF_8);
+        public byte[] serialize(String content) {
+            return content.getBytes(StandardCharsets.UTF_8);
         }
 
         @Override
-        public String deserialize(ByteString bytes) {
-            return bytes.toString(StandardCharsets.UTF_8);
+        public String deserialize(byte[] bytes) {
+            return new String(bytes, StandardCharsets.UTF_8);
         }
 
         @Override

--- a/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostElementRoundTripTest.java
+++ b/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostElementRoundTripTest.java
@@ -16,7 +16,6 @@
  */
 package com.hellblazer.luciferase.lucien.forest.ghost.grpc;
 
-import com.google.protobuf.ByteString;
 import com.hellblazer.luciferase.lucien.SpatialKey;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.entity.LongEntityID;
@@ -54,13 +53,13 @@ class GhostElementRoundTripTest {
 
     private static final ContentSerializer<String> SERIALIZER = new ContentSerializer<>() {
         @Override
-        public ByteString serialize(String content) {
-            return ByteString.copyFrom(content, StandardCharsets.UTF_8);
+        public byte[] serialize(String content) {
+            return content.getBytes(StandardCharsets.UTF_8);
         }
 
         @Override
-        public String deserialize(ByteString bytes) {
-            return bytes.toString(StandardCharsets.UTF_8);
+        public String deserialize(byte[] bytes) {
+            return new String(bytes, StandardCharsets.UTF_8);
         }
 
         @Override
@@ -130,12 +129,12 @@ class GhostElementRoundTripTest {
             new GhostElement<>(new MortonKey(0x1L, (byte) 1), new LongEntityID(1L), "x", POSITION, 0, 0L), SERIALIZER);
         ContentSerializer<String> failing = new ContentSerializer<>() {
             @Override
-            public ByteString serialize(String content) {
-                return ByteString.EMPTY;
+            public byte[] serialize(String content) {
+                return new byte[0];
             }
 
             @Override
-            public String deserialize(ByteString bytes) throws SerializationException {
+            public String deserialize(byte[] bytes) throws SerializationException {
                 throw new SerializationException("simulated content corruption");
             }
 

--- a/lucien/pom.xml
+++ b/lucien/pom.xml
@@ -33,10 +33,6 @@
             <artifactId>common</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/ContentSerializer.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/ContentSerializer.java
@@ -1,63 +1,68 @@
 /*
  * Copyright (c) 2025 Hal Hildebrand. All rights reserved.
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package com.hellblazer.luciferase.lucien.forest.ghost;
 
-import com.google.protobuf.ByteString;
+import java.nio.charset.StandardCharsets;
 
 /**
- * Interface for serializing and deserializing content objects to/from Protocol Buffers.
- * 
+ * Interface for serializing and deserializing content objects to/from raw bytes.
+ *
  * This allows the ghost system to handle arbitrary content types by delegating
  * serialization to type-specific implementations. Implementations should handle
  * null content appropriately.
- * 
+ *
+ * <p>The byte-array contract (rather than a transport-specific container such as protobuf's
+ * {@code ByteString}) keeps lucien core free of any transport/serialization-framework dependency;
+ * the gRPC transport in {@code lucien-distributed} bridges {@code byte[]} to its wire types at the
+ * proto boundary. This matches the {@code byte[]} convention already used by {@code SpatialKeySerde}.
+ *
  * @param <Content> the type of content to serialize/deserialize
- * 
+ *
  * @author Hal Hildebrand
  */
 public interface ContentSerializer<Content> {
-    
+
     /**
-     * Serializes content to bytes for Protocol Buffer transport.
-     * 
+     * Serializes content to bytes for transport.
+     *
      * @param content the content to serialize (may be null)
-     * @return serialized bytes, or empty ByteString for null content
+     * @return serialized bytes, or an empty array for null content
      * @throws SerializationException if serialization fails
      */
-    ByteString serialize(Content content) throws SerializationException;
-    
+    byte[] serialize(Content content) throws SerializationException;
+
     /**
      * Deserializes content from bytes.
-     * 
-     * @param bytes the serialized bytes
+     *
+     * @param bytes the serialized bytes (never null; empty array for absent content)
      * @return the deserialized content, or null if bytes are empty
      * @throws SerializationException if deserialization fails
      */
-    Content deserialize(ByteString bytes) throws SerializationException;
-    
+    Content deserialize(byte[] bytes) throws SerializationException;
+
     /**
      * Gets the content type identifier for this serializer.
      * Used for type checking and registry lookup.
-     * 
+     *
      * @return a unique identifier for the content type
      */
     String getContentType();
-    
+
     /**
      * Exception thrown when serialization or deserialization fails.
      */
@@ -65,46 +70,46 @@ public interface ContentSerializer<Content> {
         public SerializationException(String message) {
             super(message);
         }
-        
+
         public SerializationException(String message, Throwable cause) {
             super(message, cause);
         }
     }
-    
+
     /**
      * No-op serializer for null or void content types.
      */
     ContentSerializer<Void> NULL_SERIALIZER = new ContentSerializer<>() {
         @Override
-        public ByteString serialize(Void content) {
-            return ByteString.EMPTY;
+        public byte[] serialize(Void content) {
+            return new byte[0];
         }
-        
+
         @Override
-        public Void deserialize(ByteString bytes) {
+        public Void deserialize(byte[] bytes) {
             return null;
         }
-        
+
         @Override
         public String getContentType() {
             return "void";
         }
     };
-    
+
     /**
      * String content serializer for simple text content.
      */
     ContentSerializer<String> STRING_SERIALIZER = new ContentSerializer<>() {
         @Override
-        public ByteString serialize(String content) {
-            return content != null ? ByteString.copyFromUtf8(content) : ByteString.EMPTY;
+        public byte[] serialize(String content) {
+            return content != null ? content.getBytes(StandardCharsets.UTF_8) : new byte[0];
         }
-        
+
         @Override
-        public String deserialize(ByteString bytes) {
-            return bytes.isEmpty() ? null : bytes.toStringUtf8();
+        public String deserialize(byte[] bytes) {
+            return (bytes == null || bytes.length == 0) ? null : new String(bytes, StandardCharsets.UTF_8);
         }
-        
+
         @Override
         public String getContentType() {
             return "string";


### PR DESCRIPTION
## Summary

Closes `Luciferase-uxx`. `ContentSerializer` was the **only** lucien-core file using `com.google.protobuf` (`ByteString` in its public `serialize`/`deserialize` API), which forced a direct `protobuf-java` dependency even after RDR-007 extracted the gRPC transport. Switch the API to `byte[]` (matching `SpatialKeySerde`'s existing convention), bridge `byte[]`↔`ByteString` at the lucien-distributed proto boundary, and drop `protobuf-java` from lucien.

- **`ContentSerializer`**: `serialize(Content)→byte[]`, `deserialize(byte[])→Content`; `NULL_SERIALIZER`/`STRING_SERIALIZER` preserve the null↔empty semantics; no `com.google.protobuf` import.
- **`AbstractSpatialIndex` ctor UNCHANGED** — its param type `ContentSerializer<Content>` is unchanged (the bead overstated this).
- **`ProtobufConverters`**: `ByteString.copyFrom(serialize(...))` on the way out, `deserialize(getContent().toByteArray())` on the way in.
- 4 test serializer impls migrated to `byte[]`.
- **`lucien/pom.xml`**: removed `protobuf-java`.

## Verification

- [x] `mvn dependency:tree -pl lucien` → **no protobuf** (verified; lucien is now transport/proto-free)
- [x] `GhostElementRoundTripTest` + `GrpcBalanceExchangeTest` round-trips green (content fidelity preserved)
- [x] full `lucien-distributed` suite 46/46
- [ ] CI green

Mechanical, no behavior change (same bytes, different container type) — review-light per the approved design. `io.grpc:grpc-api` transitive-via-`common` is a separate concern, out of scope.