### PR TITLE
RDR-009 P1: Triangle Bey orientation + derived n single-source-of-truth (Luciferase-al5)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/PrismGeometry.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/PrismGeometry.java
@@ -127,28 +127,15 @@ public final class PrismGeometry {
      * @return list of 3 vertices in 2D (x,y) coordinates
      */
     private static List<float[]> getTriangleVertices(Triangle triangle) {
+        // Single source of truth: use the triangle's own t8code/Bey-oriented vertices rather than
+        // recomputing a fixed lower-left shape. The prior hardcoded shape ignored the triangle's
+        // type, so the prism mesh disagreed with Triangle.getVertices() for type-1 (and, after the
+        // RDR-009 P1 main-diagonal reorientation, for type-0 too). Delegating keeps the mesh used
+        // by ray intersection / collision / nearest-neighbor consistent with the triangle geometry.
         var vertices = new ArrayList<float[]>(3);
-        
-        var bounds = triangle.getWorldBounds();
-        float minX = bounds[0];
-        float minY = bounds[1];
-        float maxX = bounds[2];
-        float maxY = bounds[3];
-        
-        // Create proper triangular vertices for triangular prism
-        // Standard right triangle in first quadrant with vertices at:
-        // (minX, minY), (maxX, minY), (minX, maxY)
-        // This ensures we stay within triangular constraint x + y <= 1.0
-        
-        // Bottom-left vertex (origin of triangle)
-        vertices.add(new float[] {minX, minY});
-        
-        // Bottom-right vertex 
-        vertices.add(new float[] {maxX, minY});
-        
-        // Top-left vertex (forms right triangle)
-        vertices.add(new float[] {minX, maxY});
-        
+        for (var v : triangle.getVertices()) {
+            vertices.add(new float[] { v[0], v[1] });
+        }
         return vertices;
     }
     

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/Triangle.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/Triangle.java
@@ -25,13 +25,37 @@ import java.util.Objects;
  * of prism spatial keys. The space-filling curve is complex, adapted from t8code's triangular SFC
  * algorithm that preserves spatial locality through recursive subdivision.
  * 
- * Triangles use a type system (0 or 1) to handle orientation during subdivision, similar to
- * t8code's dtri implementation. Each triangle subdivides into 4 child triangles with appropriate
- * type transitions to maintain geometric consistency.
- * 
- * The coordinate system uses (x, y, n) coordinates where n is an auxiliary coordinate for
- * the triangular space-filling curve computation.
- * 
+ * Triangles use a type system (0 or 1) encoding the t8code/Bey <em>orientation</em>:
+ * {@code Type(T) = i ⟺ T ≃ Sᵢ}. Geometrically each grid cell is split along its
+ * <em>main</em> diagonal (anchor → opposite corner): a type-0 triangle is the lower-right
+ * Kuhn simplex {@code {anchor, anchor+x̂, anchor+x̂+ŷ}} (≃ the reference root S0, the region
+ * {@code y ≤ x}), and a type-1 triangle is the upper-left simplex
+ * {@code {anchor, anchor+ŷ, anchor+x̂+ŷ}} (≃ S1). Refining a triangle of type {@code b} yields
+ * children whose types form the Bey multiset {@code [b, b, b, 1-b]}: three corner-children keep
+ * the orientation, one flips. See {@link #getVertices()}, {@link #computeChildType(int)} and
+ * {@link #computeParentType()}.
+ *
+ * <p><b>Refinement is square-quadrant, not yet true Bey nesting.</b> {@link #child(int)} subdivides
+ * by Morton grid-quadrant ({@code childX = 2x + bit}), and the type transition is a
+ * <em>placeholder</em> that reproduces the Bey multiset shape and round-trips, but the
+ * geometrically-faithful Bey interior-child (which flips orientation) is type-dependent and is
+ * <em>not</em> the fixed cube-id-3 used here. True triangle-into-four Bey nesting is inseparable
+ * from the tetrahedral Morton index and is deferred to RDR-009 Phase 2/Phase 7 along with the
+ * SFC packing.
+ *
+ * <p>The coordinate system uses {@code (x, y, n)} coordinates. The auxiliary coordinate
+ * {@code n} is <b>derived</b> as {@code min(x, y)}: every triangle produced by the world-coordinate
+ * constructors or by {@link #child(int)}/{@link #parent()} satisfies the invariant
+ * {@code n == min(x, y)}, so it is conceptually a cache of {@code min(x, y)} in the
+ * construction/navigation API. It carries no term in the true tetrahedral Morton index. However,
+ * the <em>current</em> {@link #consecutiveIndex()} packing is not the TM-index — it is the
+ * literature-rejected positional ("semiquadcode") form that still treats {@code n} as an
+ * independent coordinate dimension. That is why the field cannot be eliminated yet and the raw
+ * 5-arg constructor preserves {@code n} verbatim as a low-level escape hatch (e.g. exhaustive
+ * collision-freeness sweeps over arbitrary {@code n}). Dropping {@code n} from the key is deferred
+ * to RDR-009 Phase 2/Phase 7, which replaces the packing with the real TM-index; until then
+ * {@link #consecutiveIndex()} and {@code PrismKey.compareTo} are left unchanged.
+ *
  * @author hal.hildebrand
  */
 public final class Triangle {
@@ -55,7 +79,7 @@ public final class Triangle {
     private final byte type;           // Triangle type (0 or 1)
     private final int x;               // X coordinate
     private final int y;               // Y coordinate  
-    private final int n;               // Auxiliary coordinate for SFC
+    private final int n;               // Derived auxiliary coordinate, cached as min(x, y) (see class javadoc)
     
     /**
      * Create a Triangle from world coordinates at a specific level.
@@ -67,45 +91,12 @@ public final class Triangle {
      * @throws IllegalArgumentException if coordinates are invalid
      */
     public static Triangle fromWorldCoordinate(float worldX, float worldY, int level) {
-        if (worldX < 0 || worldX >= 1.0f || worldY < 0 || worldY >= 1.0f) {
-            throw new IllegalArgumentException(
-                String.format("World coordinates must be in [0,1), got: (%.3f, %.3f)", worldX, worldY));
-        }
-        if (level < 0 || level > MAX_LEVEL) {
-            throw new IllegalArgumentException("Level must be 0-" + MAX_LEVEL + ", got: " + level);
-        }
-        
-        // For level 0, return root triangle
-        if (level == 0) {
-            return new Triangle(0, 0, 0, 0, 0);
-        }
-        
-        // Quantize to grid
-        int scale = 1 << level;
-        int x = (int)(worldX * scale);
-        int y = (int)(worldY * scale);
-        
-        // Clamp to valid range
-        x = Math.min(x, scale - 1);
-        y = Math.min(y, scale - 1);
-        
-        // Ensure x + y < scale (triangular constraint)
-        if (x + y >= scale) {
-            // Point is outside triangular region, clamp to nearest valid point
-            // This maintains x + y = scale - 1
-            int total = scale - 1;
-            x = x * total / (x + y);
-            y = total - x;
-        }
-        
-        // Calculate n coordinate - ensure it's within bounds
-        int n = Math.min(scale - x - y, scale - 1);
-        
-        // Determine type based on parity of coordinates
-        // This is a simplified approach - in practice you might need more sophisticated type determination
-        int type = ((x + y) % 2 == 0) ? 0 : 1;
-        
-        return new Triangle(level, type, x, y, n);
+        // Single source of truth: delegate to fromWorldCoordinates. The prior body assigned a
+        // non-Bey type from coordinate parity ((x+y)%2), derived n from min(scale-x-y, scale-1)
+        // (inconsistent with the min(x,y) source of truth), and silently relocated x+y >= scale
+        // points onto the diagonal — a latent data-relocation hazard. All three are removed
+        // (RDR-009 Phase 1); both construction paths now agree.
+        return fromWorldCoordinates(worldX, worldY, level);
     }
     
     /**
@@ -172,27 +163,33 @@ public final class Triangle {
         if (worldY < 0.0f || worldY >= 1.0f) {
             throw new IllegalArgumentException("World Y coordinate must be [0.0, 1.0), got: " + worldY);
         }
-        
+        if (level < 0 || level > MAX_LEVEL) {
+            throw new IllegalArgumentException("Level must be 0-" + MAX_LEVEL + ", got: " + level);
+        }
+
         // For level 0, return root triangle
         if (level == 0) {
             return new Triangle(0, 0, 0, 0, 0);
         }
-        
+
         var scale = 1 << level;
         var quantX = Math.min((int) (worldX * scale), scale - 1);
         var quantY = Math.min((int) (worldY * scale), scale - 1);
-        
-        // Determine which triangle in the square contains the point
-        // Convert to local coordinates within the square [0,1) x [0,1)
+
+        // Determine which sub-triangle of the grid cell contains the point.
+        // Local coordinates within the cell [0,1) x [0,1):
         float localX = (worldX * scale) - quantX;
         float localY = (worldY * scale) - quantY;
-        
-        // Determine triangle type based on which side of the diagonal the point is on
-        // Type 0: bottom-left triangle (localX + localY <= 1.0)
-        // Type 1: top-right triangle (localX + localY > 1.0)
-        var type = (localX + localY > 1.0f) ? 1 : 0;
+
+        // t8code/Bey orientation: the cell is split along its MAIN diagonal (anchor → opposite
+        // corner). The lower-right half (localY <= localX) is the type-0 (≃ S0) triangle; the
+        // upper-left half (localY > localX) is the type-1 (≃ S1) triangle. This matches
+        // getVertices() so that the located triangle always contains its own point.
+        var type = (localY > localX) ? 1 : 0;
+
+        // n is the derived auxiliary coordinate min(x, y) — the single source of truth.
         var n = Math.min(quantX, quantY);
-        
+
         return new Triangle(level, type, quantX, quantY, n);
     }
     
@@ -233,26 +230,29 @@ public final class Triangle {
             return null;
         }
         
-        // Simplified parent computation - the full t8code algorithm handles type transitions
         var parentX = x >>> 1;
         var parentY = y >>> 1;
-        var parentN = n >>> 1;
+        // n is derived: recompute from the parent's coordinates rather than un-shifting the
+        // child's n, so the single source of truth (n = min(x, y)) is preserved at every level.
+        var parentN = Math.min(parentX, parentY);
         var parentType = computeParentType();
-        
+
         return new Triangle(level - 1, parentType, parentX, parentY, parentN);
     }
-    
+
     /**
-     * Compute the parent type based on current triangle state.
-     * This is a simplified version of t8code's type transition algorithm.
+     * Compute the parent's type from this triangle's type and cube-id — the exact inverse of
+     * {@link #computeChildType(int)}. The cube-id-3 child flips orientation relative to its
+     * parent while cube-ids 0–2 preserve it, so the parent's type is recovered by flipping back
+     * exactly when this triangle is the cube-id-3 child. (Placeholder convention — see
+     * {@link #computeChildType(int)}.)
      */
     private int computeParentType() {
-        // For simplified implementation, derive parent type from child index
         var childIndex = getChildIndex();
-        if (childIndex == -1) return type; // Already at root
-        
-        // Reverse the child type computation to get parent type
-        return (type - (childIndex % 2) + TYPES) % TYPES;
+        if (childIndex == -1) {
+            return type; // already at root
+        }
+        return (childIndex == 3) ? (1 - type) : type;
     }
     
     /**
@@ -270,22 +270,32 @@ public final class Triangle {
             throw new IllegalArgumentException("Cannot get child of triangle at maximum level " + MAX_LEVEL);
         }
         
-        // Simplified child computation - full t8code algorithm more complex
         var childX = (x << 1) + (childIndex & 1);
         var childY = (y << 1) + ((childIndex >> 1) & 1);
-        var childN = n << 1; // Simplified
+        // n is derived: compute from the child's coordinates so the single source of truth
+        // (n = min(x, y)) holds at every refinement level.
+        var childN = Math.min(childX, childY);
         var childType = computeChildType(childIndex);
-        
+
         return new Triangle(level + 1, childType, childX, childY, childN);
     }
-    
+
     /**
-     * Compute child type based on parent type and child index.
-     * This is a simplified version of t8code's type transition algorithm.
+     * Compute a child's type from this (parent) triangle's type and the child's cube-id. A parent
+     * of type {@code b} produces children with the Bey multiset {@code [b, b, b, 1-b]}: three
+     * children inherit the parent's orientation and one flips. This replaces the prior non-Bey
+     * alternating rule {@code (type + i%2)%2}, which produced the wrong multiset
+     * {@code [b, b, 1-b, 1-b]}.
+     *
+     * <p><b>Placeholder, not the geometric Bey transition.</b> The flip is assigned to the fixed
+     * cube-id-3 child because that is the only assignment that round-trips under the type-independent
+     * {@link #getChildIndex()} (it is a bijection {@code b ↦ childType} at every cube-id). The
+     * geometrically-correct Bey interior-child is type-dependent (cube-id 2 for type 0, cube-id 1
+     * for type 1) and does <em>not</em> round-trip under square-quadrant refinement; reconciling
+     * that requires true Bey triangle nesting, deferred to RDR-009 Phase 2 with the TM-index.
      */
     private int computeChildType(int childIndex) {
-        // Simplified type transitions - alternate based on parent type and child position
-        return (type + (childIndex % 2)) % TYPES;
+        return (childIndex == 3) ? (1 - type) : type;
     }
     
     /**
@@ -314,7 +324,12 @@ public final class Triangle {
             return false;
         }
         
-        // Special case for level 0 root triangle - covers entire [0,1) x [0,1) square
+        // Level-0 root covers the entire [0,1)² square. This is intentionally retained as a
+        // half-cube placeholder: with the main-diagonal geometry established here (P1), a strict
+        // type-0 root would only contain the lower-right half {y ≤ x}, leaving upper-left points
+        // unreachable until the S1 root is added. Removing this special case is therefore coupled
+        // to the two-prism cover — RDR-009 Phase 3 (Luciferase-7iu) "remove/specialize per root".
+        // TODO(RDR-009 P3): replace with type-based triangular containment once the S1 root exists.
         if (level == 0) {
             return true; // Already passed the [0,1) range check above
         }
@@ -373,22 +388,23 @@ public final class Triangle {
     public Triangle[] neighbors() {
         var neighbors = new Triangle[EDGES];
         
-        // Simplified neighbor finding - full t8code algorithm is more complex
+        // Simplified same-type neighbor finding (the cross-diagonal S0↔S1 crossing logic is
+        // RDR-009 Phase 4); n is recomputed as min(x,y) for each neighbor's coordinates.
         // Edge 0: right neighbor
         if (x + 1 < (1 << level)) {
-            neighbors[0] = new Triangle(level, type, x + 1, y, n);
+            neighbors[0] = new Triangle(level, type, x + 1, y, Math.min(x + 1, y));
         }
-        
-        // Edge 1: top neighbor  
+
+        // Edge 1: top neighbor
         if (y + 1 < (1 << level)) {
-            neighbors[1] = new Triangle(level, type, x, y + 1, n);
+            neighbors[1] = new Triangle(level, type, x, y + 1, Math.min(x, y + 1));
         }
-        
+
         // Edge 2: diagonal neighbor (simplified)
         if (x > 0 && y > 0) {
-            neighbors[2] = new Triangle(level, type, x - 1, y - 1, n);
+            neighbors[2] = new Triangle(level, type, x - 1, y - 1, Math.min(x - 1, y - 1));
         }
-        
+
         return neighbors;
     }
     
@@ -404,21 +420,22 @@ public final class Triangle {
             throw new IllegalArgumentException("Edge index must be 0-2, got: " + edge);
         }
         
-        // Simplified neighbor finding - full t8code algorithm is more complex
+        // Simplified same-type neighbor finding (cross-diagonal crossing is RDR-009 Phase 4);
+        // n is recomputed as min(x,y) for the neighbor's coordinates.
         switch (edge) {
             case 0: // right neighbor
                 if (x + 1 < (1 << level)) {
-                    return new Triangle(level, type, x + 1, y, n);
+                    return new Triangle(level, type, x + 1, y, Math.min(x + 1, y));
                 }
                 break;
             case 1: // top neighbor
                 if (y + 1 < (1 << level)) {
-                    return new Triangle(level, type, x, y + 1, n);
+                    return new Triangle(level, type, x, y + 1, Math.min(x, y + 1));
                 }
                 break;
             case 2: // diagonal neighbor (simplified)
                 if (x > 0 && y > 0) {
-                    return new Triangle(level, type, x - 1, y - 1, n);
+                    return new Triangle(level, type, x - 1, y - 1, Math.min(x - 1, y - 1));
                 }
                 break;
         }
@@ -506,18 +523,20 @@ public final class Triangle {
         float maxX = bounds[2];
         float maxY = bounds[3];
         
-        // For simplicity, return triangle vertices based on type
+        // t8code/Bey orientation: split the cell along its MAIN diagonal (minX,minY)→(maxX,maxY).
         if (type == 0) {
+            // Lower-right Kuhn simplex {anchor, anchor+x̂, anchor+x̂+ŷ} (the S0 orientation, y ≤ x).
             return new float[][]{
                 {minX, minY},
                 {maxX, minY},
-                {minX, maxY}
+                {maxX, maxY}
             };
         } else {
+            // Upper-left Kuhn simplex {anchor, anchor+ŷ, anchor+x̂+ŷ} (the S1 orientation, x ≤ y).
             return new float[][]{
-                {maxX, minY},
-                {maxX, maxY},
-                {minX, maxY}
+                {minX, minY},
+                {minX, maxY},
+                {maxX, maxY}
             };
         }
     }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismKeyTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismKeyTest.java
@@ -209,8 +209,10 @@ class PrismKeyTest {
         assertNull(root.parent());
         assertEquals(-1, root.getChildIndex());
         
-        // Test parent-child round trips
-        var key = new PrismKey(new Triangle(3, 1, 5, 3, 2), new Line(3, 6));
+        // Test parent-child round trips. n = min(x,y) = min(5,3) = 3 (RDR-009 P1: n is the
+        // derived auxiliary coordinate min(x,y); the parent()/child() round-trip recomputes it
+        // from coordinates rather than bit-shifting, so the fixture uses the consistent value).
+        var key = new PrismKey(new Triangle(3, 1, 5, 3, 3), new Line(3, 6));
         
         for (int childIndex = 0; childIndex < PrismKey.CHILDREN; childIndex++) {
             var child = key.child(childIndex);

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismTest.java
@@ -350,8 +350,10 @@ class PrismTest {
     @Test
     @DisplayName("Subdivision creates correct prism children")
     void testPrismSubdivision() {
-        // Create a prism key at level 2
-        var triangle = new Triangle(2, 0, 1, 1, 2);
+        // Create a prism key at level 2. n = min(x,y) = min(1,1) = 1 (RDR-009 P1: n is the
+        // derived auxiliary coordinate min(x,y); parent()/child() recompute it from coordinates,
+        // so a fixture must use the consistent value to round-trip to itself).
+        var triangle = new Triangle(2, 0, 1, 1, 1);
         var line = new Line(2, 1);
         var parentKey = new PrismKey(triangle, line);
         

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleBeyTypeTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleBeyTypeTest.java
@@ -234,8 +234,81 @@ class TriangleBeyTypeTest {
                 Point3f bottom = prismVerts.get(i);
                 assertEquals(triVerts[i][0], bottom.x, EPS, "prism bottom vertex " + i + " x, type " + type);
                 assertEquals(triVerts[i][1], bottom.y, EPS, "prism bottom vertex " + i + " y, type " + type);
+                // Top triangle (indices 3-5) shares the same (x,y), only z differs.
+                Point3f top = prismVerts.get(i + 3);
+                assertEquals(triVerts[i][0], top.x, EPS, "prism top vertex " + i + " x, type " + type);
+                assertEquals(triVerts[i][1], top.y, EPS, "prism top vertex " + i + " y, type " + type);
             }
         }
+    }
+
+    // ── n=min(x,y) invariant under neighbor finding ───────────────────────────────────
+
+    @Test
+    @DisplayName("neighbors()/neighbor() preserve the n = min(x,y) invariant for both types")
+    void neighborNInvariant() {
+        // Guards the RDR-009 P1 change that recomputes n from each neighbor's coordinates
+        // (was: copied the source triangle's n). A P2 regression in neighbor n-derivation would
+        // otherwise have no trip-wire — neighbor traversal is correctness-critical for the TM-index.
+        for (int type = 0; type < Triangle.TYPES; type++) {
+            var t = new Triangle(3, type, 3, 2, Math.min(3, 2));
+            for (var nb : t.neighbors()) {
+                if (nb != null) {
+                    assertEquals(Math.min(nb.getX(), nb.getY()), nb.getN(),
+                        "neighbors()[*] must satisfy n = min(x,y), type " + type);
+                }
+            }
+            for (int e = 0; e < Triangle.EDGES; e++) {
+                var nb = t.neighbor(e);
+                if (nb != null) {
+                    assertEquals(Math.min(nb.getX(), nb.getY()), nb.getN(),
+                        "neighbor(" + e + ") must satisfy n = min(x,y), type " + type);
+                }
+            }
+        }
+    }
+
+    // ── point-location boundary + clamp-removal conventions (RDR-009 P1) ───────────────
+
+    @Test
+    @DisplayName("a point exactly on a cell's main diagonal (localX==localY) classifies as type 0 and is contained")
+    void diagonalBoundaryIsTypeZero() {
+        // localX == localY → the (localY > localX) rule yields type 0; getVertices()'s inclusive
+        // barycentric test must contain the on-diagonal point. Pins the documented boundary convention.
+        int level = 2;                 // scale = 4
+        float w = 1.5f / 4.0f;         // cell (1,1), localX = localY = 0.5 exactly
+        var tri = Triangle.fromWorldCoordinates(w, w, level);
+        assertEquals(1, tri.getX());
+        assertEquals(1, tri.getY());
+        assertEquals(0, tri.getType(), "on-diagonal point must classify as type 0");
+        assertTrue(tri.contains(w, w), "type-0 triangle must contain its on-diagonal boundary point");
+    }
+
+    @Test
+    @DisplayName("x+y>=scale points are NOT relocated (the silent diagonal clamp was removed)")
+    void nearBoundaryPointsAreNotClamped() {
+        // Old fromWorldCoordinate relocated x+y>=scale onto the diagonal: (0.9,0.9,2) → quant (3,3)
+        // with x+y=6 >= scale=4 was clamped to (1,2). The clamp is gone; the point keeps its true cell.
+        var tri = Triangle.fromWorldCoordinates(0.9f, 0.9f, 2);
+        assertEquals(3, tri.getX(), "x must not be relocated off its quantized cell");
+        assertEquals(3, tri.getY(), "y must not be relocated off its quantized cell");
+        assertEquals(Math.min(3, 3), tri.getN());
+        assertTrue(tri.contains(0.9f, 0.9f), "the located triangle must still contain its own point");
+        // fromWorldCoordinate (delegating) must agree — no residual clamp on that path either.
+        var viaSingular = Triangle.fromWorldCoordinate(0.9f, 0.9f, 2);
+        assertEquals(tri, viaSingular);
+    }
+
+    @Test
+    @DisplayName("level-0 root contains the full [0,1)^2 square (P3-deferred placeholder trip-wire)")
+    void levelZeroRootContainsFullSquare() {
+        // Machine-enforces the TODO(RDR-009 P3) placeholder: until the S1 root exists, the level-0
+        // root must keep covering the whole square (both the lower-right S0 half and the upper-left
+        // half). If this is "fixed" to strict type-0 containment before P3, this test trips.
+        var root = new Triangle(0, 0, 0, 0, 0);
+        assertTrue(root.contains(0.8f, 0.2f), "root must contain lower-right (y < x) points");
+        assertTrue(root.contains(0.2f, 0.8f), "root must contain upper-left (y > x) points");
+        assertTrue(root.contains(0.5f, 0.5f), "root must contain on-diagonal points");
     }
 
     // ── helpers ─────────────────────────────────────────────────────────────────────

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleBeyTypeTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleBeyTypeTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.prism;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3f;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RDR-009 Phase 1 (Luciferase-al5): pins the reconciliation of {@link Triangle#getType()}
+ * to the t8code/Bey orientation definition and the {@code n} auxiliary-coordinate
+ * single-source-of-truth ({@code n = min(x, y)}) with a consistent parent/child round-trip.
+ *
+ * <p><b>Geometry (t8 main-diagonal split).</b> A type-0 triangle is the lower-right
+ * Kuhn simplex of its grid cell — vertices {@code (anchor, anchor+x̂, anchor+x̂+ŷ)} —
+ * and a type-1 triangle is the upper-left simplex — {@code (anchor, anchor+ŷ, anchor+x̂+ŷ)}.
+ * The two halves are split along the cell's <i>main</i> diagonal (anchor → opposite
+ * corner), matching t8code's reference where the root S0 is the lower-right triangle
+ * {@code {0 ≤ y ≤ x}} of the square. (The prior implementation split each cell along the
+ * <i>anti</i>-diagonal, which is not the Bey orientation.)
+ *
+ * <p><b>Bey classification.</b> {@code Type(T) = i ⟺ T ≃ Sᵢ}. Refining a triangle of type
+ * {@code b} yields children whose types form the multiset {@code [b, b, b, 1-b]} (Burstedde &
+ * Holke, TM-SFC paper, Table 1 / Fig 7): three corner-children keep the parent's orientation
+ * and one flips. The prior {@code (type + i%2)%2} produced the non-Bey alternating multiset
+ * {@code [b, b, 1-b, 1-b]}.
+ *
+ * <p><b>{@code n} fate.</b> {@code n} is derivable as {@code min(x, y)} and carries no term in
+ * the TM-index, so it is retained this phase only as a derived <i>cache</i> (its elimination is
+ * deferred to the TM-index adoption in RDR-009 P2/P7, which drops it from the key). Every
+ * triangle produced by the world-coordinate constructors or by {@code child()}/{@code parent()}
+ * must satisfy {@code n == min(x, y)}, and {@code child(i).parent()} must reproduce the parent's
+ * {@code n} for every child index.
+ *
+ * @author hal.hildebrand
+ */
+class TriangleBeyTypeTest {
+
+    private static final float EPS = 1e-5f;
+
+    // ── Geometry: type → t8 main-diagonal orientation ────────────────────────────────
+
+    @Test
+    @DisplayName("type-0 vertices are the lower-right Kuhn simplex (main-diagonal split)")
+    void typeZeroIsLowerRight() {
+        // Level-1 cell at anchor (0,0): world cell [0,0.5]×[0,0.5].
+        var t0 = new Triangle(1, 0, 0, 0, 0);
+        assertVertices(t0.getVertices(), new float[][] { { 0f, 0f }, { 0.5f, 0f }, { 0.5f, 0.5f } });
+    }
+
+    @Test
+    @DisplayName("type-1 vertices are the upper-left Kuhn simplex (main-diagonal split)")
+    void typeOneIsUpperLeft() {
+        var t1 = new Triangle(1, 1, 0, 0, 0);
+        assertVertices(t1.getVertices(), new float[][] { { 0f, 0f }, { 0f, 0.5f }, { 0.5f, 0.5f } });
+    }
+
+    // ── Point location matches orientation, and is consistent with contains() ─────────
+
+    @Test
+    @DisplayName("point location assigns the main-diagonal half-cell type and contains the point")
+    void pointLocationMatchesOrientationAndContains() {
+        for (int level = 1; level <= 6; level++) {
+            int scale = 1 << level;
+            // Sweep a grid of interior sample points, skipping any that land on a cell's
+            // main diagonal (localX == localY), where the type is boundary-ambiguous.
+            for (int i = 1; i < 8; i++) {
+                for (int j = 1; j < 8; j++) {
+                    float wx = i / 8.0f * 0.999f;
+                    float wy = j / 8.0f * 0.999f;
+                    int qx = Math.min((int) (wx * scale), scale - 1);
+                    int qy = Math.min((int) (wy * scale), scale - 1);
+                    float localX = wx * scale - qx;
+                    float localY = wy * scale - qy;
+                    if (Math.abs(localX - localY) < 1e-3f) {
+                        continue; // on/near the diagonal — skip ambiguous boundary
+                    }
+                    int expectedType = (localY > localX) ? 1 : 0;
+                    var tri = Triangle.fromWorldCoordinates(wx, wy, level);
+                    assertEquals(expectedType, tri.getType(), String.format(
+                        "type mismatch at level=%d (%.4f,%.4f) localX=%.3f localY=%.3f", level, wx, wy, localX,
+                        localY));
+                    assertTrue(tri.contains(wx, wy), String.format(
+                        "located triangle must contain its own point at level=%d (%.4f,%.4f)", level, wx, wy));
+                }
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("fromWorldCoordinate and fromWorldCoordinates agree on type, n, x, y")
+    void bothConstructionPathsAgree() {
+        for (int level = 1; level <= 8; level++) {
+            for (int i = 1; i < 10; i++) {
+                for (int j = 1; j < 10; j++) {
+                    float wx = i / 10.0f * 0.999f;
+                    float wy = j / 10.0f * 0.999f;
+                    var a = Triangle.fromWorldCoordinate(wx, wy, level);
+                    var b = Triangle.fromWorldCoordinates(wx, wy, level);
+                    assertEquals(b.getType(), a.getType(), "type disagreement at " + wx + "," + wy + " L" + level);
+                    assertEquals(b.getN(), a.getN(), "n disagreement at " + wx + "," + wy + " L" + level);
+                    assertEquals(b.getX(), a.getX(), "x disagreement at " + wx + "," + wy + " L" + level);
+                    assertEquals(b.getY(), a.getY(), "y disagreement at " + wx + "," + wy + " L" + level);
+                }
+            }
+        }
+    }
+
+    // ── Bey child-type classification ─────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("refining type b yields the Bey multiset [b,b,b,1-b] (three keep, one flips)")
+    void childTypesFollowBeyPattern() {
+        // This asserts the Bey multiset SHAPE only (three children keep the parent's orientation,
+        // one flips) — NOT which cube-id carries the flip. The current placeholder flips cube-id 3;
+        // the geometrically-faithful Bey interior-child is type-dependent and is reconciled in
+        // RDR-009 Phase 2 (see Triangle.computeChildType javadoc). Pinning the index here would
+        // pre-commit a value P2 must change, so the test deliberately checks counts, not position.
+        for (int parentType = 0; parentType < Triangle.TYPES; parentType++) {
+            // Anchor (1,1) at level 2 → children at level 3 with coords ≤ 3 < 2^3.
+            var parent = new Triangle(2, parentType, 1, 1, Math.min(1, 1));
+            int[] counts = new int[Triangle.TYPES];
+            for (int i = 0; i < Triangle.CHILDREN; i++) {
+                counts[parent.child(i).getType()]++;
+            }
+            assertEquals(3, counts[parentType], "three corner-children must keep parent type " + parentType);
+            assertEquals(1, counts[1 - parentType], "exactly one child must flip from type " + parentType);
+        }
+    }
+
+    // ── Parent/child round-trips: type and n ───────────────────────────────────────────
+
+    @Test
+    @DisplayName("child(i).parent() reproduces the parent's type for all children and types")
+    void typeRoundTrip() {
+        int[][] anchors = { { 0, 0 }, { 1, 0 }, { 0, 1 }, { 2, 1 }, { 3, 2 }, { 5, 3 } };
+        for (int level = 1; level < Triangle.MAX_LEVEL; level++) {
+            for (int type = 0; type < Triangle.TYPES; type++) {
+                for (int[] a : anchors) {
+                    int max = 1 << level;
+                    if (a[0] >= max || a[1] >= max) {
+                        continue;
+                    }
+                    var parent = new Triangle(level, type, a[0], a[1], Math.min(a[0], a[1]));
+                    for (int i = 0; i < Triangle.CHILDREN; i++) {
+                        var child = parent.child(i);
+                        assertEquals(i, child.getChildIndex(), "child index must round-trip");
+                        assertEquals(parent.getType(), child.parent().getType(), String.format(
+                            "type round-trip failed: L=%d type=%d anchor=(%d,%d) child=%d", level, type, a[0], a[1],
+                            i));
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("n == min(x,y) for produced triangles, and child(i).parent() reproduces parent n")
+    void nIsSingleSourceOfTruthAndRoundTrips() {
+        for (int level = 1; level < Triangle.MAX_LEVEL; level++) {
+            int scale = 1 << level;
+            for (int i = 1; i < 8; i++) {
+                for (int j = 1; j < 8; j++) {
+                    float wx = i / 8.0f * 0.999f;
+                    float wy = j / 8.0f * 0.999f;
+                    var parent = Triangle.fromWorldCoordinates(wx, wy, level);
+                    assertEquals(Math.min(parent.getX(), parent.getY()), parent.getN(),
+                        "constructed triangle must satisfy n = min(x,y)");
+                    if (level + 1 > Triangle.MAX_LEVEL) {
+                        continue;
+                    }
+                    for (int c = 0; c < Triangle.CHILDREN; c++) {
+                        var child = parent.child(c);
+                        assertEquals(Math.min(child.getX(), child.getY()), child.getN(),
+                            "child must satisfy n = min(x,y)");
+                        assertEquals(parent.getN(), child.parent().getN(),
+                            "child(i).parent() must reproduce parent n");
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("n round-trip holds for the root and its descendants")
+    void nRoundTripFromRoot() {
+        var root = new Triangle(0, 0, 0, 0, 0);
+        assertEquals(0, root.getN());
+        // Descend an arbitrary child path and verify the invariant at each level.
+        var t = root;
+        int[] path = { 3, 1, 2, 0, 3, 2 };
+        for (int step : path) {
+            var child = t.child(step);
+            assertEquals(Math.min(child.getX(), child.getY()), child.getN(), "n=min(x,y) at each refinement");
+            assertEquals(t.getN(), child.parent().getN(), "parent n reproduced after child→parent");
+            assertEquals(t.getType(), child.parent().getType(), "parent type reproduced after child→parent");
+            t = child;
+        }
+    }
+
+    // ── PrismGeometry must use the triangle's orientation (regression guard) ──────────
+
+    @Test
+    @DisplayName("PrismGeometry vertices match Triangle.getVertices() orientation for both types")
+    void prismGeometryUsesTriangleOrientation() {
+        // Regression guard: PrismGeometry.getTriangleVertices() previously hardcoded a fixed
+        // lower-left shape that ignored the triangle's type, so the prism mesh used by ray
+        // intersection / collision / nearest-neighbor disagreed with Triangle.getVertices().
+        // It must delegate to the triangle's own (t8 main-diagonal) vertices for both types.
+        for (int type = 0; type < Triangle.TYPES; type++) {
+            var triangle = new Triangle(2, type, 1, 1, Math.min(1, 1));
+            var prism = new PrismKey(triangle, new Line(2, 1));
+            var triVerts = triangle.getVertices();              // float[3][2]
+            var prismVerts = PrismGeometry.getVertices(prism);  // 6 Point3f: bottom (minZ) then top
+            for (int i = 0; i < 3; i++) {
+                Point3f bottom = prismVerts.get(i);
+                assertEquals(triVerts[i][0], bottom.x, EPS, "prism bottom vertex " + i + " x, type " + type);
+                assertEquals(triVerts[i][1], bottom.y, EPS, "prism bottom vertex " + i + " y, type " + type);
+            }
+        }
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────────
+
+    private static void assertVertices(float[][] actual, float[][] expected) {
+        assertEquals(expected.length, actual.length, "vertex count");
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(expected[i][0], actual[i][0], EPS, "vertex " + i + " x");
+            assertEquals(expected[i][1], actual[i][1], EPS, "vertex " + i + " y");
+        }
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleTest.java
@@ -42,12 +42,12 @@ class TriangleTest {
         // Exhaustive sweep at low levels — cheap and complete over the
         // coordinate cube [0, 2^level) for each of x/y/n. Note: this is a
         // STRICT SUPERSET of the geometrically valid Triangle domain (the
-        // valid region is bounded by the triangular constraint x + y <
-        // 2^level, enforced by Triangle.fromWorldCoordinate but NOT by the
-        // direct constructor used here). Proving injectivity over the
-        // superset is a stronger claim than the valid domain alone, so this
-        // is conservative — any collision within the valid domain would
-        // also show here. The level cap is 6 because exhaustive at level
+        // world-coordinate constructors only ever produce triangles with the
+        // derived auxiliary coordinate n = min(x, y); the direct constructor
+        // used here stores arbitrary n, so it sweeps far more tuples than can
+        // actually occur). Proving injectivity over the superset is a stronger
+        // claim than the valid domain alone, so this is conservative — any
+        // collision within the valid domain would also show here. The level cap is 6 because exhaustive at level
         // 10 would be 2 * 1024^3 = 2B combinations, too slow for unit
         // tests. Levels 7..21 are covered by the sampled test below.
         for (int level = 1; level <= 6; level++) {


### PR DESCRIPTION
## RDR-009 Phase 1 (bead `Luciferase-al5`)

First implementation phase of the accepted RDR-009 two-prism cover (Option A-full). Reconciles `Triangle.type` to the t8code/Bey orientation and makes the auxiliary coordinate `n` a derived single-source-of-truth (`min(x,y)`) with a consistent parent/child round-trip.

### Scope decision (user-confirmed)
The bead was planned as "swap two type formulas + fix n," but `type` is coupled to the leaf geometry (`getVertices`/`contains`, planned for P3/P5) and to the SFC packing (`consecutiveIndex`/`compareTo`, locked to P2). Confirmed the **Fuller** option: pull the leaf geometry into P1 so `type` genuinely encodes the Bey orientation rather than a relabel. True Bey *triangle-into-four nesting* remains inseparable from the TM-index and is deferred to P2; the SFC packing is untouched here.

### Changes (`Triangle.java`, all within `lucien/.../prism`)
- **Geometry:** `getVertices`/`contains` switch from the anti-diagonal per-cell split to the t8 **main-diagonal** split — type-0 = lower-right Kuhn simplex (≃ S0, `y ≤ x`), type-1 = upper-left (≃ S1).
- **Point location:** both `fromWorldCoordinate(s)` unified to one main-diagonal rule (`localY>localX?1:0`); removed the non-Bey `(x+y)%2` type and the **silent `x+y>=scale` relocation clamp** (a latent data-relocation hazard). `fromWorldCoordinate` now delegates.
- **Type transition:** Bey multiset `[b,b,b,1-b]` replacing the non-Bey alternating rule. The flip is the fixed cube-id-3 child — the *only* choice that round-trips under the type-independent `getChildIndex`. The geometrically-faithful (type-dependent) Bey interior-child and true nesting are deferred to P2 (documented in code).
- **`n`:** derived `min(x,y)` in `fromWorld*`/`child`/`parent`/`neighbors`, recomputed (not bit-shifted) so `n==min(x,y)` holds at every level. The 5-arg ctor keeps storing `n` verbatim as a low-level escape hatch (required by `TriangleTest`'s arbitrary-`n` bijection sweep + the locked `consecutiveIndex`).
- **`PrismGeometry.getTriangleVertices`:** delegate to `triangle.getVertices()` — it was a type-blind hardcoded lower-left shape that diverged from the new orientation (feeds ray/collision/nearest-neighbor). *(Found in review.)*
- `consecutiveIndex()` and `PrismKey.compareTo` left **unchanged** (RDR-009 P2).

### Tests
- New `TriangleBeyTypeTest`: Bey-orientation geometry, point-location/`contains` consistency, Bey multiset shape, type + `n` round-trips, and `PrismGeometry`↔`Triangle` vertex parity (regression guard).
- Fixture `n` corrected in `PrismKeyTest`/`PrismTest` (the old values were invalid under `n=min(x,y)`).
- Full prism + occlusion + forest suite **186 tests green** with `CI=true` (2 skipped = the `@DisabledIfEnvironmentVariable(CI)` range-query perf methods, which flake only under local JVM contention).

### Review
Stacked review per repo practice (geometry/correctness change): **code-review-expert** (1 Important — the `PrismGeometry` divergence, fixed) + **substantive-critic** (2 Significant — both doc/framing: the cube-id-3 placeholder was overclaimed as the literal Table-1 transition, and the level-0 `contains()` deferral needed an explicit `TODO(RDR-009 P3)`). All findings verified against source and addressed.

### Deferred (recorded on the bead for downstream phases)
- **P2 (`4ky`):** `getChildIndex`/`computeChildType`/`computeParentType` become type-aware; reconcile the placeholder flip-child with true Bey nesting + the TM-index.
- **P3 (`7iu`):** remove/specialize the level-0 `contains()` full-square special case once the S1 root exists.

Blocks: `Luciferase-4ky` (P2), `Luciferase-wos` (GATE-A).