### PR TITLE
Luciferase-h65: Prism kNN/region completeness for sparse indices

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
@@ -2848,9 +2848,38 @@ implements SpatialIndex<Key, ID, Content> {
     }
 
     /**
-     * Get the cell size at a given level (to be implemented by subclasses)
+     * Get the cell size at a given level, in the same (world) coordinate space as entity positions
+     * and query distances (to be implemented by subclasses).
+     *
+     * <p>Returns {@code float} rather than {@code int} so indices using normalized fractional
+     * coordinates (e.g. Prism's [0,1) world) report a meaningful sub-unit cell size instead of
+     * truncating it to 0. Integer-coordinate indices (Octree, Tetree, SFCArrayIndex) return their
+     * integer cell size widened to {@code float} — exact for all levels (cell sizes are powers of
+     * two below 2^24). Several distance/extent comparisons (k-NN search radius, level selection,
+     * spanning) depend on this being world-space, not a truncated integer.</p>
      */
-    protected abstract int getCellSizeAtLevel(byte level);
+    protected abstract float getCellSizeAtLevel(byte level);
+
+    /**
+     * Whether {@code kNearestNeighbors} must perform a final full-domain sweep when the
+     * expanding-radius fallback leaves it short of {@code k}.
+     *
+     * <p>Default {@code false}: the integer-coordinate indices (Octree, Tetree, SFCArrayIndex) reach
+     * completeness through their dedicated SFC range-pruning path ({@code performKNNSFCRangePruning}
+     * and its Morton/Tetree variants), which derives the Morton/TM interval of an AABB covering the
+     * whole {@code maxDistance} sphere and so already sees every in-range neighbor — the
+     * expanding-radius search is only a fallback there, not the guarantee. A domain-spanning sweep
+     * for them would be redundant, and worse: a large/unbounded search box drives their
+     * {@code findNodesIntersectingBounds} (LITMAX/BIGMIN interval walk) non-terminating. Indices whose
+     * coordinate space defeats the incremental expansion AND lack a fractional SFC-range path (e.g.
+     * Prism's normalized [0,1) coordinates route to the generic BFS + expanding-radius fallback, and
+     * a sub-unit initial radius cannot span the world within the cap) override this to {@code true};
+     * their {@code findNodesIntersectingBounds} is an O(n) scan, so the sweep is cheap and bounded.
+     * (Luciferase-h65)</p>
+     */
+    protected boolean knnRequiresFullDomainSweep() {
+        return false;
+    }
 
     /**
      * Get child nodes of a given node. Default implementation returns empty list. Subclasses should override to provide
@@ -4261,6 +4290,61 @@ implements SpatialIndex<Key, ID, Content> {
             // If we didn't find any new entities in this expansion, stop
             if (!foundNewEntities && searchExpansions > 1) {
                 break;
+            }
+        }
+
+        // Final safety sweep: the incremental expansion above can terminate before covering the
+        // index — its "no new entities" heuristic and fixed expansion cap assume entities are
+        // densely clustered near the query, and its initial radius is a fine-level cell size. Over a
+        // SPARSE index the true neighbors can sit beyond the last ring (this is what left Prism
+        // k-NN under-returning — the doublings from a sub-unit cell size never spanned the [0,1)
+        // world within the cap). If still short of k, do one pass whose radius spans the whole
+        // coordinate domain. The radius is bounded by the root-cell edge (getCellSizeAtLevel(0) =
+        // the domain extent), NOT by maxDistance: an unbounded maxDistance (e.g. Float.MAX_VALUE for
+        // "all within range") would otherwise build an overflowing search box that makes the
+        // integer-SFC findNodesIntersectingBounds (LITMAX/BIGMIN) non-terminating. (Luciferase-h65)
+        if (candidates.size() < k && knnRequiresFullDomainSweep()) {
+            // Full-domain safety sweep — gated to indices that need it (see
+            // knnRequiresFullDomainSweep). The incremental expansion above can terminate before
+            // covering the index when the coordinate space defeats its heuristics (Prism's
+            // normalized fractional coordinates: the doublings from a sub-unit initial radius never
+            // span the [0,1) world within the expansion cap, and the "no new entities" early-exit
+            // fires on the empty rings before the real neighbors). One pass over a domain-spanning
+            // box closes the gap. This is NOT run for the integer-SFC indices (Octree/Tetree/SFC):
+            // their SFC range-pruning path already covers the whole maxDistance sphere, so a
+            // domain-spanning findNodesIntersectingBounds there would be a costly LITMAX/BIGMIN no-op
+            // (and non-terminating for a large box). See knnRequiresFullDomainSweep. (Luciferase-h65)
+            //
+            // The box spans only the root-cell edge (getCellSizeAtLevel(0)): for any query inside the
+            // domain, query +/- edge already encloses the whole domain, so every node is a candidate.
+            // Acceptance uses the full maxDistance (decoupled from the box radius), so far-corner
+            // neighbors up to the domain diagonal are not wrongly rejected.
+            var edge = getCellSizeAtLevel((byte) 0);
+            var sweepBounds = new VolumeBounds(queryPoint.x - edge, queryPoint.y - edge, queryPoint.z - edge,
+                                               queryPoint.x + edge, queryPoint.y + edge, queryPoint.z + edge);
+            for (var nodeKey : findNodesIntersectingBounds(sweepBounds)) {
+                var node = spatialIndex.get(nodeKey);
+                if (node == null || node.isEmpty()) {
+                    continue;
+                }
+                for (var entityId : node.getEntityIds()) {
+                    if (addedToCandidates.contains(entityId)) {
+                        continue;
+                    }
+                    var entityPos = getCachedEntityPosition(entityId);
+                    if (entityPos == null) {
+                        continue;
+                    }
+                    var distance = queryPoint.distance(entityPos);
+                    if (distance <= maxDistance) {
+                        candidates.add(new EntityDistance<>(entityId, distance));
+                        addedToCandidates.add(entityId);
+                        if (candidates.size() > k) {
+                            var removed = candidates.poll();
+                            addedToCandidates.remove(removed.entityId());
+                        }
+                    }
+                }
             }
         }
 

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/octree/Octree.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/octree/Octree.java
@@ -311,7 +311,7 @@ public class Octree<ID extends EntityID, Content> extends AbstractSpatialIndex<M
     }
 
     @Override
-    protected int getCellSizeAtLevel(byte level) {
+    protected float getCellSizeAtLevel(byte level) {
         return Constants.lengthAtLevel(level);
     }
 

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/Prism.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/Prism.java
@@ -449,23 +449,55 @@ public class Prism<ID extends com.hellblazer.luciferase.lucien.entity.EntityID, 
     
     @Override
     protected Set<PrismKey> findNodesIntersectingBounds(com.hellblazer.luciferase.lucien.VolumeBounds bounds) {
-        // For now, return empty set - would need spatial traversal implementation
-        return new HashSet<>();
+        // Map-scan over both prism families (the index holds S0 and S1 keys), collecting every node
+        // whose world AABB intersects the query bounds. Mirrors the entitiesInRegion / rayIntersectAll
+        // scan philosophy and is consistent with Prism's O(n) k-NN BFS.
+        //
+        // Luciferase-h65: previously a stub returning empty, which silently no-op'd its callers for
+        // Prism — most importantly the k-NN expanding-radius fallback (searchKNNInRadius), as well as
+        // bounded/region search (findCollisionsInRegion, bounded-spanning insert). Scanning both
+        // halves makes those find entities in either family.
+        var result = new HashSet<PrismKey>();
+        for (var key : spatialIndex.keySet()) {
+            var b = getBounds(key); // [minX, minY, minZ, maxX, maxY, maxZ] world AABB
+            var disjoint = b[3] < bounds.minX() || b[0] > bounds.maxX()
+                        || b[4] < bounds.minY() || b[1] > bounds.maxY()
+                        || b[5] < bounds.minZ() || b[2] > bounds.maxZ();
+            if (!disjoint) {
+                result.add(key);
+            }
+        }
+        return result;
     }
     
     @Override
-    protected int getCellSizeAtLevel(byte level) {
-        return (int)(worldSize / Math.pow(2, level));
+    protected float getCellSizeAtLevel(byte level) {
+        // Normalized [0,1) world: the cell size is fractional (worldSize / 2^level). Returning the
+        // true value (not an int truncation to 0) is required for the ASI k-NN search radius,
+        // level selection, and spanning comparisons to work in Prism's coordinate space (Luciferase-h65).
+        return (float) (worldSize / Math.pow(2, level));
     }
-    
+
+    @Override
+    protected boolean knnRequiresFullDomainSweep() {
+        // Prism's normalized [0,1) fractional coordinates defeat the ASI expanding-radius heuristic
+        // (sub-unit initial radius cannot span the world within the expansion cap), so a sparse k-NN
+        // needs the final full-domain sweep. Affordable here: findNodesIntersectingBounds is an O(n)
+        // map-scan, not an SFC interval walk. (Luciferase-h65)
+        return true;
+    }
+
     /**
      * Get the cell size at a specific level as a float.
-     * 
+     *
      * @param level the level (0-21)
      * @return the cell size as a float
+     * @deprecated {@link #getCellSizeAtLevel(byte)} now returns {@code float}; this delegates to it
+     *             and is retained for source compatibility.
      */
+    @Deprecated
     public float getCellSizeAtLevelFloat(byte level) {
-        return (float)(worldSize / Math.pow(2, level));
+        return getCellSizeAtLevel(level);
     }
     
     @Override

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/sfc/SFCArrayIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/sfc/SFCArrayIndex.java
@@ -392,7 +392,7 @@ public class SFCArrayIndex<ID extends EntityID, Content> extends AbstractSpatial
     }
 
     @Override
-    protected int getCellSizeAtLevel(byte level) {
+    protected float getCellSizeAtLevel(byte level) {
         return Constants.lengthAtLevel(level);
     }
 

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/Tetree.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/Tetree.java
@@ -1669,7 +1669,7 @@ extends AbstractSpatialIndex<TetreeKey<? extends TetreeKey<?>>, ID, Content> {
     }
 
     @Override
-    protected int getCellSizeAtLevel(byte level) {
+    protected float getCellSizeAtLevel(byte level) {
         return Constants.lengthAtLevel(level);
     }
 

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismCrossDiagonalQueryTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismCrossDiagonalQueryTest.java
@@ -93,12 +93,9 @@ class PrismCrossDiagonalQueryTest {
         // level 2, S0 vs S1 — so the S0 node's hypotenuse face-neighbor is exactly the S1 node,
         // reached in one BFS hop iff addNeighboringNodes crosses the diagonal (RDR-009 P6).
         //
-        // NOTE: this uses adjacent cells deliberately. kNN over a SPARSE prism index (close
-        // neighbours several empty cells away) under-returns regardless of the diagonal — a
-        // pre-existing Prism/ASI coordinate-model gap (getCellSizeAtLevel int-truncates the
-        // normalized cell size to 0, stalling the expanding-radius fallback; findNodesIntersectingBounds
-        // is also a stub). That is orthogonal to family-crossing (same-half sparse kNN fails
-        // identically) and is tracked separately; fixing it needs an ASI signature change.
+        // NOTE: this uses adjacent cells deliberately, to isolate the addNeighboringNodes BFS hop.
+        // The orthogonal "sparse index" case (close neighbours several empty cells away) is covered
+        // by PrismSparseKnnCompletenessTest (Luciferase-h65).
         var s0 = prism.insert(new Point3f(0.45f, 0.30f, 0.50f), (byte) 2, "S0"); // y<x -> S0, cell (1,1)
         var s1 = prism.insert(new Point3f(0.30f, 0.45f, 0.50f), (byte) 2, "S1"); // y>x -> S1, mirror cell
 

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismSparseKnnCompletenessTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismSparseKnnCompletenessTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.prism;
+
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3f;
+
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Luciferase-h65: kNN completeness over a SPARSE Prism index. The pre-existing gap (found during
+ * RDR-009 P6) was that Prism uses normalized [0,1) world coordinates, but the {@code AbstractSpatialIndex}
+ * kNN machinery assumed integer coordinate space: {@code getCellSizeAtLevel} returned {@code int} and
+ * truncated the fractional cell size to 0, so the expanding-radius fallback's search radius started at
+ * 0 and never grew; and {@code Prism.findNodesIntersectingBounds} was a stub. Together they made kNN
+ * (and bounded/region search) under-return whenever the nearest entities were several empty cells away
+ * — regardless of the S0/S1 diagonal. This pins the fix: widened {@code getCellSizeAtLevel} to float +
+ * a real {@code findNodesIntersectingBounds}.
+ *
+ * @author hal.hildebrand
+ */
+class PrismSparseKnnCompletenessTest {
+
+    private Prism<LongEntityID, String> prism;
+
+    @BeforeEach
+    void setUp() {
+        prism = new Prism<>(new SequentialLongIDGenerator(), 1.0f, 21);
+    }
+
+    @Test
+    @DisplayName("same-half sparse kNN returns k (regression: the gap is orthogonal to the diagonal)")
+    void sameHalfSparseKnnReturnsK() {
+        // All four entities in S0 (y<x), scattered so their cells are several empty cells apart at
+        // level 10. Before the fix this returned 1 (the BFS could not bridge the empty cells and the
+        // expanding-radius fallback was stalled at radius 0).
+        var near1 = prism.insert(new Point3f(0.52f, 0.49f, 0.50f), (byte) 10, "near1");
+        var near2 = prism.insert(new Point3f(0.55f, 0.48f, 0.50f), (byte) 10, "near2");
+        prism.insert(new Point3f(0.90f, 0.10f, 0.50f), (byte) 10, "far1");
+        prism.insert(new Point3f(0.95f, 0.05f, 0.50f), (byte) 10, "far2");
+
+        var nearest = prism.kNearestNeighbors(new Point3f(0.51f, 0.49f, 0.50f), 2, 1.0f);
+        var nearestSet = new HashSet<>(nearest);
+        assertEquals(2, nearest.size(), "k=2 neighbors expected over a sparse index");
+        assertTrue(nearestSet.contains(near1) && nearestSet.contains(near2),
+            "the two closest S0 entities must be returned, not the far ones");
+    }
+
+    @Test
+    @DisplayName("sparse cross-diagonal kNN: an S0 query returns its true nearest neighbors across the diagonal in S1")
+    void sparseCrossDiagonalKnnReturnsK() {
+        // The acceptance proper: a sparse index where the S0 query's true nearest neighbors are two
+        // entities just across the diagonal in S1, several empty cells from the query, and the only
+        // S0 entities are far. Exercises the expanding-radius fallback scanning both families.
+        var s1Near1 = prism.insert(new Point3f(0.49f, 0.52f, 0.50f), (byte) 10, "S1-near1"); // y>x, closest
+        var s1Near2 = prism.insert(new Point3f(0.48f, 0.55f, 0.50f), (byte) 10, "S1-near2"); // y>x, close
+        prism.insert(new Point3f(0.90f, 0.10f, 0.50f), (byte) 10, "S0-far1"); // y<x, far
+        prism.insert(new Point3f(0.95f, 0.05f, 0.50f), (byte) 10, "S0-far2"); // y<x, far
+
+        var nearest = prism.kNearestNeighbors(new Point3f(0.51f, 0.49f, 0.50f), 2, 1.0f); // query y<x -> S0
+        var nearestSet = new HashSet<>(nearest);
+        assertEquals(2, nearest.size(), "k=2 neighbors expected");
+        assertTrue(nearestSet.contains(s1Near1) && nearestSet.contains(s1Near2),
+            "the two nearest neighbors of the S0 query are the close S1 entities across the diagonal");
+    }
+
+    @Test
+    @DisplayName("far-corner sparse kNN: a neighbor farther than the cube edge (up to the diagonal) is still returned")
+    void farCornerSparseKnnReturnsK() {
+        // Query near one corner; its two nearest are a mid entity and one near the OPPOSITE corner,
+        // ~1.66 apart — farther than the unit-cube edge (1.0), within the diagonal (sqrt(3)=1.73)
+        // and within maxDistance (2.0). The BFS finds only the mid one; the far-corner one is reached
+        // only by the final safety sweep. The sweep's box (query +/- edge) already encloses the whole
+        // domain, so the far-corner entity IS a candidate; what matters is that acceptance is governed
+        // by maxDistance (2.0), NOT by the box/edge radius — so a neighbor beyond the edge but within
+        // maxDistance is not wrongly rejected. (Without the sweep, Prism sparse kNN returns just the
+        // mid entity.)
+        var mid = prism.insert(new Point3f(0.50f, 0.30f, 0.50f), (byte) 10, "mid");          // 0.74 away
+        var farCorner = prism.insert(new Point3f(0.98f, 0.97f, 0.98f), (byte) 10, "corner"); // 1.66 away
+
+        var nearest = prism.kNearestNeighbors(new Point3f(0.02f, 0.01f, 0.02f), 2, 2.0f); // query near origin, S0
+        var nearestSet = new HashSet<>(nearest);
+        assertEquals(2, nearest.size(), "k=2 neighbors expected");
+        assertTrue(nearestSet.contains(mid) && nearestSet.contains(farCorner),
+            "both nearest must be returned; the sweep accepts up to maxDistance, so the far-corner "
+            + "neighbor beyond the cube edge is not rejected");
+    }
+
+    @Test
+    @DisplayName("getCellSizeAtLevel returns the true fractional world cell size (not truncated to 0)")
+    void cellSizeIsFractional() {
+        assertEquals(1.0f, prism.getCellSizeAtLevel((byte) 0), 0f, "level 0 cell size is the world size");
+        assertEquals(0.5f, prism.getCellSizeAtLevel((byte) 1), 0f, "level 1 cell size is half");
+        assertEquals(1.0f / 1024.0f, prism.getCellSizeAtLevel((byte) 10), 1e-9f, "level 10 cell size");
+    }
+}


### PR DESCRIPTION
## Luciferase-h65 — Prism k-NN/region completeness for sparse indices

Fixes Prism k-NN under-returning over a **sparse** index (a `k=2` query returning 1 when the nearest entities are several empty cells away). Verified **orthogonal to the S0/S1 diagonal** — an all-same-half sparse k-NN failed identically before this change. Discovered during RDR-009 P6 (#117); pulled into the epic per the **Option B re-weigh** (the `AbstractSpatialIndex` signature change is the RDR-009 Option B trigger — Option A retained, the change is proportionate and contained within the k-NN path).

### Root causes (the ASI k-NN machinery assumed integer coordinate space; Prism uses normalized `[0,1)` world coords)

1. **`getCellSizeAtLevel` returned `int`** and truncated Prism's fractional cell size (`worldSize/2^level < 1`) to **0**, so the expanding-radius fallback seeded its radius at 0 and `radius *= 2` stayed 0. **Fix:** widened the abstract `getCellSizeAtLevel` `int→float`. Octree/Tetree/SFCArrayIndex return their integer cell size widened to `float` (exact — powers of two below 2²⁴); Prism returns the true fractional size. All 9 ASI callers use `var`/float-compatible arithmetic; the now-redundant `Prism.getCellSizeAtLevelFloat` delegates (`@Deprecated`). *(Side benefit: this also fixes a latent Prism spanning bug — `nodeSize==0` had made every Prism entity look like a spanning entity.)*
2. **`Prism.findNodesIntersectingBounds` was a stub** returning empty, no-op'ing the k-NN radius search, `findCollisionsInRegion`, and bounded-spanning insert for Prism. **Fix:** a map-scan over both prism families collecting nodes whose world AABB intersects the query bounds.
3. **The expanding-radius fallback can still terminate before covering a sparse index** (fine-level initial radius + "no new entities" early-exit assume dense clustering near the query). **Fix:** a final full-domain sweep when still short of `k`, **gated behind a new `knnRequiresFullDomainSweep()` hook** (default `false`; Prism overrides `true`). Integer-SFC indices keep their **exact prior behavior** — their SFC range-pruning path already covers the whole `maxDistance` sphere, and an unconditional sweep there was both redundant **and** a hang (a large/unbounded box drives `cellsQ`/LITMAX-BIGMIN non-terminating — caught by full-suite timeouts during development). The sweep box spans only the root-cell edge (`getCellSizeAtLevel(0)`, which already encloses the domain for any in-domain query) while per-entity acceptance uses the full `maxDistance` (decoupled from the box radius), so neighbors beyond the edge but within range are not rejected. Prism's `findNodesIntersectingBounds` is O(n), so the sweep is cheap and bounded.

### Tests
`PrismSparseKnnCompletenessTest` — same-half sparse k-NN regression; sparse cross-diagonal k-NN; far-corner (beyond-edge) completeness; fractional cell size. All fail before this change. Full `lucien` module green (**2441**, `CI=true`), including `ForestSpatialQueriesTest.testLargeKValue` (`Float.MAX_VALUE`, `k>n`, the integer-SFC hang case) and the Octree/Tetree/SFCArrayIndex k-NN suites (behavior unchanged — the sweep is not run for them; their integer cell sizes widen to the same float values).

### Review
Stacked review (code-review-expert + substantive-critic): **0 critical issues, code approved.** Both flagged comment inaccuracies (a misleading far-corner test comment; the gate's Octree-completeness rationale citing expanding-radius rather than the SFC range-pruning AABB→Morton-interval coverage) — both corrected in this PR. The critic also noted a pre-existing exception-path gap (if Octree's SFC pruning throws and falls to the BFS+expanding fallback, the sparse gap could surface) — pre-existing and unchanged by this PR; out of scope.