### PR TITLE
Luciferase-d41: remove vestigial Triangle.n field + 5-arg constructor + getN()

### DIFF
--- a/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/PrismKeySerde.java
+++ b/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/PrismKeySerde.java
@@ -109,7 +109,7 @@ public final class PrismKeySerde implements SpatialKeySerde<PrismKey> {
                     int x = bb.getInt();
                     int y = bb.getInt();
                     int z = bb.getInt();
-                    yield new PrismKey(new Triangle(level, type, x, y, Math.min(x, y), half), new Line(level, z));
+                    yield new PrismKey(new Triangle(level, type, x, y, half), new Line(level, z));
                 }
                 case VERSION_LEGACY_S0 -> {
                     // Lower-half (S0-only) legacy format: no half field — upgrade to half=0 (S0).
@@ -118,7 +118,7 @@ public final class PrismKeySerde implements SpatialKeySerde<PrismKey> {
                     int x = bb.getInt();
                     int y = bb.getInt();
                     int z = bb.getInt();
-                    yield new PrismKey(new Triangle(level, type, x, y, Math.min(x, y), 0), new Line(level, z));
+                    yield new PrismKey(new Triangle(level, type, x, y, 0), new Line(level, z));
                 }
                 default -> throw new IllegalArgumentException(
                     "PrismKeySerde: unrecognised format version " + (version & 0xFF)

--- a/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/PrismKeyMigrationTest.java
+++ b/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/PrismKeyMigrationTest.java
@@ -38,14 +38,14 @@ class PrismKeyMigrationTest {
     private static final PrismKeySerde SERDE = new PrismKeySerde();
 
     private static PrismKey key(int level, int type, int x, int y, int half, int z) {
-        return new PrismKey(new Triangle(level, type, x, y, Math.min(x, y), half), new Line(level, z));
+        return new PrismKey(new Triangle(level, type, x, y, half), new Line(level, z));
     }
 
     @Test
     @DisplayName("(round-trip) v1 serialize/deserialize is identity for S0 and S1 keys at several levels")
     void v1RoundTripIdentity() {
         var keys = new PrismKey[] {
-            new PrismKey(new Triangle(0, 0, 0, 0, 0, 0), new Line(0, 0)),       // S0 root
+            new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0)),       // S0 root
             PrismKey.createRootS1(),                                            // S1 root
             key(2, 0, 3, 1, 0, 2),                                             // S0, type 0
             key(2, 1, 3, 2, 0, 3),                                             // S0, type 1

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/PrismKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/PrismKey.java
@@ -120,7 +120,7 @@ public final class PrismKey implements SpatialKey<PrismKey> {
      * @return the S0 root prism key
      */
     public static PrismKey createRoot() {
-        return new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
+        return new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
     }
 
     /**

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/Triangle.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/Triangle.java
@@ -53,11 +53,9 @@ import java.util.Objects;
  * half first, so the two roots form contiguous SFC blocks.
  *
  * <p>The coordinate system stores {@code (level, type, x, y)} — the t8 Tet-id — which is the
- * identity used by {@link #equals(Object)}/{@link #hashCode()} and the SFC index. The legacy
- * {@code n} field is the derived auxiliary coordinate {@code min(x, y)}; it carries no term in the
- * consecutive index and is excluded from identity. It is retained only so the 5-arg constructor
- * signature is unchanged; {@link #getN()} is deprecated and the field is slated for removal in
- * RDR-009 Phase 7.
+ * identity used by {@link #equals(Object)}/{@link #hashCode()} and the SFC index. (The vestigial
+ * auxiliary coordinate {@code n = min(x, y)} carried no identity or consecutive-index term and was
+ * removed in RDR-009 Phase 7 along with the 5-arg constructor and {@code getN()}.)
  *
  * @author hal.hildebrand
  */
@@ -99,8 +97,7 @@ public final class Triangle {
     private final byte level;          // Hierarchical level (0-21)
     private final byte type;           // Triangle type (0 or 1)
     private final int x;               // X coordinate
-    private final int y;               // Y coordinate  
-    private final int n;               // Derived auxiliary coordinate, cached as min(x, y) (see class javadoc)
+    private final int y;               // Y coordinate
     private final byte half;           // Root half: 0 = S0 (lower-right y<=x), 1 = S1 (reflected upper-left) — RDR-009 P3
 
     // Lazily-computed cache of consecutiveIndex(). Triangle is immutable and the index is a
@@ -133,11 +130,10 @@ public final class Triangle {
      * @param type the triangle type (0 or 1)
      * @param x the x coordinate
      * @param y the y coordinate
-     * @param n the auxiliary n coordinate
      * @throws IllegalArgumentException if parameters are invalid
      */
-    public Triangle(int level, int type, int x, int y, int n) {
-        this(level, type, x, y, n, 0);
+    public Triangle(int level, int type, int x, int y) {
+        this(level, type, x, y, 0);
     }
 
     /**
@@ -147,11 +143,10 @@ public final class Triangle {
      * @param type the triangle type (0 or 1)
      * @param x the x coordinate (in the S0 frame — see {@link #getHalf()})
      * @param y the y coordinate (in the S0 frame)
-     * @param n the auxiliary n coordinate
      * @param half the root half: 0 = S0 (lower-right {@code y <= x}), 1 = S1 (reflected upper-left)
      * @throws IllegalArgumentException if parameters are invalid
      */
-    public Triangle(int level, int type, int x, int y, int n, int half) {
+    public Triangle(int level, int type, int x, int y, int half) {
         if (level < 0 || level > MAX_LEVEL) {
             throw new IllegalArgumentException("Level must be 0-" + MAX_LEVEL + ", got: " + level);
         }
@@ -167,42 +162,38 @@ public final class Triangle {
         if (y < 0 || y > MAX_COORDINATE) {
             throw new IllegalArgumentException("Y coordinate must be 0-" + MAX_COORDINATE + ", got: " + y);
         }
-        if (n < 0 || n > MAX_COORDINATE) {
-            throw new IllegalArgumentException("N coordinate must be 0-" + MAX_COORDINATE + ", got: " + n);
-        }
-        
+
         // For level 0, coordinates must be 0
         if (level == 0) {
-            if (x != 0 || y != 0 || n != 0) {
+            if (x != 0 || y != 0) {
                 throw new IllegalArgumentException("Level 0 coordinates must all be 0");
             }
         } else {
             // For other levels, validate coordinates are reasonable (relaxed validation)
             var maxCoordForLevel = 1 << level;
-            if (x >= maxCoordForLevel || y >= maxCoordForLevel || n >= maxCoordForLevel) {
+            if (x >= maxCoordForLevel || y >= maxCoordForLevel) {
                 throw new IllegalArgumentException(
-                    String.format("Coordinates (%d,%d,%d) exceed maximum %d for level %d", 
-                                x, y, n, maxCoordForLevel - 1, level));
+                    String.format("Coordinates (%d,%d) exceed maximum %d for level %d",
+                                x, y, maxCoordForLevel - 1, level));
             }
         }
-        
+
         this.level = (byte) level;
         this.type = (byte) type;
         this.x = x;
         this.y = y;
-        this.n = n;
         this.half = (byte) half;
     }
 
     /**
      * The level-0 root of the S1 family — the upper-left Kuhn triangle {@code y >= x}, the
-     * reflection of the S0 root across the main diagonal. Together with {@code new Triangle(0,...)}
+     * reflection of the S0 root across the main diagonal. Together with {@code new Triangle(0, ...)}
      * (the S0 root) the two roots tile the full square (RDR-009 P3).
      *
      * @return the S1 root triangle
      */
     public static Triangle rootS1() {
-        return new Triangle(0, 0, 0, 0, 0, 1);
+        return new Triangle(0, 0, 0, 0, 1);
     }
     
     /**
@@ -235,7 +226,7 @@ public final class Triangle {
 
         // For level 0, return the root triangle of the appropriate half.
         if (level == 0) {
-            return new Triangle(0, 0, 0, 0, 0, half);
+            return new Triangle(0, 0, 0, 0, half);
         }
 
         var scale = 1 << level;
@@ -248,10 +239,7 @@ public final class Triangle {
         float localY = (fy * scale) - quantY;
         var type = (localY > localX) ? 1 : 0;
 
-        // n is the derived auxiliary coordinate min(x, y) — the single source of truth.
-        var n = Math.min(quantX, quantY);
-
-        return new Triangle(level, type, quantX, quantY, n, half);
+        return new Triangle(level, type, quantX, quantY, half);
     }
     
     /**
@@ -318,9 +306,8 @@ public final class Triangle {
         var parentX = x >>> 1;
         var parentY = y >>> 1;
         var parentType = PARENT_TYPE[cubeId][type];
-        // n remains the derived auxiliary coordinate min(x,y) (vestigial; not in the SFC index).
         // half is preserved — refinement/ancestry stays within the same root (S0 or S1).
-        return new Triangle(level - 1, parentType, parentX, parentY, Math.min(parentX, parentY), half);
+        return new Triangle(level - 1, parentType, parentX, parentY, half);
     }
     
     /**
@@ -346,9 +333,8 @@ public final class Triangle {
         var childX = (x << 1) + offset[0];
         var childY = (y << 1) + offset[1];
         var childType = CHILD_TYPE[type][beyId];
-        // n remains the derived auxiliary coordinate min(x,y) (vestigial; not in the SFC index).
         // half is preserved — children stay within the same root (S0 or S1).
-        return new Triangle(level + 1, childType, childX, childY, Math.min(childX, childY), half);
+        return new Triangle(level + 1, childType, childX, childY, half);
     }
     
     /**
@@ -450,15 +436,15 @@ public final class Triangle {
         var max = 1 << level;
         // Edge 0: right neighbor (x+1, y) — stays in S0 since y <= x < x+1.
         if (x + 1 < max && y <= x + 1) {
-            neighbors[0] = new Triangle(level, type, x + 1, y, Math.min(x + 1, y), half);
+            neighbors[0] = new Triangle(level, type, x + 1, y, half);
         }
         // Edge 1: top neighbor (x, y+1) — only valid when y+1 <= x (else it crosses into S1).
         if (y + 1 < max && y + 1 <= x) {
-            neighbors[1] = new Triangle(level, type, x, y + 1, Math.min(x, y + 1), half);
+            neighbors[1] = new Triangle(level, type, x, y + 1, half);
         }
         // Edge 2: diagonal neighbor (x-1, y-1) — preserves y <= x.
         if (x > 0 && y > 0 && y - 1 <= x - 1) {
-            neighbors[2] = new Triangle(level, type, x - 1, y - 1, Math.min(x - 1, y - 1), half);
+            neighbors[2] = new Triangle(level, type, x - 1, y - 1, half);
         }
 
         return neighbors;
@@ -482,17 +468,17 @@ public final class Triangle {
         switch (edge) {
             case 0: // right neighbor (x+1, y)
                 if (x + 1 < max && y <= x + 1) {
-                    return new Triangle(level, type, x + 1, y, Math.min(x + 1, y), half);
+                    return new Triangle(level, type, x + 1, y, half);
                 }
                 break;
             case 1: // top neighbor (x, y+1) — only valid when y+1 <= x
                 if (y + 1 < max && y + 1 <= x) {
-                    return new Triangle(level, type, x, y + 1, Math.min(x, y + 1), half);
+                    return new Triangle(level, type, x, y + 1, half);
                 }
                 break;
             case 2: // diagonal neighbor (x-1, y-1)
                 if (x > 0 && y > 0 && y - 1 <= x - 1) {
-                    return new Triangle(level, type, x - 1, y - 1, Math.min(x - 1, y - 1), half);
+                    return new Triangle(level, type, x - 1, y - 1, half);
                 }
                 break;
         }
@@ -541,10 +527,10 @@ public final class Triangle {
         // Crossed the main diagonal into the sibling root (S0 <-> S1): reflect across y = x — swap
         // coordinates, flip orientation (1 - neighborType == type) and the half.
         if (ny > nx || (ny == nx && neighborType == 1)) {
-            return new Triangle(level, 1 - neighborType, ny, nx, Math.min(ny, nx), 1 - half);
+            return new Triangle(level, 1 - neighborType, ny, nx, 1 - half);
         }
         // Same-half neighbor within this root.
-        return new Triangle(level, neighborType, nx, ny, Math.min(nx, ny), half);
+        return new Triangle(level, neighborType, nx, ny, half);
     }
 
     /**
@@ -607,17 +593,6 @@ public final class Triangle {
         return y;
     }
     
-    /**
-     * @deprecated The auxiliary coordinate {@code n} is the derived value {@code min(x, y)}; it
-     *     carries no identity or ordering information (RDR-009 P2 excluded it from
-     *     {@code equals}/{@code hashCode}/{@code consecutiveIndex}). The field and this accessor
-     *     are slated for removal with the 5-arg constructor in RDR-009 Phase 7.
-     */
-    @Deprecated
-    public int getN() {
-        return n;
-    }
-    
     // Object methods
     
     @Override
@@ -625,8 +600,6 @@ public final class Triangle {
         if (this == obj) return true;
         if (!(obj instanceof Triangle other)) return false;
         // Identity is (half, level, type, x, y) — the t8 Tet-id plus the root half (RDR-009 P3).
-        // n is the derived min(x,y) and carries no independent information, so it is excluded
-        // (including it would make equals inconsistent with consecutiveIndex()/PrismKey.compareTo).
         return half == other.half && level == other.level && type == other.type && x == other.x && y == other.y;
     }
 
@@ -638,8 +611,8 @@ public final class Triangle {
     @Override
     public String toString() {
         var centroid = getCentroidWorldCoordinates();
-        return String.format("Triangle(level=%d, type=%d, coords=(%d,%d,%d), center=(%.4f,%.4f))", 
-                           level, type, x, y, n, centroid[0], centroid[1]);
+        return String.format("Triangle(level=%d, type=%d, coords=(%d,%d), half=%d, center=(%.4f,%.4f))",
+                           level, type, x, y, half, centroid[0], centroid[1]);
     }
     
     /**

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismCollisionDetectorTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismCollisionDetectorTest.java
@@ -35,8 +35,8 @@ public class PrismCollisionDetectorTest {
     @Test
     public void testPrismPrismCollisionOverlapping() {
         // Create two overlapping prisms
-        var prism1 = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
-        var prism2 = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
+        var prism1 = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
+        var prism2 = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
         
         var result = PrismCollisionDetector.testPrismPrismCollision(prism1, prism2);
         
@@ -49,8 +49,8 @@ public class PrismCollisionDetectorTest {
     @Test
     public void testPrismPrismCollisionSeparated() {
         // Create two separated prisms at the same level
-        var prism1 = new PrismKey(new Triangle(2, 0, 0, 0, 2), new Line(2, 0));
-        var prism2 = new PrismKey(new Triangle(2, 0, 3, 0, 2), new Line(2, 3));
+        var prism1 = new PrismKey(new Triangle(2, 0, 0, 0), new Line(2, 0));
+        var prism2 = new PrismKey(new Triangle(2, 0, 3, 0), new Line(2, 3));
         
         var result = PrismCollisionDetector.testPrismPrismCollision(prism1, prism2);
         
@@ -60,8 +60,8 @@ public class PrismCollisionDetectorTest {
     @Test
     public void testPrismPrismCollisionTouching() {
         // Create two prisms that just touch
-        var prism1 = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
-        var prism2 = new PrismKey(new Triangle(1, 0, 0, 0, 1), new Line(1, 0));
+        var prism1 = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
+        var prism2 = new PrismKey(new Triangle(1, 0, 0, 0), new Line(1, 0));
         
         var result = PrismCollisionDetector.testPrismPrismCollision(prism1, prism2);
         
@@ -75,7 +75,7 @@ public class PrismCollisionDetectorTest {
     @Test
     public void testPrismSphereCollisionInside() {
         // Create a prism and a sphere inside it
-        var prism = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
+        var prism = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
         var sphereCenter = new Point3f(0.25f, 0.25f, 0.5f);
         float sphereRadius = 0.1f;
         
@@ -90,7 +90,7 @@ public class PrismCollisionDetectorTest {
     @Test
     public void testPrismSphereCollisionOutside() {
         // Create a prism and a sphere outside it
-        var prism = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
+        var prism = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
         var sphereCenter = new Point3f(5, 5, 5);
         float sphereRadius = 0.1f;
         
@@ -102,7 +102,7 @@ public class PrismCollisionDetectorTest {
     @Test
     public void testPrismSphereCollisionOverlapping() {
         // Create a prism and a sphere that overlaps it
-        var prism = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
+        var prism = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
         var sphereCenter = new Point3f(0.8f, 0.1f, 0.5f);
         float sphereRadius = 0.3f;
         
@@ -115,18 +115,18 @@ public class PrismCollisionDetectorTest {
     @Test
     public void testFindCollidingPrisms() {
         // Create a test prism at level 2
-        var testPrism = new PrismKey(new Triangle(2, 0, 1, 1, 2), new Line(2, 1));
+        var testPrism = new PrismKey(new Triangle(2, 0, 1, 1), new Line(2, 1));
         
         // Create candidate prisms
         List<PrismKey> candidates = new ArrayList<>();
         // Overlapping prism (same position)
-        candidates.add(new PrismKey(new Triangle(2, 0, 1, 1, 2), new Line(2, 1)));
+        candidates.add(new PrismKey(new Triangle(2, 0, 1, 1), new Line(2, 1)));
         // Adjacent prism
-        candidates.add(new PrismKey(new Triangle(2, 0, 2, 1, 2), new Line(2, 1)));
+        candidates.add(new PrismKey(new Triangle(2, 0, 2, 1), new Line(2, 1)));
         // Far away prism (different Z layer)
-        candidates.add(new PrismKey(new Triangle(2, 0, 1, 1, 2), new Line(2, 3)));
+        candidates.add(new PrismKey(new Triangle(2, 0, 1, 1), new Line(2, 3)));
         // Another overlapping prism
-        candidates.add(new PrismKey(new Triangle(2, 0, 1, 1, 2), new Line(2, 1)));
+        candidates.add(new PrismKey(new Triangle(2, 0, 1, 1), new Line(2, 1)));
         
         Set<PrismKey> colliding = PrismCollisionDetector.findCollidingPrisms(testPrism, candidates);
         
@@ -138,8 +138,8 @@ public class PrismCollisionDetectorTest {
     @Test
     public void testCollisionWithIdenticalPrisms() {
         // Create two identical prisms
-        var prism1 = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
-        var prism2 = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
+        var prism1 = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
+        var prism2 = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
         
         var result = PrismCollisionDetector.testPrismPrismCollision(prism1, prism2);
         
@@ -150,8 +150,8 @@ public class PrismCollisionDetectorTest {
     @Test
     public void testCollisionAtDifferentLevels() {
         // Create prisms at different subdivision levels
-        var prism1 = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
-        var prism2 = new PrismKey(new Triangle(1, 0, 0, 0, 0), new Line(1, 0));
+        var prism1 = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
+        var prism2 = new PrismKey(new Triangle(1, 0, 0, 0), new Line(1, 0));
         
         var result = PrismCollisionDetector.testPrismPrismCollision(prism1, prism2);
         
@@ -162,8 +162,8 @@ public class PrismCollisionDetectorTest {
     @Test
     public void testEdgeOnCollision() {
         // Create prisms that share an edge
-        var prism1 = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
-        var prism2 = new PrismKey(new Triangle(1, 0, 0, 0, 1), new Line(1, 0));
+        var prism1 = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
+        var prism2 = new PrismKey(new Triangle(1, 0, 0, 0), new Line(1, 0));
         
         var result = PrismCollisionDetector.testPrismPrismCollision(prism1, prism2);
         
@@ -174,8 +174,8 @@ public class PrismCollisionDetectorTest {
     @Test
     public void testVertexCollision() {
         // Create prisms that touch at a vertex
-        var prism1 = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
-        var prism2 = new PrismKey(new Triangle(1, 0, 0, 0, 1), new Line(1, 0));
+        var prism1 = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
+        var prism2 = new PrismKey(new Triangle(1, 0, 0, 0), new Line(1, 0));
         
         var result = PrismCollisionDetector.testPrismPrismCollision(prism1, prism2);
         
@@ -186,7 +186,7 @@ public class PrismCollisionDetectorTest {
     @Test
     public void testLargeSphereCollision() {
         // Test with a very large sphere that encompasses the prism
-        var prism = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
+        var prism = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
         var sphereCenter = new Point3f(0.25f, 0.25f, 0.5f);
         float sphereRadius = 10.0f;
         
@@ -200,13 +200,13 @@ public class PrismCollisionDetectorTest {
     @Tag("performance")
     public void testCollisionPerformance() {
         // Test performance with many candidates
-        var testPrism = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
+        var testPrism = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
         
         List<PrismKey> candidates = new ArrayList<>();
         for (int i = 0; i < 1000; i++) {
             float offset = i * 0.1f;
             candidates.add(new PrismKey(
-                new Triangle(i % 10, 0, 0, 0, 0), 
+                new Triangle(i % 10, 0, 0, 0), 
                 new Line(i % 10, 0)
             ));
         }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismCrossDiagonalNeighborTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismCrossDiagonalNeighborTest.java
@@ -42,7 +42,7 @@ class PrismCrossDiagonalNeighborTest {
     @DisplayName("a diagonal-cell S0 triangle's hypotenuse neighbor is its S1 mirror (not null)")
     void crossDiagonalReturnsS1() {
         // Diagonal cell (x == y) at level 3, type 0 (lower-right), S0.
-        var s0 = new Triangle(3, 0, 3, 3, 3, 0);
+        var s0 = new Triangle(3, 0, 3, 3, 0);
         var neighbor = s0.faceNeighbor(DIAGONAL_FACE);
         assertNotNull(neighbor, "interior diagonal face must have a neighbor (S1), not null");
         assertEquals(1, neighbor.getHalf(), "cross-diagonal neighbor must be in the S1 half");
@@ -61,7 +61,7 @@ class PrismCrossDiagonalNeighborTest {
                 for (int half = 0; half < 2; half++) {
                     // A diagonal cell (x == y == d), type 0: its hypotenuse lies on the global
                     // diagonal, so its face-1 neighbor crosses into the other half.
-                    var t = new Triangle(level, 0, d, d, d, half);
+                    var t = new Triangle(level, 0, d, d, half);
                     var n = t.faceNeighbor(DIAGONAL_FACE);
                     assertNotNull(n, "diagonal-cell hypotenuse neighbor must not be null at " + t);
                     assertEquals(1 - half, n.getHalf(), "must cross to the other half");
@@ -77,7 +77,7 @@ class PrismCrossDiagonalNeighborTest {
     void interiorHypotenuseStaysSameHalf() {
         // Cell strictly below the diagonal (x > y): the hypotenuse neighbor is the same-cell
         // type-1 sub-triangle, still in S0.
-        var t = new Triangle(3, 0, 5, 2, 2, 0);
+        var t = new Triangle(3, 0, 5, 2, 0);
         var n = t.faceNeighbor(DIAGONAL_FACE);
         assertNotNull(n);
         assertEquals(0, n.getHalf(), "interior hypotenuse neighbor stays in S0");
@@ -103,7 +103,7 @@ class PrismCrossDiagonalNeighborTest {
                             continue;
                         }
                         for (int half = 0; half < 2; half++) {
-                            var t = new Triangle(level, type, x, y, Math.min(x, y), half);
+                            var t = new Triangle(level, type, x, y, half);
                             for (int f = 0; f < 3; f++) {
                                 var n = t.faceNeighbor(f);
                                 if (n == null) {
@@ -123,7 +123,7 @@ class PrismCrossDiagonalNeighborTest {
     @Test
     @DisplayName("PrismNeighborFinder crosses the diagonal: the quad face neighbor is an S1 prism")
     void prismNeighborFinderCrossesDiagonal() {
-        var s0Prism = new PrismKey(new Triangle(3, 0, 3, 3, 3, 0), new Line(3, 4));
+        var s0Prism = new PrismKey(new Triangle(3, 0, 3, 3, 0), new Line(3, 4));
         var neighbor = PrismNeighborFinder.findFaceNeighbor(s0Prism, DIAGONAL_FACE);
         assertNotNull(neighbor, "diagonal quad face must have an interior (S1) neighbor, not null");
         assertEquals(1, neighbor.getTriangle().getHalf(), "the cross-diagonal prism neighbor is in S1");

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismFullCubeCoverageTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismFullCubeCoverageTest.java
@@ -64,8 +64,7 @@ class PrismFullCubeCoverageTest {
                     // two closed half-triangles share the edge, so both contain it — fromWorldCoordinates
                     // assigns it to S0 by convention; see Triangle.contains javadoc.)
                     if (Math.abs(wx - wy) > 1e-4f) {
-                        var opposite = new Triangle(tri.getLevel(), tri.getType(), tri.getX(), tri.getY(),
-                                                    Math.min(tri.getX(), tri.getY()), 1 - tri.getHalf());
+                        var opposite = new Triangle(tri.getLevel(), tri.getType(), tri.getX(), tri.getY(), 1 - tri.getHalf());
                         assertFalse(opposite.contains(wx, wy), String.format(
                             "opposite half must NOT contain (%.4f,%.4f) — no double count", wx, wy));
                         var prism = PrismKey.fromWorldCoordinates(wx, wy, 0.5f, level);
@@ -130,7 +129,7 @@ class PrismFullCubeCoverageTest {
         var tri = Triangle.fromWorldCoordinates(0.8f, 0.3f, 5); // y < x => S0
         assertEquals(0, tri.getHalf());
         // The 5-arg constructor (legacy) defaults to S0/half 0 and equals an S0 fromWorld* triangle.
-        var manual = new Triangle(tri.getLevel(), tri.getType(), tri.getX(), tri.getY(), tri.getN());
+        var manual = new Triangle(tri.getLevel(), tri.getType(), tri.getX(), tri.getY());
         assertEquals(0, manual.getHalf());
         assertEquals(manual, tri, "legacy 5-arg ctor must equal the S0 located triangle");
         assertEquals(manual.consecutiveIndex(), tri.consecutiveIndex());
@@ -139,7 +138,7 @@ class PrismFullCubeCoverageTest {
     @Test
     @DisplayName("level-0 roots are per-half: S0 root contains only y<=x, S1 root only y>=x")
     void levelZeroRootsArePerHalf() {
-        var s0Root = new Triangle(0, 0, 0, 0, 0);          // S0 (half 0)
+        var s0Root = new Triangle(0, 0, 0, 0);          // S0 (half 0)
         assertEquals(0, s0Root.getHalf());
         assertTrue(s0Root.contains(0.8f, 0.2f), "S0 root contains lower-right (y<x)");
         assertFalse(s0Root.contains(0.2f, 0.8f), "S0 root must NOT contain upper-left (y>x) — no full-square special case");

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismKeyTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismKeyTest.java
@@ -37,7 +37,7 @@ class PrismKeyTest {
     @Test
     @DisplayName("PrismKey construction validates components")
     void testPrismKeyConstruction() {
-        var triangle = new Triangle(3, 1, 4, 2, 1);
+        var triangle = new Triangle(3, 1, 4, 2);
         var line = new Line(3, 5);
         
         // Valid construction
@@ -102,7 +102,7 @@ class PrismKeyTest {
     void testLevelSynchronization() {
         // Create keys at various levels
         for (int level = 0; level <= 5; level++) {
-            var triangle = new Triangle(level, 0, 0, 0, 0);
+            var triangle = new Triangle(level, 0, 0, 0);
             var line = new Line(level, 0);
             var key = new PrismKey(triangle, line);
             
@@ -113,7 +113,7 @@ class PrismKeyTest {
         }
         
         // Test parent-child level consistency
-        var parent = new PrismKey(new Triangle(3, 0, 2, 1, 1), new Line(3, 4));
+        var parent = new PrismKey(new Triangle(3, 0, 2, 1), new Line(3, 4));
         for (int childIndex = 0; childIndex < PrismKey.CHILDREN; childIndex++) {
             var child = parent.child(childIndex);
             assertEquals(parent.getLevel() + 1, child.getLevel());
@@ -146,13 +146,13 @@ class PrismKeyTest {
         
         // Test monotonicity within a level
         for (int level = 1; level <= 3; level++) {
-            var triangleBase = new Triangle(level, 0, 0, 0, 0);
+            var triangleBase = new Triangle(level, 0, 0, 0);
             var lineBase = new Line(level, 0);
             var baseKey = new PrismKey(triangleBase, lineBase);
             var baseIndex = baseKey.consecutiveIndex();
             
             // Keys with higher coordinates should generally have higher indices
-            var triangleNext = new Triangle(level, 0, 1, 0, 0);
+            var triangleNext = new Triangle(level, 0, 1, 0);
             var nextKey = new PrismKey(triangleNext, lineBase);
             assertTrue(nextKey.consecutiveIndex() > baseIndex,
                      String.format("SFC not monotonic at level %d", level));
@@ -162,7 +162,7 @@ class PrismKeyTest {
     @Test
     @DisplayName("Morton-order child generation works correctly")
     void testMortonOrderChildren() {
-        var parent = new PrismKey(new Triangle(2, 1, 2, 1, 1), new Line(2, 3));
+        var parent = new PrismKey(new Triangle(2, 1, 2, 1), new Line(2, 3));
         
         // Test all 8 children
         var children = new PrismKey[PrismKey.CHILDREN];
@@ -212,7 +212,7 @@ class PrismKeyTest {
         // Test parent-child round trips. n = min(x,y) = min(5,3) = 3 (RDR-009 P1: n is the
         // derived auxiliary coordinate min(x,y); the parent()/child() round-trip recomputes it
         // from coordinates rather than bit-shifting, so the fixture uses the consistent value).
-        var key = new PrismKey(new Triangle(3, 1, 5, 3, 3), new Line(3, 6));
+        var key = new PrismKey(new Triangle(3, 1, 5, 3), new Line(3, 6));
         
         for (int childIndex = 0; childIndex < PrismKey.CHILDREN; childIndex++) {
             var child = key.child(childIndex);
@@ -228,7 +228,7 @@ class PrismKeyTest {
         }
         
         // Test multi-level hierarchy
-        var grandparent = new PrismKey(new Triangle(1, 0, 1, 0, 0), new Line(1, 1));
+        var grandparent = new PrismKey(new Triangle(1, 0, 1, 0), new Line(1, 1));
         var parent = grandparent.child(3);
         var child = parent.child(5);
         
@@ -266,7 +266,7 @@ class PrismKeyTest {
         }
         
         // Test that children partition parent space (simplified test)
-        var parent = new PrismKey(new Triangle(2, 0, 1, 1, 0), new Line(2, 2));
+        var parent = new PrismKey(new Triangle(2, 0, 1, 1), new Line(2, 2));
         var parentCentroid = parent.getCentroid();
         
         var containedByChild = false;
@@ -284,7 +284,7 @@ class PrismKeyTest {
     @Test
     @DisplayName("Geometric calculations are accurate")
     void testGeometricCalculations() {
-        var key = new PrismKey(new Triangle(2, 0, 1, 2, 1), new Line(2, 3));
+        var key = new PrismKey(new Triangle(2, 0, 1, 2), new Line(2, 3));
         
         // Test centroid
         var centroid = key.getCentroid();
@@ -327,7 +327,7 @@ class PrismKeyTest {
     @DisplayName("SpatialKey interface compliance")
     void testSpatialKeyInterface() {
         // Test that PrismKey properly implements SpatialKey
-        SpatialKey<PrismKey> spatialKey = new PrismKey(new Triangle(3, 1, 4, 2, 1), new Line(3, 5));
+        SpatialKey<PrismKey> spatialKey = new PrismKey(new Triangle(3, 1, 4, 2), new Line(3, 5));
         
         // Basic interface methods
         assertEquals(3, spatialKey.getLevel());
@@ -344,7 +344,7 @@ class PrismKeyTest {
         // Test that it works in collections (requires proper equals/hashCode/compareTo)
         var keys = new java.util.TreeSet<PrismKey>();
         for (int i = 0; i < 8; i++) { // Level 3 max coord is 7
-            var triangle = new Triangle(3, 0, i, i/2, i/3);
+            var triangle = new Triangle(3, 0, i, i/2);
             var line = new Line(3, i);
             keys.add(new PrismKey(triangle, line));
         }
@@ -354,9 +354,9 @@ class PrismKeyTest {
     @Test
     @DisplayName("Comparable interface works correctly")
     void testComparableInterface() {
-        var key1 = new PrismKey(new Triangle(2, 0, 0, 0, 0), new Line(2, 0));
-        var key2 = new PrismKey(new Triangle(2, 0, 1, 0, 0), new Line(2, 0));
-        var key3 = new PrismKey(new Triangle(2, 0, 0, 0, 0), new Line(2, 1));
+        var key1 = new PrismKey(new Triangle(2, 0, 0, 0), new Line(2, 0));
+        var key2 = new PrismKey(new Triangle(2, 0, 1, 0), new Line(2, 0));
+        var key3 = new PrismKey(new Triangle(2, 0, 0, 0), new Line(2, 1));
         
         // Test comparison based on SFC index
         assertTrue(key1.compareTo(key2) < 0 || key1.compareTo(key2) > 0); // Should be different
@@ -364,7 +364,7 @@ class PrismKeyTest {
         assertEquals(0, key1.compareTo(key1)); // Self comparison
         
         // Test consistency with equals
-        var key1Copy = new PrismKey(new Triangle(2, 0, 0, 0, 0), new Line(2, 0));
+        var key1Copy = new PrismKey(new Triangle(2, 0, 0, 0), new Line(2, 0));
         assertEquals(0, key1.compareTo(key1Copy));
         assertEquals(key1, key1Copy);
         
@@ -388,7 +388,7 @@ class PrismKeyTest {
     @DisplayName("Boundary conditions are handled correctly")
     void testBoundaryConditions() {
         // Maximum level
-        var maxTriangle = new Triangle(Triangle.MAX_LEVEL, 0, 0, 0, 0);
+        var maxTriangle = new Triangle(Triangle.MAX_LEVEL, 0, 0, 0);
         var maxLine = new Line(Line.MAX_LEVEL, 0);
         var maxLevelKey = new PrismKey(maxTriangle, maxLine);
         
@@ -399,7 +399,7 @@ class PrismKeyTest {
         // Edge coordinates
         for (int level = 0; level <= 3; level++) {
             var maxCoord = (1 << level) - 1;
-            var edgeTriangle = new Triangle(level, 1, maxCoord, maxCoord, maxCoord);
+            var edgeTriangle = new Triangle(level, 1, maxCoord, maxCoord);
             var edgeLine = new Line(level, maxCoord);
             var edgeKey = new PrismKey(edgeTriangle, edgeLine);
             
@@ -419,14 +419,14 @@ class PrismKeyTest {
     @Test
     @DisplayName("Equals and hashCode work correctly") 
     void testEqualsAndHashCode() {
-        var triangle1 = new Triangle(3, 1, 4, 2, 1);
+        var triangle1 = new Triangle(3, 1, 4, 2);
         var line1 = new Line(3, 5);
         var key1 = new PrismKey(triangle1, line1);
         var key2 = new PrismKey(triangle1, line1);
         
         // RDR-009 P2: n is no longer part of Triangle identity (it is the derived min(x,y)), so a
         // distinct key must differ in a real field. Use a different anchor x (still S0: y <= x).
-        var triangle2 = new Triangle(3, 1, 3, 2, 2);
+        var triangle2 = new Triangle(3, 1, 3, 2);
         var key3 = new PrismKey(triangle2, line1);
         
         var line2 = new Line(3, 4); // Different coordinate
@@ -450,14 +450,14 @@ class PrismKeyTest {
         assertEquals(key1, key1);
         assertEquals(key1.equals(key2), key2.equals(key1));
         
-        var key2Copy = new PrismKey(new Triangle(3, 1, 4, 2, 1), new Line(3, 5));
+        var key2Copy = new PrismKey(new Triangle(3, 1, 4, 2), new Line(3, 5));
         assertTrue(key1.equals(key2) && key2.equals(key2Copy) && key1.equals(key2Copy));
     }
     
     @Test
     @DisplayName("String representation is informative")
     void testToString() {
-        var key = new PrismKey(new Triangle(3, 1, 4, 2, 1), new Line(3, 5));
+        var key = new PrismKey(new Triangle(3, 1, 4, 2), new Line(3, 5));
         var str = key.toString();
         
         assertTrue(str.contains("PrismKey"));
@@ -518,7 +518,7 @@ class PrismKeyTest {
         // only in Line.z — the buggy long-packed encoding made these compare
         // equal because lineId << 64 reduces to lineId << 0.
         int maxLevel = Triangle.MAX_LEVEL;
-        var triangle = new Triangle(maxLevel, 0, 0, 0, 0);
+        var triangle = new Triangle(maxLevel, 0, 0, 0);
         var lineA = new Line(maxLevel, 0);
         var lineB = new Line(maxLevel, 1);
         var keyA = new PrismKey(triangle, lineA);

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismNeighborFinderTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismNeighborFinderTest.java
@@ -35,7 +35,7 @@ class PrismNeighborFinderTest {
 
     // An interior prism: x in (0, max-1), 0 < y < x, line z in (0, max-1) — all 5 faces in-domain.
     private static PrismKey interiorPrism() {
-        return new PrismKey(new Triangle(4, 0, 8, 5, 5, 0), new Line(4, 7));
+        return new PrismKey(new Triangle(4, 0, 8, 5, 0), new Line(4, 7));
     }
 
     @Test
@@ -68,7 +68,7 @@ class PrismNeighborFinderTest {
     @Test
     @DisplayName("the diagonal quad face of a diagonal-cell prism reaches the S1 family")
     void diagonalQuadFaceReachesS1() {
-        var prism = new PrismKey(new Triangle(4, 0, 6, 6, 6, 0), new Line(4, 7)); // diagonal cell, S0
+        var prism = new PrismKey(new Triangle(4, 0, 6, 6, 0), new Line(4, 7)); // diagonal cell, S0
         var neighbor = PrismNeighborFinder.findFaceNeighbor(prism, 1); // hypotenuse
         assertNotNull(neighbor, "interior diagonal face must reach the S1 neighbor, not null");
         assertEquals(1, neighbor.getTriangle().getHalf(), "neighbor across the diagonal is in S1");

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismPhase4CompilationTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismPhase4CompilationTest.java
@@ -29,7 +29,7 @@ public class PrismPhase4CompilationTest {
     @Test
     public void testPrismNeighborFinderCompiles() {
         // Test that PrismNeighborFinder can be instantiated and basic methods work
-        var triangle = new Triangle(0, 0, 0, 0, 0);
+        var triangle = new Triangle(0, 0, 0, 0);
         var line = new Line(0, 0);
         var prism = new PrismKey(triangle, line);
         
@@ -56,8 +56,8 @@ public class PrismPhase4CompilationTest {
     @Test
     public void testPrismCollisionDetectorCompiles() {
         // Test that PrismCollisionDetector compiles and basic methods work
-        var prism1 = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
-        var prism2 = new PrismKey(new Triangle(1, 0, 0, 0, 1), new Line(1, 1));
+        var prism1 = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
+        var prism2 = new PrismKey(new Triangle(1, 0, 0, 0), new Line(1, 1));
         
         // Test prism-prism collision
         var result = PrismCollisionDetector.testPrismPrismCollision(prism1, prism2);

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismRayIntersectorTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismRayIntersectorTest.java
@@ -35,7 +35,7 @@ public class PrismRayIntersectorTest {
     @Test
     public void testRayPrismIntersectionHit() {
         // Create a prism at the origin
-        var triangle = new Triangle(0, 0, 0, 0, 0);
+        var triangle = new Triangle(0, 0, 0, 0);
         var line = new Line(0, 0);
         var prism = new PrismKey(triangle, line);
         
@@ -59,7 +59,7 @@ public class PrismRayIntersectorTest {
     @Test
     public void testRayPrismIntersectionMiss() {
         // Create a prism at the origin
-        var triangle = new Triangle(0, 0, 0, 0, 0);
+        var triangle = new Triangle(0, 0, 0, 0);
         var line = new Line(0, 0);
         var prism = new PrismKey(triangle, line);
         
@@ -77,7 +77,7 @@ public class PrismRayIntersectorTest {
     @Test
     public void testRayAABBIntersection() {
         // Create a prism
-        var triangle = new Triangle(0, 0, 0, 0, 0);
+        var triangle = new Triangle(0, 0, 0, 0);
         var line = new Line(0, 0);
         var prism = new PrismKey(triangle, line);
         
@@ -103,7 +103,7 @@ public class PrismRayIntersectorTest {
     @Test
     public void testFindEntryExitPoints() {
         // Create a prism
-        var triangle = new Triangle(0, 0, 0, 0, 0);
+        var triangle = new Triangle(0, 0, 0, 0);
         var line = new Line(0, 0);
         var prism = new PrismKey(triangle, line);
         
@@ -124,7 +124,7 @@ public class PrismRayIntersectorTest {
     @Test
     public void testRayFromInsidePrism() {
         // Create a prism
-        var triangle = new Triangle(0, 0, 0, 0, 0);
+        var triangle = new Triangle(0, 0, 0, 0);
         var line = new Line(0, 0);
         var prism = new PrismKey(triangle, line);
         
@@ -144,7 +144,7 @@ public class PrismRayIntersectorTest {
     @Test
     public void testRayThroughBottomTriangle() {
         // Create a prism
-        var triangle = new Triangle(0, 0, 0, 0, 0);
+        var triangle = new Triangle(0, 0, 0, 0);
         var line = new Line(0, 0);
         var prism = new PrismKey(triangle, line);
         
@@ -164,7 +164,7 @@ public class PrismRayIntersectorTest {
     @Test
     public void testRayThroughSideFace() {
         // Create a prism
-        var triangle = new Triangle(0, 0, 0, 0, 0);
+        var triangle = new Triangle(0, 0, 0, 0);
         var line = new Line(0, 0);
         var prism = new PrismKey(triangle, line);
         
@@ -184,7 +184,7 @@ public class PrismRayIntersectorTest {
     @Test
     public void testParallelRay() {
         // Create a prism
-        var triangle = new Triangle(0, 0, 0, 0, 0);
+        var triangle = new Triangle(0, 0, 0, 0);
         var line = new Line(0, 0);
         var prism = new PrismKey(triangle, line);
         
@@ -205,7 +205,7 @@ public class PrismRayIntersectorTest {
     @Test
     public void testGrazingRay() {
         // Create a prism
-        var triangle = new Triangle(0, 0, 0, 0, 0);
+        var triangle = new Triangle(0, 0, 0, 0);
         var line = new Line(0, 0);
         var prism = new PrismKey(triangle, line);
         
@@ -224,9 +224,9 @@ public class PrismRayIntersectorTest {
     @Test
     public void testMultiplePrismIntersections() {
         // Create multiple prisms at different positions
-        var prism1 = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
-        var prism2 = new PrismKey(new Triangle(1, 0, 0, 0, 1), new Line(1, 0));
-        var prism3 = new PrismKey(new Triangle(2, 0, 0, 0, 2), new Line(2, 0));
+        var prism1 = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
+        var prism2 = new PrismKey(new Triangle(1, 0, 0, 0), new Line(1, 0));
+        var prism3 = new PrismKey(new Triangle(2, 0, 0, 0), new Line(2, 0));
         
         // Ray through all prisms
         var origin = new Point3f(-0.5f, 0.25f, 0.5f);

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismSpatialQueriesSimpleTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismSpatialQueriesSimpleTest.java
@@ -50,7 +50,7 @@ public class PrismSpatialQueriesSimpleTest {
         var id4 = prism.insert(new Point3f(0.2f, 0.1f, 5), (byte)5, "Entity4"); // was (0.1,0.2): flipped to y<=x
         
         // Create a search triangle in XY plane
-        Triangle searchTriangle = new Triangle(0, 0, 0, 0, 0);
+        Triangle searchTriangle = new Triangle(0, 0, 0, 0);
         searchTriangle.setBounds(0, 0, 0.5f, 0.5f);
         
         // Search in Z range 1-4
@@ -84,7 +84,7 @@ public class PrismSpatialQueriesSimpleTest {
         var id4 = prism.insert(new Point3f(0.3f, 0.3f, 3), (byte)5, "AlsoInside");
         
         // Create search triangular prism
-        Triangle searchTriangle = new Triangle(0, 0, 0, 0, 0);
+        Triangle searchTriangle = new Triangle(0, 0, 0, 0);
         searchTriangle.setBounds(0, 0, 0.5f, 0.5f);
         
         Set<LongEntityID> results = prism.findInTriangularPrism(searchTriangle, 1, 4);
@@ -97,7 +97,7 @@ public class PrismSpatialQueriesSimpleTest {
     public void testEmptyResults() {
         // Don't insert any entities
         
-        Triangle searchTriangle = new Triangle(0, 0, 0, 0, 0);
+        Triangle searchTriangle = new Triangle(0, 0, 0, 0);
         searchTriangle.setBounds(0, 0, 0.5f, 0.5f);
         
         Set<LongEntityID> results1 = prism.findInTriangularRegion(searchTriangle, 0, 10);

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismSubdivisionTilingTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismSubdivisionTilingTest.java
@@ -105,7 +105,7 @@ class PrismSubdivisionTilingTest {
     void childTypesFollowBeyBothHalves() {
         for (int half = 0; half < 2; half++) {
             for (int parentType = 0; parentType < Triangle.TYPES; parentType++) {
-                var t = new Triangle(2, parentType, 1, 1, Math.min(1, 1), half);
+                var t = new Triangle(2, parentType, 1, 1, half);
                 int[] counts = new int[Triangle.TYPES];
                 for (int i = 0; i < Triangle.CHILDREN; i++) {
                     counts[t.child(i).getType()]++;
@@ -122,7 +122,7 @@ class PrismSubdivisionTilingTest {
         // Every point in [0,1)^2 (off the exact diagonal) maps to exactly one half, and to a child
         // of that half's root after one refinement.
         var rnd = new Random(99L);
-        var s0Root = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
+        var s0Root = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
         var s1Root = PrismKey.createRootS1();
         for (int s = 0; s < 2000; s++) {
             float x = 0.001f + 0.997f * rnd.nextFloat();
@@ -145,7 +145,7 @@ class PrismSubdivisionTilingTest {
         // it is contained by both (geometrically correct). This pins the documented overlap as a
         // specification rather than a bug; canonical single-half assignment is via
         // fromWorldCoordinates (which gives the diagonal to S0). See Triangle.contains javadoc.
-        var s0Root = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
+        var s0Root = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
         var s1Root = PrismKey.createRootS1();
         for (float t = 0.1f; t < 1.0f; t += 0.1f) {
             assertTrue(countContaining(s0Root, t, t, 0.5f) >= 1 && countContaining(s1Root, t, t, 0.5f) >= 1,
@@ -167,7 +167,7 @@ class PrismSubdivisionTilingTest {
 
     /** A representative set of S0 and S1 parent prisms at several levels. */
     private static PrismKey[] sampleParents() {
-        var s0Root = new PrismKey(new Triangle(0, 0, 0, 0, 0), new Line(0, 0));
+        var s0Root = new PrismKey(new Triangle(0, 0, 0, 0), new Line(0, 0));
         var s1Root = PrismKey.createRootS1();
         // Descend a few levels in each half (child preserves half).
         var s0Mid = s0Root.child(0).child(3);

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismTest.java
@@ -348,7 +348,7 @@ class PrismTest {
         // Create a prism key at level 2. n = min(x,y) = min(1,1) = 1 (RDR-009 P1: n is the
         // derived auxiliary coordinate min(x,y); parent()/child() recompute it from coordinates,
         // so a fixture must use the consistent value to round-trip to itself).
-        var triangle = new Triangle(2, 0, 1, 1, 1);
+        var triangle = new Triangle(2, 0, 1, 1);
         var line = new Line(2, 1);
         var parentKey = new PrismKey(triangle, line);
         

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleBeyTypeTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleBeyTypeTest.java
@@ -62,14 +62,14 @@ class TriangleBeyTypeTest {
     @DisplayName("type-0 vertices are the lower-right Kuhn simplex (main-diagonal split)")
     void typeZeroIsLowerRight() {
         // Level-1 cell at anchor (0,0): world cell [0,0.5]×[0,0.5].
-        var t0 = new Triangle(1, 0, 0, 0, 0);
+        var t0 = new Triangle(1, 0, 0, 0);
         assertVertices(t0.getVertices(), new float[][] { { 0f, 0f }, { 0.5f, 0f }, { 0.5f, 0.5f } });
     }
 
     @Test
     @DisplayName("type-1 vertices are the upper-left Kuhn simplex (main-diagonal split)")
     void typeOneIsUpperLeft() {
-        var t1 = new Triangle(1, 1, 0, 0, 0);
+        var t1 = new Triangle(1, 1, 0, 0);
         assertVertices(t1.getVertices(), new float[][] { { 0f, 0f }, { 0f, 0.5f }, { 0.5f, 0.5f } });
     }
 
@@ -109,7 +109,7 @@ class TriangleBeyTypeTest {
     }
 
     @Test
-    @DisplayName("fromWorldCoordinate and fromWorldCoordinates agree on type, n, x, y")
+    @DisplayName("fromWorldCoordinate and fromWorldCoordinates agree on type, x, y")
     void bothConstructionPathsAgree() {
         for (int level = 1; level <= 8; level++) {
             for (int i = 1; i < 10; i++) {
@@ -122,7 +122,6 @@ class TriangleBeyTypeTest {
                     var a = Triangle.fromWorldCoordinate(wx, wy, level);
                     var b = Triangle.fromWorldCoordinates(wx, wy, level);
                     assertEquals(b.getType(), a.getType(), "type disagreement at " + wx + "," + wy + " L" + level);
-                    assertEquals(b.getN(), a.getN(), "n disagreement at " + wx + "," + wy + " L" + level);
                     assertEquals(b.getX(), a.getX(), "x disagreement at " + wx + "," + wy + " L" + level);
                     assertEquals(b.getY(), a.getY(), "y disagreement at " + wx + "," + wy + " L" + level);
                 }
@@ -142,7 +141,7 @@ class TriangleBeyTypeTest {
         // pre-commit a value P2 must change, so the test deliberately checks counts, not position.
         for (int parentType = 0; parentType < Triangle.TYPES; parentType++) {
             // Anchor (1,1) at level 2 → children at level 3 with coords ≤ 3 < 2^3.
-            var parent = new Triangle(2, parentType, 1, 1, Math.min(1, 1));
+            var parent = new Triangle(2, parentType, 1, 1);
             int[] counts = new int[Triangle.TYPES];
             for (int i = 0; i < Triangle.CHILDREN; i++) {
                 counts[parent.child(i).getType()]++;
@@ -165,7 +164,7 @@ class TriangleBeyTypeTest {
                     if (a[0] >= max || a[1] >= max) {
                         continue;
                     }
-                    var parent = new Triangle(level, type, a[0], a[1], Math.min(a[0], a[1]));
+                    var parent = new Triangle(level, type, a[0], a[1]);
                     for (int i = 0; i < Triangle.CHILDREN; i++) {
                         var child = parent.child(i);
                         assertEquals(i, child.getChildIndex(), "child index must round-trip");
@@ -179,47 +178,12 @@ class TriangleBeyTypeTest {
     }
 
     @Test
-    @DisplayName("n == min(x,y) for produced triangles, and child(i).parent() reproduces parent n")
-    void nIsSingleSourceOfTruthAndRoundTrips() {
-        for (int level = 1; level < Triangle.MAX_LEVEL; level++) {
-            int scale = 1 << level;
-            for (int i = 1; i < 8; i++) {
-                for (int j = 1; j < 8; j++) {
-                    float wx = i / 8.0f * 0.999f;
-                    float wy = j / 8.0f * 0.999f;
-                    if (wy > wx) {
-                        continue; // RDR-009 P2: only the S0 root (y <= x) is indexable until P3
-                    }
-                    var parent = Triangle.fromWorldCoordinates(wx, wy, level);
-                    assertEquals(Math.min(parent.getX(), parent.getY()), parent.getN(),
-                        "constructed triangle must satisfy n = min(x,y)");
-                    if (level + 1 > Triangle.MAX_LEVEL) {
-                        continue;
-                    }
-                    for (int c = 0; c < Triangle.CHILDREN; c++) {
-                        var child = parent.child(c);
-                        assertEquals(Math.min(child.getX(), child.getY()), child.getN(),
-                            "child must satisfy n = min(x,y)");
-                        assertEquals(parent.getN(), child.parent().getN(),
-                            "child(i).parent() must reproduce parent n");
-                    }
-                }
-            }
-        }
-    }
-
-    @Test
-    @DisplayName("n round-trip holds for the root and its descendants")
-    void nRoundTripFromRoot() {
-        var root = new Triangle(0, 0, 0, 0, 0);
-        assertEquals(0, root.getN());
-        // Descend an arbitrary child path and verify the invariant at each level.
-        var t = root;
+    @DisplayName("child(i).parent() reproduces the parent type along a refinement path")
+    void parentTypeRoundTripsFromRoot() {
+        var t = new Triangle(0, 0, 0, 0);
         int[] path = { 3, 1, 2, 0, 3, 2 };
         for (int step : path) {
             var child = t.child(step);
-            assertEquals(Math.min(child.getX(), child.getY()), child.getN(), "n=min(x,y) at each refinement");
-            assertEquals(t.getN(), child.parent().getN(), "parent n reproduced after child→parent");
             assertEquals(t.getType(), child.parent().getType(), "parent type reproduced after child→parent");
             t = child;
         }
@@ -235,7 +199,7 @@ class TriangleBeyTypeTest {
         // intersection / collision / nearest-neighbor disagreed with Triangle.getVertices().
         // It must delegate to the triangle's own (t8 main-diagonal) vertices for both types.
         for (int type = 0; type < Triangle.TYPES; type++) {
-            var triangle = new Triangle(2, type, 1, 1, Math.min(1, 1));
+            var triangle = new Triangle(2, type, 1, 1);
             var prism = new PrismKey(triangle, new Line(2, 1));
             var triVerts = triangle.getVertices();              // float[3][2]
             var prismVerts = PrismGeometry.getVertices(prism);  // 6 Point3f: bottom (minZ) then top
@@ -252,30 +216,6 @@ class TriangleBeyTypeTest {
     }
 
     // ── n=min(x,y) invariant under neighbor finding ───────────────────────────────────
-
-    @Test
-    @DisplayName("neighbors()/neighbor() preserve the n = min(x,y) invariant for both types")
-    void neighborNInvariant() {
-        // Guards the RDR-009 P1 change that recomputes n from each neighbor's coordinates
-        // (was: copied the source triangle's n). A P2 regression in neighbor n-derivation would
-        // otherwise have no trip-wire — neighbor traversal is correctness-critical for the TM-index.
-        for (int type = 0; type < Triangle.TYPES; type++) {
-            var t = new Triangle(3, type, 3, 2, Math.min(3, 2));
-            for (var nb : t.neighbors()) {
-                if (nb != null) {
-                    assertEquals(Math.min(nb.getX(), nb.getY()), nb.getN(),
-                        "neighbors()[*] must satisfy n = min(x,y), type " + type);
-                }
-            }
-            for (int e = 0; e < Triangle.EDGES; e++) {
-                var nb = t.neighbor(e);
-                if (nb != null) {
-                    assertEquals(Math.min(nb.getX(), nb.getY()), nb.getN(),
-                        "neighbor(" + e + ") must satisfy n = min(x,y), type " + type);
-                }
-            }
-        }
-    }
 
     // ── point-location boundary + clamp-removal conventions (RDR-009 P1) ───────────────
 
@@ -301,7 +241,6 @@ class TriangleBeyTypeTest {
         var tri = Triangle.fromWorldCoordinates(0.9f, 0.9f, 2);
         assertEquals(3, tri.getX(), "x must not be relocated off its quantized cell");
         assertEquals(3, tri.getY(), "y must not be relocated off its quantized cell");
-        assertEquals(Math.min(3, 3), tri.getN());
         assertTrue(tri.contains(0.9f, 0.9f), "the located triangle must still contain its own point");
         // fromWorldCoordinate (delegating) must agree — no residual clamp on that path either.
         var viaSingular = Triangle.fromWorldCoordinate(0.9f, 0.9f, 2);
@@ -313,7 +252,7 @@ class TriangleBeyTypeTest {
     void levelZeroRootIsPerHalf() {
         // RDR-009 P3 replaced the level-0 full-square placeholder with per-root containment: the
         // S0 root contains only its lower-right half {y <= x}; the upper-left half is the S1 root.
-        var s0Root = new Triangle(0, 0, 0, 0, 0);
+        var s0Root = new Triangle(0, 0, 0, 0);
         assertTrue(s0Root.contains(0.8f, 0.2f), "S0 root must contain lower-right (y < x) points");
         assertTrue(s0Root.contains(0.5f, 0.5f), "S0 root must contain on-diagonal points");
         assertTrue(!s0Root.contains(0.2f, 0.8f), "S0 root must NOT contain upper-left (y > x) points");

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleTest.java
@@ -39,6 +39,6 @@ class TriangleTest {
     void testRootIndexZero() {
         // Anchor for the SFC: the root triangle always indexes to 0. Used by PrismKey.createRoot
         // and asserted by PrismKeyTest.testCompositeSFC / PrismKeyTmSfcTest.
-        assertEquals(0L, new Triangle(0, 0, 0, 0, 0).consecutiveIndex());
+        assertEquals(0L, new Triangle(0, 0, 0, 0).consecutiveIndex());
     }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleTmSfcTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleTmSfcTest.java
@@ -48,7 +48,7 @@ class TriangleTmSfcTest {
     @Test
     @DisplayName("root consecutive index is 0")
     void rootIndexZero() {
-        assertEquals(0L, new Triangle(0, 0, 0, 0, 0).consecutiveIndex());
+        assertEquals(0L, new Triangle(0, 0, 0, 0).consecutiveIndex());
     }
 
     @Test
@@ -57,7 +57,7 @@ class TriangleTmSfcTest {
         // S0 anchors (y <= x) at a few levels and both types.
         int[][] seeds = { { 1, 0, 0, 0 }, { 2, 0, 2, 1 }, { 2, 1, 3, 1 }, { 3, 0, 5, 2 }, { 4, 1, 9, 4 } };
         for (int[] s : seeds) {
-            var parent = new Triangle(s[0], s[1], s[2], s[3], Math.min(s[2], s[3]));
+            var parent = new Triangle(s[0], s[1], s[2], s[3]);
             long base = parent.consecutiveIndex();
             var seen = new HashSet<Long>();
             for (int i = 0; i < Triangle.CHILDREN; i++) {
@@ -78,7 +78,7 @@ class TriangleTmSfcTest {
             if (s[0] >= Triangle.MAX_LEVEL) {
                 continue;
             }
-            var parent = new Triangle(s[0], s[1], s[2], s[3], Math.min(s[2], s[3]));
+            var parent = new Triangle(s[0], s[1], s[2], s[3]);
             for (int i = 0; i < Triangle.CHILDREN; i++) {
                 var child = parent.child(i);
                 assertEquals(i, child.getChildIndex(), "TM child index must round-trip");
@@ -94,7 +94,7 @@ class TriangleTmSfcTest {
     @Test
     @DisplayName("all level-k descendants of a triangle form a contiguous index range")
     void descendantsFormContiguousRange() {
-        var t = new Triangle(1, 0, 0, 0, 0);
+        var t = new Triangle(1, 0, 0, 0);
         // Two levels down: 16 descendants occupying [I(t)*16, I(t)*16 + 16).
         long base = t.consecutiveIndex();
         var indices = new ArrayList<Long>();
@@ -114,7 +114,7 @@ class TriangleTmSfcTest {
     @Test
     @DisplayName("anchors stay in the S0 region y <= x under refinement")
     void anchorsStayInS0() {
-        var roots = new Triangle[] { new Triangle(0, 0, 0, 0, 0) };
+        var roots = new Triangle[] { new Triangle(0, 0, 0, 0) };
         var frontier = new ArrayList<Triangle>();
         frontier.add(roots[0]);
         for (int depth = 0; depth < 6; depth++) {
@@ -135,7 +135,7 @@ class TriangleTmSfcTest {
     void maxLevelOrdering() {
         // Build a handful of level-21 triangles by descending a fixed path, plus their siblings,
         // and assert indices are non-negative and strictly ordered by the consecutive index.
-        var t = new Triangle(0, 0, 0, 0, 0);
+        var t = new Triangle(0, 0, 0, 0);
         int[] path = { 0, 2, 1, 3, 0, 1, 2, 3, 1, 0, 2, 3, 1, 2, 0, 3, 1, 0, 2, 1, 3 }; // 21 steps
         for (int step : path) {
             t = t.child(step);
@@ -202,7 +202,7 @@ class TriangleTmSfcTest {
             for (int x = 0; x < max; x++) {
                 for (int y = 0; y <= x; y++) { // all S0 anchors
                     for (int type = 0; type < Triangle.TYPES; type++) {
-                        var t = new Triangle(level, type, x, y, Math.min(x, y));
+                        var t = new Triangle(level, type, x, y);
                         for (var nb : t.neighbors()) {
                             if (nb != null) {
                                 assertTrue(nb.getY() <= nb.getX(),
@@ -228,7 +228,7 @@ class TriangleTmSfcTest {
         // Enumerate all level-5 descendants of the root via refinement; indices must be the
         // dense contiguous range [0, 4^5).
         var frontier = new ArrayList<Triangle>();
-        frontier.add(new Triangle(0, 0, 0, 0, 0));
+        frontier.add(new Triangle(0, 0, 0, 0));
         for (int depth = 0; depth < 5; depth++) {
             var next = new ArrayList<Triangle>();
             for (var t : frontier) {


### PR DESCRIPTION
## Luciferase-d41 — remove the vestigial `Triangle.n` (RDR-009 P7 follow-up)

The RDR-009 P2 note tied this cleanup to P7; it was deferred from the serde-focused P7 as an orthogonal mechanical change. `Triangle.n` was the derived value `min(x,y)` — excluded from `equals`/`hashCode`/`consecutiveIndex` since P2, carrying **no identity or ordering information**. It, the `@Deprecated getN()`, and the 5-arg constructor `(l,t,x,y,n)` are removed.

### Constructor change
```
before:  Triangle(level, type, x, y, n)         Triangle(level, type, x, y, n, half)
after:   Triangle(level, type, x, y)            Triangle(level, type, x, y, half)
```
`n` is no longer stored or validated; where it was the derived `min(x,y)` it simply drops out (recomputation was never needed — it was inert).

### Call sites (verified by the compiler)
Updated mechanically via a paren-depth-aware transform (handles `Math.min(x,y)` internal commas): **13** internal calls in `Triangle.java`, **1** in `PrismKey`, **2** in `PrismKeySerde` (the P7 deserialize paths) + its migration test, and **~95** across the prism test suite. Both `lucien` and `lucien-distributed` compile clean.

### Tests
The three n-invariant tests in `TriangleBeyTypeTest` (`nIsSingleSourceOfTruthAndRoundTrips`, `nRoundTripFromRoot`, `neighborNInvariant`) are removed — they pinned a field that no longer exists; the still-valid parent-type round-trip assertion they also carried is retained as `parentTypeRoundTripsFromRoot`. Stale `n` references in javadoc/comments (class doc, `child`/`parent`, `equals`, `toString`) updated.

**No behavior change** — `n` carried no semantics. Full `lucien` suite green (**2439**, `CI=true`); `lucien-distributed` green (**52**, `CI=true`).