### PR TITLE
Luciferase-tlb: robustify cold-start flaky perf tests (warmup + best-of-N)

### DIFF
--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/PerfMeasure.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/PerfMeasure.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien;
+
+/**
+ * Microbenchmark hygiene helpers for latency-asserting tests.
+ *
+ * <p>A test that times a <i>single, cold</i> invocation and asserts an absolute latency bound is measuring one-time
+ * costs the warm JVM hides — class loading and interpreted execution before the JIT compiles the path. On a fast warm
+ * machine the cold call is a few hundred microseconds; under CI or concurrent-benchmark CPU load it can spike an order
+ * of magnitude higher and trip the bound, producing a flaky failure that is a measurement artifact, not a regression.
+ *
+ * <p>The fix (used by {@code Luciferase-a7r}/{@code lgu} and consolidated here for {@code Luciferase-tlb}): {@link
+ * #warmup(int, Runnable)} the path with untimed iterations so it is class-loaded and JIT-compiled, then take the
+ * {@link #bestNanos(int, Runnable) best (minimum)} of several timed runs — the minimum is the run least perturbed by
+ * scheduler/GC/CPU contention, i.e. the closest estimate of true steady-state cost. Keep the original functional
+ * assertions; only the timing measurement changes.
+ */
+public final class PerfMeasure {
+
+    private PerfMeasure() {
+    }
+
+    /**
+     * Run {@code op} {@code iterations} times without timing, to trigger class loading and JIT compilation of the path
+     * before it is measured.
+     *
+     * @param iterations number of untimed warmup runs (must be {@code >= 0})
+     * @param op         the operation to warm
+     */
+    public static void warmup(int iterations, Runnable op) {
+        if (iterations < 0) {
+            throw new IllegalArgumentException("iterations must be >= 0, was " + iterations);
+        }
+        for (int i = 0; i < iterations; i++) {
+            op.run();
+        }
+    }
+
+    /**
+     * Execute {@code op} {@code runs} times and return the minimum elapsed wall-clock time in nanoseconds. The minimum
+     * is reported because it is the run least perturbed by external CPU contention, giving the most stable estimate of
+     * steady-state cost. Warm the path with {@link #warmup(int, Runnable)} first.
+     *
+     * @param runs number of timed runs (must be {@code >= 1})
+     * @param op   the operation to measure
+     * @return the smallest {@link System#nanoTime()} delta observed across the runs
+     */
+    public static long bestNanos(int runs, Runnable op) {
+        if (runs < 1) {
+            throw new IllegalArgumentException("runs must be >= 1, was " + runs);
+        }
+        long best = Long.MAX_VALUE;
+        for (int i = 0; i < runs; i++) {
+            var start = System.nanoTime();
+            op.run();
+            best = Math.min(best, System.nanoTime() - start);
+        }
+        return best;
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/TetrahedralForestE2ETest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/TetrahedralForestE2ETest.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @DisabledIfEnvironmentVariable(
     named = "CI",
     matches = "true",
-    disabledReason = "Class-level gate: every test uses waitForSubdivision(., 2000ms) which polls for async subdivision to settle. 3 methods have failed across CI rounds (testGhostLayerWithBeySubdivision, testDistributedTwoServer, testEntityMovementAcrossSubdividedTrees) — the 2s deadline isn't reliable on GitHub Actions runners. Tracking: a follow-up bead should refactor these to either use a wait-with-large-bound (Awaitility) or move the perf-asserting parts to a dedicated PerformanceTest class. Local dev coverage retained.")
+    disabledReason = "Class-level gate retained. Luciferase-tlb hardened the subdivision waits: waitForSubdivision now also requires child tree ids to be registered (not just the isSubdivided() flag, which flips first), and the 3 methods that asserted exactly 6 children (testGhostLayerWithBeySubdivision, testDistributedTwoServer, testEntityMovementAcrossSubdividedTrees) wait on that terminal condition via waitForCondition(5000ms). Gate stays on until validated green across several CI rounds. Local dev coverage retained.")
 class TetrahedralForestE2ETest {
 
     /** Ghost zone width used in tests requiring ghost boundary detection. */
@@ -68,7 +68,11 @@ class TetrahedralForestE2ETest {
             try {
                 Thread.sleep(50);
                 waited += 50;
-                if (tree.isSubdivided()) {
+                // Require children registered, not just the flag: isSubdivided() flips before
+                // establishHierarchy() finishes adding child tree ids, so polling the flag alone races
+                // under load (Luciferase-tlb). This hardens all waitForSubdivision callers, not just the
+                // three that switched to the stricter waitForCondition(size==N) below.
+                if (tree.isSubdivided() && !tree.getChildTreeIds().isEmpty()) {
                     return waited;
                 }
             } catch (InterruptedException e) {
@@ -79,6 +83,28 @@ class TetrahedralForestE2ETest {
         fail(String.format("Tree %s did not subdivide within %dms (waited %dms)",
                           tree.getTreeId(), maxWaitMs, waited));
         return waited; // unreachable
+    }
+
+    /**
+     * Poll until {@code condition} holds or {@code maxWaitMs} elapses, failing with {@code desc} on timeout. Use this
+     * (rather than {@link #waitForSubdivision}) when the test depends on state that settles <i>after</i> the
+     * {@code isSubdivided()} flag flips — e.g. child-tree registration, which lags the flag under load (Luciferase-tlb).
+     */
+    private void waitForCondition(int maxWaitMs, String desc, java.util.function.BooleanSupplier condition) {
+        int waited = 0;
+        while (waited < maxWaitMs) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            try {
+                Thread.sleep(50);
+                waited += 50;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        fail(String.format("Condition not met within %dms: %s", maxWaitMs, desc));
     }
 
     /**
@@ -592,8 +618,10 @@ class TetrahedralForestE2ETest {
         // 3. Trigger subdivision
         forest.checkAndAdapt();
 
-        // Wait for subdivision to complete
-        waitForSubdivision(root, 2000);
+        // Wait for the terminal state, not the intermediate flag: isSubdivided() flips before the 6 child
+        // trees finish registering, so polling the flag alone races under load (Luciferase-tlb).
+        waitForCondition(5000, "root subdivided into 6 child trees",
+                         () -> root.isSubdivided() && root.getChildTreeIds().size() == 6);
 
         // 4. Verify subdivision occurred
         assertTrue(root.isSubdivided(), "Root should be subdivided");
@@ -697,8 +725,10 @@ class TetrahedralForestE2ETest {
         // 3. Trigger subdivision
         forest.checkAndAdapt();
 
-        // Wait for subdivision to complete
-        waitForSubdivision(root, 2000);
+        // Wait for the terminal state, not the intermediate flag: isSubdivided() flips before the 6 child
+        // trees finish registering, so polling the flag alone races under load (Luciferase-tlb).
+        waitForCondition(5000, "root subdivided into 6 child trees",
+                         () -> root.isSubdivided() && root.getChildTreeIds().size() == 6);
 
         // 4. Verify subdivision occurred
         assertTrue(root.isSubdivided(), "Root should be subdivided");
@@ -790,8 +820,10 @@ class TetrahedralForestE2ETest {
         // 3. Trigger subdivision
         forest.checkAndAdapt();
 
-        // Wait for subdivision to complete
-        waitForSubdivision(root, 2000);
+        // Wait for the terminal state, not the intermediate flag: isSubdivided() flips before the 6 child
+        // trees finish registering, so polling the flag alone races under load (Luciferase-tlb).
+        waitForCondition(5000, "root subdivided into 6 child trees",
+                         () -> root.isSubdivided() && root.getChildTreeIds().size() == 6);
 
         // 4. Verify subdivision occurred
         assertTrue(root.isSubdivided(), "Root should be subdivided");

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/octree/OctreeRayPerformanceTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/octree/OctreeRayPerformanceTest.java
@@ -3,6 +3,7 @@
  */
 package com.hellblazer.luciferase.lucien.octree;
 
+import com.hellblazer.luciferase.lucien.PerfMeasure;
 import com.hellblazer.luciferase.lucien.Ray3D;
 import com.hellblazer.luciferase.lucien.SpatialIndex;
 import com.hellblazer.luciferase.lucien.entity.EntityBounds;
@@ -201,27 +202,28 @@ public class OctreeRayPerformanceTest {
 
         Ray3D ray = new Ray3D(new Point3f(50, 50, 50), new Vector3f(1, 1, 1), 2000.0f);
 
-        // Test rayIntersectAll performance
-        long startTime = System.nanoTime();
-        for (int i = 0; i < 100; i++) {
-            List<SpatialIndex.RayIntersection<LongEntityID, String>> allIntersections = octree.rayIntersectAll(ray);
-        }
-        long allDuration = System.nanoTime() - startTime;
+        // Warm both ray paths so the comparison reflects steady state, not the first loop's JIT cost,
+        // and compare in nanos (ms rounding made the firstMs<=allMs*2 ratio unstable for sub-ms work).
+        // Luciferase-tlb.
+        PerfMeasure.warmup(20, () -> octree.rayIntersectAll(ray));
+        PerfMeasure.warmup(20, () -> octree.rayIntersectFirst(ray));
+        long allNanos = PerfMeasure.bestNanos(5, () -> {
+            for (int i = 0; i < 100; i++) {
+                octree.rayIntersectAll(ray);
+            }
+        });
+        long firstNanos = PerfMeasure.bestNanos(5, () -> {
+            for (int i = 0; i < 100; i++) {
+                octree.rayIntersectFirst(ray);
+            }
+        });
 
-        // Test rayIntersectFirst performance
-        startTime = System.nanoTime();
-        for (int i = 0; i < 100; i++) {
-            octree.rayIntersectFirst(ray);
-        }
-        long firstDuration = System.nanoTime() - startTime;
+        System.out.printf("rayIntersectAll: %.3f ms, rayIntersectFirst: %.3f ms (best-of-5 x100 iters)%n",
+                          allNanos / 1_000_000.0, firstNanos / 1_000_000.0);
 
-        long allMs = allDuration / 1_000_000;
-        long firstMs = firstDuration / 1_000_000;
-
-        System.out.printf("rayIntersectAll: %d ms, rayIntersectFirst: %d ms%n", allMs, firstMs);
-
-        // rayIntersectFirst should be faster or at least not significantly slower
-        assertTrue(firstMs <= allMs * 2, "rayIntersectFirst should not be significantly slower than rayIntersectAll");
+        // rayIntersectFirst (early-exit) should not be significantly slower than rayIntersectAll.
+        assertTrue(firstNanos <= allNanos * 2,
+                   "rayIntersectFirst should not be significantly slower than rayIntersectAll");
     }
 
     @Test

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismVsOctreeComparisonTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismVsOctreeComparisonTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import com.hellblazer.luciferase.lucien.entity.LongEntityID;
 import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.PerfMeasure;
 import com.hellblazer.luciferase.lucien.octree.Octree;
 
 import javax.vecmath.Point3f;
@@ -130,14 +131,16 @@ public class PrismVsOctreeComparisonTest {
         var searchCube = new com.hellblazer.luciferase.lucien.Spatial.Cube(20.0f, 20.0f, 20.0f, 20.0f);
         
         // Test Prism range query performance
-        long prismStartTime = System.nanoTime();
+        // Warm both query paths (class-load + JIT), then take the steady-state best-of-N: a single cold
+        // entitiesInRegion call can spike past the 5ms bound under CI/benchmark load (Luciferase-tlb).
+        PerfMeasure.warmup(5, () -> prism.entitiesInRegion(searchCube));
+        PerfMeasure.warmup(5, () -> octree.entitiesInRegion(searchCube));
+        long prismRangeTime = PerfMeasure.bestNanos(3, () -> prism.entitiesInRegion(searchCube));
         var prismResults = prism.entitiesInRegion(searchCube);
-        long prismRangeTime = System.nanoTime() - prismStartTime;
         
         // Test Octree range query performance
-        long octreeStartTime = System.nanoTime();
+        long octreeRangeTime = PerfMeasure.bestNanos(3, () -> octree.entitiesInRegion(searchCube));
         var octreeResults = octree.entitiesInRegion(searchCube);
-        long octreeRangeTime = System.nanoTime() - octreeStartTime;
         
         // Log performance comparison
         double rangeRatio = (double)prismRangeTime / octreeRangeTime;

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismVsTetreeComparisonTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismVsTetreeComparisonTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import com.hellblazer.luciferase.lucien.PerfMeasure;
 import com.hellblazer.luciferase.lucien.entity.LongEntityID;
 import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
 import com.hellblazer.luciferase.lucien.tetree.Tetree;
@@ -129,14 +130,16 @@ public class PrismVsTetreeComparisonTest {
         var searchCube = new com.hellblazer.luciferase.lucien.Spatial.Cube(20.0f, 20.0f, 20.0f, 20.0f);
         
         // Test Prism range query performance
-        long prismStartTime = System.nanoTime();
+        // Warm both query paths (class-load + JIT), then take the steady-state best-of-N: a single cold
+        // entitiesInRegion call can spike past the 5ms bound under CI/benchmark load (Luciferase-tlb).
+        PerfMeasure.warmup(5, () -> prism.entitiesInRegion(searchCube));
+        PerfMeasure.warmup(5, () -> tetree.entitiesInRegion(searchCube));
+        long prismRangeTime = PerfMeasure.bestNanos(3, () -> prism.entitiesInRegion(searchCube));
         var prismResults = prism.entitiesInRegion(searchCube);
-        long prismRangeTime = System.nanoTime() - prismStartTime;
         
         // Test Tetree range query performance
-        long tetreeStartTime = System.nanoTime();
+        long tetreeRangeTime = PerfMeasure.bestNanos(3, () -> tetree.entitiesInRegion(searchCube));
         var tetreeResults = tetree.entitiesInRegion(searchCube);
-        long tetreeRangeTime = System.nanoTime() - tetreeStartTime;
         
         // Log performance comparison
         double rangeRatio = (double)prismRangeTime / tetreeRangeTime;

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeLocateMethodTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeLocateMethodTest.java
@@ -1,6 +1,7 @@
 package com.hellblazer.luciferase.lucien.tetree;
 
 import com.hellblazer.luciferase.geometry.MortonCurve;
+import com.hellblazer.luciferase.lucien.PerfMeasure;
 import com.hellblazer.luciferase.lucien.benchmark.CIEnvironmentCheck;
 import com.hellblazer.luciferase.lucien.entity.LongEntityID;
 import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
@@ -255,36 +256,31 @@ public class TetreeLocateMethodTest {
             );
         }
         
-        // Time the new locate() method
-        long startTime = System.nanoTime();
-        for (Point3f point : testPoints) {
-            tetree.locate(point, level);
-        }
-        long newMethodTime = System.nanoTime() - startTime;
-        
-        // Simulate old method (test all 6 tetrahedra until first match)
-        Tet[] testTets = new Tet[6];
-        for (byte type = 0; type < 6; type++) {
-            testTets[type] = new Tet(0, 0, 0, level, type);
-        }
-        
-        startTime = System.nanoTime();
-        for (Point3f point : testPoints) {
-            // Simulate old approach: test all until first match
-            for (byte type = 0; type < 6; type++) {
-                Tet tet = new Tet(
-                    (int)(Math.floor(point.x / cellSize) * cellSize),
-                    (int)(Math.floor(point.y / cellSize) * cellSize), 
-                    (int)(Math.floor(point.z / cellSize) * cellSize),
-                    level, type
-                );
-                if (tet.contains(point)) {
-                    break; // Found first match
+        // Warm both paths (class-load + JIT), then compare steady-state best-of-N: a single cold pair of
+        // timed loops makes the speedup ratio noisy and trips the 1.5x bound under load (Luciferase-tlb).
+        Runnable newMethod = () -> {
+            for (Point3f point : testPoints) {
+                tetree.locate(point, level);
+            }
+        };
+        Runnable oldMethod = () -> {
+            for (Point3f point : testPoints) {
+                // Simulate old approach: test all 6 tetrahedra until first match
+                for (byte type = 0; type < 6; type++) {
+                    Tet tet = new Tet((int) (Math.floor(point.x / cellSize) * cellSize),
+                                      (int) (Math.floor(point.y / cellSize) * cellSize),
+                                      (int) (Math.floor(point.z / cellSize) * cellSize), level, type);
+                    if (tet.contains(point)) {
+                        break; // Found first match
+                    }
                 }
             }
-        }
-        long oldMethodTime = System.nanoTime() - startTime;
-        
+        };
+        PerfMeasure.warmup(3, newMethod);
+        PerfMeasure.warmup(3, oldMethod);
+        long newMethodTime = PerfMeasure.bestNanos(3, newMethod);
+        long oldMethodTime = PerfMeasure.bestNanos(3, oldMethod);
+
         double speedup = (double) oldMethodTime / newMethodTime;
         
         System.out.printf("New method: %.2f ms\n", newMethodTime / 1_000_000.0);


### PR DESCRIPTION
## Summary

Eliminates the recurring family of flaky perf-asserting tests that intermittently fail local `mvn -pl lucien test` runs (where RDR-008 phase gates execute) while passing in isolation. Same cold-start measurement bug fixed in #123/#129 (a7r/lgu), now consolidated behind a shared helper.

## Root cause

The `*Benchmark`/`*PerformanceTest` classes are already excluded from the default test cycle by the root pom (`<excludes>` + `excludedGroups=performance`). These five **slip through** because they are `*ComparisonTest` or plain `*Test` guarded only by `assumeFalse`/`@Disabled(CI)` — so they still run in **local** default runs. Each timed a single un-warmed invocation (or ratio) and asserted a latency bound; class-loading + pre-JIT cost under normal suite CPU contention tripped the assertion.

## Changes

- **New `PerfMeasure` test helper** — `warmup(n, op)` + `bestNanos(n, op)` (minimum of N timed runs, least perturbed by contention).
- `PrismVsOctreeComparisonTest` + `PrismVsTetreeComparisonTest` `.testRangeQueryPerformanceComparison`: warm both paths, best-of-N, keep the 5ms bound.
- `OctreeRayPerformanceTest.testRayIntersectFirstVsAllPerformance`: warm both ray paths; compare in nanos (ms rounding made the `first <= all*2` ratio unstable for sub-ms work).
- `TetreeLocateMethodTest.testPerformanceImprovement`: warm both paths, best-of-N, keep the `>=1.5x` speedup assertion; drop the dead `testTets` array.
- `TetrahedralForestE2ETest`: **not a perf flake but a wait race** — `isSubdivided()` flips before `establishHierarchy()` registers the child trees. `waitForSubdivision` now also requires child ids present (hardens all callers); the 3 methods that assert exactly 6 children wait on that terminal condition via `waitForCondition(5000ms)`.

## Verification

- All touched classes green in isolation.
- **Full default-cycle `mvn -pl lucien test` green: 2441 tests, 0 failures** (benchmarks excluded, as in CI/phase gates) — the same run previously flaked these.
- `OctreeRayPerformanceTest` is additionally excluded from the default cycle (`*PerformanceTest`); its fix applies under `-Pperformance`.

## Review

Stacked review (code-review-expert + substantive-critic), 0 Critical. Both significant findings addressed in-commit: forest race hardened across **all** `waitForSubdivision` callers (not just 3); verification claims corrected.

## Systemic follow-up

The recurring whack-a-mole (5 distinct tests across runs) confirms perf-asserting tests don't belong in the correctness suite. **`Luciferase-opw`** (P3) tracks tagging the remaining pure-perf methods `@Tag("performance")` — the project's existing exclusion mechanism, already used by `testKNNPerformanceComparison`.

Refs: `Luciferase-tlb`. Independent of #130 (RDR-008 P0; different files).