### PR TITLE
RDR-009 GATE-B: remove dead, wrong-ordered Prism.getChildIndex/getAllChildren (Luciferase-m0w)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/Prism.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/Prism.java
@@ -314,33 +314,11 @@ public class Prism<ID extends com.hellblazer.luciferase.lucien.entity.EntityID, 
         
         return new PrismKey(parentTriangle, parentLine);
     }
-    
-    protected PrismKey getChildIndex(PrismKey parentKey, int childIdx) {
-        if (childIdx < 0 || childIdx >= 8) {
-            throw new IllegalArgumentException("Child index must be 0-7, got: " + childIdx);
-        }
-        
-        // Prisms have 8 children: 4 triangle children × 2 line children
-        // Decode Morton order: childIdx = triangleIdx * 2 + lineIdx
-        int triangleIdx = childIdx / 2;
-        int lineIdx = childIdx % 2;
-        
-        var childTriangle = parentKey.getTriangle().child(triangleIdx);
-        var childLine = parentKey.getLine().child(lineIdx);
-        
-        return new PrismKey(childTriangle, childLine);
-    }
-    
-    protected List<PrismKey> getAllChildren(PrismKey parentKey) {
-        var children = new ArrayList<PrismKey>(8);
-        
-        // Generate all 8 children in Morton order
-        for (int i = 0; i < 8; i++) {
-            children.add(getChildIndex(parentKey, i));
-        }
-        
-        return children;
-    }
+
+    // NOTE: child enumeration is PrismKey.child(i) — the canonical SFC-consistent ordering
+    // (triangle-major: triangleChild = i % 4, lineChild = i / 4, matching consecutiveIndex). Earlier
+    // dead getChildIndex/getAllChildren helpers here used an incompatible line-major order and were
+    // removed (RDR-009 GATE-B) so P7 serialization cannot accidentally traverse in the wrong order.
     
     protected TreeBalancer<PrismKey, ID> getTreeBalancer() {
         return balancer;


### PR DESCRIPTION
## RDR-009 GATE-B (Luciferase-m0w) — gate-closing cleanup

GATE-B is the mandatory integration review of the merged P3+P4+P5+P6 (+h65) prism full-cube foundation, before P7 locks serialization. **Verdict: PASS** (stacked review = code-review-expert + substantive-critic + test-validator; 0 critical issues; full `lucien` suite green at 2441).

This PR resolves the one concrete finding flagged by both code reviewers:

**`Prism.getChildIndex` / `getAllChildren` were dead code with an order incompatible with the canonical `PrismKey.child`.** They decoded child indices line-major (`triangleIdx = childIdx/2, lineIdx = childIdx%2`); `PrismKey.child` is triangle-major (`triangle = i%4, line = i/4`), matching `consecutiveIndex`'s 3-bit-per-level interleave. Both methods are `protected`, non-`@Override`, and have **zero callers** (verified via Serena — `getAllChildren` unreferenced; `getChildIndex` called only by `getAllChildren`). Dead today, but a silent wrong-traversal landmine for P7 serialization (which enumerates children in tree order). Removed; left a pointer comment to `PrismKey.child`. No behavior change.

### Gate findings summary
- **Tiling** (no gaps/double-count on the diagonal), **cross-diagonal neighbor round-trip**, **subdivision tiling + half propagation**, **SFC half-major ordering**, **ray/range/kNN/collision both families** — all verified correct at the composition seams; 62 epic tests + full suite green.
- **Option B**: P6 made no `AbstractSpatialIndex` change (trigger did not fire); h65's ASI change (`getCellSizeAtLevel int→float` + `knnRequiresFullDomainSweep` hook) was a separately user-re-weighed decision (Option A retained). All three reviewers confirmed this framing is honest. Gate does **not** stop.
- **Deferred** (filed Luciferase-q8z, not a blocker): no `StackBasedTreeBuilder`+Prism integration test for the S0-only-seed carry-over — a default-off, structurally-safe path; hardening recommended around P7.

Full `lucien` module green (**2441**, `CI=true`).