### PR TITLE
docs(RDR-009): mark implemented — Prism full-cube two-prism cover complete

### DIFF
--- a/docs/rdr/RDR-009-prism-full-cube-coverage.md
+++ b/docs/rdr/RDR-009-prism-full-cube-coverage.md
@@ -2,12 +2,13 @@
 title: "Prism Full-Cube Coverage via Two-Prism Cover"
 id: RDR-009
 type: Architecture
-status: accepted
+status: implemented
 priority: medium
 author: hal.hildebrand
 reviewed-by: self
 created: 2026-05-26
 accepted_date: 2026-05-26
+implemented_date: 2026-05-27
 related_issues: [Luciferase-fzm, Luciferase-4g6, RDR-001, RDR-002, RDR-003]
 ---
 


### PR DESCRIPTION
Marks **RDR-009 "Prism Full-Cube Coverage via Two-Prism Cover"** as `implemented` (frontmatter status `accepted` → `implemented`, `implemented_date: 2026-05-27`).

All 7 §Approach items delivered; epic **Luciferase-b3k** + GATE-A + GATE-B + PHASE-REVIEW-GATE closed; originating feature bead **Luciferase-fzm** closed as fulfilled.

PRs that delivered it: #112 (P1) · #113 (P2) · #114 (P3) · #115 (P4) · #116 (P5) · #117 (P6) · #118 (h65 sparse-kNN) · #119 (GATE-B cleanup) · #120 (P7 versioned serde) · #121 (q8z StackBuilder test) · #122 (d41 remove `Triangle.n`) · #123 (a7r flaky `testGhostSync` fix) · #124 (1k9 centroid fix).

Option B (half-cube-specialist fallback) was **not** taken; its trigger fired once (h65's `getCellSizeAtLevel int→float`), was surfaced + re-weighed with the user → proceed with Option A.

Doc-only change.