### PR TITLE
Luciferase-x5i.1: introduce SpatialIndexCore nucleus (RDR-008 P0)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
@@ -101,8 +101,9 @@ implements SpatialIndex<Key, ID, Content> {
     protected final ReadWriteLock                                    lock;
     protected final Set<Long>                                        deferredSubdivisionNodes = new HashSet<>();
     private final   TreeBalancer<Key, ID>                            treeBalancer;
-    // Entity data cache for performance
-    private final   EntityCache<ID>                                  entityCache;
+    // Entity data cache for performance. RDR-008: protected so all four structural-nucleus fields
+    // (spatialIndex, lock, entityManager, entityCache) share uniform visibility; reached by feature objects via core.
+    protected final EntityCache<ID>                                  entityCache;
     // Fine-grained locking strategy for high-concurrency operations
     protected       FineGrainedLockingStrategy<ID, Content>          lockingStrategy;
     // Bulk operation support
@@ -136,6 +137,10 @@ implements SpatialIndex<Key, ID, Content> {
     // k-NN caching (Phase 2: 20-30× speedup for cached hits)
     private final   java.util.concurrent.atomic.AtomicLong           spatialVersion = new java.util.concurrent.atomic.AtomicLong(0);
     private final   com.hellblazer.luciferase.lucien.cache.KNNCache<Key, ID> knnCache;
+    // RDR-008: shared storage+concurrency nucleus handed to feature-object collaborators. Additive view over the six
+    // nucleus fields (spatialIndex, lock, spatialVersion, knnCache, entityManager, entityCache), which remain the
+    // authoritative declarations on this façade; constructed once below after those fields are initialized.
+    protected final SpatialIndexCore<Key, ID, Content>                       core;
     // k-NN performance metrics
     private final   java.util.concurrent.atomic.AtomicLong           knnCacheHits = new java.util.concurrent.atomic.AtomicLong(0);
     private final   java.util.concurrent.atomic.AtomicLong           knnCacheMisses = new java.util.concurrent.atomic.AtomicLong(0);
@@ -177,7 +182,9 @@ implements SpatialIndex<Key, ID, Content> {
         this.treeBuilder = new StackBasedTreeBuilder<>(StackBasedTreeBuilder.defaultConfig());
         this.entityCache = new EntityCache<>(10000); // Cache up to 10k entities
         this.knnCache = new com.hellblazer.luciferase.lucien.cache.KNNCache<>(); // k-NN result caching
-        
+        // RDR-008: wrap the now-initialized six-field nucleus in a single shared view for feature-object collaborators
+        this.core = new SpatialIndexCore<>(spatialIndex, lock, spatialVersion, knnCache, entityManager, entityCache);
+
         // Initialize ghost components (neighbor detector and element manager set by subclasses)
         this.ghostLayer = new GhostLayer<>(GhostType.NONE);
         // ElementGhostManager initialized when neighbor detector is set

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialIndexCore.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialIndexCore.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien;
+
+import com.hellblazer.luciferase.lucien.cache.KNNCache;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+import com.hellblazer.luciferase.lucien.entity.EntityManager;
+import com.hellblazer.luciferase.lucien.internal.EntityCache;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReadWriteLock;
+
+/**
+ * The shared storage + concurrency nucleus of {@link AbstractSpatialIndex}.
+ *
+ * <p>This is the six-field nucleus that every cluster of the spatial index touches: the sorted node map, the
+ * read-write lock guarding it, the spatial version counter, the k-NN result cache, the entity manager, and the entity
+ * data cache. RDR-008 decomposes the {@code AbstractSpatialIndex} god-class into a façade plus cohesive feature-object
+ * collaborators ({@code DsocController}, {@code KnnSearcher}, {@code CollisionEngine}, …); each collaborator needs the
+ * same shared state, and handing it one {@code SpatialIndexCore} reference is cleaner — and keeps the concurrency
+ * primitives auditable in one place — than wiring six fields into every constructor.
+ *
+ * <p><b>P0 (RDR-008) introduction shape.</b> This type is introduced as an additive <i>view</i> over the façade's
+ * existing nucleus fields: {@code AbstractSpatialIndex} retains its (mostly {@code protected}) fields and constructs a
+ * single {@code SpatialIndexCore} wrapping the <i>same</i> object references in its constructor. No field is moved out
+ * of the façade and no internal access is rewritten in P0, so behaviour is unchanged and the four subclasses
+ * (Octree/Tetree/Prism/SFCArrayIndex), which reach the {@code protected} nucleus fields directly, compile untouched.
+ * Subsequent phases relocate each feature cluster into its own collaborator, which receives this core for nucleus
+ * access; the nucleus fields themselves stay on the façade.
+ *
+ * <p>The wrapped references are shared mutable collaborators (the map, lock, caches, and counters are live, concurrent
+ * objects); this holder is an identity aggregate over them, not a value object — it deliberately does not override
+ * {@code equals}/{@code hashCode}.
+ *
+ * @param <Key>     the spatial key type
+ * @param <ID>      the entity identifier type
+ * @param <Content> the entity content type
+ * @author hal.hildebrand
+ */
+public final class SpatialIndexCore<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
+
+    private final ConcurrentNavigableMap<Key, SpatialNodeImpl<ID>> spatialIndex;
+    private final ReadWriteLock                                    lock;
+    private final AtomicLong                                       spatialVersion;
+    private final KNNCache<Key, ID>                               knnCache;
+    private final EntityManager<Key, ID, Content>                 entityManager;
+    private final EntityCache<ID>                                 entityCache;
+
+    /**
+     * Wrap the six nucleus collaborators. All arguments are required; the references are shared with the owning
+     * {@link AbstractSpatialIndex} façade and must not be {@code null}.
+     */
+    public SpatialIndexCore(ConcurrentNavigableMap<Key, SpatialNodeImpl<ID>> spatialIndex, ReadWriteLock lock,
+                            AtomicLong spatialVersion, KNNCache<Key, ID> knnCache,
+                            EntityManager<Key, ID, Content> entityManager, EntityCache<ID> entityCache) {
+        this.spatialIndex = Objects.requireNonNull(spatialIndex, "spatialIndex");
+        this.lock = Objects.requireNonNull(lock, "lock");
+        this.spatialVersion = Objects.requireNonNull(spatialVersion, "spatialVersion");
+        this.knnCache = Objects.requireNonNull(knnCache, "knnCache");
+        this.entityManager = Objects.requireNonNull(entityManager, "entityManager");
+        this.entityCache = Objects.requireNonNull(entityCache, "entityCache");
+    }
+
+    /** The sorted spatial index: spatial key to the node holding the entity IDs at that key. */
+    public ConcurrentNavigableMap<Key, SpatialNodeImpl<ID>> spatialIndex() {
+        return spatialIndex;
+    }
+
+    /** The read-write lock guarding multi-step operations over the spatial index. */
+    public ReadWriteLock lock() {
+        return lock;
+    }
+
+    /** Monotonic version counter bumped on structural mutation; read by the k-NN cache for invalidation. */
+    public AtomicLong spatialVersion() {
+        return spatialVersion;
+    }
+
+    /** The k-NN result cache, invalidated against {@link #spatialVersion()}. */
+    public KNNCache<Key, ID> knnCache() {
+        return knnCache;
+    }
+
+    /** The entity manager owning entity lifecycle and entity-to-location mappings. */
+    public EntityManager<Key, ID, Content> entityManager() {
+        return entityManager;
+    }
+
+    /** The entity data cache used to reduce repeated entity lookups. */
+    public EntityCache<ID> entityCache() {
+        return entityCache;
+    }
+}


### PR DESCRIPTION
## Summary

RDR-008 P0 (prep) — establishes the shared storage+concurrency nucleus the locked RDR-008 decomposition mandates, **before** any feature object is extracted. Part of the AbstractSpatialIndex god-class breakup (epic `Luciferase-x5i`, RDR-008 `accepted`).

This is **not** a feature-extraction phase. It introduces the type the six phases (P1 DSOC → P6 entity-lifecycle) will all consume, in one no-cluster-moved changeset so the partial-bypass-risk primitive lands and is reviewed once.

## Changes

- **New `SpatialIndexCore<Key,ID,Content>`** — holds the six-field nucleus (`spatialIndex`, `lock`, `spatialVersion`, `knnCache`, `entityManager`, `entityCache`) behind null-guarded accessors. Identity aggregate over live shared collaborators (no `equals`/`hashCode`).
- **`AbstractSpatialIndex`** constructs one `protected final core` wrapping the same references after the nucleus fields initialize.
- **`entityCache` promoted `private` → `protected`** so the four structural-nucleus fields share uniform façade visibility (stacked-review finding).

## Invariants honored

- **Additive only.** Nucleus fields remain the authoritative façade declarations; no internal access rewritten; `core` is not yet read on any path (P1/`DsocController` is the first consumer).
- **Subclasses unchanged.** Octree/Tetree/Prism/SFCArrayIndex compile untouched (verified).
- **No behavior change.** Pre-change baseline and post-change full lucien suite are identical: 2441 tests, the single failure (`PrismVsOctreeComparisonTest.testRangeQueryPerformanceComparison`) is a pre-existing load-sensitive flake (tracked `Luciferase-tlb`, passes in isolation) present on both → **zero new failures**.
- **perf parity by-construction** — `core` constructed once, never read on a hot path. Formal `-Pperformance` gate folds into G1 with P1.

## Review

Stacked review per project rule (both run, 0 Critical):
- **code-review-expert** — approved for merge; 1 Medium (`entityCache` accessor escalation) **fixed** in this PR.
- **substantive-critic** — 0 Critical, 3 Significant: `entityCache` asymmetry **fixed**; `core` placement already correct; pre-P0 `-Pperformance` baseline + accessor-visibility/feature-object-package decision **recorded as P1 obligations on `Luciferase-x5i.2`**.

## Tracked follow-ups (P1)

- Capture `-Pperformance` baseline on `main` before P1's PR (clean two-point G1 comparison).
- Decide `DsocController` package (lucien root vs `lucien.occlusion`) → drives whether accessors tighten to package-private.
- P1 reviewer: verify `DsocController` reaches lock/spatialIndex only via `core` (no independent bypass reference).

Refs: RDR-008, `Luciferase-x5i.1`. Next: `Luciferase-x5i.2` (P1 DsocController) gated by G1 (`x5i.3`).