### PR TITLE
Luciferase-x5i.4: SpatialGeometry seam + GhostCoordinator extraction (RDR-008 P2)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
@@ -2566,11 +2566,12 @@ implements SpatialIndex<Key, ID, Content> {
     }
 
     /**
-     * Supplies {@link DsocController} the façade operations its cull still needs — the frustum traversal order and
-     * frustum-node test (subclass-overridden template hooks), node bounds, the cached entity position, and the
-     * standard non-DSOC cull fallback — without widening those methods' visibility. RDR-008 P1.
+     * The façade's implementation of the unified {@link SpatialGeometry} seam (RDR-008): supplies feature objects the
+     * façade-resident operations they consume — the subclass-overridden geometry template hooks plus concrete spatial
+     * helpers — without widening those methods' visibility (this is a private inner class, so the delegated methods
+     * keep their original {@code private}/{@code protected}/abstract access). Grows by one cluster's needs per phase.
      */
-    private final class DsocCallbackImpl implements DsocCallback<Key, ID, Content> {
+    private final class SpatialGeometryImpl implements SpatialGeometry<Key, ID, Content> {
         @Override
         public Stream<Key> getFrustumTraversalOrder(Frustum3D frustum, Point3f cameraPosition) {
             return AbstractSpatialIndex.this.getFrustumTraversalOrder(frustum, cameraPosition);
@@ -5415,7 +5416,7 @@ implements SpatialIndex<Key, ID, Content> {
      */
     public void enableDSOC(DSOCConfiguration config, int bufferWidth, int bufferHeight) {
         // RDR-008 P1: the DSOC cluster is encapsulated in DsocController.
-        this.dsoc = new DsocController<>(core, new DsocCallbackImpl(), config, bufferWidth, bufferHeight);
+        this.dsoc = new DsocController<>(core, new SpatialGeometryImpl(), config, bufferWidth, bufferHeight);
     }
     
     /**

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
@@ -127,6 +127,8 @@ implements SpatialIndex<Key, ID, Content> {
     // RDR-008 P1: Dynamic Scene Occlusion Culling cluster, encapsulated in DsocController (null until enableDSOC).
     // volatile: enableDSOC may run concurrently with frustumCullVisible/isDSOCEnabled; publish the reference safely.
     private volatile DsocController<Key, ID, Content>                        dsoc;
+    // RDR-008 P2: distributed-ghost cluster, encapsulated in GhostCoordinator (always present; eager init in ctor).
+    protected final GhostCoordinator<Key, ID, Content>                       ghost;
     // k-NN performance metrics
     private final   java.util.concurrent.atomic.AtomicLong           knnCacheHits = new java.util.concurrent.atomic.AtomicLong(0);
     private final   java.util.concurrent.atomic.AtomicLong           knnCacheMisses = new java.util.concurrent.atomic.AtomicLong(0);
@@ -136,14 +138,6 @@ implements SpatialIndex<Key, ID, Content> {
     private         TreeBalancingStrategy<ID>                        balancingStrategy;
     private         boolean                                          autoBalancingEnabled     = false;
     private         long                                             lastBalancingTime        = 0;
-    
-    // Ghost layer support
-    protected       GhostType                                        ghostType                = GhostType.NONE;
-    protected       GhostAlgorithm                                   ghostAlgorithm           = GhostAlgorithm.CONSERVATIVE;
-    protected       GhostLayer<Key, ID, Content>                     ghostLayer;
-    protected       com.hellblazer.luciferase.lucien.forest.ghost.GhostBoundaryDetector<Key, ID, Content> ghostBoundaryDetector;
-    protected       DistributedGhostManager<Key, ID, Content>        distributedGhostManager;
-    protected       NeighborDetector<Key>                            neighborDetector;
 
     /**
      * Constructor with common parameters
@@ -171,9 +165,13 @@ implements SpatialIndex<Key, ID, Content> {
         // RDR-008: wrap the now-initialized six-field nucleus in a single shared view for feature-object collaborators
         this.core = new SpatialIndexCore<>(spatialIndex, lock, spatialVersion, knnCache, entityManager, entityCache);
 
-        // Initialize ghost components (neighbor detector and element manager set by subclasses)
-        this.ghostLayer = new GhostLayer<>(GhostType.NONE);
-        // ElementGhostManager initialized when neighbor detector is set
+        // RDR-008 P2: distributed-ghost cluster lives in GhostCoordinator; constructed eagerly so subclasses can
+        // call setNeighborDetector during their own initialization.
+        // INVARIANT for future phases: GhostCoordinator's ctor (and the ctors of any other feature object created
+        // here) MUST NOT invoke any method on the supplied SpatialGeometryImpl or on `this` — `this` is still
+        // partially constructed at this point, and any virtual dispatch into a not-yet-initialized subclass is a
+        // classic this-escape hazard. Storing the references is fine; calling through them is not.
+        this.ghost = new GhostCoordinator<>(core, new SpatialGeometryImpl(), this);
     }
 
     @Override
@@ -2597,6 +2595,11 @@ implements SpatialIndex<Key, ID, Content> {
                                                                                  Point3f cameraPosition) {
             return AbstractSpatialIndex.this.frustumCullVisibleStandard(frustum, cameraPosition);
         }
+
+        @Override
+        public List<ID> kNearestNeighbors(Point3f queryPoint, int k, float maxDistance) {
+            return AbstractSpatialIndex.this.kNearestNeighbors(queryPoint, k, maxDistance);
+        }
     }
 
     /**
@@ -4974,52 +4977,41 @@ implements SpatialIndex<Key, ID, Content> {
     // ========================================
     // Ghost Layer Configuration and Operations
     // ========================================
-    
-    /**
-     * Sets the ghost type for this spatial index.
-     * 
-     * @param type the ghost type to set
-     */
+    // RDR-008 P2: the ghost cluster lives in GhostCoordinator; the methods below are thin delegators that
+    // preserve the long-standing public API and the protected setNeighborDetector seam subclasses call.
+
+    /** Sets the ghost type. */
     public void setGhostType(GhostType type) {
-        lock.writeLock().lock();
-        try {
-            this.ghostType = Objects.requireNonNull(type);
-            this.ghostLayer = new GhostLayer<>(type);
-            // Recreate ElementGhostManager with new ghost type if we have a neighbor detector
-            if (this.neighborDetector != null) {
-                this.ghostBoundaryDetector = new com.hellblazer.luciferase.lucien.forest.ghost.GhostBoundaryDetector<>(this, neighborDetector, type, ghostAlgorithm);
-            }
-        } finally {
-            lock.writeLock().unlock();
-        }
+        ghost.setGhostType(type);
     }
-    
-    /**
-     * Gets the current ghost type.
-     * 
-     * @return the current ghost type
-     */
+
+    /** Gets the current ghost type. */
     public GhostType getGhostType() {
-        return ghostType;
+        return ghost.getGhostType();
     }
-    
+
+    /** Gets the ghost layer for this spatial index. */
+    public GhostLayer<Key, ID, Content> getGhostLayer() {
+        return ghost.getGhostLayer();
+    }
+
+    /** Gets the neighbor detector for this spatial index. */
+    public NeighborDetector<Key> getNeighborDetector() {
+        return ghost.getNeighborDetector();
+    }
+
+    /** Subclasses call this during initialization to supply their tree-specific neighbor detector. */
+    protected void setNeighborDetector(NeighborDetector<Key> detector) {
+        ghost.setNeighborDetector(detector);
+    }
+
     /**
      * Sets the ghost creation algorithm for this spatial index.
-     * 
+     *
      * @param algorithm the ghost creation algorithm to use
      */
     public void setGhostCreationAlgorithm(GhostAlgorithm algorithm) {
-        lock.writeLock().lock();
-        try {
-            this.ghostAlgorithm = Objects.requireNonNull(algorithm);
-            // Recreate ElementGhostManager with new algorithm if we have one
-            if (this.ghostBoundaryDetector != null) {
-                this.ghostBoundaryDetector = new com.hellblazer.luciferase.lucien.forest.ghost.GhostBoundaryDetector<>(this, neighborDetector, ghostType, algorithm);
-            }
-            log.debug("Set ghost creation algorithm to: {}", algorithm);
-        } finally {
-            lock.writeLock().unlock();
-        }
+        ghost.setGhostCreationAlgorithm(algorithm);
     }
     
     /**
@@ -5028,7 +5020,7 @@ implements SpatialIndex<Key, ID, Content> {
      * @return the current ghost creation algorithm
      */
     public GhostAlgorithm getGhostCreationAlgorithm() {
-        return ghostAlgorithm;
+        return ghost.getGhostCreationAlgorithm();
     }
     
     /**
@@ -5037,17 +5029,7 @@ implements SpatialIndex<Key, ID, Content> {
      * for neighboring elements owned by other processes.
      */
     public void createGhostLayer() {
-        if (ghostType == GhostType.NONE || ghostBoundaryDetector == null) {
-            return;
-        }
-        
-        lock.writeLock().lock();
-        try {
-            log.debug("Creating ghost layer with type: {}", ghostType);
-            ghostBoundaryDetector.createGhostLayer();
-        } finally {
-            lock.writeLock().unlock();
-        }
+        ghost.createGhostLayer();
     }
     
     /**
@@ -5055,40 +5037,9 @@ implements SpatialIndex<Key, ID, Content> {
      * modifications to the spatial index.
      */
     public void updateGhostLayer() {
-        if (ghostType == GhostType.NONE || ghostBoundaryDetector == null) {
-            return;
-        }
-        
-        lock.writeLock().lock();
-        try {
-            log.debug("Updating ghost layer");
-            // For now, just recreate the entire ghost layer
-            // More sophisticated incremental updates could be implemented later
-            ghostBoundaryDetector.createGhostLayer();
-        } finally {
-            lock.writeLock().unlock();
-        }
+        ghost.updateGhostLayer();
     }
-    
-    /**
-     * Gets the ghost layer for this spatial index.
-     * 
-     * @return the ghost layer, or null if none exists
-     */
-    public GhostLayer<Key, ID, Content> getGhostLayer() {
-        return ghostLayer;
-    }
-    
-    /**
-     * Gets the neighbor detector for this spatial index.
-     * Implementation-specific, set by subclasses.
-     * 
-     * @return the neighbor detector, or null if not set
-     */
-    public NeighborDetector<Key> getNeighborDetector() {
-        return neighborDetector;
-    }
-    
+
     /**
      * Gets all spatial keys currently in the spatial index.
      * Used by ghost layer management to iterate through elements.
@@ -5114,21 +5065,7 @@ implements SpatialIndex<Key, ID, Content> {
     public boolean containsSpatialKey(Key key) {
         return spatialIndex.containsKey(key);
     }
-    
-    /**
-     * Sets the neighbor detector for this spatial index.
-     * Should be called by subclasses during initialization.
-     * 
-     * @param detector the neighbor detector to set
-     */
-    protected void setNeighborDetector(NeighborDetector<Key> detector) {
-        this.neighborDetector = detector;
-        // Initialize ElementGhostManager now that we have a neighbor detector
-        if (detector != null && this.ghostBoundaryDetector == null) {
-            this.ghostBoundaryDetector = new com.hellblazer.luciferase.lucien.forest.ghost.GhostBoundaryDetector<>(this, detector, ghostType, ghostAlgorithm);
-        }
-    }
-    
+
     /**
      * Finds entities at the given spatial key, including ghost elements.
      * 
@@ -5136,39 +5073,7 @@ implements SpatialIndex<Key, ID, Content> {
      * @return list of entity IDs including both local and ghost entities
      */
     public List<ID> findEntitiesIncludingGhosts(Key key) {
-        var result = new ArrayList<ID>();
-        
-        lock.readLock().lock();
-        try {
-            // Add local entities
-            var node = spatialIndex.get(key);
-            if (node != null) {
-                var entityIds = node.getEntityIds();
-                if (entityIds != null) {
-                    result.addAll(entityIds);
-                }
-            }
-            
-            // Add ghost entities if available
-            var currentGhostLayer = ghostLayer; // Capture reference to avoid race conditions
-            if (currentGhostLayer != null) {
-                var ghostElements = currentGhostLayer.getGhostElements(key);
-                if (ghostElements != null) {
-                    for (var ghost : ghostElements) {
-                        if (ghost != null) {
-                            var entityId = ghost.getEntityId();
-                            if (entityId != null) {
-                                result.add(entityId);
-                            }
-                        }
-                    }
-                }
-            }
-            
-            return result;
-        } finally {
-            lock.readLock().unlock();
-        }
+        return ghost.findEntitiesIncludingGhosts(key);
     }
     
     /**
@@ -5179,37 +5084,7 @@ implements SpatialIndex<Key, ID, Content> {
      * @return list of neighbor results including both local and ghost neighbors
      */
     public List<NeighborResult<ID, Content>> findNeighborsIncludingGhosts(Point3f position, float radius) {
-        var result = new ArrayList<NeighborResult<ID, Content>>();
-        
-        lock.readLock().lock();
-        try {
-            // Find local neighbors using k-nearest approach with large k
-            var localNeighbors = kNearestNeighbors(position, Integer.MAX_VALUE, radius);
-            for (var entityId : localNeighbors) {
-                var entityContent = entityManager.getEntityContent(entityId);
-                var entityPosition = entityManager.getEntityPosition(entityId);
-                if (entityContent != null && entityPosition != null) {
-                    float distance = position.distance(entityPosition);
-                    result.add(new NeighborResult<>(entityId, entityContent, distance));
-                }
-            }
-            
-            // Add ghost neighbors if available
-            if (ghostLayer != null && ghostBoundaryDetector != null) {
-                // For now, iterate through all ghost elements to find those within range
-                // This could be optimized with spatial range queries later
-                for (var entry : ghostLayer.getAllGhostElements()) {
-                    float distance = position.distance(entry.getPosition());
-                    if (distance <= radius) {
-                        result.add(new NeighborResult<>(entry.getEntityId(), entry.getContent(), distance));
-                    }
-                }
-            }
-            
-            return result;
-        } finally {
-            lock.readLock().unlock();
-        }
+        return ghost.findNeighborsIncludingGhosts(position, radius);
     }
     
     // ========================================
@@ -5220,25 +5095,14 @@ implements SpatialIndex<Key, ID, Content> {
      * Called after bulk insertions to trigger ghost updates if enabled.
      */
     protected void triggerGhostUpdateAfterBulkInsert() {
-        if (ghostType != GhostType.NONE && ghostBoundaryDetector != null) {
-            log.debug("Triggering ghost update after bulk insertion");
-            updateGhostLayer();
-        }
+        ghost.triggerGhostUpdateAfterBulkInsert();
     }
     
     /**
      * Called after tree adaptation to trigger ghost updates if enabled.
      */
     protected void triggerGhostUpdateAfterAdaptation() {
-        if (ghostType != GhostType.NONE && ghostBoundaryDetector != null) {
-            log.debug("Triggering ghost update after tree adaptation");
-            updateGhostLayer();
-            
-            // Also trigger distributed ghost updates if enabled
-            if (distributedGhostManager != null) {
-                distributedGhostManager.updateDistributedGhostLayer();
-            }
-        }
+        ghost.triggerGhostUpdateAfterAdaptation();
     }
     
     // ========================================
@@ -5259,24 +5123,9 @@ implements SpatialIndex<Key, ID, Content> {
      * @param treeId the tree identifier
      */
     public void setupDistributedGhosts(GhostChannel<Key, ID, Content> ghostChannel,
-                                      ContentSerializer<Content> contentSerializer,
-                                      Class<ID> entityIdClass,
-                                      int currentRank,
-                                      long treeId) {
-        lock.writeLock().lock();
-        try {
-            if (ghostBoundaryDetector == null) {
-                log.warn("Cannot setup distributed ghosts - local ghost manager not initialized");
-                return;
-            }
-
-            this.distributedGhostManager = new DistributedGhostManager<>(
-                this, ghostChannel, ghostBoundaryDetector);
-
-            log.info("Distributed ghost management enabled for rank {} tree {}", currentRank, treeId);
-        } finally {
-            lock.writeLock().unlock();
-        }
+                                       ContentSerializer<Content> contentSerializer, Class<ID> entityIdClass,
+                                       int currentRank, long treeId) {
+        ghost.setupDistributedGhosts(ghostChannel, contentSerializer, entityIdClass, currentRank, treeId);
     }
 
     /**
@@ -5286,11 +5135,7 @@ implements SpatialIndex<Key, ID, Content> {
      * @param serviceDiscovery the service discovery to find other processes
      */
     public void initializeDistributedGhosts(ServiceDiscovery serviceDiscovery) {
-        if (distributedGhostManager != null) {
-            distributedGhostManager.initialize(serviceDiscovery);
-        } else {
-            log.warn("Cannot initialize distributed ghosts - distributed ghost manager not set up");
-        }
+        ghost.initializeDistributedGhosts(serviceDiscovery);
     }
     
     /**
@@ -5298,12 +5143,7 @@ implements SpatialIndex<Key, ID, Content> {
      * This coordinates with other processes to exchange ghost elements.
      */
     public void createDistributedGhostLayer() {
-        if (distributedGhostManager != null) {
-            distributedGhostManager.createDistributedGhostLayer();
-        } else {
-            // Fall back to local ghost layer creation
-            createGhostLayer();
-        }
+        ghost.createDistributedGhostLayer();
     }
     
     /**
@@ -5312,9 +5152,7 @@ implements SpatialIndex<Key, ID, Content> {
      * @param rank the process rank to add
      */
     public void addDistributedProcess(int rank) {
-        if (distributedGhostManager != null) {
-            distributedGhostManager.addKnownProcess(rank);
-        }
+        ghost.addDistributedProcess(rank);
     }
     
     /**
@@ -5323,9 +5161,7 @@ implements SpatialIndex<Key, ID, Content> {
      * @param rank the process rank to remove
      */
     public void removeDistributedProcess(int rank) {
-        if (distributedGhostManager != null) {
-            distributedGhostManager.removeKnownProcess(rank);
-        }
+        ghost.removeDistributedProcess(rank);
     }
     
     /**
@@ -5335,18 +5171,14 @@ implements SpatialIndex<Key, ID, Content> {
      * @param ownerRank the rank of the process that owns this element
      */
     public void setElementOwner(Key key, int ownerRank) {
-        if (distributedGhostManager != null) {
-            distributedGhostManager.setElementOwner(key, ownerRank);
-        }
+        ghost.setElementOwner(key, ownerRank);
     }
     
     /**
      * Synchronize ghost elements with all known processes.
      */
     public void synchronizeDistributedGhosts() {
-        if (distributedGhostManager != null) {
-            distributedGhostManager.synchronizeWithAllProcesses();
-        }
+        ghost.synchronizeDistributedGhosts();
     }
     
     /**
@@ -5355,9 +5187,7 @@ implements SpatialIndex<Key, ID, Content> {
      * @param enabled true to enable auto-sync, false to disable
      */
     public void setDistributedGhostAutoSync(boolean enabled) {
-        if (distributedGhostManager != null) {
-            distributedGhostManager.setAutoSyncEnabled(enabled);
-        }
+        ghost.setDistributedGhostAutoSync(enabled);
     }
     
     /**
@@ -5366,10 +5196,7 @@ implements SpatialIndex<Key, ID, Content> {
      * @return map of statistics, or empty map if distributed ghosts not enabled
      */
     public Map<String, Object> getDistributedGhostStatistics() {
-        if (distributedGhostManager != null) {
-            return distributedGhostManager.getStatistics();
-        }
-        return Map.of();
+        return ghost.getDistributedGhostStatistics();
     }
     
     /**
@@ -5378,18 +5205,14 @@ implements SpatialIndex<Key, ID, Content> {
      * @return true if distributed ghosts are enabled
      */
     public boolean isDistributedGhostsEnabled() {
-        return distributedGhostManager != null;
+        return ghost.isDistributedGhostsEnabled();
     }
     
     /**
      * Shutdown distributed ghost management.
      */
     public void shutdownDistributedGhosts() {
-        if (distributedGhostManager != null) {
-            distributedGhostManager.shutdown();
-            distributedGhostManager = null;
-            log.info("Distributed ghost management shut down");
-        }
+        ghost.shutdownDistributedGhosts();
     }
     
     

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialGeometry.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialGeometry.java
@@ -62,4 +62,9 @@ public interface SpatialGeometry<Key extends SpatialKey<Key>, ID extends EntityI
 
     /** The standard (non-DSOC) frustum cull — the fallback when DSOC is skipped or its Z-buffer is inactive. */
     List<FrustumIntersection<ID, Content>> frustumCullVisibleStandard(Frustum3D frustum, Point3f cameraPosition);
+
+    // ---- k-nearest-neighbor query (consumed by GhostCoordinator; P3 will re-home the provider) -------------------
+
+    /** k-nearest entities to {@code queryPoint}, optionally bounded by {@code maxDistance}. */
+    List<ID> kNearestNeighbors(Point3f queryPoint, int k, float maxDistance);
 }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialGeometry.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialGeometry.java
@@ -14,11 +14,8 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
-package com.hellblazer.luciferase.lucien.occlusion;
+package com.hellblazer.luciferase.lucien;
 
-import com.hellblazer.luciferase.lucien.Frustum3D;
-import com.hellblazer.luciferase.lucien.FrustumIntersection;
-import com.hellblazer.luciferase.lucien.SpatialKey;
 import com.hellblazer.luciferase.lucien.entity.EntityBounds;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 
@@ -27,22 +24,29 @@ import java.util.List;
 import java.util.stream.Stream;
 
 /**
- * The callback surface a {@link DsocController} needs from its owning spatial-index façade.
+ * The unified callback seam through which RDR-008 feature objects reach their owning {@code AbstractSpatialIndex}
+ * façade.
  *
- * <p>RDR-008 P1 extracts the Dynamic Scene Occlusion Culling cluster out of {@code AbstractSpatialIndex} into
- * {@link DsocController}. The DSOC traversal still relies on a handful of façade operations that belong to other
- * clusters (the frustum/cull traversal hooks — which are subclass-overridden template methods — and the cached
- * entity-position lookup), or that are deferred to a later phase (the standard, non-DSOC frustum cull which remains
- * the fallback path). Rather than widen those methods' visibility, the façade supplies them through this interface;
- * the façade's implementation is a private inner class, so the underlying methods keep their original (often
- * {@code private}/{@code protected}/abstract) visibility.
+ * <p>RDR-008 §Decision names a single {@code SpatialGeometry<Key>} interface, implemented by the façade and handed to
+ * each cohesive collaborator ({@code DsocController}, {@code GhostCoordinator}, {@code KnnSearcher}, …) alongside the
+ * shared {@link SpatialIndexCore}. It carries the façade-resident operations a collaborator needs but does not own:
+ * the subclass-overridden geometry template hooks (e.g. {@link #getFrustumTraversalOrder},
+ * {@link #doesFrustumIntersectNode}) plus the concrete spatial helpers that remain on the façade or belong to a
+ * not-yet-extracted cluster (e.g. {@link #frustumCullVisibleStandard}, which is the frustum/cull cluster's — P4).
+ * The façade supplies the implementation through a private inner class, so the underlying methods keep their original
+ * ({@code private}/{@code protected}/abstract) visibility — no public widening.
+ *
+ * <p>The interface grows by one phase's worth of operations as each feature object is extracted; collaborators call
+ * only the subset they need. This is the deliberate "one named seam" the RDR chose over per-feature callbacks.
  *
  * @param <Key>     the spatial key type
  * @param <ID>      the entity identifier type
  * @param <Content> the entity content type
  * @author hal.hildebrand
  */
-public interface DsocCallback<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
+public interface SpatialGeometry<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
+
+    // ---- Frustum / cull geometry (consumed by DsocController; P4 will re-home the providers) ---------------------
 
     /** Spatial keys of nodes potentially intersecting the frustum, in front-to-back traversal order. */
     Stream<Key> getFrustumTraversalOrder(Frustum3D frustum, Point3f cameraPosition);

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/GhostCoordinator.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/GhostCoordinator.java
@@ -1,0 +1,336 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.forest.ghost;
+
+import com.hellblazer.luciferase.lucien.AbstractSpatialIndex;
+import com.hellblazer.luciferase.lucien.SpatialGeometry;
+import com.hellblazer.luciferase.lucien.SpatialIndexCore;
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+import com.hellblazer.luciferase.lucien.neighbor.NeighborDetector;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.vecmath.Point3f;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * The distributed-ghost feature object for a spatial index (RDR-008 P2).
+ *
+ * <p>Owns the ghost state — type, algorithm, local {@link GhostLayer}, {@link GhostBoundaryDetector}, optional
+ * {@link DistributedGhostManager}, and the subclass-supplied {@link NeighborDetector} — plus the local and distributed
+ * ghost-layer lifecycle, neighbor/entity queries that span ghosts, and the bulk-insert/adaptation update hooks.
+ *
+ * <p>Unlike {@code DsocController} (lazy on {@code enableDSOC}), this coordinator is constructed eagerly with the
+ * owning façade because the ghost state is always present (an empty {@code GhostLayer(NONE)} from construction, with
+ * subclasses calling {@link #setNeighborDetector} during their own initialization). Shared storage and concurrency
+ * arrive via {@link SpatialIndexCore}; the one façade query the ghost cluster needs ({@code kNearestNeighbors},
+ * extracted in P3) is reached through the unified {@link SpatialGeometry} seam.
+ *
+ * <p><b>Concrete-façade back-reference.</b> {@code GhostBoundaryDetector} and {@code DistributedGhostManager} both
+ * take the concrete {@code AbstractSpatialIndex} in their constructors, so the coordinator holds a façade reference
+ * solely to pass to them. That's an honest deviation from the otherwise-clean feature-object decoupling, tracked as a
+ * follow-up (interface-inversion of those collaborators is separable work into {@code forest.ghost}/{@code Forest}).
+ *
+ * @param <Key>     the spatial key type
+ * @param <ID>      the entity identifier type
+ * @param <Content> the entity content type
+ * @author hal.hildebrand
+ */
+public final class GhostCoordinator<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
+
+    private static final Logger log = LoggerFactory.getLogger(GhostCoordinator.class);
+
+    private final SpatialIndexCore<Key, ID, Content>    core;
+    private final SpatialGeometry<Key, ID, Content>     geometry;
+    private final AbstractSpatialIndex<Key, ID, Content> facade;
+
+    private GhostType                                            ghostType        = GhostType.NONE;
+    private GhostAlgorithm                                       ghostAlgorithm   = GhostAlgorithm.CONSERVATIVE;
+    private GhostLayer<Key, ID, Content>                         ghostLayer;
+    private GhostBoundaryDetector<Key, ID, Content>              ghostBoundaryDetector;
+    private DistributedGhostManager<Key, ID, Content>            distributedGhostManager;
+    private NeighborDetector<Key>                                neighborDetector;
+
+    /**
+     * Construct the ghost coordinator with an empty {@code GhostLayer(NONE)}. Subclasses subsequently call
+     * {@link #setNeighborDetector} during their own initialization.
+     */
+    public GhostCoordinator(SpatialIndexCore<Key, ID, Content> core, SpatialGeometry<Key, ID, Content> geometry,
+                            AbstractSpatialIndex<Key, ID, Content> facade) {
+        this.core = core;
+        this.geometry = geometry;
+        this.facade = facade;
+        this.ghostLayer = new GhostLayer<>(GhostType.NONE);
+    }
+
+    // ---- Ghost type + algorithm ---------------------------------------------------------------------------------
+
+    public void setGhostType(GhostType type) {
+        core.lock().writeLock().lock();
+        try {
+            this.ghostType = Objects.requireNonNull(type);
+            this.ghostLayer = new GhostLayer<>(type);
+            // Recreate GhostBoundaryDetector with new ghost type if we have a neighbor detector
+            if (this.neighborDetector != null) {
+                this.ghostBoundaryDetector = new GhostBoundaryDetector<>(facade, neighborDetector, type, ghostAlgorithm);
+            }
+        } finally {
+            core.lock().writeLock().unlock();
+        }
+    }
+
+    public GhostType getGhostType() {
+        return ghostType;
+    }
+
+    public void setGhostCreationAlgorithm(GhostAlgorithm algorithm) {
+        core.lock().writeLock().lock();
+        try {
+            this.ghostAlgorithm = Objects.requireNonNull(algorithm);
+            if (this.ghostBoundaryDetector != null) {
+                this.ghostBoundaryDetector = new GhostBoundaryDetector<>(facade, neighborDetector, ghostType, algorithm);
+            }
+            log.debug("Set ghost creation algorithm to: {}", algorithm);
+        } finally {
+            core.lock().writeLock().unlock();
+        }
+    }
+
+    public GhostAlgorithm getGhostCreationAlgorithm() {
+        return ghostAlgorithm;
+    }
+
+    // ---- Ghost layer lifecycle ----------------------------------------------------------------------------------
+
+    public void createGhostLayer() {
+        if (ghostType == GhostType.NONE || ghostBoundaryDetector == null) {
+            return;
+        }
+        core.lock().writeLock().lock();
+        try {
+            log.debug("Creating ghost layer with type: {}", ghostType);
+            ghostBoundaryDetector.createGhostLayer();
+        } finally {
+            core.lock().writeLock().unlock();
+        }
+    }
+
+    public void updateGhostLayer() {
+        if (ghostType == GhostType.NONE || ghostBoundaryDetector == null) {
+            return;
+        }
+        core.lock().writeLock().lock();
+        try {
+            log.debug("Updating ghost layer");
+            // For now, just recreate the entire ghost layer; incremental updates can be a future refinement.
+            ghostBoundaryDetector.createGhostLayer();
+        } finally {
+            core.lock().writeLock().unlock();
+        }
+    }
+
+    public GhostLayer<Key, ID, Content> getGhostLayer() {
+        return ghostLayer;
+    }
+
+    public NeighborDetector<Key> getNeighborDetector() {
+        return neighborDetector;
+    }
+
+    /**
+     * Subclass-facing: the spatial-index subclass supplies its own neighbor detector during initialization. Triggers
+     * lazy creation of the {@link GhostBoundaryDetector} on first call.
+     */
+    public void setNeighborDetector(NeighborDetector<Key> detector) {
+        this.neighborDetector = detector;
+        if (detector != null && this.ghostBoundaryDetector == null) {
+            this.ghostBoundaryDetector = new GhostBoundaryDetector<>(facade, detector, ghostType, ghostAlgorithm);
+        }
+    }
+
+    // ---- Combined local + ghost queries -------------------------------------------------------------------------
+
+    public List<ID> findEntitiesIncludingGhosts(Key key) {
+        var result = new ArrayList<ID>();
+        core.lock().readLock().lock();
+        try {
+            var node = core.spatialIndex().get(key);
+            if (node != null) {
+                var entityIds = node.getEntityIds();
+                if (entityIds != null) {
+                    result.addAll(entityIds);
+                }
+            }
+            var currentGhostLayer = ghostLayer; // capture to avoid race
+            if (currentGhostLayer != null) {
+                var ghostElements = currentGhostLayer.getGhostElements(key);
+                if (ghostElements != null) {
+                    for (var ghost : ghostElements) {
+                        if (ghost != null) {
+                            var entityId = ghost.getEntityId();
+                            if (entityId != null) {
+                                result.add(entityId);
+                            }
+                        }
+                    }
+                }
+            }
+            return result;
+        } finally {
+            core.lock().readLock().unlock();
+        }
+    }
+
+    public List<AbstractSpatialIndex.NeighborResult<ID, Content>> findNeighborsIncludingGhosts(Point3f position,
+                                                                                               float radius) {
+        var result = new ArrayList<AbstractSpatialIndex.NeighborResult<ID, Content>>();
+        core.lock().readLock().lock();
+        try {
+            // Local neighbors via the unified façade k-NN seam (P3 will own this provider).
+            var localNeighbors = geometry.kNearestNeighbors(position, Integer.MAX_VALUE, radius);
+            for (var entityId : localNeighbors) {
+                var entityContent = core.entityManager().getEntityContent(entityId);
+                var entityPosition = core.entityManager().getEntityPosition(entityId);
+                if (entityContent != null && entityPosition != null) {
+                    float distance = position.distance(entityPosition);
+                    result.add(new AbstractSpatialIndex.NeighborResult<>(entityId, entityContent, distance));
+                }
+            }
+            // Ghost neighbors (linear scan for now; spatial range queries over ghosts are a future refinement).
+            if (ghostLayer != null && ghostBoundaryDetector != null) {
+                for (var entry : ghostLayer.getAllGhostElements()) {
+                    float distance = position.distance(entry.getPosition());
+                    if (distance <= radius) {
+                        result.add(new AbstractSpatialIndex.NeighborResult<>(entry.getEntityId(), entry.getContent(),
+                                                                             distance));
+                    }
+                }
+            }
+            return result;
+        } finally {
+            core.lock().readLock().unlock();
+        }
+    }
+
+    // ---- Update hooks (called by the façade after bulk insert / adaptation) -------------------------------------
+
+    public void triggerGhostUpdateAfterBulkInsert() {
+        if (ghostType != GhostType.NONE && ghostBoundaryDetector != null) {
+            log.debug("Triggering ghost update after bulk insertion");
+            updateGhostLayer();
+        }
+    }
+
+    public void triggerGhostUpdateAfterAdaptation() {
+        if (ghostType != GhostType.NONE && ghostBoundaryDetector != null) {
+            log.debug("Triggering ghost update after tree adaptation");
+            updateGhostLayer();
+            if (distributedGhostManager != null) {
+                distributedGhostManager.updateDistributedGhostLayer();
+            }
+        }
+    }
+
+    // ---- Distributed ghost management ---------------------------------------------------------------------------
+
+    public void setupDistributedGhosts(GhostChannel<Key, ID, Content> ghostChannel,
+                                       ContentSerializer<Content> contentSerializer, Class<ID> entityIdClass,
+                                       int currentRank, long treeId) {
+        core.lock().writeLock().lock();
+        try {
+            if (ghostBoundaryDetector == null) {
+                log.warn("Cannot setup distributed ghosts - local ghost manager not initialized");
+                return;
+            }
+            this.distributedGhostManager = new DistributedGhostManager<>(facade, ghostChannel, ghostBoundaryDetector);
+            log.info("Distributed ghost management enabled for rank {} tree {}", currentRank, treeId);
+        } finally {
+            core.lock().writeLock().unlock();
+        }
+    }
+
+    public void initializeDistributedGhosts(ServiceDiscovery serviceDiscovery) {
+        if (distributedGhostManager != null) {
+            distributedGhostManager.initialize(serviceDiscovery);
+        } else {
+            log.warn("Cannot initialize distributed ghosts - distributed ghost manager not set up");
+        }
+    }
+
+    public void createDistributedGhostLayer() {
+        if (distributedGhostManager != null) {
+            distributedGhostManager.createDistributedGhostLayer();
+        } else {
+            // Fall back to local ghost layer creation
+            createGhostLayer();
+        }
+    }
+
+    public void addDistributedProcess(int rank) {
+        if (distributedGhostManager != null) {
+            distributedGhostManager.addKnownProcess(rank);
+        }
+    }
+
+    public void removeDistributedProcess(int rank) {
+        if (distributedGhostManager != null) {
+            distributedGhostManager.removeKnownProcess(rank);
+        }
+    }
+
+    public void setElementOwner(Key key, int ownerRank) {
+        if (distributedGhostManager != null) {
+            distributedGhostManager.setElementOwner(key, ownerRank);
+        }
+    }
+
+    public void synchronizeDistributedGhosts() {
+        if (distributedGhostManager != null) {
+            distributedGhostManager.synchronizeWithAllProcesses();
+        }
+    }
+
+    public void setDistributedGhostAutoSync(boolean enabled) {
+        if (distributedGhostManager != null) {
+            distributedGhostManager.setAutoSyncEnabled(enabled);
+        }
+    }
+
+    public Map<String, Object> getDistributedGhostStatistics() {
+        if (distributedGhostManager != null) {
+            return distributedGhostManager.getStatistics();
+        }
+        return Map.of();
+    }
+
+    public boolean isDistributedGhostsEnabled() {
+        return distributedGhostManager != null;
+    }
+
+    public void shutdownDistributedGhosts() {
+        if (distributedGhostManager != null) {
+            distributedGhostManager.shutdown();
+            distributedGhostManager = null;
+            log.info("Distributed ghost management shut down");
+        }
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/occlusion/DsocController.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/occlusion/DsocController.java
@@ -20,6 +20,7 @@ import com.hellblazer.luciferase.lucien.FrameManager;
 import com.hellblazer.luciferase.lucien.Frustum3D;
 import com.hellblazer.luciferase.lucien.FrustumIntersection;
 import com.hellblazer.luciferase.lucien.FrustumIntersection.VisibilityType;
+import com.hellblazer.luciferase.lucien.SpatialGeometry;
 import com.hellblazer.luciferase.lucien.SpatialIndexCore;
 import com.hellblazer.luciferase.lucien.SpatialKey;
 import com.hellblazer.luciferase.lucien.entity.EntityBounds;
@@ -70,7 +71,7 @@ public final class DsocController<Key extends SpatialKey<Key>, ID extends Entity
     private static final int    MIN_ENTITIES_FOR_DSOC           = 50;
 
     private final SpatialIndexCore<Key, ID, Content> core;
-    private final DsocCallback<Key, ID, Content>     callback;
+    private final SpatialGeometry<Key, ID, Content>     callback;
     private final DSOCConfiguration                  config;
 
     private final FrameManager                              frameManager;
@@ -91,7 +92,7 @@ public final class DsocController<Key extends SpatialKey<Key>, ID extends Entity
      * Construct and, when the configuration is enabled, initialize the DSOC machinery and wire entity auto-dynamics.
      * Mirrors the former {@code AbstractSpatialIndex.enableDSOC(config, bufferWidth, bufferHeight)}.
      */
-    public DsocController(SpatialIndexCore<Key, ID, Content> core, DsocCallback<Key, ID, Content> callback,
+    public DsocController(SpatialIndexCore<Key, ID, Content> core, SpatialGeometry<Key, ID, Content> callback,
                           DSOCConfiguration config, int bufferWidth, int bufferHeight) {
         this.core = core;
         this.callback = callback;

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/occlusion/DsocController.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/occlusion/DsocController.java
@@ -53,7 +53,7 @@ import java.util.stream.Collectors;
  * public DSOC API and three integration seams (frustum-cull entry, entity-update visibility/TBV, occlusion-aware
  * node creation) to it. Shared storage and concurrency come from {@link SpatialIndexCore}; the few façade operations
  * the cull still needs (frustum traversal order, the subclass frustum-node test, node bounds, cached entity position,
- * and the standard non-DSOC cull fallback) arrive through {@link DsocCallback}.
+ * and the standard non-DSOC cull fallback) arrive through {@link SpatialGeometry}.
  *
  * @param <Key>     the spatial key type
  * @param <ID>      the entity identifier type


### PR DESCRIPTION
## Summary

RDR-008 **P2** — extract the distributed-ghost cluster out of the `AbstractSpatialIndex` god-class into a feature object, AND introduce the unified **`SpatialGeometry<Key,ID,Content>`** callback seam per the RDR §Decision (chosen by the user over per-feature callbacks). Two commits, both verifiable independently. Builds on P0 (`SpatialIndexCore`) + P1 (`DsocController`).

## Changes

### Increment 1 — `8ec73ecc`: introduce SpatialGeometry seam, migrate DsocController
- **New `lucien.SpatialGeometry<Key,ID,Content>`** — the unified façade→feature-object callback. Implemented by the façade through a private inner class (`SpatialGeometryImpl`) so the underlying methods keep their original visibility (no public widening). Grows by one cluster's needs per phase; collaborators call the subset they need.
- `DsocController`: migrated off `DsocCallback` onto `SpatialGeometry` (same 5 methods, pure rename/relocation). `DsocCallback` deleted; `DsocCallbackImpl` → `SpatialGeometryImpl`.

### Increment 2 — `02cd52fa`: extract GhostCoordinator
- **New `forest.ghost.GhostCoordinator<Key,ID,Content>`** — owns the ghost state (type, algorithm, `GhostLayer`, `GhostBoundaryDetector`, optional `DistributedGhostManager`, `NeighborDetector`), the local + distributed ghost-layer lifecycle, neighbor/entity queries spanning ghosts, and the bulk-insert/adaptation update hooks. Reaches shared storage/concurrency only through `SpatialIndexCore`. **Constructed eagerly** in the façade ctor (always-present lifecycle, unlike DSOC's lazy `enableDSOC`) because subclasses call `setNeighborDetector` during their own initialization.
- `SpatialGeometry`: +`kNearestNeighbors` (the one façade op ghost needs from a not-yet-extracted cluster — P3 will own the provider).
- `AbstractSpatialIndex`: 6 ghost fields + ~24 ghost methods replaced by a `protected final GhostCoordinator ghost`; public ghost API + the protected `setNeighborDetector` subclass seam become thin delegators. **−239 lines net for P2**; cumulative arc: 5851 → 5349 (**−502 lines**).

## Invariants

- **No behavior change.** Full lucien suite green (**2441 tests, 0 failures**), including the entire distributed-ghost test suite.
- **Subclasses untouched** (P1–P4 invariant): only `AbstractSpatialIndex` + the new/renamed files changed; Octree/Tetree/Prism/SFCArrayIndex byte-for-byte unchanged. `setNeighborDetector` kept its `protected` signature so subclass init calls compile.
- **No nucleus partial-bypass.** `GhostCoordinator` reaches lock/spatialIndex/entityManager only through `core`.

## Documented concession

`GhostBoundaryDetector` AND `DistributedGhostManager` both take the **concrete `AbstractSpatialIndex`** in their constructors. `GhostCoordinator` therefore holds a façade back-reference *solely* to pass to them (used at exactly 4 ctor-call sites — confirmed by review, never invoked otherwise). Honest deviation from the otherwise-clean feature-object decoupling; tracked as follow-up **`Luciferase-703`** (re-inverting GBD/DGM onto an interface would expand scope into `forest.ghost` + `Forest` callers).

## Review

Stacked review (code-review-expert + substantive-critic), **0 Critical**, approved. Fixed in-PR:
- Stale `{@link DsocCallback}` Javadoc → `{@link SpatialGeometry}`.
- Unused `HashSet` import in `GhostCoordinator` (Serena-cascade residue).
- `this`-escape fragility at the ctor site → added an explicit **invariant comment** that feature-object ctors must not invoke methods on the supplied callback or `this` during façade construction.

**Recorded obligations (not silently dropped):**
- **G3 (`x5i.7`)**: when P3 lands, evaluate whether `KnnSearcher` should depend on the full `SpatialGeometry` or a narrower `KnnProvider`.
- **G4 (`x5i.9`)**: **shrink-step decision for P4** — when the frustum/cull cluster moves, either keep its methods in `SpatialGeometry` via delegation or split into per-cluster sub-interfaces. Required to prevent `SpatialGeometry` from accreting all 6 clusters' back-call surfaces permanently (fat-interface antipattern).

## perf parity

P2 touches no hot query path. G2 entry criterion (recorded on `x5i.5`) is the targeted ghost-related perf check against `main 46c5233e`.

Refs: RDR-008 P2, `Luciferase-x5i.4`. Next: **G2 gate** (`x5i.5`, covers P2) → **P3** (`x5i.6`, `KnnSearcher`).