### PR TITLE
Luciferase-x5i.6: extract KnnSearcher (RDR-008 P3-main)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
@@ -21,6 +21,7 @@ import com.hellblazer.luciferase.lucien.balancing.DefaultBalancingStrategy;
 import com.hellblazer.luciferase.lucien.balancing.TreeBalancer;
 import com.hellblazer.luciferase.lucien.balancing.TreeBalancingStrategy;
 import com.hellblazer.luciferase.lucien.cache.KnnGeometry;
+import com.hellblazer.luciferase.lucien.cache.KnnSearcher;
 import com.hellblazer.luciferase.lucien.collision.CollisionShape;
 import com.hellblazer.luciferase.lucien.entity.*;
 import com.hellblazer.luciferase.lucien.forest.ghost.*;
@@ -81,7 +82,7 @@ import java.util.stream.Stream;
  * @author hal.hildebrand
  */
 public abstract class AbstractSpatialIndex<Key extends SpatialKey<Key>, ID extends EntityID, Content>
-implements SpatialIndex<Key, ID, Content>, com.hellblazer.luciferase.lucien.cache.KnnProvider<Key, ID> {
+implements SpatialIndex<Key, ID, Content> {
 
     /**
      * Record representing a neighbor search result with distance information.
@@ -104,8 +105,12 @@ implements SpatialIndex<Key, ID, Content>, com.hellblazer.luciferase.lucien.cach
     // Entity data cache for performance. RDR-008: protected so all four structural-nucleus fields
     // (spatialIndex, lock, entityManager, entityCache) share uniform visibility; reached by feature objects via core.
     protected final EntityCache<ID>                                  entityCache;
-    // Fine-grained locking strategy for high-concurrency operations
-    protected       FineGrainedLockingStrategy<ID, Content>          lockingStrategy;
+    // Fine-grained locking strategy for high-concurrency operations.
+    // volatile: configureFineGrainedLocking may replace this reference while concurrent kNearestNeighbors / other
+    // callers read it outside any lock (RDR-008 P3-main moved the k-NN read path into KnnSearcher, where the supplier
+    // `() -> this.lockingStrategy` reads the field from a different class — same JMM publication requirement as the
+    // pre-extraction direct field read, but now visible at the package seam). Matches the dsoc volatile pattern.
+    protected volatile FineGrainedLockingStrategy<ID, Content>       lockingStrategy;
     // Bulk operation support
     protected       BulkOperationConfig                              bulkConfig               = new BulkOperationConfig();
     protected       boolean                                          bulkLoadingMode          = false;
@@ -130,11 +135,10 @@ implements SpatialIndex<Key, ID, Content>, com.hellblazer.luciferase.lucien.cach
     private volatile DsocController<Key, ID, Content>                        dsoc;
     // RDR-008 P2: distributed-ghost cluster, encapsulated in GhostCoordinator (always present; eager init in ctor).
     protected final GhostCoordinator<Key, ID, Content>                       ghost;
-    // k-NN performance metrics
-    private final   java.util.concurrent.atomic.AtomicLong           knnCacheHits = new java.util.concurrent.atomic.AtomicLong(0);
-    private final   java.util.concurrent.atomic.AtomicLong           knnCacheMisses = new java.util.concurrent.atomic.AtomicLong(0);
-    private final   java.util.concurrent.atomic.AtomicLong           knnExpandingSearchUsed = new java.util.concurrent.atomic.AtomicLong(0);
-    private final   java.util.concurrent.atomic.AtomicLong           knnSFCPruningUsed = new java.util.concurrent.atomic.AtomicLong(0);
+    // RDR-008 P3: k-NN cluster, encapsulated in KnnSearcher (always present; eager init in ctor). KnnSearcher
+    // implements KnnProvider — the façade's public k-NN API now delegates to it, and other feature objects that
+    // consume k-NN (e.g. GhostCoordinator) take this directly as their KnnProvider.
+    protected final KnnSearcher<Key, ID, Content>                            knn;
     // Tree balancing support
     private         TreeBalancingStrategy<ID>                        balancingStrategy;
     private         boolean                                          autoBalancingEnabled     = false;
@@ -166,17 +170,23 @@ implements SpatialIndex<Key, ID, Content>, com.hellblazer.luciferase.lucien.cach
         // RDR-008: wrap the now-initialized six-field nucleus in a single shared view for feature-object collaborators
         this.core = new SpatialIndexCore<>(spatialIndex, lock, spatialVersion, knnCache, entityManager, entityCache);
 
+        // RDR-008 P3: k-NN cluster lives in KnnSearcher (implements KnnProvider). Constructed before
+        // GhostCoordinator so the latter can take it directly as its KnnProvider.  The lockingStrategy supplier is
+        // late-bound because configureFineGrainedLocking can replace the field.
+        this.knn = new KnnSearcher<>(core, new KnnGeometryImpl(), () -> this.lockingStrategy);
+
         // RDR-008 P2: distributed-ghost cluster lives in GhostCoordinator; constructed eagerly so subclasses can
         // call setNeighborDetector during their own initialization.
         // INVARIANT for future phases: GhostCoordinator's ctor (and the ctors of any other feature object created
-        // here) MUST NOT invoke any method on the supplied FrustumGeometryImpl / KnnGeometryImpl, on the KnnProvider
-        // (`this`), or on `this` directly — `this` is still partially constructed at this point, and any virtual
-        // dispatch into a not-yet-initialized subclass is a classic this-escape hazard. Storing the references is
-        // fine; calling through them is not.
-        // The two `this` arguments below: first satisfies KnnProvider<Key,ID> (façade implements it; P3-main will
-        // pass the KnnSearcher instance instead and drop the `implements`); second is the façade back-reference the
-        // ghost subsystem (GhostBoundaryDetector + DistributedGhostManager) needs in their ctors.
-        this.ghost = new GhostCoordinator<>(core, this, this);
+        // here — including KnnSearcher above) MUST NOT invoke any method on the supplied FrustumGeometryImpl /
+        // KnnGeometryImpl, on the KnnProvider, or on `this` directly — `this` is still partially constructed at this
+        // point, and any virtual dispatch into a not-yet-initialized subclass is a classic this-escape hazard.
+        // Storing the references is fine; calling through them is not.  (KnnSearcher's ctor stores only; the
+        // lockingStrategy supplier captures `this` but is invoked post-construction.)
+        // The `knn` argument below satisfies KnnProvider<Key,ID> (P3-main moved this role off the façade); the
+        // second `this` is the façade back-reference the ghost subsystem (GhostBoundaryDetector +
+        // DistributedGhostManager) needs in their ctors.
+        this.ghost = new GhostCoordinator<>(core, knn, this);
     }
 
     @Override
@@ -896,31 +906,9 @@ implements SpatialIndex<Key, ID, Content>, com.hellblazer.luciferase.lucien.cach
         return entityCache.getStats();
     }
 
-    /**
-     * Get k-NN performance metrics
-     */
-    public record KNNPerformanceMetrics(
-        long cacheHits,
-        long cacheMisses,
-        long expandingSearchUsed,
-        long sfcPruningUsed,
-        double cacheHitRate,
-        double sfcPruningRate
-    ) {}
-
-    public KNNPerformanceMetrics getKNNPerformanceMetrics() {
-        var hits = knnCacheHits.get();
-        var misses = knnCacheMisses.get();
-        var expanding = knnExpandingSearchUsed.get();
-        var sfc = knnSFCPruningUsed.get();
-        
-        var totalQueries = hits + misses;
-        var cacheHitRate = totalQueries > 0 ? (double) hits / totalQueries : 0.0;
-        
-        var totalSearches = expanding + sfc;
-        var sfcPruningRate = totalSearches > 0 ? (double) sfc / totalSearches : 0.0;
-        
-        return new KNNPerformanceMetrics(hits, misses, expanding, sfc, cacheHitRate, sfcPruningRate);
+    /** Get k-NN performance metrics. RDR-008 P3: delegates to {@link KnnSearcher}. */
+    public KnnSearcher.KNNPerformanceMetrics getKNNPerformanceMetrics() {
+        return knn.getKNNPerformanceMetrics();
     }
 
     @Override
@@ -1387,82 +1375,12 @@ implements SpatialIndex<Key, ID, Content>, com.hellblazer.luciferase.lucien.cach
     }
 
     /**
-     * Find k nearest neighbors to a query point using spatial locality optimization
-     *
-     * @param queryPoint  the point to search from
-     * @param k           the number of neighbors to find
-     * @param maxDistance maximum search distance
-     * @return list of entity IDs sorted by distance (closest first)
+     * Find k nearest neighbors to a query point using spatial locality optimization.
+     * <p>RDR-008 P3: delegates to {@link KnnSearcher}; the cluster (cache, version pinning, SFC range pruning,
+     * expanding-radius fallback, full-domain sweep, legacy BFS fallback) lives there.
      */
     public List<ID> kNearestNeighbors(Point3f queryPoint, int k, float maxDistance) {
-        validateSpatialConstraints(queryPoint);
-
-        if (k <= 0) {
-            return Collections.emptyList();
-        }
-
-        log.debug("k-NN search: queryPoint={}, k={}, maxDistance={}, spatialIndex.size()={}", 
-                  queryPoint, k, maxDistance, spatialIndex.size());
-
-        // k-NN cache: Check cache with composite key (position + k + maxDistance)
-        // Use level 15 for cache granularity (cell size = 64) to distinguish nearby queries
-        // Level 0 is too coarse (cell size = 2,097,152) and causes false cache hits
-        var spatialKey = calculateSpatialIndex(queryPoint, (byte) 15);
-        var queryKey = new com.hellblazer.luciferase.lucien.cache.KNNQueryKey<>(spatialKey, k, maxDistance);
-        var currentVersion = spatialVersion.get();
-        var cached = knnCache.get(queryKey, currentVersion);
-        if (cached != null) {
-            // Cache hit: return cached entity IDs (0.05-0.1ms vs 0.3-0.5ms)
-            knnCacheHits.incrementAndGet();
-            log.debug("k-NN cache hit: returning {} entities", cached.entityIds().size());
-            return cached.entityIds();
-        }
-
-        knnCacheMisses.incrementAndGet();
-        log.debug("k-NN cache miss: computing k-NN");
-
-        // Cache miss: compute k-NN and store result
-        // Use fine-grained locking for read operations
-        return lockingStrategy.executeRead(0L, () -> {
-            // Priority queue to keep track of k nearest entities (max heap)
-            var candidates = ObjectPools.borrowPriorityQueue(EntityDistance.<ID>maxHeapComparator());
-            var addedToCandidates = ObjectPools.<ID>borrowHashSet();
-            try {
-                // Use optimized SFC range pruning first (4-6× speedup from Paper 4)
-                knnSFCPruningUsed.incrementAndGet();
-                performKNNSFCRangePruning(queryPoint, k, maxDistance, candidates, addedToCandidates);
-                
-                // If SFC pruning didn't find enough entities, fall back to expanding radius search
-                if (candidates.size() < k) {
-                    knnExpandingSearchUsed.incrementAndGet();
-                    performKNNExpandingRadiusSearch(queryPoint, k, maxDistance, candidates, addedToCandidates);
-                }
-
-                // Convert to sorted list (closest first) and extract distances
-                var sorted = ObjectPools.<EntityDistance<ID>>borrowArrayList(candidates.size());
-                try {
-                    sorted.addAll(candidates);
-                    sorted.sort(EntityDistance.minHeapComparator());
-
-                    var entityIds = new ArrayList<ID>(sorted.size());
-                    var distances = new ArrayList<Float>(sorted.size());
-                    for (var entry : sorted) {
-                        entityIds.add(entry.entityId());
-                        distances.add(entry.distance());
-                    }
-
-                    // Store in cache for future queries
-                    knnCache.put(queryKey, entityIds, distances, currentVersion);
-
-                    return entityIds;
-                } finally {
-                    ObjectPools.returnArrayList(sorted);
-                }
-            } finally {
-                ObjectPools.returnPriorityQueue(candidates);
-                ObjectPools.returnHashSet(addedToCandidates);
-            }
-        });
+        return knn.kNearestNeighbors(queryPoint, k, maxDistance);
     }
 
     /**
@@ -2625,8 +2543,38 @@ implements SpatialIndex<Key, ID, Content>, com.hellblazer.luciferase.lucien.cach
         }
 
         @Override
+        public float getCellSizeAtLevel(byte level) {
+            return AbstractSpatialIndex.this.getCellSizeAtLevel(level);
+        }
+
+        @Override
+        public java.util.Set<Key> findNodesIntersectingBounds(VolumeBounds bounds) {
+            return AbstractSpatialIndex.this.findNodesIntersectingBounds(bounds);
+        }
+
+        @Override
+        public boolean knnRequiresFullDomainSweep() {
+            return AbstractSpatialIndex.this.knnRequiresFullDomainSweep();
+        }
+
+        @Override
+        public void addNeighboringNodes(Key nodeIndex, java.util.Queue<Key> toVisit, java.util.Set<Key> visitedNodes) {
+            AbstractSpatialIndex.this.addNeighboringNodes(nodeIndex, toVisit, visitedNodes);
+        }
+
+        @Override
         public void validateSpatialConstraints(Point3f position) {
             AbstractSpatialIndex.this.validateSpatialConstraints(position);
+        }
+
+        @Override
+        public Point3f getCachedEntityPosition(ID entityId) {
+            return AbstractSpatialIndex.this.getCachedEntityPosition(entityId);
+        }
+
+        @Override
+        public byte maxDepth() {
+            return AbstractSpatialIndex.this.maxDepth;
         }
     }
 
@@ -3809,25 +3757,6 @@ implements SpatialIndex<Key, ID, Content>, com.hellblazer.luciferase.lucien.cach
     }
 
     /**
-     * Convert k-NN candidates to sorted list
-     */
-    private List<ID> convertKNNCandidatesToList(PriorityQueue<EntityDistance<ID>> candidates) {
-        var sorted = ObjectPools.<EntityDistance<ID>>borrowArrayList(candidates.size());
-        try {
-            sorted.addAll(candidates);
-            sorted.sort(EntityDistance.minHeapComparator());
-
-            var result = new ArrayList<ID>(sorted.size());
-            for (var entry : sorted) {
-                result.add(entry.entityId());
-            }
-            return result;
-        } finally {
-            ObjectPools.returnArrayList(sorted);
-        }
-    }
-
-    /**
      * Determine the effective level for batch insertion
      */
     private byte determineBatchInsertionLevel(List<Point3f> positions, byte level) {
@@ -3971,35 +3900,6 @@ implements SpatialIndex<Key, ID, Content>, com.hellblazer.luciferase.lucien.cach
                 }
             }
         }
-    }
-
-    /**
-     * Find the nearest node to a query point
-     */
-    private Key findNearestNodeToPoint(Point3f queryPoint) {
-        var bestDistance = Float.MAX_VALUE;
-        Key nearestNodeIndex = null;
-        var cellSize = getCellSizeAtLevel(maxDepth);
-
-        for (var nodeIndex : spatialIndex.keySet()) {
-            var node = spatialIndex.get(nodeIndex);
-            if (node == null || node.isEmpty()) {
-                continue;
-            }
-
-            var nodeDistance = estimateNodeDistance(nodeIndex, queryPoint);
-            if (nodeDistance < bestDistance) {
-                bestDistance = nodeDistance;
-                nearestNodeIndex = nodeIndex;
-            }
-
-            // Early termination
-            if (nodeDistance < cellSize) {
-                break;
-            }
-        }
-
-        return nearestNodeIndex;
     }
 
     /**
@@ -4279,342 +4179,6 @@ implements SpatialIndex<Key, ID, Content>, com.hellblazer.luciferase.lucien.cach
     }
 
     /**
-     * Perform expanding radius search for k-NN
-     *
-     * @return true if enough candidates were found
-     */
-    private boolean performKNNExpandingRadiusSearch(Point3f queryPoint, int k, float maxDistance,
-                                                    PriorityQueue<EntityDistance<ID>> candidates,
-                                                    Set<ID> addedToCandidates) {
-        // Start with a reasonable initial radius - at least the cell size at a mid-level
-        var minInitialRadius = getCellSizeAtLevel((byte) Math.min(maxDepth, 15));
-        var searchRadius = Math.min(maxDistance, Math.max(minInitialRadius, getCellSizeAtLevel(maxDepth)));
-        var searchExpansions = 0;
-        final var maxExpansions = 10; // Allow more expansions to reach distant entities
-
-        log.debug("k-NN expanding search: initialRadius={}, maxDistance={}", searchRadius, maxDistance);
-
-        while (candidates.size() < k && searchRadius <= maxDistance && searchExpansions < maxExpansions) {
-            var foundNewEntities = searchKNNInRadius(queryPoint, searchRadius, maxDistance, k, candidates,
-                                                     addedToCandidates);
-
-            log.debug("k-NN expansion {}: radius={}, found={}, candidates={}", 
-                      searchExpansions, searchRadius, foundNewEntities, candidates.size());
-
-            if (candidates.size() < k && searchRadius < maxDistance) {
-                searchRadius *= 2.0f;
-                searchExpansions++;
-            } else {
-                break;
-            }
-
-            // If we didn't find any new entities in this expansion, stop
-            if (!foundNewEntities && searchExpansions > 1) {
-                break;
-            }
-        }
-
-        // Final safety sweep: the incremental expansion above can terminate before covering the
-        // index — its "no new entities" heuristic and fixed expansion cap assume entities are
-        // densely clustered near the query, and its initial radius is a fine-level cell size. Over a
-        // SPARSE index the true neighbors can sit beyond the last ring (this is what left Prism
-        // k-NN under-returning — the doublings from a sub-unit cell size never spanned the [0,1)
-        // world within the cap). If still short of k, do one pass whose radius spans the whole
-        // coordinate domain. The radius is bounded by the root-cell edge (getCellSizeAtLevel(0) =
-        // the domain extent), NOT by maxDistance: an unbounded maxDistance (e.g. Float.MAX_VALUE for
-        // "all within range") would otherwise build an overflowing search box that makes the
-        // integer-SFC findNodesIntersectingBounds (LITMAX/BIGMIN) non-terminating. (Luciferase-h65)
-        if (candidates.size() < k && knnRequiresFullDomainSweep()) {
-            // Full-domain safety sweep — gated to indices that need it (see
-            // knnRequiresFullDomainSweep). The incremental expansion above can terminate before
-            // covering the index when the coordinate space defeats its heuristics (Prism's
-            // normalized fractional coordinates: the doublings from a sub-unit initial radius never
-            // span the [0,1) world within the expansion cap, and the "no new entities" early-exit
-            // fires on the empty rings before the real neighbors). One pass over a domain-spanning
-            // box closes the gap. This is NOT run for the integer-SFC indices (Octree/Tetree/SFC):
-            // their SFC range-pruning path already covers the whole maxDistance sphere, so a
-            // domain-spanning findNodesIntersectingBounds there would be a costly LITMAX/BIGMIN no-op
-            // (and non-terminating for a large box). See knnRequiresFullDomainSweep. (Luciferase-h65)
-            //
-            // The box spans only the root-cell edge (getCellSizeAtLevel(0)): for any query inside the
-            // domain, query +/- edge already encloses the whole domain, so every node is a candidate.
-            // Acceptance uses the full maxDistance (decoupled from the box radius), so far-corner
-            // neighbors up to the domain diagonal are not wrongly rejected.
-            var edge = getCellSizeAtLevel((byte) 0);
-            var sweepBounds = new VolumeBounds(queryPoint.x - edge, queryPoint.y - edge, queryPoint.z - edge,
-                                               queryPoint.x + edge, queryPoint.y + edge, queryPoint.z + edge);
-            for (var nodeKey : findNodesIntersectingBounds(sweepBounds)) {
-                var node = spatialIndex.get(nodeKey);
-                if (node == null || node.isEmpty()) {
-                    continue;
-                }
-                for (var entityId : node.getEntityIds()) {
-                    if (addedToCandidates.contains(entityId)) {
-                        continue;
-                    }
-                    var entityPos = getCachedEntityPosition(entityId);
-                    if (entityPos == null) {
-                        continue;
-                    }
-                    var distance = queryPoint.distance(entityPos);
-                    if (distance <= maxDistance) {
-                        candidates.add(new EntityDistance<>(entityId, distance));
-                        addedToCandidates.add(entityId);
-                        if (candidates.size() > k) {
-                            var removed = candidates.poll();
-                            addedToCandidates.remove(removed.entityId());
-                        }
-                    }
-                }
-            }
-        }
-
-        log.debug("k-NN expanding search complete: found {} candidates", candidates.size());
-        return candidates.size() >= k;
-    }
-
-    /**
-     * Perform SFC-based search starting from the nearest node
-     */
-    private void performKNNSFCBasedSearch(Point3f queryPoint, int k, float maxDistance,
-                                          PriorityQueue<EntityDistance<ID>> candidates, Set<ID> addedToCandidates) {
-        if (spatialIndex.isEmpty()) {
-            return;
-        }
-
-        var nearestNodeIndex = findNearestNodeToPoint(queryPoint);
-        if (nearestNodeIndex == null) {
-            return;
-        }
-
-        // Breadth-first search from nearest node
-        var toVisit = new LinkedList<Key>();
-        var visitedNodes = ObjectPools.<Key>borrowHashSet();
-        try {
-            toVisit.add(nearestNodeIndex);
-
-            while (!toVisit.isEmpty() && candidates.size() < k) {
-                var current = toVisit.poll();
-                if (!visitedNodes.add(current)) {
-                    continue;
-                }
-
-                var node = spatialIndex.get(current);
-                if (node == null) {
-                    continue;
-                }
-
-                // Process entities in current node
-                for (var entityId : node.getEntityIds()) {
-                    if (!addedToCandidates.contains(entityId)) {
-                        var entityPos = getCachedEntityPosition(entityId);
-                        if (entityPos != null) {
-                            var distance = queryPoint.distance(entityPos);
-                            if (distance <= maxDistance) {
-                                candidates.add(new EntityDistance<>(entityId, distance));
-                                addedToCandidates.add(entityId);
-                                if (candidates.size() > k) {
-                                    var removed = candidates.poll();
-                                    addedToCandidates.remove(removed.entityId());
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Add neighboring nodes if we need more candidates
-                if (candidates.size() < k || shouldContinueKNNSearch(current, queryPoint, candidates)) {
-                    addNeighboringNodes(current, toVisit, visitedNodes);
-                }
-            }
-        } finally {
-            ObjectPools.returnHashSet(visitedNodes);
-        }
-    }
-
-    /**
-     * Perform optimized SFC range-based k-NN search using range pruning.
-     * 
-     * This implements the algorithm from Paper 4 (Space-Filling Trees for Motion Planning):
-     * 1. Estimate appropriate SFC depth for the search radius
-     * 2. Compute SFC key range covering the search sphere
-     * 3. Use subMap() to iterate only over relevant nodes (4-6× speedup vs breadth-first)
-     * 
-     * @param queryPoint the point to search from
-     * @param k the number of neighbors to find
-     * @param maxDistance maximum search distance
-     * @param candidates priority queue to store candidates
-     * @param addedToCandidates set of already-added entity IDs
-     */
-    private void performKNNSFCRangePruning(Point3f queryPoint, int k, float maxDistance,
-                                          PriorityQueue<EntityDistance<ID>> candidates, Set<ID> addedToCandidates) {
-        if (spatialIndex.isEmpty()) {
-            return;
-        }
-
-        // Get the root key to determine key type
-        var rootKey = spatialIndex.firstKey();
-        
-        try {
-            // Use appropriate SFC range estimation based on key type
-            if (rootKey instanceof com.hellblazer.luciferase.lucien.octree.MortonKey) {
-                performKNNSFCRangePruningMorton(queryPoint, k, maxDistance, candidates, addedToCandidates);
-            } else if (rootKey instanceof com.hellblazer.luciferase.lucien.tetree.TetreeKey) {
-                performKNNSFCRangePruningTetree(queryPoint, k, maxDistance, candidates, addedToCandidates);
-            } else {
-                // Fallback to old breadth-first search for unknown key types
-                performKNNSFCBasedSearch(queryPoint, k, maxDistance, candidates, addedToCandidates);
-            }
-        } catch (Exception e) {
-            log.warn("SFC range pruning failed, falling back to breadth-first search: {}", e.getMessage());
-            performKNNSFCBasedSearch(queryPoint, k, maxDistance, candidates, addedToCandidates);
-        }
-    }
-
-    /**
-     * SFC range-based k-NN search for MortonKey (Octree).
-     *
-     * <p>Because {@link com.hellblazer.luciferase.lucien.octree.MortonKey#compareTo} now orders keys
-     * first by level then by Morton code, a {@code subMap} call whose bounds are at level L will only
-     * return keys that are also stored at level L.  Entities can be inserted at different levels, so
-     * we collect the set of distinct storage levels present in the index and issue one {@code subMap}
-     * query per unique level, using bounds computed at that same level.</p>
-     */
-    @SuppressWarnings("unchecked")
-    private void performKNNSFCRangePruningMorton(Point3f queryPoint, int k, float maxDistance,
-                                                PriorityQueue<EntityDistance<ID>> candidates, Set<ID> addedToCandidates) {
-        // When maxDistance is very large, SFC range pruning at level 0 won't work properly
-        // because entities are stored at a finer level. Fall back to full scan.
-        if (maxDistance >= Constants.MAX_COORD) {
-            performFullScanKNN(queryPoint, k, maxDistance, candidates, addedToCandidates);
-            return;
-        }
-
-        // Collect the distinct levels at which keys are stored so we can issue a correctly-levelled
-        // subMap query for each one.  In the common single-level case this is a single pass.
-        var storageLevels = new LinkedHashSet<Byte>();
-        for (var key : spatialIndex.keySet()) {
-            storageLevels.add(((com.hellblazer.luciferase.lucien.octree.MortonKey) key).getLevel());
-        }
-
-        for (byte storageLevel : storageLevels) {
-            // Compute SFC range bounds at the same level as the stored keys so that
-            // subMap() returns the correct entries with level-aware compareTo.
-            var sfcRange = com.hellblazer.luciferase.lucien.octree.MortonKey.estimateSFCRange(
-                queryPoint, maxDistance, storageLevel);
-
-            var rangeMap = spatialIndex.subMap((Key) sfcRange.lower(), (Key) sfcRange.upper());
-
-            for (var entry : rangeMap.entrySet()) {
-                var node = entry.getValue();
-                if (node == null) {
-                    continue;
-                }
-
-                for (var entityId : node.getEntityIds()) {
-                    if (!addedToCandidates.contains(entityId)) {
-                        var entityPos = getCachedEntityPosition(entityId);
-                        if (entityPos != null) {
-                            var distance = queryPoint.distance(entityPos);
-                            if (distance <= maxDistance) {
-                                candidates.add(new EntityDistance<>(entityId, distance));
-                                addedToCandidates.add(entityId);
-
-                                // Maintain max heap of size k
-                                if (candidates.size() > k) {
-                                    var removed = candidates.poll();
-                                    addedToCandidates.remove(removed.entityId());
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * SFC range-based k-NN search for TetreeKey (Tetree)
-     */
-    @SuppressWarnings("unchecked")
-    private void performKNNSFCRangePruningTetree(Point3f queryPoint, int k, float maxDistance,
-                                                PriorityQueue<EntityDistance<ID>> candidates, Set<ID> addedToCandidates) {
-        // When maxDistance is very large, SFC range pruning at level 0 won't work properly
-        // because entities are stored at a finer level. Fall back to full scan.
-        if (maxDistance >= Constants.MAX_COORD) {
-            performFullScanKNN(queryPoint, k, maxDistance, candidates, addedToCandidates);
-            return;
-        }
-
-        // Estimate SFC range covering the search sphere
-        var sfcRange = com.hellblazer.luciferase.lucien.tetree.TetreeKey.estimateSFCRange(queryPoint, maxDistance);
-
-        // Use subMap to iterate only over keys in the SFC range (this is the optimization!)
-        var rangeMap = spatialIndex.subMap((Key) sfcRange.lower(), (Key) sfcRange.upper());
-
-        // Process entities in nodes within the SFC range
-        for (var entry : rangeMap.entrySet()) {
-            var node = entry.getValue();
-            if (node == null) {
-                continue;
-            }
-
-            for (var entityId : node.getEntityIds()) {
-                if (!addedToCandidates.contains(entityId)) {
-                    var entityPos = getCachedEntityPosition(entityId);
-                    if (entityPos != null) {
-                        var distance = queryPoint.distance(entityPos);
-                        if (distance <= maxDistance) {
-                            candidates.add(new EntityDistance<>(entityId, distance));
-                            addedToCandidates.add(entityId);
-
-                            // Maintain max heap of size k
-                            if (candidates.size() > k) {
-                                var removed = candidates.poll();
-                                addedToCandidates.remove(removed.entityId());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Full scan k-NN search for unlimited distance queries.
-     * Used when maxDistance is so large that SFC range pruning won't work correctly.
-     */
-    private void performFullScanKNN(Point3f queryPoint, int k, float maxDistance,
-                                    PriorityQueue<EntityDistance<ID>> candidates, Set<ID> addedToCandidates) {
-        // Iterate through all nodes in the spatial index
-        for (var entry : spatialIndex.entrySet()) {
-            var node = entry.getValue();
-            if (node == null) {
-                continue;
-            }
-
-            for (var entityId : node.getEntityIds()) {
-                if (!addedToCandidates.contains(entityId)) {
-                    var entityPos = getCachedEntityPosition(entityId);
-                    if (entityPos != null) {
-                        var distance = queryPoint.distance(entityPos);
-                        if (distance <= maxDistance) {
-                            candidates.add(new EntityDistance<>(entityId, distance));
-                            addedToCandidates.add(entityId);
-
-                            // Maintain max heap of size k
-                            if (candidates.size() > k) {
-                                var removed = candidates.poll();
-                                addedToCandidates.remove(removed.entityId());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
      * Perform bulk insert using stack-based builder
      */
     private List<ID> performStackBasedBulkInsert(List<Point3f> positions, List<Content> contents, byte level) {
@@ -4660,59 +4224,6 @@ implements SpatialIndex<Key, ID, Content>, com.hellblazer.luciferase.lucien.cach
         while ((nodeIndex = context.popNode()) != null) {
             var level = context.getNodeLevel(nodeIndex);
             traverseNode(nodeIndex, visitor, strategy, context, null, level);
-        }
-    }
-
-    /**
-     * Search for entities within a specific radius
-     */
-    private boolean searchKNNInRadius(Point3f queryPoint, float searchRadius, float maxDistance, int k,
-                                      PriorityQueue<EntityDistance<ID>> candidates, Set<ID> addedToCandidates) {
-        var visitedThisExpansion = ObjectPools.<ID>borrowHashSet();
-        try {
-            var searchBounds = new VolumeBounds(queryPoint.x - searchRadius, queryPoint.y - searchRadius,
-                                                queryPoint.z - searchRadius, queryPoint.x + searchRadius,
-                                                queryPoint.y + searchRadius, queryPoint.z + searchRadius);
-
-            var candidateNodes = findNodesIntersectingBounds(searchBounds);
-            log.debug("k-NN searchInRadius: radius={}, bounds={}, candidateNodes={}", 
-                      searchRadius, searchBounds, candidateNodes.size());
-            var foundNewEntities = false;
-
-            for (Key nodeKey : candidateNodes) {
-                var node = spatialIndex.get(nodeKey);
-                if (node == null || node.isEmpty()) {
-                    continue;
-                }
-
-                // Check all entities in this node
-                for (ID entityId : node.getEntityIds()) {
-                    if (visitedThisExpansion.add(entityId)) {
-                        var entityPos = getCachedEntityPosition(entityId);
-                        if (entityPos != null) {
-                            var distance = queryPoint.distance(entityPos);
-
-                            // Only consider entities within current search radius
-                            if (distance <= searchRadius && distance <= maxDistance && !addedToCandidates.contains(
-                            entityId)) {
-                                candidates.add(new EntityDistance<>(entityId, distance));
-                                addedToCandidates.add(entityId);
-                                foundNewEntities = true;
-
-                                // Keep only k elements
-                                if (candidates.size() > k) {
-                                    candidates.poll();
-                                    // Don't remove from addedToCandidates to prevent re-adding
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            return foundNewEntities;
-        } finally {
-            ObjectPools.returnHashSet(visitedThisExpansion);
         }
     }
 

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/cache/KnnGeometry.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/cache/KnnGeometry.java
@@ -17,26 +17,38 @@
 package com.hellblazer.luciferase.lucien.cache;
 
 import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.VolumeBounds;
 import com.hellblazer.luciferase.lucien.entity.EntityDistance;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 
 import javax.vecmath.Point3f;
 import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Set;
 
 /**
  * Façade operations the k-NN feature object consumes during search.
  *
  * <p>P3 (RDR-008) refines the seam architecture into per-cluster sub-interfaces; {@code KnnSearcher} depends only on
  * what it actually uses — the subclass-overridden geometry hooks ({@link #calculateSpatialIndex},
- * {@link #estimateNodeDistance}, {@link #shouldContinueKNNSearch}) and the façade's input-validation helper
- * {@link #validateSpatialConstraints}. The façade implements this through a private inner class so the underlying
- * methods keep their original ({@code protected}/abstract) visibility.
+ * {@link #estimateNodeDistance}, {@link #shouldContinueKNNSearch}, {@link #getCellSizeAtLevel},
+ * {@link #findNodesIntersectingBounds}, {@link #knnRequiresFullDomainSweep}, {@link #addNeighboringNodes}), the
+ * façade's input-validation helper {@link #validateSpatialConstraints}, the cached entity-position lookup
+ * {@link #getCachedEntityPosition}, and the façade's depth constant {@link #maxDepth}. The façade implements this
+ * through a private inner class so the underlying methods keep their original ({@code protected}/abstract) visibility.
+ *
+ * <p>Note: {@link #getCachedEntityPosition} is duplicated on {@link com.hellblazer.luciferase.lucien.occlusion.FrustumGeometry}
+ * by intent — each per-cluster sub-interface keeps its own narrow surface so the façade's private inner classes can
+ * route the entity-cache lookup without growing a single fat callback. The duplication is one method declaration each;
+ * if a third cluster needs the same lookup, factor it into a tiny shared sub-interface at that point (YAGNI until then).
  *
  * @param <Key> the spatial key type
  * @param <ID>  the entity identifier type
  * @author hal.hildebrand
  */
 public interface KnnGeometry<Key extends SpatialKey<Key>, ID extends EntityID> {
+
+    // ---- Subclass-overridden geometry hooks -----------------------------------------------------------------------
 
     /** Spatial key of the cell containing {@code position} at the given level (subclass geometry). */
     Key calculateSpatialIndex(Point3f position, byte level);
@@ -50,6 +62,38 @@ public interface KnnGeometry<Key extends SpatialKey<Key>, ID extends EntityID> {
      */
     boolean shouldContinueKNNSearch(Key nodeIndex, Point3f queryPoint, PriorityQueue<EntityDistance<ID>> candidates);
 
+    /**
+     * World-space edge length of a cell at the given subdivision level. Returned as {@code float} so fractional-
+     * coordinate indices (Prism) report a meaningful sub-unit cell size; integer-coordinate indices widen exactly to
+     * {@code float} for all levels (cell sizes are powers of two below 2^24).
+     */
+    float getCellSizeAtLevel(byte level);
+
+    /**
+     * Spatial keys of all nodes intersecting {@code bounds}. Subclasses provide an efficient implementation using
+     * their concrete SFC structure (e.g. Morton/TM interval walks via LITMAX/BIGMIN, or an O(n) scan for Prism).
+     */
+    Set<Key> findNodesIntersectingBounds(VolumeBounds bounds);
+
+    /**
+     * Whether {@code kNearestNeighbors} must perform a final full-domain sweep when the expanding-radius fallback
+     * leaves it short of {@code k}. Default {@code false} for integer-SFC indices (Octree/Tetree/SFCArrayIndex) whose
+     * SFC range-pruning path already covers the whole {@code maxDistance} sphere; Prism returns {@code true} because
+     * its normalized [0,1) coordinate space defeats the incremental expansion (Luciferase-h65).
+     */
+    boolean knnRequiresFullDomainSweep();
+
+    /** Push the neighbors of {@code nodeIndex} into {@code toVisit}, respecting {@code visitedNodes}. */
+    void addNeighboringNodes(Key nodeIndex, Queue<Key> toVisit, Set<Key> visitedNodes);
+
+    // ---- Façade helpers -------------------------------------------------------------------------------------------
+
     /** Validate that {@code position} satisfies the façade's spatial constraints (range, positivity, etc.). */
     void validateSpatialConstraints(Point3f position);
+
+    /** Cached world position of the entity, or {@code null} if unknown. */
+    Point3f getCachedEntityPosition(ID entityId);
+
+    /** The façade's maximum subdivision depth (constant for the lifetime of the index). */
+    byte maxDepth();
 }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/cache/KnnSearcher.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/cache/KnnSearcher.java
@@ -1,0 +1,607 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.cache;
+
+import com.hellblazer.luciferase.lucien.Constants;
+import com.hellblazer.luciferase.lucien.FineGrainedLockingStrategy;
+import com.hellblazer.luciferase.lucien.SpatialIndexCore;
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.SpatialNodeImpl;
+import com.hellblazer.luciferase.lucien.VolumeBounds;
+import com.hellblazer.luciferase.lucien.entity.EntityDistance;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+import com.hellblazer.luciferase.lucien.internal.ObjectPools;
+import com.hellblazer.luciferase.lucien.octree.MortonKey;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.vecmath.Point3f;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+/**
+ * The k-nearest-neighbors feature object for a spatial index (RDR-008 P3).
+ *
+ * <p>Owns the k-NN cluster: the public {@code kNearestNeighbors} query, the SFC-range-pruning fast path with its
+ * MortonKey/TetreeKey-specific variants, the expanding-radius fallback (with the Prism-specific full-domain safety
+ * sweep), the legacy breadth-first fallback for unknown key types, and the four cache/path-selection performance
+ * counters. The shared storage and concurrency primitives (the sorted node map, the {@link KNNCache}, the spatial-
+ * version counter for cache invalidation) arrive through {@link SpatialIndexCore}; the subclass-overridden geometry
+ * hooks and the façade's input-validation, cached-position, and depth-constant helpers arrive through
+ * {@link KnnGeometry}; the read-lock wrapper is supplied as a {@link Supplier} because the façade's
+ * {@link FineGrainedLockingStrategy} is mutable via {@code configureFineGrainedLocking}.
+ *
+ * <h2>Concurrency invariant (RDR-008 §Open Questions, resolved)</h2>
+ *
+ * <p>The version-check pattern is load-bearing and intentionally retained verbatim from the pre-extraction façade:
+ * {@link #kNearestNeighbors} reads {@link SpatialIndexCore#spatialVersion()} <em>before</em> entering the read-lock
+ * region, uses that version to consult the cache (early-return on hit), and writes the cache result under the same
+ * version inside the read-lock region. {@link KNNCache#get} returns {@code null} on version mismatch; combined with
+ * the happens-before from the entity-lifecycle write-lock release to this read-lock acquire (Java Memory Model
+ * monitor semantics), a concurrent {@code updateEntity} between the version-read and the cache-write cannot return
+ * stale or torn results — at worst the next reader sees a cache miss for that key (the cache entry's version no
+ * longer matches the current version) and recomputes.
+ *
+ * <h2>Subclass-coupled dispatch</h2>
+ *
+ * <p>{@link #performKNNSFCRangePruning} dispatches on the concrete spatial-key type via
+ * {@code instanceof MortonKey / TetreeKey} to use each subclass's SFC range estimator. This couples
+ * {@code lucien.cache} to {@code lucien.octree} and {@code lucien.tetree}; the dispatch was present before
+ * extraction (in the façade) and the alternative — pushing the range estimator into a method on the key type —
+ * is out of scope for the no-behavior-change extraction phase. The unknown-key-type branch and the catch-all
+ * exception fallback both route to the legacy breadth-first {@link #performKNNSFCBasedSearch}, so the dispatch is
+ * forward-compatible with future key types.
+ *
+ * @param <Key>     the spatial key type
+ * @param <ID>      the entity identifier type
+ * @param <Content> the entity content type
+ * @author hal.hildebrand
+ */
+public final class KnnSearcher<Key extends SpatialKey<Key>, ID extends EntityID, Content>
+implements KnnProvider<Key, ID> {
+
+    /** Performance metrics for the k-NN cluster, exposed via {@link #getKNNPerformanceMetrics}. */
+    public record KNNPerformanceMetrics(long cacheHits, long cacheMisses, long expandingSearchUsed, long sfcPruningUsed,
+                                        double cacheHitRate, double sfcPruningRate) {}
+
+    private static final Logger log = LoggerFactory.getLogger(KnnSearcher.class);
+
+    private final SpatialIndexCore<Key, ID, Content>             core;
+    private final KnnGeometry<Key, ID>                           geometry;
+    private final Supplier<FineGrainedLockingStrategy<ID, Content>> lockingStrategySupplier;
+
+    // Performance counters (P3-main: moved from AbstractSpatialIndex; subclass-private — no external mutators).
+    private final AtomicLong knnCacheHits           = new AtomicLong(0);
+    private final AtomicLong knnCacheMisses         = new AtomicLong(0);
+    private final AtomicLong knnExpandingSearchUsed = new AtomicLong(0);
+    private final AtomicLong knnSFCPruningUsed      = new AtomicLong(0);
+
+    /**
+     * Construct the k-NN searcher. References are stored only — the constructor does not invoke any method on
+     * {@code core}, {@code geometry}, or {@code lockingStrategySupplier}, so it is safe to construct from inside the
+     * façade ctor before the façade is fully initialized (the this-escape invariant documented on
+     * {@code AbstractSpatialIndex}).
+     */
+    public KnnSearcher(SpatialIndexCore<Key, ID, Content> core, KnnGeometry<Key, ID> geometry,
+                       Supplier<FineGrainedLockingStrategy<ID, Content>> lockingStrategySupplier) {
+        this.core = core;
+        this.geometry = geometry;
+        this.lockingStrategySupplier = lockingStrategySupplier;
+    }
+
+    /**
+     * k-NN performance metrics aggregated since construction. Returned as a snapshot record (no live binding).
+     */
+    public KNNPerformanceMetrics getKNNPerformanceMetrics() {
+        var hits = knnCacheHits.get();
+        var misses = knnCacheMisses.get();
+        var expanding = knnExpandingSearchUsed.get();
+        var sfc = knnSFCPruningUsed.get();
+
+        var totalQueries = hits + misses;
+        var cacheHitRate = totalQueries > 0 ? (double) hits / totalQueries : 0.0;
+
+        var totalSearches = expanding + sfc;
+        var sfcPruningRate = totalSearches > 0 ? (double) sfc / totalSearches : 0.0;
+
+        return new KNNPerformanceMetrics(hits, misses, expanding, sfc, cacheHitRate, sfcPruningRate);
+    }
+
+    /**
+     * Find k nearest neighbors to a query point using spatial locality optimization.
+     *
+     * @param queryPoint  the point to search from
+     * @param k           the number of neighbors to find
+     * @param maxDistance maximum search distance
+     * @return list of entity IDs sorted by distance (closest first)
+     */
+    @Override
+    public List<ID> kNearestNeighbors(Point3f queryPoint, int k, float maxDistance) {
+        geometry.validateSpatialConstraints(queryPoint);
+
+        if (k <= 0) {
+            return Collections.emptyList();
+        }
+
+        var spatialIndex = core.spatialIndex();
+        var knnCache = core.knnCache();
+        log.debug("k-NN search: queryPoint={}, k={}, maxDistance={}, spatialIndex.size()={}",
+                  queryPoint, k, maxDistance, spatialIndex.size());
+
+        // k-NN cache: Check cache with composite key (position + k + maxDistance)
+        // Use level 15 for cache granularity (cell size = 64) to distinguish nearby queries
+        // Level 0 is too coarse (cell size = 2,097,152) and causes false cache hits
+        var spatialKey = geometry.calculateSpatialIndex(queryPoint, (byte) 15);
+        var queryKey = new KNNQueryKey<>(spatialKey, k, maxDistance);
+        var currentVersion = core.spatialVersion().get();
+        var cached = knnCache.get(queryKey, currentVersion);
+        if (cached != null) {
+            // Cache hit: return cached entity IDs (0.05-0.1ms vs 0.3-0.5ms)
+            knnCacheHits.incrementAndGet();
+            log.debug("k-NN cache hit: returning {} entities", cached.entityIds().size());
+            return cached.entityIds();
+        }
+
+        knnCacheMisses.incrementAndGet();
+        log.debug("k-NN cache miss: computing k-NN");
+
+        // Cache miss: compute k-NN and store result
+        // Use fine-grained locking for read operations
+        return lockingStrategySupplier.get().executeRead(0L, () -> {
+            // Priority queue to keep track of k nearest entities (max heap)
+            var candidates = ObjectPools.borrowPriorityQueue(EntityDistance.<ID>maxHeapComparator());
+            var addedToCandidates = ObjectPools.<ID>borrowHashSet();
+            try {
+                // Use optimized SFC range pruning first (4-6× speedup from Paper 4)
+                knnSFCPruningUsed.incrementAndGet();
+                performKNNSFCRangePruning(queryPoint, k, maxDistance, candidates, addedToCandidates);
+
+                // If SFC pruning didn't find enough entities, fall back to expanding radius search
+                if (candidates.size() < k) {
+                    knnExpandingSearchUsed.incrementAndGet();
+                    performKNNExpandingRadiusSearch(queryPoint, k, maxDistance, candidates, addedToCandidates);
+                }
+
+                // Convert to sorted list (closest first) and extract distances
+                var sorted = ObjectPools.<EntityDistance<ID>>borrowArrayList(candidates.size());
+                try {
+                    sorted.addAll(candidates);
+                    sorted.sort(EntityDistance.minHeapComparator());
+
+                    var entityIds = new ArrayList<ID>(sorted.size());
+                    var distances = new ArrayList<Float>(sorted.size());
+                    for (var entry : sorted) {
+                        entityIds.add(entry.entityId());
+                        distances.add(entry.distance());
+                    }
+
+                    // Store in cache for future queries
+                    knnCache.put(queryKey, entityIds, distances, currentVersion);
+
+                    return entityIds;
+                } finally {
+                    ObjectPools.returnArrayList(sorted);
+                }
+            } finally {
+                ObjectPools.returnPriorityQueue(candidates);
+                ObjectPools.returnHashSet(addedToCandidates);
+            }
+        });
+    }
+
+    // ---- SFC range pruning (Paper 4: 4-6× speedup) ----------------------------------------------------------------
+
+    /**
+     * Optimized SFC range-based k-NN search using range pruning. Dispatches on the concrete spatial-key type to use
+     * each subclass's SFC range estimator; unknown key types and any thrown exception fall back to the legacy
+     * breadth-first search.
+     */
+    private void performKNNSFCRangePruning(Point3f queryPoint, int k, float maxDistance,
+                                           PriorityQueue<EntityDistance<ID>> candidates, Set<ID> addedToCandidates) {
+        var spatialIndex = core.spatialIndex();
+        if (spatialIndex.isEmpty()) {
+            return;
+        }
+
+        // Get the root key to determine key type
+        var rootKey = spatialIndex.firstKey();
+
+        try {
+            // Use appropriate SFC range estimation based on key type
+            if (rootKey instanceof MortonKey) {
+                performKNNSFCRangePruningMorton(queryPoint, k, maxDistance, candidates, addedToCandidates);
+            } else if (rootKey instanceof TetreeKey) {
+                performKNNSFCRangePruningTetree(queryPoint, k, maxDistance, candidates, addedToCandidates);
+            } else {
+                // Fallback to old breadth-first search for unknown key types
+                performKNNSFCBasedSearch(queryPoint, k, maxDistance, candidates, addedToCandidates);
+            }
+        } catch (Exception e) {
+            log.warn("SFC range pruning failed, falling back to breadth-first search: {}", e.getMessage());
+            performKNNSFCBasedSearch(queryPoint, k, maxDistance, candidates, addedToCandidates);
+        }
+    }
+
+    /**
+     * SFC range-based k-NN search for MortonKey (Octree).
+     *
+     * <p>Because {@link MortonKey#compareTo} orders keys first by level then by Morton code, a {@code subMap} call
+     * whose bounds are at level L will only return keys that are also stored at level L. Entities can be inserted at
+     * different levels, so we collect the set of distinct storage levels present in the index and issue one
+     * {@code subMap} query per unique level, using bounds computed at that same level.
+     */
+    @SuppressWarnings("unchecked")
+    private void performKNNSFCRangePruningMorton(Point3f queryPoint, int k, float maxDistance,
+                                                 PriorityQueue<EntityDistance<ID>> candidates,
+                                                 Set<ID> addedToCandidates) {
+        var spatialIndex = core.spatialIndex();
+        // When maxDistance is very large, SFC range pruning at level 0 won't work properly
+        // because entities are stored at a finer level. Fall back to full scan.
+        if (maxDistance >= Constants.MAX_COORD) {
+            performFullScanKNN(queryPoint, k, maxDistance, candidates, addedToCandidates);
+            return;
+        }
+
+        // Collect the distinct levels at which keys are stored so we can issue a correctly-levelled
+        // subMap query for each one.  In the common single-level case this is a single pass.
+        var storageLevels = new LinkedHashSet<Byte>();
+        for (var key : spatialIndex.keySet()) {
+            storageLevels.add(((MortonKey) key).getLevel());
+        }
+
+        for (byte storageLevel : storageLevels) {
+            // Compute SFC range bounds at the same level as the stored keys so that
+            // subMap() returns the correct entries with level-aware compareTo.
+            var sfcRange = MortonKey.estimateSFCRange(queryPoint, maxDistance, storageLevel);
+
+            var rangeMap = spatialIndex.subMap((Key) sfcRange.lower(), (Key) sfcRange.upper());
+
+            for (var entry : rangeMap.entrySet()) {
+                var node = entry.getValue();
+                if (node == null) {
+                    continue;
+                }
+
+                collectCandidatesFromNode(node, queryPoint, k, maxDistance, candidates, addedToCandidates);
+            }
+        }
+    }
+
+    /** SFC range-based k-NN search for TetreeKey (Tetree). */
+    @SuppressWarnings("unchecked")
+    private void performKNNSFCRangePruningTetree(Point3f queryPoint, int k, float maxDistance,
+                                                 PriorityQueue<EntityDistance<ID>> candidates,
+                                                 Set<ID> addedToCandidates) {
+        var spatialIndex = core.spatialIndex();
+        // When maxDistance is very large, SFC range pruning at level 0 won't work properly
+        // because entities are stored at a finer level. Fall back to full scan.
+        if (maxDistance >= Constants.MAX_COORD) {
+            performFullScanKNN(queryPoint, k, maxDistance, candidates, addedToCandidates);
+            return;
+        }
+
+        // Estimate SFC range covering the search sphere
+        var sfcRange = TetreeKey.estimateSFCRange(queryPoint, maxDistance);
+
+        // Use subMap to iterate only over keys in the SFC range (this is the optimization!)
+        var rangeMap = spatialIndex.subMap((Key) sfcRange.lower(), (Key) sfcRange.upper());
+
+        // Process entities in nodes within the SFC range
+        for (var entry : rangeMap.entrySet()) {
+            var node = entry.getValue();
+            if (node == null) {
+                continue;
+            }
+
+            collectCandidatesFromNode(node, queryPoint, k, maxDistance, candidates, addedToCandidates);
+        }
+    }
+
+    /**
+     * Full scan k-NN search for unlimited distance queries. Used when {@code maxDistance} is so large that SFC range
+     * pruning won't work correctly.
+     */
+    private void performFullScanKNN(Point3f queryPoint, int k, float maxDistance,
+                                    PriorityQueue<EntityDistance<ID>> candidates, Set<ID> addedToCandidates) {
+        // Iterate through all nodes in the spatial index
+        for (var entry : core.spatialIndex().entrySet()) {
+            var node = entry.getValue();
+            if (node == null) {
+                continue;
+            }
+
+            collectCandidatesFromNode(node, queryPoint, k, maxDistance, candidates, addedToCandidates);
+        }
+    }
+
+    // ---- Expanding radius fallback --------------------------------------------------------------------------------
+
+    /**
+     * Expanding-radius k-NN fallback. Returns {@code true} if enough candidates were found.
+     */
+    private boolean performKNNExpandingRadiusSearch(Point3f queryPoint, int k, float maxDistance,
+                                                    PriorityQueue<EntityDistance<ID>> candidates,
+                                                    Set<ID> addedToCandidates) {
+        // Start with a reasonable initial radius - at least the cell size at a mid-level
+        var maxDepth = geometry.maxDepth();
+        var minInitialRadius = geometry.getCellSizeAtLevel((byte) Math.min(maxDepth, 15));
+        var searchRadius = Math.min(maxDistance, Math.max(minInitialRadius, geometry.getCellSizeAtLevel(maxDepth)));
+        var searchExpansions = 0;
+        final var maxExpansions = 10; // Allow more expansions to reach distant entities
+
+        log.debug("k-NN expanding search: initialRadius={}, maxDistance={}", searchRadius, maxDistance);
+
+        while (candidates.size() < k && searchRadius <= maxDistance && searchExpansions < maxExpansions) {
+            var foundNewEntities = searchKNNInRadius(queryPoint, searchRadius, maxDistance, k, candidates,
+                                                     addedToCandidates);
+
+            log.debug("k-NN expansion {}: radius={}, found={}, candidates={}",
+                      searchExpansions, searchRadius, foundNewEntities, candidates.size());
+
+            if (candidates.size() < k && searchRadius < maxDistance) {
+                searchRadius *= 2.0f;
+                searchExpansions++;
+            } else {
+                break;
+            }
+
+            // If we didn't find any new entities in this expansion, stop
+            if (!foundNewEntities && searchExpansions > 1) {
+                break;
+            }
+        }
+
+        // Final safety sweep: the incremental expansion above can terminate before covering the
+        // index — its "no new entities" heuristic and fixed expansion cap assume entities are
+        // densely clustered near the query, and its initial radius is a fine-level cell size. Over a
+        // SPARSE index the true neighbors can sit beyond the last ring (this is what left Prism
+        // k-NN under-returning — the doublings from a sub-unit cell size never spanned the [0,1)
+        // world within the cap). If still short of k, do one pass whose radius spans the whole
+        // coordinate domain. The radius is bounded by the root-cell edge (getCellSizeAtLevel(0) =
+        // the domain extent), NOT by maxDistance: an unbounded maxDistance (e.g. Float.MAX_VALUE for
+        // "all within range") would otherwise build an overflowing search box that makes the
+        // integer-SFC findNodesIntersectingBounds (LITMAX/BIGMIN) non-terminating. (Luciferase-h65)
+        if (candidates.size() < k && geometry.knnRequiresFullDomainSweep()) {
+            // Full-domain safety sweep — gated to indices that need it (see
+            // knnRequiresFullDomainSweep). The incremental expansion above can terminate before
+            // covering the index when the coordinate space defeats its heuristics (Prism's
+            // normalized fractional coordinates: the doublings from a sub-unit initial radius never
+            // span the [0,1) world within the expansion cap, and the "no new entities" early-exit
+            // fires on the empty rings before the real neighbors). One pass over a domain-spanning
+            // box closes the gap. This is NOT run for the integer-SFC indices (Octree/Tetree/SFC):
+            // their SFC range-pruning path already covers the whole maxDistance sphere, so a
+            // domain-spanning findNodesIntersectingBounds there would be a costly LITMAX/BIGMIN no-op
+            // (and non-terminating for a large box). See knnRequiresFullDomainSweep. (Luciferase-h65)
+            //
+            // The box spans only the root-cell edge (getCellSizeAtLevel(0)): for any query inside the
+            // domain, query +/- edge already encloses the whole domain, so every node is a candidate.
+            // Acceptance uses the full maxDistance (decoupled from the box radius), so far-corner
+            // neighbors up to the domain diagonal are not wrongly rejected.
+            var edge = geometry.getCellSizeAtLevel((byte) 0);
+            var sweepBounds = new VolumeBounds(queryPoint.x - edge, queryPoint.y - edge, queryPoint.z - edge,
+                                               queryPoint.x + edge, queryPoint.y + edge, queryPoint.z + edge);
+            var spatialIndex = core.spatialIndex();
+            for (var nodeKey : geometry.findNodesIntersectingBounds(sweepBounds)) {
+                var node = spatialIndex.get(nodeKey);
+                if (node == null || node.isEmpty()) {
+                    continue;
+                }
+                for (var entityId : node.getEntityIds()) {
+                    if (addedToCandidates.contains(entityId)) {
+                        continue;
+                    }
+                    var entityPos = geometry.getCachedEntityPosition(entityId);
+                    if (entityPos == null) {
+                        continue;
+                    }
+                    var distance = queryPoint.distance(entityPos);
+                    if (distance <= maxDistance) {
+                        candidates.add(new EntityDistance<>(entityId, distance));
+                        addedToCandidates.add(entityId);
+                        if (candidates.size() > k) {
+                            var removed = candidates.poll();
+                            addedToCandidates.remove(removed.entityId());
+                        }
+                    }
+                }
+            }
+        }
+
+        log.debug("k-NN expanding search complete: found {} candidates", candidates.size());
+        return candidates.size() >= k;
+    }
+
+    /** Search for entities within a specific radius. Returns {@code true} if new entities were added. */
+    private boolean searchKNNInRadius(Point3f queryPoint, float searchRadius, float maxDistance, int k,
+                                      PriorityQueue<EntityDistance<ID>> candidates, Set<ID> addedToCandidates) {
+        var visitedThisExpansion = ObjectPools.<ID>borrowHashSet();
+        try {
+            var searchBounds = new VolumeBounds(queryPoint.x - searchRadius, queryPoint.y - searchRadius,
+                                                queryPoint.z - searchRadius, queryPoint.x + searchRadius,
+                                                queryPoint.y + searchRadius, queryPoint.z + searchRadius);
+
+            var candidateNodes = geometry.findNodesIntersectingBounds(searchBounds);
+            log.debug("k-NN searchInRadius: radius={}, bounds={}, candidateNodes={}",
+                      searchRadius, searchBounds, candidateNodes.size());
+            var foundNewEntities = false;
+
+            var spatialIndex = core.spatialIndex();
+            for (Key nodeKey : candidateNodes) {
+                var node = spatialIndex.get(nodeKey);
+                if (node == null || node.isEmpty()) {
+                    continue;
+                }
+
+                // Check all entities in this node
+                for (ID entityId : node.getEntityIds()) {
+                    if (visitedThisExpansion.add(entityId)) {
+                        var entityPos = geometry.getCachedEntityPosition(entityId);
+                        if (entityPos != null) {
+                            var distance = queryPoint.distance(entityPos);
+
+                            // Only consider entities within current search radius
+                            if (distance <= searchRadius && distance <= maxDistance && !addedToCandidates.contains(
+                            entityId)) {
+                                candidates.add(new EntityDistance<>(entityId, distance));
+                                addedToCandidates.add(entityId);
+                                foundNewEntities = true;
+
+                                // Keep only k elements
+                                if (candidates.size() > k) {
+                                    candidates.poll();
+                                    // Don't remove from addedToCandidates to prevent re-adding
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return foundNewEntities;
+        } finally {
+            ObjectPools.returnHashSet(visitedThisExpansion);
+        }
+    }
+
+    // ---- Legacy breadth-first fallback (unknown key types + SFC-pruning exception fallback) -----------------------
+
+    /** Breadth-first search from the nearest node. */
+    private void performKNNSFCBasedSearch(Point3f queryPoint, int k, float maxDistance,
+                                          PriorityQueue<EntityDistance<ID>> candidates, Set<ID> addedToCandidates) {
+        var spatialIndex = core.spatialIndex();
+        if (spatialIndex.isEmpty()) {
+            return;
+        }
+
+        var nearestNodeIndex = findNearestNodeToPoint(queryPoint);
+        if (nearestNodeIndex == null) {
+            return;
+        }
+
+        // Breadth-first search from nearest node
+        var toVisit = new LinkedList<Key>();
+        var visitedNodes = ObjectPools.<Key>borrowHashSet();
+        try {
+            toVisit.add(nearestNodeIndex);
+
+            while (!toVisit.isEmpty() && candidates.size() < k) {
+                var current = toVisit.poll();
+                if (!visitedNodes.add(current)) {
+                    continue;
+                }
+
+                var node = spatialIndex.get(current);
+                if (node == null) {
+                    continue;
+                }
+
+                // Process entities in current node
+                for (var entityId : node.getEntityIds()) {
+                    if (!addedToCandidates.contains(entityId)) {
+                        var entityPos = geometry.getCachedEntityPosition(entityId);
+                        if (entityPos != null) {
+                            var distance = queryPoint.distance(entityPos);
+                            if (distance <= maxDistance) {
+                                candidates.add(new EntityDistance<>(entityId, distance));
+                                addedToCandidates.add(entityId);
+                                if (candidates.size() > k) {
+                                    var removed = candidates.poll();
+                                    addedToCandidates.remove(removed.entityId());
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Add neighboring nodes if we need more candidates
+                if (candidates.size() < k || geometry.shouldContinueKNNSearch(current, queryPoint, candidates)) {
+                    geometry.addNeighboringNodes(current, toVisit, visitedNodes);
+                }
+            }
+        } finally {
+            ObjectPools.returnHashSet(visitedNodes);
+        }
+    }
+
+    /** Find the nearest node to a query point using the subclass-supplied distance estimator. */
+    private Key findNearestNodeToPoint(Point3f queryPoint) {
+        var bestDistance = Float.MAX_VALUE;
+        Key nearestNodeIndex = null;
+        var cellSize = geometry.getCellSizeAtLevel(geometry.maxDepth());
+        var spatialIndex = core.spatialIndex();
+
+        for (var nodeIndex : spatialIndex.keySet()) {
+            var node = spatialIndex.get(nodeIndex);
+            if (node == null || node.isEmpty()) {
+                continue;
+            }
+
+            var nodeDistance = geometry.estimateNodeDistance(nodeIndex, queryPoint);
+            if (nodeDistance < bestDistance) {
+                bestDistance = nodeDistance;
+                nearestNodeIndex = nodeIndex;
+            }
+
+            // Early termination
+            if (nodeDistance < cellSize) {
+                break;
+            }
+        }
+
+        return nearestNodeIndex;
+    }
+
+    // ---- Shared candidate accumulation ----------------------------------------------------------------------------
+
+    /**
+     * Accumulate eligible entities from a single node into the candidate max-heap, keeping the heap size <= k.
+     * Factored out of the three SFC-range / full-scan paths (Morton, Tetree, full-scan) which were byte-for-byte
+     * identical inner loops.
+     */
+    private void collectCandidatesFromNode(SpatialNodeImpl<ID> node, Point3f queryPoint, int k, float maxDistance,
+                                           PriorityQueue<EntityDistance<ID>> candidates, Set<ID> addedToCandidates) {
+        for (var entityId : node.getEntityIds()) {
+            if (addedToCandidates.contains(entityId)) {
+                continue;
+            }
+            var entityPos = geometry.getCachedEntityPosition(entityId);
+            if (entityPos == null) {
+                continue;
+            }
+            var distance = queryPoint.distance(entityPos);
+            if (distance <= maxDistance) {
+                candidates.add(new EntityDistance<>(entityId, distance));
+                addedToCandidates.add(entityId);
+
+                // Maintain max heap of size k
+                if (candidates.size() > k) {
+                    var removed = candidates.poll();
+                    addedToCandidates.remove(removed.entityId());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
RDR-008 P3-main of the locked AbstractSpatialIndex decomposition arc.
Moves the k-NN cluster out of the 5409-line façade into a new
`lucien.cache.KnnSearcher` feature object implementing the `KnnProvider`
sub-interface the P3-prep split introduced.

## What moves

| Element | Before (façade) | After |
|---|---|---|
| `kNearestNeighbors(...)` public entry | full impl | thin delegator → `knn.kNearestNeighbors` |
| `performKNNExpandingRadiusSearch` | private | private in KnnSearcher |
| `performKNNSFCBasedSearch` | private | private in KnnSearcher |
| `performKNNSFCRangePruning` + Morton/Tetree variants | private | private in KnnSearcher |
| `performFullScanKNN`, `searchKNNInRadius`, `findNearestNodeToPoint` | private | private in KnnSearcher |
| 4 `AtomicLong` counters (cacheHits/Misses/Expanding/SFC) | fields | fields in KnnSearcher |
| `KNNPerformanceMetrics` record | inner record on façade | `KnnSearcher.KNNPerformanceMetrics` |
| `getKNNPerformanceMetrics()` | full impl | thin delegator → `knn.getKNNPerformanceMetrics()` |

## Façade transformations

- Drops `implements KnnProvider<Key,ID>` from the class declaration. P3-prep added it transiently as a scaffold so `GhostCoordinator` could take `this` as a `KnnProvider`; P3-main completes the handoff — `GhostCoordinator` now takes the `KnnSearcher` instance.
- ctor wires `this.knn = new KnnSearcher<>(core, new KnnGeometryImpl(), () -> this.lockingStrategy)` before the existing `this.ghost = new GhostCoordinator<>(core, knn, this)`.
- Added `volatile` to the `lockingStrategy` field (matches the existing `dsoc` volatile pattern) — `configureFineGrainedLocking` writes the field under write-lock but `KnnSearcher`'s supplier reads it outside any lock from a different package; volatile closes the JMM publication gap.
- `KnnGeometryImpl` inner class delegates 6 new methods to the underlying façade hooks (gets `getCellSizeAtLevel`, `findNodesIntersectingBounds`, `knnRequiresFullDomainSweep`, `addNeighboringNodes`, `getCachedEntityPosition`, `maxDepth`).

## Concurrency invariant preserved (RDR-008 §Open Questions §2)

The version-read-outside-lock pattern is verbatim: `kNearestNeighbors` reads `core.spatialVersion().get()` BEFORE entering the read-lock region; the cache write inside the locked region uses that snapshot. `KNNCache.get` returns null on version mismatch, so a concurrent `updateEntity` between version-read and cache-write cannot return stale results — at worst the next reader sees a miss and recomputes. The write-lock-release happens-before read-lock-acquire (JMM monitor semantics) guarantees `spatialVersion` visibility. No new synchronization added.

## Defensive DRY

The three byte-for-byte-identical inner candidate loops (Morton / Tetree / FullScan) consolidate into a shared `collectCandidatesFromNode` helper inside `KnnSearcher`. Behaviorally equivalent (continue-style guards match the original nested-if structure); cuts ~75 lines of duplication.

## Subclass-coupled dispatch (known, accepted)

`performKNNSFCRangePruning` does `instanceof MortonKey / TetreeKey` to route to subclass-specific SFC range estimators. This introduces cross-package coupling from `lucien.cache` to `lucien.octree` and `lucien.tetree`. The dispatch was already present (in the façade); P3-main makes it visible at the package seam. Long-term fix is hoisting `estimateSFCRange` to a method on `SpatialKey` — tracked as a follow-up bead, not required for P3-main acceptance.

## Façade arc (cumulative since P0)

| Stage | Lines | Δ |
|---|---|---|
| Pre-P0 | 5851 | — |
| After P0 (SpatialIndexCore) | 5806 | −45 |
| After P1 (DsocController) | 5634 | −172 |
| After P2 (GhostCoordinator) | 5349 | −285 |
| After P3-prep (sub-interface split) | 5409 | +60 (struct.) |
| **After P3-main (this PR)** | **4916** | **−493** |

Cumulative −935 lines. G6 acceptance target ≈70 methods residual; tracking on schedule.

## Subclasses unchanged (P1-P4 invariant)

`git diff --stat origin/main..HEAD` shows only `AbstractSpatialIndex.java` + `KnnGeometry.java` + new `KnnSearcher.java` touched. Octree, Tetree, Prism, SFCArrayIndex all compile unchanged.

## Tests

Lucien suite: 2441 / 0 failures / 0 errors / 22 skipped — identical to baseline (`main` at `17ac6335`). Targeted k-NN test pass (background run, exit code 0).

`-Pperformance` parity (including the 20-30× cached-hit speedup invariant) verified at the G3 phase-review-gate (the next bead `Luciferase-x5i.7`).

## Stacked review (per the standing feedback)

- code-review-expert: approved for merge, 0 Critical, 0 High. Flagged the lockingStrategy volatility as a non-blocking suggestion — fixed in this PR.
- substantive-critic: 1 Critical (lockingStrategy volatile — fixed in this PR), 2 Significant (supplier debt acknowledged as P6 prerequisite to move lockingStrategy into SpatialIndexCore; metric counter accuracy on empty-index — pre-existing, follow-up worth filing). Concurrency reasoning audited and confirmed sound.

## Refs

- RDR: `docs/rdr/RDR-008-decompose-abstractspatialindex.md` §Decision item 1 (with the P3 refinement note locked at P3-prep)
- Bead: `Luciferase-x5i.6` (this PR; closes on merge)
- Next phase gate: `Luciferase-x5i.7` (G3 phase-review-gate)