### PR TITLE
Luciferase-1k9: fix Triangle.getCentroidWorldCoordinates (cell center -> true vertex mean)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/Triangle.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/prism/Triangle.java
@@ -556,11 +556,14 @@ public final class Triangle {
      * @return array of [centerX, centerY] coordinates in world space
      */
     public float[] getCentroidWorldCoordinates() {
-        var scale = 1.0f / (1 << level);
-        var centerX = x * scale + scale * 0.5f;
-        var centerY = y * scale + scale * 0.5f;
-        // Reflect across y = x for the S1 half (see getWorldBounds).
-        return (half == 1) ? new float[]{centerY, centerX} : new float[]{centerX, centerY};
+        // The true triangle centroid is the mean of the 3 vertices, NOT the grid-cell center
+        // (x*scale + scale/2): the cell center lies on the cell's main diagonal — the shared
+        // hypotenuse boundary of the two Kuhn half-cells — not in either triangle's interior
+        // (Luciferase-1k9; cf. the CUBE-vs-SIMPLEX center pitfall in CLAUDE.md). getVertices() is
+        // already type- and half-aware, so averaging it is correct for both types and both roots.
+        var v = getVertices();
+        return new float[] { (v[0][0] + v[1][0] + v[2][0]) / 3.0f,
+                             (v[0][1] + v[1][1] + v[2][1]) / 3.0f };
     }
     
     // Accessors

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleBeyTypeTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/TriangleBeyTypeTest.java
@@ -73,6 +73,34 @@ class TriangleBeyTypeTest {
         assertVertices(t1.getVertices(), new float[][] { { 0f, 0f }, { 0f, 0.5f }, { 0.5f, 0.5f } });
     }
 
+    @Test
+    @DisplayName("getCentroidWorldCoordinates is the mean of the 3 vertices (not the cell center) — both types and halves (Luciferase-1k9)")
+    void centroidIsVertexMeanNotCellCenter() {
+        for (int half = 0; half < 2; half++) {
+            for (int type = 0; type < Triangle.TYPES; type++) {
+                for (int level = 1; level <= 6; level++) {
+                    int max = 1 << level;
+                    // Anchor stored in the S0 frame (y <= x), valid at this level.
+                    var t = new Triangle(level, type, Math.min(3, max - 1), Math.min(2, max - 1), half);
+                    var v = t.getVertices();
+                    var c = t.getCentroidWorldCoordinates();
+                    float expX = (v[0][0] + v[1][0] + v[2][0]) / 3.0f;
+                    float expY = (v[0][1] + v[1][1] + v[2][1]) / 3.0f;
+                    assertEquals(expX, c[0], EPS, String.format("centroid x = vertex mean (half=%d type=%d L=%d)", half, type, level));
+                    assertEquals(expY, c[1], EPS, String.format("centroid y = vertex mean (half=%d type=%d L=%d)", half, type, level));
+                    // The true centroid is strictly interior; the old grid-cell center sat on the
+                    // hypotenuse (the cell's main diagonal), so this also pins the bug fix.
+                    assertTrue(t.contains(c[0], c[1]), String.format(
+                        "centroid must lie inside the triangle (half=%d type=%d L=%d)", half, type, level));
+                    float cellCx = t.getX() * (1.0f / max) + 0.5f / max;
+                    float cellCy = t.getY() * (1.0f / max) + 0.5f / max;
+                    assertTrue(Math.abs(c[0] - cellCx) > EPS || Math.abs(c[1] - cellCy) > EPS,
+                        "centroid must differ from the grid-cell center (the old buggy value)");
+                }
+            }
+        }
+    }
+
     // ── Point location matches orientation, and is consistent with contains() ─────────
 
     @Test


### PR DESCRIPTION
## Luciferase-1k9 — Triangle centroid bug

`Triangle.getCentroidWorldCoordinates()` returned the **grid-cell center** (`x*scale + scale/2`) instead of the triangle's centroid. The cell center lies on the cell's **main diagonal** — the shared hypotenuse boundary of the two Kuhn half-cells — not in either triangle's interior (the CUBE-vs-SIMPLEX center pitfall, cf. CLAUDE.md).

### Fix
Return the mean of `getVertices()`, which is already **type-aware** (t8 main-diagonal orientation, P1) and **half-aware** (S1 reflection, P3) — correct for both types and both roots.

Example (type-0, level-1, anchor (0,0)): centroid is now `(1/3, 1/6)` (= `(2/3, 1/3)·cell`), was `(1/2, 1/2)·cell` sitting on the hypotenuse.

### Impact (re-validated green)
The centroid feeds `PrismKey.getCentroid` → `estimateDistanceTo` (the **kNN distance heuristic**), `PrismGeometry.computeCentroid`, and `toString()`. kNN consumers re-validated: `PrismKeyTest`, `PrismCrossDiagonalQueryTest`, `PrismSparseKnnCompletenessTest` all green — the heuristic now uses the true centroid.

### Test
`TriangleBeyTypeTest.centroidIsVertexMeanNotCellCenter`: centroid `== mean(getVertices())` for both types and both halves across levels, strictly interior (`contains(centroid)`), and differs from the old grid-cell center.

Full `lucien` suite green (**2441**, `CI=true`). No behavior regression — a strictly more accurate centroid.