### PR TITLE
Luciferase-x5i.2: extract DsocController from AbstractSpatialIndex (RDR-008 P1)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
@@ -25,7 +25,6 @@ import com.hellblazer.luciferase.lucien.entity.*;
 import com.hellblazer.luciferase.lucien.forest.ghost.*;
 import com.hellblazer.luciferase.lucien.internal.EntityCache;
 import com.hellblazer.luciferase.lucien.occlusion.*;
-import com.hellblazer.luciferase.lucien.FrustumIntersection.VisibilityType;
 import com.hellblazer.luciferase.lucien.internal.ObjectPools;
 import com.hellblazer.luciferase.lucien.internal.UnorderedPair;
 import com.hellblazer.luciferase.lucien.neighbor.NeighborDetector;
@@ -112,25 +111,9 @@ implements SpatialIndex<Key, ID, Content> {
     protected       BulkOperationProcessor<Key, ID, Content>         bulkProcessor;
     protected       DeferredSubdivisionManager<Key, ID>              subdivisionManager;
     protected       SpatialNodePool<ID>                              nodePool;
-    
-    // DSOC fields (optional)
-    protected DSOCConfiguration dsocConfig;
-    protected FrameManager frameManager;
-    protected VisibilityStateManager<ID> visibilityManager;
-    protected HierarchicalOcclusionCuller<Key, ID, Content> occlusionCuller;
+
     protected       ParallelBulkOperations<Key, ID, Content>         parallelOperations;
-    protected float[] currentViewMatrix;
-    protected float[] currentProjectionMatrix;
-    
-    // DSOC performance monitoring
-    private volatile long dsocFrameCount = 0;
-    private volatile long dsocTotalTime = 0;
-    private volatile long standardFrameCount = 0;
-    private volatile long standardTotalTime = 0;
-    private volatile boolean dsocAutoDisabled = false;
-    private static final int MIN_FRAMES_FOR_EVALUATION = 10;
-    private static final double PERFORMANCE_THRESHOLD_MULTIPLIER = 1.2; // 20% overhead tolerance
-    private static final int EVALUATION_INTERVAL = 50; // Check every 50 frames
+
     protected       SubdivisionStrategy<Key, ID, Content>            subdivisionStrategy;
     protected       StackBasedTreeBuilder<Key, ID, Content>          treeBuilder;
     
@@ -141,6 +124,9 @@ implements SpatialIndex<Key, ID, Content> {
     // nucleus fields (spatialIndex, lock, spatialVersion, knnCache, entityManager, entityCache), which remain the
     // authoritative declarations on this façade; constructed once below after those fields are initialized.
     protected final SpatialIndexCore<Key, ID, Content>                       core;
+    // RDR-008 P1: Dynamic Scene Occlusion Culling cluster, encapsulated in DsocController (null until enableDSOC).
+    // volatile: enableDSOC may run concurrently with frustumCullVisible/isDSOCEnabled; publish the reference safely.
+    private volatile DsocController<Key, ID, Content>                        dsoc;
     // k-NN performance metrics
     private final   java.util.concurrent.atomic.AtomicLong           knnCacheHits = new java.util.concurrent.atomic.AtomicLong(0);
     private final   java.util.concurrent.atomic.AtomicLong           knnCacheMisses = new java.util.concurrent.atomic.AtomicLong(0);
@@ -768,27 +754,12 @@ implements SpatialIndex<Key, ID, Content> {
             throw new NullPointerException("Frustum cannot be null");
         }
         
-        // Check if DSOC should be auto-disabled
-        if (isDSOCEnabled() && !dsocAutoDisabled && shouldEvaluatePerformance()) {
-            if (shouldAutoDisableDSOC()) {
-                log.warn("Auto-disabling DSOC due to performance degradation: {}x overhead", 
-                        getDSOCOverheadMultiplier());
-                dsocAutoDisabled = true;
-            }
+        // RDR-008 P1: the DSOC decision (auto-disable, skip heuristics) and perf measurement live in
+        // DsocController. When DSOC was never enabled, run the standard cull directly.
+        if (dsoc != null) {
+            return dsoc.frustumCullVisible(frustum, cameraPosition);
         }
-        
-        // Early exit checks for DSOC optimization
-        if (isDSOCEnabled() && !dsocAutoDisabled && dsocConfig.isEnableHierarchicalOcclusion()) {
-            // Check if DSOC is worth using for this scenario
-            if (shouldSkipDSOC()) {
-                return measureAndExecute(() -> frustumCullVisibleStandard(frustum, cameraPosition), false);
-            }
-            
-            return measureAndExecute(() -> frustumCullVisibleWithDSOC(frustum, cameraPosition), true);
-        }
-        
-        // Use standard frustum culling with performance measurement
-        return measureAndExecute(() -> frustumCullVisibleStandard(frustum, cameraPosition), false);
+        return frustumCullVisibleStandard(frustum, cameraPosition);
     }
 
     @Override
@@ -2401,31 +2372,9 @@ implements SpatialIndex<Key, ID, Content> {
         try {
             validateSpatialConstraints(newPosition);
             
-            // Handle DSOC deferred updates
-            if (isDSOCEnabled() && visibilityManager != null) {
-                long currentFrame = getCurrentFrame();
-                var state = visibilityManager.getState(entityId);
-                if (state == VisibilityStateManager.VisibilityState.HIDDEN_WITH_TBV) {
-                    var tbv = visibilityManager.getTBV(entityId);
-                    if (tbv != null && tbv.isValid((int) currentFrame)) {
-                        // Defer update - just update dynamics
-                        var dynamics = entityManager.getDynamics(entityId);
-                        if (dynamics != null) {
-                            dynamics.updatePosition(newPosition, currentFrame);
-                            
-                            // Check if TBV needs refresh
-                            float quality = tbv.getQuality((int) currentFrame);
-                            if (quality < dsocConfig.getTbvRefreshThreshold()) {
-                                var bounds = entityManager.getEntityBounds(entityId);
-                                if (bounds == null) {
-                                    bounds = new EntityBounds(newPosition, 0.1f);
-                                }
-                                visibilityManager.createTBV(entityId, dynamics, bounds, currentFrame);
-                            }
-                        }
-                        return; // Skip normal update
-                    }
-                }
+            // RDR-008 P1: DSOC may defer this move behind a still-valid temporal bounding volume.
+            if (dsoc != null && dsoc.tryDeferUpdate(entityId, newPosition)) {
+                return; // Skip normal update
             }
 
             // Get the old position to calculate movement delta
@@ -2494,9 +2443,9 @@ implements SpatialIndex<Key, ID, Content> {
             var newSpatialKey = calculateSpatialIndex(newPosition, (byte) 15);
             knnCache.invalidatePosition(newSpatialKey);
             
-            // Update visibility state if DSOC is enabled
-            if (isDSOCEnabled() && visibilityManager != null) {
-                visibilityManager.updateVisibility(entityId, true, (int) getCurrentFrame());
+            // Update visibility state if DSOC is enabled (RDR-008 P1).
+            if (dsoc != null) {
+                dsoc.markVisibleOnUpdate(entityId);
             }
         } finally {
             lock.writeLock().unlock();
@@ -2610,10 +2559,43 @@ implements SpatialIndex<Key, ID, Content> {
      * Create a new node instance
      */
     protected SpatialNodeImpl<ID> createNode() {
-        if (isDSOCEnabled()) {
+        if (dsoc != null && dsoc.isEnabled()) {
             return new OcclusionAwareSpatialNode<>(maxEntitiesPerNode);
         }
         return new SpatialNodeImpl<>(maxEntitiesPerNode);
+    }
+
+    /**
+     * Supplies {@link DsocController} the façade operations its cull still needs — the frustum traversal order and
+     * frustum-node test (subclass-overridden template hooks), node bounds, the cached entity position, and the
+     * standard non-DSOC cull fallback — without widening those methods' visibility. RDR-008 P1.
+     */
+    private final class DsocCallbackImpl implements DsocCallback<Key, ID, Content> {
+        @Override
+        public Stream<Key> getFrustumTraversalOrder(Frustum3D frustum, Point3f cameraPosition) {
+            return AbstractSpatialIndex.this.getFrustumTraversalOrder(frustum, cameraPosition);
+        }
+
+        @Override
+        public boolean doesFrustumIntersectNode(Key nodeIndex, Frustum3D frustum) {
+            return AbstractSpatialIndex.this.doesFrustumIntersectNode(nodeIndex, frustum);
+        }
+
+        @Override
+        public EntityBounds computeNodeBounds(Key nodeIndex) {
+            return AbstractSpatialIndex.this.computeNodeBounds(nodeIndex);
+        }
+
+        @Override
+        public Point3f getCachedEntityPosition(ID entityId) {
+            return AbstractSpatialIndex.this.getCachedEntityPosition(entityId);
+        }
+
+        @Override
+        public List<FrustumIntersection<ID, Content>> frustumCullVisibleStandard(Frustum3D frustum,
+                                                                                 Point3f cameraPosition) {
+            return AbstractSpatialIndex.this.frustumCullVisibleStandard(frustum, cameraPosition);
+        }
     }
 
     /**
@@ -5432,19 +5414,8 @@ implements SpatialIndex<Key, ID, Content> {
      * @param bufferHeight Z-buffer height
      */
     public void enableDSOC(DSOCConfiguration config, int bufferWidth, int bufferHeight) {
-        this.dsocConfig = config;
-        
-        if (config.isEnabled()) {
-            this.frameManager = new FrameManager();
-            this.visibilityManager = new VisibilityStateManager<>(config);
-            this.occlusionCuller = new HierarchicalOcclusionCuller<>(bufferWidth, bufferHeight, config);
-            
-            // Enable auto-dynamics if configured
-            if (config.isAutoDynamicsEnabled()) {
-                entityManager.setAutoDynamicsEnabled(true);
-                entityManager.setFrameManager(frameManager);
-            }
-        }
+        // RDR-008 P1: the DSOC cluster is encapsulated in DsocController.
+        this.dsoc = new DsocController<>(core, new DsocCallbackImpl(), config, bufferWidth, bufferHeight);
     }
     
     /**
@@ -5458,26 +5429,15 @@ implements SpatialIndex<Key, ID, Content> {
      * Check if DSOC is enabled and not auto-disabled
      */
     public boolean isDSOCEnabled() {
-        return dsocConfig != null && dsocConfig.isEnabled() && !dsocAutoDisabled;
+        return dsoc != null && dsoc.isEnabled();
     }
     
     /**
      * Update camera matrices for occlusion culling
      */
     public void updateCamera(float[] viewMatrix, float[] projectionMatrix, Point3f cameraPosition) {
-        if (isDSOCEnabled()) {
-            if (viewMatrix == null || projectionMatrix == null) {
-                throw new NullPointerException("View and projection matrices cannot be null when DSOC is enabled");
-            }
-            if (viewMatrix.length != 16) {
-                throw new IllegalArgumentException("View matrix must be 4x4 (16 elements), got " + viewMatrix.length);
-            }
-            if (projectionMatrix.length != 16) {
-                throw new IllegalArgumentException("Projection matrix must be 4x4 (16 elements), got " + projectionMatrix.length);
-            }
-            // Store the camera matrices for use in beginFrame
-            this.currentViewMatrix = viewMatrix.clone();
-            this.currentProjectionMatrix = projectionMatrix.clone();
+        if (dsoc != null) {
+            dsoc.updateCamera(viewMatrix, projectionMatrix, cameraPosition);
         }
     }
     
@@ -5485,20 +5445,14 @@ implements SpatialIndex<Key, ID, Content> {
      * Advance to next frame (for DSOC)
      */
     public long nextFrame() {
-        if (frameManager != null) {
-            return frameManager.incrementFrame();
-        }
-        return 0;
+        return dsoc != null ? dsoc.nextFrame() : 0;
     }
     
     /**
      * Get current frame number
      */
     public long getCurrentFrame() {
-        if (frameManager != null) {
-            return frameManager.getCurrentFrame();
-        }
-        return 0;
+        return dsoc != null ? dsoc.getCurrentFrame() : 0;
     }
     
     /**
@@ -5507,28 +5461,11 @@ implements SpatialIndex<Key, ID, Content> {
      * @return Map of statistics
      */
     public Map<String, Object> getDSOCStatistics() {
-        Map<String, Object> stats = new HashMap<>();
-        
-        if (isDSOCEnabled()) {
-            stats.put("dsocEnabled", true);
-            stats.put("currentFrame", getCurrentFrame());
-            
-            // Add visibility statistics
-            if (visibilityManager != null) {
-                stats.putAll(visibilityManager.getStatistics());
-            }
-            
-            // Add occlusion culler statistics
-            if (occlusionCuller != null) {
-                stats.putAll(occlusionCuller.getStatistics());
-            }
-            
-            // Override totalEntities with the actual entity count from entityManager
-            stats.put("totalEntities", (long) entityManager.getEntityCount());
-        } else {
-            stats.put("dsocEnabled", false);
+        if (dsoc != null) {
+            return dsoc.getStatistics();
         }
-        
+        Map<String, Object> stats = new HashMap<>();
+        stats.put("dsocEnabled", false);
         return stats;
     }
     
@@ -5538,18 +5475,15 @@ implements SpatialIndex<Key, ID, Content> {
      * @return Set of entity IDs needing updates
      */
     public Set<ID> getEntitiesNeedingUpdate() {
-        if (occlusionCuller != null) {
-            return occlusionCuller.getEntitiesNeedingUpdate();
-        }
-        return new HashSet<>();
+        return dsoc != null ? dsoc.getEntitiesNeedingUpdate() : new HashSet<>();
     }
     
     /**
      * Reset DSOC statistics
      */
     public void resetDSOCStatistics() {
-        if (occlusionCuller != null) {
-            occlusionCuller.resetStatistics();
+        if (dsoc != null) {
+            dsoc.resetStatistics();
         }
     }
     
@@ -5557,164 +5491,11 @@ implements SpatialIndex<Key, ID, Content> {
      * Force Z-buffer activation for testing
      */
     public void forceZBufferActivation() {
-        if (occlusionCuller != null) {
-            occlusionCuller.forceActivate();
+        if (dsoc != null) {
+            dsoc.forceZBufferActivation();
         }
     }
-    
-    /**
-     * Creates a 4x4 identity matrix
-     */
-    private float[] createIdentityMatrix() {
-        float[] matrix = new float[16];
-        matrix[0] = 1.0f;
-        matrix[5] = 1.0f;
-        matrix[10] = 1.0f;
-        matrix[15] = 1.0f;
-        return matrix;
-    }
-    
-    /**
-     * Perform frustum culling with DSOC
-     */
-    protected List<FrustumIntersection<ID, Content>> frustumCullVisibleWithDSOC(Frustum3D frustum, Point3f cameraPosition) {
-        if (occlusionCuller == null) {
-            throw new IllegalStateException("DSOC not enabled");
-        }
-        
-        // Early exit if Z-buffer is not activated (no occluders)
-        if (!occlusionCuller.isActivated()) {
-            return frustumCullVisibleStandard(frustum, cameraPosition);
-        }
-        
-        lock.readLock().lock();
-        try {
-            var intersections = ObjectPools.<FrustumIntersection<ID, Content>>borrowArrayList();
-            var visitedEntities = ObjectPools.<ID>borrowHashSet();
-            
-            // Begin occlusion frame
-            // Use stored camera matrices from updateCamera or create identity matrices if not set
-            float[] viewMatrix = currentViewMatrix != null ? currentViewMatrix : createIdentityMatrix();
-            float[] projectionMatrix = currentProjectionMatrix != null ? currentProjectionMatrix : createIdentityMatrix();
-            occlusionCuller.beginFrame(viewMatrix, projectionMatrix, frustum);
-            
-            try {
-                // Get nodes in front-to-back order
-                var frustumNodes = getFrustumTraversalOrder(frustum, cameraPosition).collect(Collectors.toList());
-                
-                // Process nodes with occlusion testing
-                for (Key nodeIndex : frustumNodes) {
-                    var node = spatialIndex.get(nodeIndex);
-                    if (node == null || node.isEmpty()) {
-                        continue;
-                    }
-                    
-                    // Check if frustum intersects this node
-                    if (!doesFrustumIntersectNode(nodeIndex, frustum)) {
-                        continue;
-                    }
-                    
-                    // Test node-level occlusion
-                    EntityBounds nodeBounds = computeNodeBounds(nodeIndex);
-                    if (nodeBounds != null && occlusionCuller.isNodeOccluded(nodeBounds)) {
-                        // Still need to check TBVs even if node is occluded
-                        if (node instanceof OcclusionAwareSpatialNode) {
-                            OcclusionAwareSpatialNode<ID> occNode = (OcclusionAwareSpatialNode<ID>) node;
-                            occNode.markOccluded(getCurrentFrame());
-                            
-                            // Check TBVs
-                            for (var tbv : occNode.getTBVs()) {
-                                occlusionCuller.isTBVVisible(tbv, frustum, getCurrentFrame());
-                            }
-                        }
-                        continue;
-                    }
-                    
-                    // Node is visible - mark it if occlusion-aware
-                    if (node instanceof OcclusionAwareSpatialNode) {
-                        ((OcclusionAwareSpatialNode<ID>) node).markVisible(getCurrentFrame());
-                    }
-                    
-                    // Process entities in the node
-                    for (ID entityId : node.getEntityIds()) {
-                        // Skip if already processed
-                        if (!visitedEntities.add(entityId)) {
-                            continue;
-                        }
-                        
-                        var content = entityManager.getEntityContent(entityId);
-                        if (content == null) {
-                            continue;
-                        }
-                        
-                        var entityPos = getCachedEntityPosition(entityId);
-                        if (entityPos == null) {
-                            continue;
-                        }
-                        
-                        // Frustum test
-                        var entityBounds = entityManager.getEntityBounds(entityId);
-                        if (entityBounds == null) {
-                            entityBounds = new EntityBounds(entityPos, 0.1f);
-                        }
-                        
-                        if (!frustum.intersects(entityBounds)) {
-                            occlusionCuller.incrementFrustumCulled();
-                            // Update visibility state to hidden
-                            if (visibilityManager != null) {
-                                visibilityManager.updateVisibility(entityId, false, (int) getCurrentFrame());
-                            }
-                            continue;
-                        }
-                        
-                        // Occlusion test
-                        if (occlusionCuller.isEntityOccluded(entityBounds)) {
-                            // Update visibility state to hidden
-                            if (visibilityManager != null) {
-                                visibilityManager.updateVisibility(entityId, false, (int) getCurrentFrame());
-                            }
-                            continue;
-                        }
-                        
-                        // Entity is visible
-                        float distance = entityPos.distance(cameraPosition);
-                        var intersection = new FrustumIntersection<>(entityId, content, distance, 
-                                                                    entityPos, VisibilityType.INSIDE, entityBounds);
-                        intersections.add(intersection);
-                        occlusionCuller.incrementEntitiesVisible();
-                        
-                        // Update visibility state
-                        if (visibilityManager != null) {
-                            visibilityManager.updateVisibility(entityId, true, (int) getCurrentFrame());
-                        }
-                        
-                        // Render as occluder if configured
-                        if (dsocConfig.isRenderEntitiesAsOccluders()) {
-                            occlusionCuller.renderOccluder(entityBounds);
-                        }
-                    }
-                    
-                    // Render node as occluder if configured
-                    if (dsocConfig.isRenderNodesAsOccluders() && nodeBounds != null) {
-                        occlusionCuller.renderOccluder(nodeBounds);
-                    }
-                }
-                
-                // Sort by distance
-                intersections.sort(Comparator.comparingDouble(FrustumIntersection::distanceFromCamera));
-                
-                return new ArrayList<>(intersections);
-                
-            } finally {
-                occlusionCuller.endFrame();
-                ObjectPools.returnArrayList(intersections);
-                ObjectPools.returnHashSet(visitedEntities);
-            }
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-    
+
     /**
      * Standard frustum culling without DSOC optimizations
      */
@@ -5772,87 +5553,5 @@ implements SpatialIndex<Key, ID, Content> {
             lock.readLock().unlock();
         }
     }
-    
-    /**
-     * Performance monitoring wrapper for frustum culling operations
-     */
-    protected List<FrustumIntersection<ID, Content>> measureAndExecute(
-            java.util.function.Supplier<List<FrustumIntersection<ID, Content>>> operation, 
-            boolean isDSOC) {
-        long startTime = System.nanoTime();
-        try {
-            return operation.get();
-        } finally {
-            long duration = System.nanoTime() - startTime;
-            if (isDSOC) {
-                dsocFrameCount++;
-                dsocTotalTime += duration;
-            } else {
-                standardFrameCount++;
-                standardTotalTime += duration;
-            }
-        }
-    }
-    
-    /**
-     * Check if DSOC performance should be evaluated
-     */
-    protected boolean shouldEvaluatePerformance() {
-        return (dsocFrameCount + standardFrameCount) % EVALUATION_INTERVAL == 0;
-    }
-    
-    /**
-     * Determine if DSOC should be auto-disabled due to poor performance
-     */
-    protected boolean shouldAutoDisableDSOC() {
-        if (dsocFrameCount < MIN_FRAMES_FOR_EVALUATION || standardFrameCount < MIN_FRAMES_FOR_EVALUATION) {
-            return false;
-        }
-        
-        double dsocAvgTime = (double) dsocTotalTime / dsocFrameCount;
-        double standardAvgTime = (double) standardTotalTime / standardFrameCount;
-        
-        return dsocAvgTime > PERFORMANCE_THRESHOLD_MULTIPLIER * standardAvgTime;
-    }
-    
-    /**
-     * Get the current DSOC performance overhead multiplier
-     */
-    protected double getDSOCOverheadMultiplier() {
-        if (dsocFrameCount == 0 || standardFrameCount == 0) {
-            return 1.0;
-        }
-        
-        double dsocAvgTime = (double) dsocTotalTime / dsocFrameCount;
-        double standardAvgTime = (double) standardTotalTime / standardFrameCount;
-        
-        return dsocAvgTime / standardAvgTime;
-    }
-    
-    /**
-     * Determine if DSOC should be skipped for this frame due to poor conditions
-     */
-    protected boolean shouldSkipDSOC() {
-        // Skip if entity count is too low (DSOC overhead not worth it)
-        int entityCount = entityManager.getEntityCount();
-        if (entityCount < MIN_ENTITIES_FOR_DSOC) {
-            return true;
-        }
-        
-        // Skip if no meaningful occluders present
-        if (occlusionCuller != null && !occlusionCuller.isActivated()) {
-            return true;
-        }
-        
-        // Skip if recent performance was very poor
-        if (dsocFrameCount >= 5 && getDSOCOverheadMultiplier() > PERFORMANCE_THRESHOLD_MULTIPLIER * 2) {
-            return true;
-        }
-        
-        return false;
-    }
-    
-    // Early exit thresholds
-    private static final int MIN_ENTITIES_FOR_DSOC = 50;
 
 }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/occlusion/DsocCallback.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/occlusion/DsocCallback.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.occlusion;
+
+import com.hellblazer.luciferase.lucien.Frustum3D;
+import com.hellblazer.luciferase.lucien.FrustumIntersection;
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.entity.EntityBounds;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+
+import javax.vecmath.Point3f;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * The callback surface a {@link DsocController} needs from its owning spatial-index façade.
+ *
+ * <p>RDR-008 P1 extracts the Dynamic Scene Occlusion Culling cluster out of {@code AbstractSpatialIndex} into
+ * {@link DsocController}. The DSOC traversal still relies on a handful of façade operations that belong to other
+ * clusters (the frustum/cull traversal hooks — which are subclass-overridden template methods — and the cached
+ * entity-position lookup), or that are deferred to a later phase (the standard, non-DSOC frustum cull which remains
+ * the fallback path). Rather than widen those methods' visibility, the façade supplies them through this interface;
+ * the façade's implementation is a private inner class, so the underlying methods keep their original (often
+ * {@code private}/{@code protected}/abstract) visibility.
+ *
+ * @param <Key>     the spatial key type
+ * @param <ID>      the entity identifier type
+ * @param <Content> the entity content type
+ * @author hal.hildebrand
+ */
+public interface DsocCallback<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
+
+    /** Spatial keys of nodes potentially intersecting the frustum, in front-to-back traversal order. */
+    Stream<Key> getFrustumTraversalOrder(Frustum3D frustum, Point3f cameraPosition);
+
+    /** Whether the frustum intersects the node at the given key (subclass-specific geometry test). */
+    boolean doesFrustumIntersectNode(Key nodeIndex, Frustum3D frustum);
+
+    /** World-space bounds of the node at the given key, or {@code null} if not computable. */
+    EntityBounds computeNodeBounds(Key nodeIndex);
+
+    /** Cached world position of the entity, or {@code null} if unknown. */
+    Point3f getCachedEntityPosition(ID entityId);
+
+    /** The standard (non-DSOC) frustum cull — the fallback when DSOC is skipped or its Z-buffer is inactive. */
+    List<FrustumIntersection<ID, Content>> frustumCullVisibleStandard(Frustum3D frustum, Point3f cameraPosition);
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/occlusion/DsocController.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/occlusion/DsocController.java
@@ -1,0 +1,422 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.occlusion;
+
+import com.hellblazer.luciferase.lucien.FrameManager;
+import com.hellblazer.luciferase.lucien.Frustum3D;
+import com.hellblazer.luciferase.lucien.FrustumIntersection;
+import com.hellblazer.luciferase.lucien.FrustumIntersection.VisibilityType;
+import com.hellblazer.luciferase.lucien.SpatialIndexCore;
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.entity.EntityBounds;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+import com.hellblazer.luciferase.lucien.internal.ObjectPools;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.vecmath.Point3f;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * The Dynamic Scene Occlusion Culling (DSOC) feature object for a spatial index (RDR-008 P1).
+ *
+ * <p>Owns the DSOC state — configuration, {@link FrameManager}, {@link VisibilityStateManager},
+ * {@link HierarchicalOcclusionCuller}, camera matrices, and the performance-monitoring counters that drive auto-
+ * disable — and the occlusion-aware frustum cull, the public DSOC lifecycle/statistics API, and the entity-update
+ * hooks. It orchestrates the occlusion machinery in this package; it does not reimplement it.
+ *
+ * <p>The owning {@code AbstractSpatialIndex} façade constructs one of these when DSOC is enabled and delegates its
+ * public DSOC API and three integration seams (frustum-cull entry, entity-update visibility/TBV, occlusion-aware
+ * node creation) to it. Shared storage and concurrency come from {@link SpatialIndexCore}; the few façade operations
+ * the cull still needs (frustum traversal order, the subclass frustum-node test, node bounds, cached entity position,
+ * and the standard non-DSOC cull fallback) arrive through {@link DsocCallback}.
+ *
+ * @param <Key>     the spatial key type
+ * @param <ID>      the entity identifier type
+ * @param <Content> the entity content type
+ * @author hal.hildebrand
+ */
+public final class DsocController<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
+
+    private static final Logger log = LoggerFactory.getLogger(DsocController.class);
+
+    // Performance-evaluation thresholds (moved verbatim from AbstractSpatialIndex).
+    private static final int    MIN_FRAMES_FOR_EVALUATION       = 10;
+    private static final double PERFORMANCE_THRESHOLD_MULTIPLIER = 1.2; // 20% overhead tolerance
+    private static final int    EVALUATION_INTERVAL             = 50;   // Check every 50 frames
+    private static final int    MIN_ENTITIES_FOR_DSOC           = 50;
+
+    private final SpatialIndexCore<Key, ID, Content> core;
+    private final DsocCallback<Key, ID, Content>     callback;
+    private final DSOCConfiguration                  config;
+
+    private final FrameManager                              frameManager;
+    private final VisibilityStateManager<ID>                visibilityManager;
+    private final HierarchicalOcclusionCuller<Key, ID, Content> occlusionCuller;
+
+    private float[] currentViewMatrix;
+    private float[] currentProjectionMatrix;
+
+    // Performance monitoring
+    private volatile long    dsocFrameCount     = 0;
+    private volatile long    dsocTotalTime      = 0;
+    private volatile long    standardFrameCount = 0;
+    private volatile long    standardTotalTime  = 0;
+    private volatile boolean autoDisabled       = false;
+
+    /**
+     * Construct and, when the configuration is enabled, initialize the DSOC machinery and wire entity auto-dynamics.
+     * Mirrors the former {@code AbstractSpatialIndex.enableDSOC(config, bufferWidth, bufferHeight)}.
+     */
+    public DsocController(SpatialIndexCore<Key, ID, Content> core, DsocCallback<Key, ID, Content> callback,
+                          DSOCConfiguration config, int bufferWidth, int bufferHeight) {
+        this.core = core;
+        this.callback = callback;
+        this.config = config;
+        if (config.isEnabled()) {
+            this.frameManager = new FrameManager();
+            this.visibilityManager = new VisibilityStateManager<>(config);
+            this.occlusionCuller = new HierarchicalOcclusionCuller<>(bufferWidth, bufferHeight, config);
+            if (config.isAutoDynamicsEnabled()) {
+                core.entityManager().setAutoDynamicsEnabled(true);
+                core.entityManager().setFrameManager(frameManager);
+            }
+        } else {
+            this.frameManager = null;
+            this.visibilityManager = null;
+            this.occlusionCuller = null;
+        }
+    }
+
+    /** Whether DSOC is enabled by configuration and has not been auto-disabled. */
+    public boolean isEnabled() {
+        return config != null && config.isEnabled() && !autoDisabled;
+    }
+
+    /** Store camera matrices for use in the next occlusion frame (validates 4x4 when enabled). */
+    public void updateCamera(float[] viewMatrix, float[] projectionMatrix, Point3f cameraPosition) {
+        if (!isEnabled()) {
+            return;
+        }
+        if (viewMatrix == null || projectionMatrix == null) {
+            throw new NullPointerException("View and projection matrices cannot be null when DSOC is enabled");
+        }
+        if (viewMatrix.length != 16) {
+            throw new IllegalArgumentException("View matrix must be 4x4 (16 elements), got " + viewMatrix.length);
+        }
+        if (projectionMatrix.length != 16) {
+            throw new IllegalArgumentException(
+            "Projection matrix must be 4x4 (16 elements), got " + projectionMatrix.length);
+        }
+        this.currentViewMatrix = viewMatrix.clone();
+        this.currentProjectionMatrix = projectionMatrix.clone();
+    }
+
+    /** Advance to the next frame, returning the new frame number (0 when DSOC machinery is absent). */
+    public long nextFrame() {
+        return frameManager != null ? frameManager.incrementFrame() : 0;
+    }
+
+    /** The current frame number (0 when DSOC machinery is absent). */
+    public long getCurrentFrame() {
+        return frameManager != null ? frameManager.getCurrentFrame() : 0;
+    }
+
+    /** DSOC statistics map; {@code {dsocEnabled: false}} when disabled. */
+    public Map<String, Object> getStatistics() {
+        Map<String, Object> stats = new HashMap<>();
+        if (isEnabled()) {
+            stats.put("dsocEnabled", true);
+            stats.put("currentFrame", getCurrentFrame());
+            if (visibilityManager != null) {
+                stats.putAll(visibilityManager.getStatistics());
+            }
+            if (occlusionCuller != null) {
+                stats.putAll(occlusionCuller.getStatistics());
+            }
+            stats.put("totalEntities", (long) core.entityManager().getEntityCount());
+        } else {
+            stats.put("dsocEnabled", false);
+        }
+        return stats;
+    }
+
+    /** Entities flagged by the occlusion culler as needing position updates. */
+    public Set<ID> getEntitiesNeedingUpdate() {
+        return occlusionCuller != null ? occlusionCuller.getEntitiesNeedingUpdate() : new HashSet<>();
+    }
+
+    /** Reset the occlusion culler's statistics. */
+    public void resetStatistics() {
+        if (occlusionCuller != null) {
+            occlusionCuller.resetStatistics();
+        }
+    }
+
+    /** Force the Z-buffer active (test hook). */
+    public void forceZBufferActivation() {
+        if (occlusionCuller != null) {
+            occlusionCuller.forceActivate();
+        }
+    }
+
+    // ---- Entity-update integration seams -------------------------------------------------------------------------
+
+    /**
+     * If the entity is hidden behind a still-valid temporal bounding volume, defer its move (update dynamics + refresh
+     * the TBV when quality drops) and return {@code true} so the caller skips the normal relocation. Otherwise return
+     * {@code false}. Mirrors the DSOC branch formerly inlined at the top of {@code updateEntity}.
+     */
+    public boolean tryDeferUpdate(ID entityId, Point3f newPosition) {
+        if (!isEnabled() || visibilityManager == null) {
+            return false;
+        }
+        long currentFrame = getCurrentFrame();
+        var state = visibilityManager.getState(entityId);
+        if (state != VisibilityStateManager.VisibilityState.HIDDEN_WITH_TBV) {
+            return false;
+        }
+        var tbv = visibilityManager.getTBV(entityId);
+        if (tbv == null || !tbv.isValid((int) currentFrame)) {
+            return false;
+        }
+        var dynamics = core.entityManager().getDynamics(entityId);
+        if (dynamics != null) {
+            dynamics.updatePosition(newPosition, currentFrame);
+            float quality = tbv.getQuality((int) currentFrame);
+            if (quality < config.getTbvRefreshThreshold()) {
+                var bounds = core.entityManager().getEntityBounds(entityId);
+                if (bounds == null) {
+                    bounds = new EntityBounds(newPosition, 0.1f);
+                }
+                visibilityManager.createTBV(entityId, dynamics, bounds, currentFrame);
+            }
+        }
+        return true; // deferred — skip the normal update
+    }
+
+    /** Mark the entity visible in the current frame after a relocation (no-op when disabled). */
+    public void markVisibleOnUpdate(ID entityId) {
+        if (isEnabled() && visibilityManager != null) {
+            visibilityManager.updateVisibility(entityId, true, (int) getCurrentFrame());
+        }
+    }
+
+    // ---- Frustum cull entry seam ---------------------------------------------------------------------------------
+
+    /**
+     * The DSOC-aware frustum-cull entry point. Evaluates auto-disable, decides whether DSOC is worthwhile this frame,
+     * and measures whichever path runs. Mirrors the DSOC decision block formerly inlined in {@code frustumCullVisible}.
+     */
+    public List<FrustumIntersection<ID, Content>> frustumCullVisible(Frustum3D frustum, Point3f cameraPosition) {
+        // Auto-disable evaluation
+        if (isEnabled() && shouldEvaluatePerformance()) {
+            if (shouldAutoDisableDSOC()) {
+                log.warn("Auto-disabling DSOC due to performance degradation: {}x overhead", getOverheadMultiplier());
+                autoDisabled = true;
+            }
+        }
+
+        // Use DSOC only when still enabled and hierarchical occlusion is configured and worthwhile
+        if (isEnabled() && config.isEnableHierarchicalOcclusion()) {
+            if (shouldSkipDSOC()) {
+                return measureAndExecute(() -> callback.frustumCullVisibleStandard(frustum, cameraPosition), false);
+            }
+            return measureAndExecute(() -> frustumCullVisibleWithDSOC(frustum, cameraPosition), true);
+        }
+
+        // Standard path, still measured so the perf comparison stays meaningful
+        return measureAndExecute(() -> callback.frustumCullVisibleStandard(frustum, cameraPosition), false);
+    }
+
+    /** Perform frustum culling with occlusion testing. */
+    List<FrustumIntersection<ID, Content>> frustumCullVisibleWithDSOC(Frustum3D frustum, Point3f cameraPosition) {
+        if (occlusionCuller == null) {
+            throw new IllegalStateException("DSOC not enabled");
+        }
+        // Early exit if Z-buffer is not activated (no occluders)
+        if (!occlusionCuller.isActivated()) {
+            return callback.frustumCullVisibleStandard(frustum, cameraPosition);
+        }
+
+        core.lock().readLock().lock();
+        try {
+            var intersections = ObjectPools.<FrustumIntersection<ID, Content>>borrowArrayList();
+            var visitedEntities = ObjectPools.<ID>borrowHashSet();
+
+            // Use stored camera matrices from updateCamera, or identity matrices if not set
+            float[] viewMatrix = currentViewMatrix != null ? currentViewMatrix : createIdentityMatrix();
+            float[] projectionMatrix = currentProjectionMatrix != null ? currentProjectionMatrix : createIdentityMatrix();
+            occlusionCuller.beginFrame(viewMatrix, projectionMatrix, frustum);
+
+            try {
+                var frustumNodes = callback.getFrustumTraversalOrder(frustum, cameraPosition).collect(Collectors.toList());
+
+                for (Key nodeIndex : frustumNodes) {
+                    var node = core.spatialIndex().get(nodeIndex);
+                    if (node == null || node.isEmpty()) {
+                        continue;
+                    }
+                    if (!callback.doesFrustumIntersectNode(nodeIndex, frustum)) {
+                        continue;
+                    }
+
+                    EntityBounds nodeBounds = callback.computeNodeBounds(nodeIndex);
+                    if (nodeBounds != null && occlusionCuller.isNodeOccluded(nodeBounds)) {
+                        // Still check TBVs even if the node is occluded
+                        if (node instanceof OcclusionAwareSpatialNode) {
+                            OcclusionAwareSpatialNode<ID> occNode = (OcclusionAwareSpatialNode<ID>) node;
+                            occNode.markOccluded(getCurrentFrame());
+                            for (var tbv : occNode.getTBVs()) {
+                                occlusionCuller.isTBVVisible(tbv, frustum, getCurrentFrame());
+                            }
+                        }
+                        continue;
+                    }
+
+                    if (node instanceof OcclusionAwareSpatialNode) {
+                        ((OcclusionAwareSpatialNode<ID>) node).markVisible(getCurrentFrame());
+                    }
+
+                    for (ID entityId : node.getEntityIds()) {
+                        if (!visitedEntities.add(entityId)) {
+                            continue;
+                        }
+                        var content = core.entityManager().getEntityContent(entityId);
+                        if (content == null) {
+                            continue;
+                        }
+                        var entityPos = callback.getCachedEntityPosition(entityId);
+                        if (entityPos == null) {
+                            continue;
+                        }
+                        var entityBounds = core.entityManager().getEntityBounds(entityId);
+                        if (entityBounds == null) {
+                            entityBounds = new EntityBounds(entityPos, 0.1f);
+                        }
+                        if (!frustum.intersects(entityBounds)) {
+                            occlusionCuller.incrementFrustumCulled();
+                            if (visibilityManager != null) {
+                                visibilityManager.updateVisibility(entityId, false, (int) getCurrentFrame());
+                            }
+                            continue;
+                        }
+                        if (occlusionCuller.isEntityOccluded(entityBounds)) {
+                            if (visibilityManager != null) {
+                                visibilityManager.updateVisibility(entityId, false, (int) getCurrentFrame());
+                            }
+                            continue;
+                        }
+                        float distance = entityPos.distance(cameraPosition);
+                        var intersection = new FrustumIntersection<>(entityId, content, distance, entityPos,
+                                                                     VisibilityType.INSIDE, entityBounds);
+                        intersections.add(intersection);
+                        occlusionCuller.incrementEntitiesVisible();
+                        if (visibilityManager != null) {
+                            visibilityManager.updateVisibility(entityId, true, (int) getCurrentFrame());
+                        }
+                        if (config.isRenderEntitiesAsOccluders()) {
+                            occlusionCuller.renderOccluder(entityBounds);
+                        }
+                    }
+
+                    if (config.isRenderNodesAsOccluders() && nodeBounds != null) {
+                        occlusionCuller.renderOccluder(nodeBounds);
+                    }
+                }
+
+                intersections.sort(Comparator.comparingDouble(FrustumIntersection::distanceFromCamera));
+                return new ArrayList<>(intersections);
+            } finally {
+                occlusionCuller.endFrame();
+                ObjectPools.returnArrayList(intersections);
+                ObjectPools.returnHashSet(visitedEntities);
+            }
+        } finally {
+            core.lock().readLock().unlock();
+        }
+    }
+
+    // ---- Performance monitoring ----------------------------------------------------------------------------------
+
+    private List<FrustumIntersection<ID, Content>> measureAndExecute(
+    Supplier<List<FrustumIntersection<ID, Content>>> operation, boolean isDSOC) {
+        long startTime = System.nanoTime();
+        try {
+            return operation.get();
+        } finally {
+            long duration = System.nanoTime() - startTime;
+            if (isDSOC) {
+                dsocFrameCount++;
+                dsocTotalTime += duration;
+            } else {
+                standardFrameCount++;
+                standardTotalTime += duration;
+            }
+        }
+    }
+
+    private boolean shouldEvaluatePerformance() {
+        return (dsocFrameCount + standardFrameCount) % EVALUATION_INTERVAL == 0;
+    }
+
+    private boolean shouldAutoDisableDSOC() {
+        if (dsocFrameCount < MIN_FRAMES_FOR_EVALUATION || standardFrameCount < MIN_FRAMES_FOR_EVALUATION) {
+            return false;
+        }
+        double dsocAvgTime = (double) dsocTotalTime / dsocFrameCount;
+        double standardAvgTime = (double) standardTotalTime / standardFrameCount;
+        return dsocAvgTime > PERFORMANCE_THRESHOLD_MULTIPLIER * standardAvgTime;
+    }
+
+    private double getOverheadMultiplier() {
+        if (dsocFrameCount == 0 || standardFrameCount == 0) {
+            return 1.0;
+        }
+        double dsocAvgTime = (double) dsocTotalTime / dsocFrameCount;
+        double standardAvgTime = (double) standardTotalTime / standardFrameCount;
+        return dsocAvgTime / standardAvgTime;
+    }
+
+    private boolean shouldSkipDSOC() {
+        if (core.entityManager().getEntityCount() < MIN_ENTITIES_FOR_DSOC) {
+            return true;
+        }
+        if (occlusionCuller != null && !occlusionCuller.isActivated()) {
+            return true;
+        }
+        return dsocFrameCount >= 5 && getOverheadMultiplier() > PERFORMANCE_THRESHOLD_MULTIPLIER * 2;
+    }
+
+    private float[] createIdentityMatrix() {
+        float[] matrix = new float[16];
+        matrix[0] = 1.0f;
+        matrix[5] = 1.0f;
+        matrix[10] = 1.0f;
+        matrix[15] = 1.0f;
+        return matrix;
+    }
+}


### PR DESCRIPTION
## Summary

RDR-008 **P1** — extract the Dynamic Scene Occlusion Culling cluster out of the `AbstractSpatialIndex` god-class into a dedicated feature object, per the locked core+feature-objects design. Builds on P0's `SpatialIndexCore` (#130). Epic `Luciferase-x5i`.

## Changes

- **New `occlusion.DsocController<Key,ID,Content>`** — owns the DSOC state (config, `FrameManager`, `VisibilityStateManager`, `HierarchicalOcclusionCuller`, camera matrices, perf counters + auto-disable), the public DSOC lifecycle/statistics API, the occlusion-aware frustum cull, and the entity-update hooks. Reaches shared storage/concurrency **only** through `SpatialIndexCore`.
- **New `occlusion.DsocCallback<Key,ID,Content>`** — the 5 façade ops the cull still needs (frustum traversal order + frustum-node test [subclass-overridden template hooks], node bounds, cached entity position, standard non-DSOC cull fallback). Supplied via a **private inner class** `DsocCallbackImpl`, so those methods keep their original visibility (no public widening).
- **`AbstractSpatialIndex`** — public DSOC API → thin delegators to a `private volatile DsocController dsoc` (null until `enableDSOC`); the 3 integration seams (`frustumCullVisible` entry, `updateEntity` TBV-defer + mark-visible, occlusion-aware node creation) delegate to it. `frustumCullVisibleStandard` stays (frustum/cull cluster = P4).

Façade shrinks **302 lines** (5858 → 5556).

## Invariants

- **No behavior change.** Full lucien suite green (**2441 tests, 0 failures**), including the 19-class DSOC/occlusion suite (integration, auto-disable, edge-case, cross-index, per-tree-type). All three seams verified behavior-equivalent (TBV-defer early-return incl. `dynamics==null`; auto-disable transition; node-type selection).
- **Subclasses untouched** (P1–P4 invariant): only `AbstractSpatialIndex` + the 2 new files changed; Octree/Tetree/Prism/SFCArrayIndex byte-for-byte unchanged and green.
- **No partial-bypass**: `DsocController` holds no independent nucleus reference; all access via `core.*`. The façade retains no DSOC state.

## Review

Stacked review (code-review-expert + substantive-critic), **0 Critical**. Fixed in-PR: `dsoc` made `volatile` (publish-safety). Recorded as tracked obligations (not silently dropped):
- **G1 (`x5i.3`) entry criterion**: run `DSOCPerformanceRegressionTest` + DSOC benchmarks vs `main 1f19aebf` for `-Pperformance` parity (deferred from this phase boundary; made explicit + verifiable).
- **P2 (`x5i.4`) design obligation**: reconcile `DsocCallback` into the RDR-named unified `SpatialGeometry<Key>` once the 2nd feature object (GhostCoordinator) gives the design sample — avoids per-feature callback proliferation.

Refs: RDR-008 P1, `Luciferase-x5i.2`. Next: G1 gate (`x5i.3`, covers P0+P1) then P2 (`x5i.4`).