### PR TITLE
Luciferase-x5i.8: extract Culler (RDR-008 P4 — frustum/plane/ray bundled)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
@@ -23,6 +23,8 @@ import com.hellblazer.luciferase.lucien.balancing.TreeBalancingStrategy;
 import com.hellblazer.luciferase.lucien.cache.KnnGeometry;
 import com.hellblazer.luciferase.lucien.cache.KnnSearcher;
 import com.hellblazer.luciferase.lucien.collision.CollisionShape;
+import com.hellblazer.luciferase.lucien.cull.CullGeometry;
+import com.hellblazer.luciferase.lucien.cull.Culler;
 import com.hellblazer.luciferase.lucien.entity.*;
 import com.hellblazer.luciferase.lucien.forest.ghost.*;
 import com.hellblazer.luciferase.lucien.internal.EntityCache;
@@ -139,6 +141,10 @@ implements SpatialIndex<Key, ID, Content> {
     // implements KnnProvider — the façade's public k-NN API now delegates to it, and other feature objects that
     // consume k-NN (e.g. GhostCoordinator) take this directly as their KnnProvider.
     protected final KnnSearcher<Key, ID, Content>                            knn;
+    // RDR-008 P4: bundled frustum/plane/ray cull cluster, encapsulated in Culler (always present; eager init in
+    // ctor). Culler implements FrustumCullProvider — DsocController takes it as the standard-cull fallback so the
+    // FrustumGeometry consumer surface stays narrow.
+    protected final Culler<Key, ID, Content>                                 culler;
     // Tree balancing support
     private         TreeBalancingStrategy<ID>                        balancingStrategy;
     private         boolean                                          autoBalancingEnabled     = false;
@@ -175,13 +181,20 @@ implements SpatialIndex<Key, ID, Content> {
         // late-bound because configureFineGrainedLocking can replace the field.
         this.knn = new KnnSearcher<>(core, new KnnGeometryImpl(), () -> this.lockingStrategy);
 
+        // RDR-008 P4: bundled frustum/plane/ray cull cluster lives in Culler (implements FrustumCullProvider).
+        // Constructed before the ghost coordinator so DSOC's lazy construction (enableDSOC) can take it as the
+        // standard-cull fallback. The CullGeometryImpl callback stores `this` but the ctor doesn't dispatch through
+        // it (storage-only).
+        this.culler = new Culler<>(core, new CullGeometryImpl());
+
         // RDR-008 P2: distributed-ghost cluster lives in GhostCoordinator; constructed eagerly so subclasses can
         // call setNeighborDetector during their own initialization.
         // INVARIANT for future phases: GhostCoordinator's ctor (and the ctors of any other feature object created
-        // here — including KnnSearcher above) MUST NOT invoke any method on the supplied FrustumGeometryImpl /
-        // KnnGeometryImpl, on the KnnProvider, or on `this` directly — `this` is still partially constructed at this
-        // point, and any virtual dispatch into a not-yet-initialized subclass is a classic this-escape hazard.
-        // Storing the references is fine; calling through them is not.  (KnnSearcher's ctor stores only; the
+        // here — including KnnSearcher above and Culler immediately above) MUST NOT invoke any method on the
+        // supplied FrustumGeometryImpl / KnnGeometryImpl / CullGeometryImpl, on the KnnProvider /
+        // FrustumCullProvider, or on `this` directly — `this` is still partially constructed at this point, and any
+        // virtual dispatch into a not-yet-initialized subclass is a classic this-escape hazard. Storing the
+        // references is fine; calling through them is not.  (KnnSearcher's and Culler's ctors store only; the
         // lockingStrategy supplier captures `this` but is invoked post-construction.)
         // The `knn` argument below satisfies KnnProvider<Key,ID> (P3-main moved this role off the façade); the
         // second `this` is the façade back-reference the ghost subsystem (GhostBoundaryDetector +
@@ -729,11 +742,8 @@ implements SpatialIndex<Key, ID, Content> {
     }
 
     /**
-     * Find all entities that are completely inside the frustum (not partially visible).
-     *
-     * @param frustum        the frustum to test
-     * @param cameraPosition the camera position for distance sorting
-     * @return list of entities completely inside the frustum, sorted by distance from camera
+     * Find all entities completely inside the frustum. Composes on top of {@link #frustumCullVisible} so the result
+     * inherits the DSOC routing (when enabled) — calling {@link Culler} directly would silently bypass DSOC.
      */
     public List<FrustumIntersection<ID, Content>> frustumCullInside(Frustum3D frustum, Point3f cameraPosition) {
         return frustumCullVisible(frustum, cameraPosition).stream()
@@ -742,11 +752,8 @@ implements SpatialIndex<Key, ID, Content> {
     }
 
     /**
-     * Find all entities that intersect the frustum boundary (partially visible).
-     *
-     * @param frustum        the frustum to test
-     * @param cameraPosition the camera position for distance sorting
-     * @return list of entities intersecting frustum boundary, sorted by distance from camera
+     * Find all entities intersecting the frustum boundary. Composes on top of {@link #frustumCullVisible} so the
+     * result inherits the DSOC routing (when enabled).
      */
     public List<FrustumIntersection<ID, Content>> frustumCullIntersecting(Frustum3D frustum, Point3f cameraPosition) {
         return frustumCullVisible(frustum, cameraPosition).stream()
@@ -755,81 +762,42 @@ implements SpatialIndex<Key, ID, Content> {
     }
 
     /**
-     * Find all entities that are visible within the given frustum. Returns entities that are either completely inside
-     * or intersecting the frustum.
-     *
-     * @param frustum        the frustum to test
-     * @param cameraPosition the camera position for distance sorting
-     * @return list of frustum intersections sorted by distance from camera
+     * Find all entities visible in the frustum. Preserves the P1 DSOC seam: when a {@link DsocController} is present
+     * the cull goes through DSOC (auto-disable, occlusion, perf measurement); otherwise it runs the standard cull
+     * directly via {@link Culler}. The composed entries below ({@link #frustumCullInside},
+     * {@link #frustumCullIntersecting}, {@link #frustumCullWithinDistance}) flow through this method, never through
+     * the {@code Culler} delegators, so they all inherit the DSOC routing decision.
      */
     public List<FrustumIntersection<ID, Content>> frustumCullVisible(Frustum3D frustum, Point3f cameraPosition) {
         if (frustum == null) {
             throw new NullPointerException("Frustum cannot be null");
         }
-        
-        // RDR-008 P1: the DSOC decision (auto-disable, skip heuristics) and perf measurement live in
-        // DsocController. When DSOC was never enabled, run the standard cull directly.
         if (dsoc != null) {
             return dsoc.frustumCullVisible(frustum, cameraPosition);
         }
-        return frustumCullVisibleStandard(frustum, cameraPosition);
-    }
-
-    @Override
-    public List<ID> frustumCullVisible(Frustum3D frustum) {
-        if (frustum == null) {
-            throw new NullPointerException("Frustum cannot be null");
-        }
-        
-        // For the simple ID-only version, we don't need camera position or distance sorting
-        // We just need to find which entities are visible
-        lock.readLock().lock();
-        try {
-            var visibleEntities = new ArrayList<ID>();
-            var visitedEntities = new HashSet<ID>();
-
-            // Traverse all nodes that could intersect with the frustum
-            spatialIndex.forEach((nodeIndex, node) -> {
-                if (node == null || node.isEmpty()) {
-                    return;
-                }
-
-                // Check if frustum intersects this node
-                if (!doesFrustumIntersectNode(nodeIndex, frustum)) {
-                    return;
-                }
-
-                // Add all entities in visible nodes
-                for (ID entityId : node.getEntityIds()) {
-                    // Skip if already processed (for spanning entities)
-                    if (visitedEntities.add(entityId)) {
-                        // For the simple version, we just check if the entity position is in the frustum
-                        var entityPos = getCachedEntityPosition(entityId);
-                        if (entityPos != null && frustum.containsPoint(entityPos)) {
-                            visibleEntities.add(entityId);
-                        }
-                    }
-                }
-            });
-
-            return visibleEntities;
-        } finally {
-            lock.readLock().unlock();
-        }
+        return culler.frustumCullVisibleStandard(frustum, cameraPosition);
     }
 
     /**
-     * Find all entities within the specified distance from the camera that are visible in the frustum.
-     *
-     * @param frustum        the frustum to test
-     * @param cameraPosition the camera position
-     * @param maxDistance    maximum distance from camera to include
-     * @return list of entities within distance, sorted by distance from camera
+     * Simple ID-only frustum visibility query. <strong>Intentionally bypasses DSOC</strong>: the pre-extraction
+     * single-arg form was always non-DSOC, and DSOC culling requires a camera position and {@code Content} retrieval
+     * that the ID-only contract deliberately excludes. For DSOC-aware culling use
+     * {@link #frustumCullVisible(Frustum3D, Point3f)}.
+     */
+    @Override
+    public List<ID> frustumCullVisible(Frustum3D frustum) {
+        return culler.frustumCullVisibleIds(frustum);
+    }
+
+    /**
+     * Find all entities within {@code maxDistance} of the camera visible in the frustum. Composes on top of
+     * {@link #frustumCullVisible} so the result inherits the DSOC routing (when enabled).
      */
     public List<FrustumIntersection<ID, Content>> frustumCullWithinDistance(Frustum3D frustum, Point3f cameraPosition,
                                                                             float maxDistance) {
-        return frustumCullVisible(frustum, cameraPosition).stream().filter(
-        intersection -> intersection.distanceFromCamera() <= maxDistance).collect(Collectors.toList());
+        return frustumCullVisible(frustum, cameraPosition).stream()
+                                                          .filter(i -> i.distanceFromCamera() <= maxDistance)
+                                                          .collect(Collectors.toList());
     }
 
     // ===== Common Remove Operations =====
@@ -1502,102 +1470,31 @@ implements SpatialIndex<Key, ID, Content> {
         }
     }
 
-    /**
-     * Find all entities that intersect with the given plane. Returns entities that either intersect the plane or are
-     * within the specified tolerance distance from it.
-     *
-     * @param plane     the plane to test intersection with
-     * @param tolerance maximum distance from plane to consider as intersection (use 0 for exact intersection)
-     * @return list of plane intersections sorted by distance from plane
-     */
+    /** Find all entities intersecting the plane within {@code tolerance}. RDR-008 P4: delegates to {@link Culler}. */
     public List<PlaneIntersection<ID, Content>> planeIntersectAll(Plane3D plane, float tolerance) {
-        lock.readLock().lock();
-        try {
-            var intersections = new ArrayList<PlaneIntersection<ID, Content>>();
-
-            // Traverse nodes that could intersect with the plane
-            getPlaneTraversalOrder(plane).forEach(nodeIndex -> {
-                var node = spatialIndex.get(nodeIndex);
-                if (node == null || node.isEmpty()) {
-                    return;
-                }
-
-                // Check if plane intersects this node
-                if (!doesPlaneIntersectNode(nodeIndex, plane)) {
-                    return;
-                }
-
-                // Check each entity in the node
-                for (ID entityId : node.getEntityIds()) {
-                    var content = entityManager.getEntityContent(entityId);
-                    if (content == null) {
-                        continue;
-                    }
-
-                    var entityPos = getCachedEntityPosition(entityId);
-                    var bounds = entityManager.getEntityBounds(entityId);
-
-                    // Calculate plane-entity intersection
-                    var intersection = calculatePlaneEntityIntersection(plane, entityId, content, entityPos, bounds,
-                                                                        tolerance);
-
-                    if (intersection != null) {
-                        intersections.add(intersection);
-                    }
-                }
-            });
-
-            Collections.sort(intersections);
-            return intersections;
-        } finally {
-            lock.readLock().unlock();
-        }
+        return culler.planeIntersectAll(plane, tolerance);
     }
 
     // ===== Common Spatial Query Base =====
 
-    /**
-     * Find all entities that intersect with the given plane (exact intersection only).
-     *
-     * @param plane the plane to test intersection with
-     * @return list of plane intersections sorted by distance from plane
-     */
+    /** Find all entities exactly intersecting the plane. RDR-008 P4: delegates to {@link Culler}. */
     public List<PlaneIntersection<ID, Content>> planeIntersectAll(Plane3D plane) {
-        return planeIntersectAll(plane, 0.0f);
+        return culler.planeIntersectAll(plane);
     }
 
-    /**
-     * Find all entities on the negative side of the plane (opposite to normal).
-     *
-     * @param plane the plane to test
-     * @return list of entities on negative side, sorted by distance from plane
-     */
+    /** Find all entities on the negative side of the plane. RDR-008 P4: delegates to {@link Culler}. */
     public List<PlaneIntersection<ID, Content>> planeIntersectNegativeSide(Plane3D plane) {
-        return planeIntersectAll(plane, Float.MAX_VALUE).stream().filter(PlaneIntersection::isOnNegativeSide).collect(
-        Collectors.toList());
+        return culler.planeIntersectNegativeSide(plane);
     }
 
-    /**
-     * Find all entities on the positive side of the plane (in direction of normal).
-     *
-     * @param plane the plane to test
-     * @return list of entities on positive side, sorted by distance from plane
-     */
+    /** Find all entities on the positive side of the plane. RDR-008 P4: delegates to {@link Culler}. */
     public List<PlaneIntersection<ID, Content>> planeIntersectPositiveSide(Plane3D plane) {
-        return planeIntersectAll(plane, Float.MAX_VALUE).stream().filter(PlaneIntersection::isOnPositiveSide).collect(
-        Collectors.toList());
+        return culler.planeIntersectPositiveSide(plane);
     }
 
-    /**
-     * Find all entities within the specified distance from the plane (on either side).
-     *
-     * @param plane       the plane to test
-     * @param maxDistance maximum distance from plane to include
-     * @return list of entities within distance, sorted by distance from plane
-     */
+    /** Find all entities within {@code maxDistance} of the plane. RDR-008 P4: delegates to {@link Culler}. */
     public List<PlaneIntersection<ID, Content>> planeIntersectWithinDistance(Plane3D plane, float maxDistance) {
-        return planeIntersectAll(plane, maxDistance).stream().filter(
-        intersection -> Math.abs(intersection.distanceFromPlane()) <= maxDistance).collect(Collectors.toList());
+        return culler.planeIntersectWithinDistance(plane, maxDistance);
     }
 
     /**
@@ -1732,104 +1629,7 @@ implements SpatialIndex<Key, ID, Content> {
     @Override
     public List<RayIntersection<ID, Content>> rayIntersectAll(Ray3D ray) {
         validateSpatialConstraints(ray.origin());
-
-        lock.readLock().lock();
-        try {
-            var intersections = new ArrayList<RayIntersection<ID, Content>>();
-            var visitedEntities = new HashSet<ID>();
-
-            // Get nodes in traversal order
-            getRayTraversalOrder(ray).forEach(nodeIndex -> {
-                var node = spatialIndex.get(nodeIndex);
-                if (node == null || node.isEmpty()) {
-                    return;
-                }
-
-                // Check if ray intersects this node
-                if (!doesRayIntersectNode(nodeIndex, ray)) {
-                    return;
-                }
-
-                // Check entities in this node
-                for (ID entityId : node.getEntityIds()) {
-                    // Skip if already processed (for spanning entities)
-                    if (!visitedEntities.add(entityId)) {
-                        continue;
-                    }
-
-                    // Get entity details
-                    var entityPos = getCachedEntityPosition(entityId);
-                    if (entityPos == null) {
-                        continue;
-                    }
-
-                    // Check ray-entity intersection
-                    var distance = getRayEntityDistance(ray, entityId, entityPos);
-                    if (distance >= 0 && ray.isWithinDistance(distance)) {
-                        var content = entityManager.getEntityContent(entityId);
-                        var bounds = getCachedEntityBounds(entityId);
-
-                        // Calculate intersection point
-                        var intersectionPoint = ray.pointAt(distance);
-
-                        // Calculate normal (simplified - towards ray origin)
-                        var normal = new Vector3f();
-                        normal.sub(ray.origin(), intersectionPoint);
-                        normal.normalize();
-
-                        intersections.add(
-                        new RayIntersection<>(entityId, content, distance, intersectionPoint, normal, bounds));
-                    }
-                }
-            });
-
-            // IMPORTANT: For spanning entities, we also need to check ALL entities that have bounds
-            // This is because a spanning entity might be stored in nodes outside the ray's path
-            // but still have bounds that intersect with the ray
-            if (spanningPolicy.isSpanningEnabled()) {
-                // Check all entities with bounds
-                for (var entry : spatialIndex.entrySet()) {
-                    for (var entityId : entry.getValue().getEntityIds()) {
-                        if (!visitedEntities.contains(entityId)) {
-                            var entityBounds = entityManager.getEntityBounds(entityId);
-                            if (entityBounds != null) {
-                                // Check if ray intersects the entity bounds
-                                var distance = SpatialDistanceCalculator.rayIntersectsAABB(ray, entityBounds.getMinX(),
-                                                                                           entityBounds.getMinY(),
-                                                                                           entityBounds.getMinZ(),
-                                                                                           entityBounds.getMaxX(),
-                                                                                           entityBounds.getMaxY(),
-                                                                                           entityBounds.getMaxZ());
-
-                                if (distance >= 0 && ray.isWithinDistance(distance)) {
-                                    visitedEntities.add(entityId);
-                                    var content = entityManager.getEntityContent(entityId);
-                                    var entityPos = getCachedEntityPosition(entityId);
-
-                                    // Calculate intersection point
-                                    var intersectionPoint = ray.pointAt(distance);
-
-                                    // Calculate normal (simplified - towards ray origin)
-                                    var normal = new Vector3f();
-                                    normal.sub(ray.origin(), intersectionPoint);
-                                    normal.normalize();
-
-                                    intersections.add(
-                                    new RayIntersection<>(entityId, content, distance, intersectionPoint, normal,
-                                                          entityBounds));
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Sort by distance
-            Collections.sort(intersections);
-            return intersections;
-        } finally {
-            lock.readLock().unlock();
-        }
+        return culler.rayIntersectAll(ray);
     }
 
     // ===== Ray Intersection Abstract Methods =====
@@ -1837,205 +1637,13 @@ implements SpatialIndex<Key, ID, Content> {
     @Override
     public Optional<RayIntersection<ID, Content>> rayIntersectFirst(Ray3D ray) {
         validateSpatialConstraints(ray.origin());
-
-        lock.readLock().lock();
-        try {
-            var visitedEntities = new HashSet<ID>();
-            RayIntersection<ID, Content> closest = null;
-            var closestDistance = Float.MAX_VALUE;
-
-            // Traverse nodes in order until we find an intersection
-            var nodeIterator = getRayTraversalOrder(ray).iterator();
-            while (nodeIterator.hasNext()) {
-                var nodeIndex = nodeIterator.next();
-
-                // Early termination if node is beyond closest found
-                var nodeDistance = getRayNodeIntersectionDistance(nodeIndex, ray);
-                if (nodeDistance > closestDistance) {
-                    break;
-                }
-
-                var node = spatialIndex.get(nodeIndex);
-                if (node == null || node.isEmpty()) {
-                    continue;
-                }
-
-                // Check if ray intersects this node
-                if (!doesRayIntersectNode(nodeIndex, ray)) {
-                    continue;
-                }
-
-                // Check entities in this node
-                for (ID entityId : node.getEntityIds()) {
-                    if (!visitedEntities.add(entityId)) {
-                        continue;
-                    }
-
-                    var entityPos = getCachedEntityPosition(entityId);
-                    if (entityPos == null) {
-                        continue;
-                    }
-
-                    var distance = getRayEntityDistance(ray, entityId, entityPos);
-                    if (distance >= 0 && distance < closestDistance && ray.isWithinDistance(distance)) {
-                        var content = entityManager.getEntityContent(entityId);
-                        var bounds = getCachedEntityBounds(entityId);
-                        var intersectionPoint = ray.pointAt(distance);
-
-                        var normal = new Vector3f();
-                        normal.sub(ray.origin(), intersectionPoint);
-                        normal.normalize();
-
-                        closest = new RayIntersection<>(entityId, content, distance, intersectionPoint, normal, bounds);
-                        closestDistance = distance;
-                    }
-                }
-            }
-
-            // IMPORTANT: For spanning entities, we also need to check ALL entities that have bounds
-            // This is needed for finding spanning entities stored in nodes outside the ray's path
-            if (spanningPolicy.isSpanningEnabled()) {
-                // Check all entities with bounds to find potentially closer spanning entities
-                for (var entry : spatialIndex.entrySet()) {
-                    for (var entityId : entry.getValue().getEntityIds()) {
-                        if (!visitedEntities.contains(entityId)) {
-                            var entityBounds = entityManager.getEntityBounds(entityId);
-                            if (entityBounds != null) {
-                                // Check if ray intersects the entity bounds
-                                var distance = SpatialDistanceCalculator.rayIntersectsAABB(ray, entityBounds.getMinX(),
-                                                                                           entityBounds.getMinY(),
-                                                                                           entityBounds.getMinZ(),
-                                                                                           entityBounds.getMaxX(),
-                                                                                           entityBounds.getMaxY(),
-                                                                                           entityBounds.getMaxZ());
-
-                                if (distance >= 0 && distance < closestDistance && ray.isWithinDistance(distance)) {
-                                    visitedEntities.add(entityId);
-                                    var content = entityManager.getEntityContent(entityId);
-                                    var entityPos = getCachedEntityPosition(entityId);
-                                    var intersectionPoint = ray.pointAt(distance);
-
-                                    var normal = new Vector3f();
-                                    normal.sub(ray.origin(), intersectionPoint);
-                                    normal.normalize();
-
-                                    closest = new RayIntersection<>(entityId, content, distance, intersectionPoint,
-                                                                    normal, entityBounds);
-                                    closestDistance = distance;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            return Optional.ofNullable(closest);
-        } finally {
-            lock.readLock().unlock();
-        }
+        return culler.rayIntersectFirst(ray);
     }
 
     @Override
     public List<RayIntersection<ID, Content>> rayIntersectWithin(Ray3D ray, float maxDistance) {
         validateSpatialConstraints(ray.origin());
-
-        if (maxDistance <= 0) {
-            return Collections.emptyList();
-        }
-
-        // Create a bounded ray with the minimum of ray's max distance and provided max distance
-        var boundedRay = ray.withMaxDistance(Math.min(ray.maxDistance(), maxDistance));
-
-        lock.readLock().lock();
-        try {
-            var intersections = new ArrayList<RayIntersection<ID, Content>>();
-            var visitedEntities = new HashSet<ID>();
-
-            getRayTraversalOrder(boundedRay).forEach(nodeIndex -> {
-                // Early termination if node is beyond max distance
-                float nodeDistance = getRayNodeIntersectionDistance(nodeIndex, boundedRay);
-                if (nodeDistance > maxDistance) {
-                    return;
-                }
-
-                var node = spatialIndex.get(nodeIndex);
-                if (node == null || node.isEmpty()) {
-                    return;
-                }
-
-                if (!doesRayIntersectNode(nodeIndex, boundedRay)) {
-                    return;
-                }
-
-                for (ID entityId : node.getEntityIds()) {
-                    if (!visitedEntities.add(entityId)) {
-                        continue;
-                    }
-
-                    var entityPos = getCachedEntityPosition(entityId);
-                    if (entityPos == null) {
-                        continue;
-                    }
-
-                    float distance = getRayEntityDistance(boundedRay, entityId, entityPos);
-                    if (distance >= 0 && distance <= maxDistance) {
-                        var content = entityManager.getEntityContent(entityId);
-                        var bounds = getCachedEntityBounds(entityId);
-                        var intersectionPoint = boundedRay.pointAt(distance);
-
-                        var normal = new Vector3f();
-                        normal.sub(boundedRay.origin(), intersectionPoint);
-                        normal.normalize();
-
-                        intersections.add(
-                        new RayIntersection<>(entityId, content, distance, intersectionPoint, normal, bounds));
-                    }
-                }
-            });
-
-            // IMPORTANT: For spanning entities, we also need to check ALL entities that have bounds
-            // This is needed for finding spanning entities stored in nodes outside the ray's path
-            if (spanningPolicy.isSpanningEnabled()) {
-                // Check all entities with bounds that might be within max distance
-                for (var entry : spatialIndex.entrySet()) {
-                    for (var entityId : entry.getValue().getEntityIds()) {
-                        if (!visitedEntities.contains(entityId)) {
-                            var entityBounds = entityManager.getEntityBounds(entityId);
-                            if (entityBounds != null) {
-                                // Check if ray intersects the entity bounds
-                                var distance = SpatialDistanceCalculator.rayIntersectsAABB(boundedRay,
-                                                                                           entityBounds.getMinX(),
-                                                                                           entityBounds.getMinY(),
-                                                                                           entityBounds.getMinZ(),
-                                                                                           entityBounds.getMaxX(),
-                                                                                           entityBounds.getMaxY(),
-                                                                                           entityBounds.getMaxZ());
-
-                                if (distance >= 0 && distance <= maxDistance) {
-                                    visitedEntities.add(entityId);
-                                    var content = entityManager.getEntityContent(entityId);
-                                    var entityPos = getCachedEntityPosition(entityId);
-                                    var intersectionPoint = boundedRay.pointAt(distance);
-
-                                    var normal = new Vector3f();
-                                    normal.sub(boundedRay.origin(), intersectionPoint);
-                                    normal.normalize();
-
-                                    intersections.add(
-                                    new RayIntersection<>(entityId, content, distance, intersectionPoint, normal,
-                                                          entityBounds));
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            Collections.sort(intersections);
-            return intersections;
-        } finally {
-            lock.readLock().unlock();
-        }
+        return culler.rayIntersectWithin(ray, maxDistance);
     }
 
     /**
@@ -2385,53 +1993,6 @@ implements SpatialIndex<Key, ID, Content> {
     protected abstract void addNeighboringNodes(Key nodeIndex, Queue<Key> toVisit, Set<Key> visitedNodes);
 
     /**
-     * Calculate the intersection between a frustum and an entity.
-     *
-     * @param frustum        the frustum
-     * @param cameraPosition the camera position
-     * @param entityId       the entity ID
-     * @param content        the entity content
-     * @param entityPos      the entity position
-     * @param bounds         the entity bounds (null for point entities)
-     * @return frustum intersection result, or null if outside frustum
-     */
-    protected FrustumIntersection<ID, Content> calculateFrustumEntityIntersection(Frustum3D frustum,
-                                                                                  Point3f cameraPosition, ID entityId,
-                                                                                  Content content, Point3f entityPos,
-                                                                                  EntityBounds bounds) {
-        if (bounds != null) {
-            // For bounded entities, perform frustum-AABB intersection
-            return frustumAABBIntersection(frustum, cameraPosition, entityId, content, bounds);
-        } else {
-            // For point entities, test point containment
-            return frustumPointIntersection(frustum, cameraPosition, entityId, content, entityPos);
-        }
-    }
-
-    /**
-     * Calculate the intersection between a plane and an entity.
-     *
-     * @param plane     the plane
-     * @param entityId  the entity ID
-     * @param content   the entity content
-     * @param entityPos the entity position
-     * @param bounds    the entity bounds (null for point entities)
-     * @param tolerance tolerance for intersection detection
-     * @return plane intersection result, or null if no intersection within tolerance
-     */
-    protected PlaneIntersection<ID, Content> calculatePlaneEntityIntersection(Plane3D plane, ID entityId,
-                                                                              Content content, Point3f entityPos,
-                                                                              EntityBounds bounds, float tolerance) {
-        if (bounds != null) {
-            // For bounded entities, perform plane-AABB intersection
-            return planeAABBIntersection(plane, entityId, content, bounds, tolerance);
-        } else {
-            // For point entities, calculate distance to plane
-            return planePointIntersection(plane, entityId, content, entityPos, tolerance);
-        }
-    }
-
-    /**
      * Calculate the spatial index for a position at a given level
      */
     protected abstract Key calculateSpatialIndex(Point3f position, byte level);
@@ -2489,8 +2050,15 @@ implements SpatialIndex<Key, ID, Content> {
     /**
      * Façade implementation of the {@link FrustumGeometry} seam (RDR-008 P3, sub-interface split): supplies
      * {@code DsocController} the frustum-cluster façade operations it needs (traversal hooks, node bounds, cached
-     * entity position, standard-cull fallback). Private inner class preserves the underlying methods' original
-     * visibility.
+     * entity position). Private inner class preserves the underlying methods' original visibility. P4 re-homed the
+     * standard non-DSOC cull fallback into the {@code Culler} feature object, exposed to DSOC through a separate
+     * {@code FrustumCullProvider} seam.
+     *
+     * <p>NOTE: {@link CullGeometryImpl} mirrors three method signatures defined here — {@code getFrustumTraversalOrder},
+     * {@code doesFrustumIntersectNode}, {@code getCachedEntityPosition}. The two interfaces are intentionally
+     * independent (cluster-scoped) so they cannot share a base type without crossing the cull/occlusion package
+     * boundary. If any of these three signatures changes, BOTH inner classes need the same change — neither compiler
+     * nor IDE will warn of the asymmetry.
      */
     private final class FrustumGeometryImpl implements FrustumGeometry<Key, ID, Content> {
         @Override
@@ -2512,11 +2080,68 @@ implements SpatialIndex<Key, ID, Content> {
         public Point3f getCachedEntityPosition(ID entityId) {
             return AbstractSpatialIndex.this.getCachedEntityPosition(entityId);
         }
+    }
+
+    /**
+     * Façade implementation of the {@link CullGeometry} seam (RDR-008 P4): supplies {@code Culler} the cluster's
+     * seven subclass-overridden traversal/intersect/distance hooks, the two cached entity accessors, and the
+     * spanning-policy flag. Private inner class preserves the underlying methods' original visibility.
+     *
+     * <p>NOTE: this class duplicates three method signatures from {@link FrustumGeometryImpl} —
+     * {@code getFrustumTraversalOrder}, {@code doesFrustumIntersectNode}, {@code getCachedEntityPosition} — because
+     * each cluster's sub-interface is intentionally independent (P3 refinement) and cannot share a base type without
+     * crossing the cull/occlusion package boundary. Update BOTH inner classes if any of these three signatures
+     * changes.
+     */
+    private final class CullGeometryImpl implements CullGeometry<Key, ID, Content> {
+        @Override
+        public Stream<Key> getFrustumTraversalOrder(Frustum3D frustum, Point3f cameraPosition) {
+            return AbstractSpatialIndex.this.getFrustumTraversalOrder(frustum, cameraPosition);
+        }
 
         @Override
-        public List<FrustumIntersection<ID, Content>> frustumCullVisibleStandard(Frustum3D frustum,
-                                                                                 Point3f cameraPosition) {
-            return AbstractSpatialIndex.this.frustumCullVisibleStandard(frustum, cameraPosition);
+        public boolean doesFrustumIntersectNode(Key nodeIndex, Frustum3D frustum) {
+            return AbstractSpatialIndex.this.doesFrustumIntersectNode(nodeIndex, frustum);
+        }
+
+        @Override
+        public Stream<Key> getPlaneTraversalOrder(Plane3D plane) {
+            return AbstractSpatialIndex.this.getPlaneTraversalOrder(plane);
+        }
+
+        @Override
+        public boolean doesPlaneIntersectNode(Key nodeIndex, Plane3D plane) {
+            return AbstractSpatialIndex.this.doesPlaneIntersectNode(nodeIndex, plane);
+        }
+
+        @Override
+        public Stream<Key> getRayTraversalOrder(Ray3D ray) {
+            return AbstractSpatialIndex.this.getRayTraversalOrder(ray);
+        }
+
+        @Override
+        public boolean doesRayIntersectNode(Key nodeIndex, Ray3D ray) {
+            return AbstractSpatialIndex.this.doesRayIntersectNode(nodeIndex, ray);
+        }
+
+        @Override
+        public float getRayNodeIntersectionDistance(Key nodeIndex, Ray3D ray) {
+            return AbstractSpatialIndex.this.getRayNodeIntersectionDistance(nodeIndex, ray);
+        }
+
+        @Override
+        public Point3f getCachedEntityPosition(ID entityId) {
+            return AbstractSpatialIndex.this.getCachedEntityPosition(entityId);
+        }
+
+        @Override
+        public EntityBounds getCachedEntityBounds(ID entityId) {
+            return AbstractSpatialIndex.this.getCachedEntityBounds(entityId);
+        }
+
+        @Override
+        public boolean isSpanningEnabled() {
+            return AbstractSpatialIndex.this.spanningPolicy.isSpanningEnabled();
         }
     }
 
@@ -2660,40 +2285,6 @@ implements SpatialIndex<Key, ID, Content> {
     }
 
     /**
-     * Find the closest point on an AABB to the camera
-     *
-     * @param cameraPosition the camera position
-     * @param bounds         the AABB bounds
-     * @return closest point on AABB surface to the camera
-     */
-    protected Point3f findClosestPointOnAABBToCamera(Point3f cameraPosition, EntityBounds bounds) {
-        // Clamp camera position to AABB bounds
-        var x = Math.max(bounds.getMinX(), Math.min(cameraPosition.x, bounds.getMaxX()));
-        var y = Math.max(bounds.getMinY(), Math.min(cameraPosition.y, bounds.getMaxY()));
-        var z = Math.max(bounds.getMinZ(), Math.min(cameraPosition.z, bounds.getMaxZ()));
-
-        return new Point3f(x, y, z);
-    }
-
-    /**
-     * Find the closest point on an AABB to a plane
-     *
-     * @param plane  the plane
-     * @param bounds the AABB bounds
-     * @return closest point on AABB surface to the plane
-     */
-    protected Point3f findClosestPointOnAABBToPlane(Plane3D plane, EntityBounds bounds) {
-        var normal = plane.getNormal();
-
-        // Find the point on the AABB closest to the plane
-        var x = (normal.x >= 0) ? bounds.getMinX() : bounds.getMaxX();
-        var y = (normal.y >= 0) ? bounds.getMinY() : bounds.getMaxY();
-        var z = (normal.z >= 0) ? bounds.getMinZ() : bounds.getMaxZ();
-
-        return new Point3f(x, y, z);
-    }
-
-    /**
      * Find minimum containing level for bounds
      */
     protected byte findMinimumContainingLevel(VolumeBounds bounds) {
@@ -2736,85 +2327,6 @@ implements SpatialIndex<Key, ID, Content> {
      * @return set of node keys that intersect with the bounds
      */
     protected abstract Set<Key> findNodesIntersectingBounds(VolumeBounds bounds);
-
-    /**
-     * Frustum-AABB intersection test
-     *
-     * @param frustum        the frustum
-     * @param cameraPosition the camera position
-     * @param entityId       the entity ID
-     * @param content        the entity content
-     * @param bounds         the AABB bounds
-     * @return frustum intersection result, or null if outside frustum
-     */
-    protected FrustumIntersection<ID, Content> frustumAABBIntersection(Frustum3D frustum, Point3f cameraPosition,
-                                                                       ID entityId, Content content,
-                                                                       EntityBounds bounds) {
-        var minX = bounds.getMinX();
-        var minY = bounds.getMinY();
-        var minZ = bounds.getMinZ();
-        var maxX = bounds.getMaxX();
-        var maxY = bounds.getMaxY();
-        var maxZ = bounds.getMaxZ();
-
-        // Check if AABB is completely inside frustum
-        var completelyInside = frustum.containsAABB(minX, minY, minZ, maxX, maxY, maxZ);
-
-        // Check if AABB intersects frustum
-        var intersects = frustum.intersectsAABB(minX, minY, minZ, maxX, maxY, maxZ);
-
-        if (!intersects) {
-            // Outside frustum
-            return null;
-        }
-
-        // Determine visibility type
-        var visibilityType = (completelyInside) ? FrustumIntersection.VisibilityType.INSIDE
-                                                : FrustumIntersection.VisibilityType.INTERSECTING;
-        if (completelyInside) {
-            visibilityType = FrustumIntersection.VisibilityType.INSIDE;
-        } else {
-            visibilityType = FrustumIntersection.VisibilityType.INTERSECTING;
-        }
-
-        // Calculate distance from camera to entity center
-        var entityCenter = bounds.getCenter();
-        var distanceFromCamera = cameraPosition.distance(entityCenter);
-
-        // Calculate closest point on AABB to camera
-        var closestPoint = findClosestPointOnAABBToCamera(cameraPosition, bounds);
-
-        return new FrustumIntersection<>(entityId, content, distanceFromCamera, closestPoint, visibilityType, bounds);
-    }
-
-    /**
-     * Frustum-point intersection test
-     *
-     * @param frustum        the frustum
-     * @param cameraPosition the camera position
-     * @param entityId       the entity ID
-     * @param content        the entity content
-     * @param point          the point position
-     * @return frustum intersection result, or null if outside frustum
-     */
-    protected FrustumIntersection<ID, Content> frustumPointIntersection(Frustum3D frustum, Point3f cameraPosition,
-                                                                        ID entityId, Content content, Point3f point) {
-        // Check if point is inside frustum
-        var isInside = frustum.containsPoint(point);
-
-        if (!isInside) {
-            return null;
-        }
-
-        // Calculate distance from camera to point
-        var distanceFromCamera = cameraPosition.distance(point);
-
-        // Point is always completely inside if it passes the containment test
-        var visibilityType = FrustumIntersection.VisibilityType.INSIDE;
-
-        return new FrustumIntersection<>(entityId, content, distanceFromCamera, new Point3f(point), visibilityType,
-                                         null);
-    }
 
     /**
      * Get the cell size at a given level, in the same (world) coordinate space as entity positions
@@ -2879,26 +2391,6 @@ implements SpatialIndex<Key, ID, Content> {
      * @return stream of node indices ordered by distance from plane
      */
     protected abstract Stream<Key> getPlaneTraversalOrder(Plane3D plane);
-
-    /**
-     * Calculate the distance from ray origin to entity
-     *
-     * @param ray       the ray to test
-     * @param entityId  the entity ID
-     * @param entityPos the entity position
-     * @return distance along ray, or -1 if no intersection
-     */
-    protected float getRayEntityDistance(Ray3D ray, ID entityId, Point3f entityPos) {
-        EntityBounds bounds = entityManager.getEntityBounds(entityId);
-
-        if (bounds != null) {
-            // For bounded entities, perform ray-AABB intersection
-            return rayAABBIntersection(ray, bounds);
-        } else {
-            // For point entities, perform ray-sphere intersection with small radius
-            return raySphereIntersection(ray, entityPos, 0.1f);
-        }
-    }
 
     /**
      * Get the distance from ray origin to node intersection
@@ -3145,118 +2637,6 @@ implements SpatialIndex<Key, ID, Content> {
     }
 
     /**
-     * Plane-AABB intersection test
-     *
-     * @param plane     the plane
-     * @param entityId  the entity ID
-     * @param content   the entity content
-     * @param bounds    the AABB bounds
-     * @param tolerance tolerance for intersection
-     * @return plane intersection result, or null if outside tolerance
-     */
-    protected PlaneIntersection<ID, Content> planeAABBIntersection(Plane3D plane, ID entityId, Content content,
-                                                                   EntityBounds bounds, float tolerance) {
-        var minX = bounds.getMinX();
-        var minY = bounds.getMinY();
-        var minZ = bounds.getMinZ();
-        var maxX = bounds.getMaxX();
-        var maxY = bounds.getMaxY();
-        var maxZ = bounds.getMaxZ();
-
-        // Calculate distances to all 8 corners of the AABB
-        var corners = new Point3f[] { new Point3f(minX, minY, minZ), new Point3f(maxX, minY, minZ), new Point3f(minX,
-                                                                                                                maxY,
-                                                                                                                minZ),
-                                      new Point3f(maxX, maxY, minZ), new Point3f(minX, minY, maxZ), new Point3f(maxX,
-                                                                                                                minY,
-                                                                                                                maxZ),
-                                      new Point3f(minX, maxY, maxZ), new Point3f(maxX, maxY, maxZ) };
-
-        var minDistance = Float.POSITIVE_INFINITY;
-        var maxDistance = Float.NEGATIVE_INFINITY;
-        var closestPoint = new Point3f();
-
-        // Find min and max distances to plane
-        for (var corner : corners) {
-            var distance = plane.distanceToPoint(corner);
-            if (distance < minDistance) {
-                minDistance = distance;
-                closestPoint.set(corner);
-            }
-            if (distance > maxDistance) {
-                maxDistance = distance;
-            }
-        }
-
-        // Determine intersection type
-        PlaneIntersection.IntersectionType intersectionType;
-        float resultDistance;
-
-        if (Math.abs(minDistance) <= tolerance && Math.abs(maxDistance) <= tolerance) {
-            // Box lies on plane
-            intersectionType = PlaneIntersection.IntersectionType.ON_PLANE;
-            resultDistance = (minDistance + maxDistance) / 2.0f;
-        } else if (minDistance * maxDistance <= 0) {
-            // Box spans plane
-            intersectionType = PlaneIntersection.IntersectionType.INTERSECTING;
-            resultDistance = Math.abs(minDistance) < Math.abs(maxDistance) ? minDistance : maxDistance;
-        } else if (minDistance > 0) {
-            // Box is on positive side
-            intersectionType = PlaneIntersection.IntersectionType.POSITIVE_SIDE;
-            resultDistance = minDistance;
-        } else {
-            // Box is on negative side
-            intersectionType = PlaneIntersection.IntersectionType.NEGATIVE_SIDE;
-            resultDistance = maxDistance;
-        }
-
-        // Check tolerance
-        if (tolerance > 0 && Math.abs(resultDistance) > tolerance) {
-            return null;
-        }
-
-        // Calculate closest point on AABB to plane
-        if (intersectionType == PlaneIntersection.IntersectionType.INTERSECTING) {
-            // For intersecting boxes, find actual closest point on box surface to plane
-            closestPoint = findClosestPointOnAABBToPlane(plane, bounds);
-        }
-
-        return new PlaneIntersection<>(entityId, content, resultDistance, closestPoint, intersectionType, bounds);
-    }
-
-    /**
-     * Plane-point intersection test
-     *
-     * @param plane     the plane
-     * @param entityId  the entity ID
-     * @param content   the entity content
-     * @param point     the point position
-     * @param tolerance tolerance for intersection
-     * @return plane intersection result, or null if outside tolerance
-     */
-    protected PlaneIntersection<ID, Content> planePointIntersection(Plane3D plane, ID entityId, Content content,
-                                                                    Point3f point, float tolerance) {
-        var distance = plane.distanceToPoint(point);
-
-        // Check tolerance
-        if (tolerance > 0 && Math.abs(distance) > tolerance) {
-            return null;
-        }
-
-        // Determine intersection type
-        PlaneIntersection.IntersectionType intersectionType;
-        if (Math.abs(distance) <= 1e-6f) {
-            intersectionType = PlaneIntersection.IntersectionType.ON_PLANE;
-        } else if (distance > 0) {
-            intersectionType = PlaneIntersection.IntersectionType.POSITIVE_SIDE;
-        } else {
-            intersectionType = PlaneIntersection.IntersectionType.NEGATIVE_SIDE;
-        }
-
-        return new PlaneIntersection<>(entityId, content, distance, new Point3f(point), intersectionType, null);
-    }
-
-    /**
      * Process all entities in SFC order with the given consumer. This utility method provides a convenient way to
      * iterate over all entities in spatial order for improved cache performance.
      *
@@ -3286,108 +2666,6 @@ implements SpatialIndex<Key, ID, Content> {
                 nodeProcessor.accept(nodeIndex, node);
             }
         }
-    }
-
-    /**
-     * Ray-AABB intersection test
-     *
-     * @param ray    the ray
-     * @param bounds the axis-aligned bounding box
-     * @return distance to intersection, or -1 if no intersection
-     */
-    protected float rayAABBIntersection(Ray3D ray, EntityBounds bounds) {
-        var tmin = 0.0f;
-        var tmax = ray.maxDistance();
-
-        // For each axis
-        for (int i = 0; i < 3; i++) {
-            var origin = getComponent(ray.origin(), i);
-            var direction = getComponent(ray.direction(), i);
-            var min = getComponent(bounds, i, true);
-            var max = getComponent(bounds, i, false);
-
-            if (Math.abs(direction) < 1e-6f) {
-                // Ray is parallel to slab
-                if (origin < min || origin > max) {
-                    return -1;
-                }
-            } else {
-                // Compute intersection distances
-                var t1 = (min - origin) / direction;
-                var t2 = (max - origin) / direction;
-
-                if (t1 > t2) {
-                    var temp = t1;
-                    t1 = t2;
-                    t2 = temp;
-                }
-
-                tmin = Math.max(tmin, t1);
-                tmax = Math.min(tmax, t2);
-
-                if (tmin > tmax) {
-                    return -1;
-                }
-            }
-        }
-
-        return tmin;
-    }
-
-    /**
-     * Ray-sphere intersection test
-     *
-     * @param ray    the ray
-     * @param center sphere center
-     * @param radius sphere radius
-     * @return distance to intersection, or -1 if no intersection
-     */
-    protected float raySphereIntersection(Ray3D ray, Point3f center, float radius) {
-        // Use geometric algorithm for better numerical stability with distant entities
-
-        // First check if ray origin is inside the sphere
-        var distFromOrigin = ray.origin().distance(center);
-        if (distFromOrigin <= radius) {
-            // Ray starts inside sphere, return 0
-            return 0.0f;
-        }
-
-        // Find the closest point on the ray to the sphere center
-        var toCenter = new Vector3f();
-        toCenter.sub(center, ray.origin());
-
-        var t = toCenter.dot(ray.direction());  // Parameter for closest point
-        if (t < 0) {
-            // Sphere is behind ray origin
-            return -1;
-        }
-
-        // Calculate closest point on ray
-        var closestPoint = new Point3f(ray.origin().x + t * ray.direction().x, ray.origin().y + t * ray.direction().y,
-                                       ray.origin().z + t * ray.direction().z);
-
-        var distToCenter = closestPoint.distance(center);
-
-        if (distToCenter > radius) {
-            // Ray misses sphere
-            return -1;
-        }
-
-        // Calculate intersection points
-        var halfChordLength = (float) Math.sqrt(radius * radius - distToCenter * distToCenter);
-
-        var t1 = t - halfChordLength;
-        var t2 = t + halfChordLength;
-
-        // Return the closest positive t value within max distance
-        if (t1 >= 0 && t1 <= ray.maxDistance()) {
-            return t1;
-        }
-        if (t2 >= 0 && t2 <= ray.maxDistance()) {
-            return t2;
-        }
-
-        return -1;
     }
 
     /**
@@ -3997,42 +3275,6 @@ implements SpatialIndex<Key, ID, Content> {
             }
         }
         return position;
-    }
-
-    /**
-     * Helper to get component from Point3f
-     */
-    private float getComponent(Point3f point, int axis) {
-        return switch (axis) {
-            case 0 -> point.x;
-            case 1 -> point.y;
-            case 2 -> point.z;
-            default -> throw new IllegalArgumentException("Invalid axis: " + axis);
-        };
-    }
-
-    /**
-     * Helper to get component from Vector3f
-     */
-    private float getComponent(Vector3f vector, int axis) {
-        return switch (axis) {
-            case 0 -> vector.x;
-            case 1 -> vector.y;
-            case 2 -> vector.z;
-            default -> throw new IllegalArgumentException("Invalid axis: " + axis);
-        };
-    }
-
-    /**
-     * Helper to get min/max component from EntityBounds
-     */
-    private float getComponent(EntityBounds bounds, int axis, boolean min) {
-        return switch (axis) {
-            case 0 -> min ? bounds.getMinX() : bounds.getMaxX();
-            case 1 -> min ? bounds.getMinY() : bounds.getMaxY();
-            case 2 -> min ? bounds.getMinZ() : bounds.getMaxZ();
-            default -> throw new IllegalArgumentException("Invalid axis: " + axis);
-        };
     }
 
     /**
@@ -4778,7 +4020,7 @@ implements SpatialIndex<Key, ID, Content> {
      */
     public void enableDSOC(DSOCConfiguration config, int bufferWidth, int bufferHeight) {
         // RDR-008 P1: the DSOC cluster is encapsulated in DsocController.
-        this.dsoc = new DsocController<>(core, new FrustumGeometryImpl(), config, bufferWidth, bufferHeight);
+        this.dsoc = new DsocController<>(core, new FrustumGeometryImpl(), culler, config, bufferWidth, bufferHeight);
     }
     
     /**
@@ -4856,64 +4098,6 @@ implements SpatialIndex<Key, ID, Content> {
     public void forceZBufferActivation() {
         if (dsoc != null) {
             dsoc.forceZBufferActivation();
-        }
-    }
-
-    /**
-     * Standard frustum culling without DSOC optimizations
-     */
-    protected List<FrustumIntersection<ID, Content>> frustumCullVisibleStandard(Frustum3D frustum, Point3f cameraPosition) {
-        lock.readLock().lock();
-        try {
-            var intersections = ObjectPools.<FrustumIntersection<ID, Content>>borrowArrayList();
-            var visitedEntities = ObjectPools.<ID>borrowHashSet();
-            try {
-                // Traverse nodes that could intersect with the frustum
-                getFrustumTraversalOrder(frustum, cameraPosition).forEach(nodeIndex -> {
-                    var node = spatialIndex.get(nodeIndex);
-                    if (node == null || node.isEmpty()) {
-                        return;
-                    }
-
-                    // Check if frustum intersects this node
-                    if (!doesFrustumIntersectNode(nodeIndex, frustum)) {
-                        return;
-                    }
-
-                    // Check each entity in the node
-                    for (ID entityId : node.getEntityIds()) {
-                        // Skip if already processed (for spanning entities)
-                        if (!visitedEntities.add(entityId)) {
-                            continue;
-                        }
-
-                        var content = entityManager.getEntityContent(entityId);
-                        if (content == null) {
-                            continue;
-                        }
-
-                        var entityPos = getCachedEntityPosition(entityId);
-                        var bounds = getCachedEntityBounds(entityId);
-
-                        // Calculate frustum-entity intersection
-                        var intersection = calculateFrustumEntityIntersection(frustum, cameraPosition, entityId,
-                                                                              content, entityPos, bounds);
-
-                        if (intersection != null && intersection.isVisible()) {
-                            intersections.add(intersection);
-                        }
-                    }
-                });
-
-                Collections.sort(intersections);
-                // Return a copy to avoid returning pooled object
-                return new ArrayList<>(intersections);
-            } finally {
-                ObjectPools.returnArrayList(intersections);
-                ObjectPools.returnHashSet(visitedEntities);
-            }
-        } finally {
-            lock.readLock().unlock();
         }
     }
 

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/cull/CullGeometry.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/cull/CullGeometry.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.cull;
+
+import com.hellblazer.luciferase.lucien.Frustum3D;
+import com.hellblazer.luciferase.lucien.Plane3D;
+import com.hellblazer.luciferase.lucien.Ray3D;
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.entity.EntityBounds;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+
+import javax.vecmath.Point3f;
+import java.util.stream.Stream;
+
+/**
+ * Façade operations the frustum/plane/ray {@link Culler} consumes (RDR-008 P4).
+ *
+ * <p>Following the P3 per-cluster sub-interface refinement (RDR-008 §Decision item 1 P3 refinement), each feature
+ * object depends only on the narrow surface it actually uses — for the bundled cull cluster that surface is the seven
+ * subclass-overridden traversal/intersect/distance hooks (each cluster's three) plus the two cached entity accessors
+ * and the spanning-policy flag. The façade implements this through a private inner class so the underlying methods
+ * keep their original visibility.
+ *
+ * @param <Key>     the spatial key type
+ * @param <ID>      the entity identifier type
+ * @param <Content> the entity content type
+ * @author hal.hildebrand
+ */
+public interface CullGeometry<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
+
+    // ===== Frustum subclass hooks =====
+
+    /** Spatial keys of nodes potentially intersecting the frustum, in front-to-back traversal order. */
+    Stream<Key> getFrustumTraversalOrder(Frustum3D frustum, Point3f cameraPosition);
+
+    /** Whether the frustum intersects the node at the given key (subclass-specific geometry test). */
+    boolean doesFrustumIntersectNode(Key nodeIndex, Frustum3D frustum);
+
+    // ===== Plane subclass hooks =====
+
+    /** Spatial keys of nodes potentially intersecting the plane, in traversal order. */
+    Stream<Key> getPlaneTraversalOrder(Plane3D plane);
+
+    /** Whether the plane intersects the node at the given key (subclass-specific geometry test). */
+    boolean doesPlaneIntersectNode(Key nodeIndex, Plane3D plane);
+
+    // ===== Ray subclass hooks =====
+
+    /** Spatial keys of nodes potentially intersecting the ray, in ray-distance traversal order. */
+    Stream<Key> getRayTraversalOrder(Ray3D ray);
+
+    /** Whether the ray intersects the node at the given key (subclass-specific geometry test). */
+    boolean doesRayIntersectNode(Key nodeIndex, Ray3D ray);
+
+    /** Distance from the ray origin to the node's entry point, or {@code Float.MAX_VALUE} if it misses. */
+    float getRayNodeIntersectionDistance(Key nodeIndex, Ray3D ray);
+
+    // ===== Cached accessors + spanning =====
+
+    /** Cached world position of the entity, or {@code null} if unknown. */
+    Point3f getCachedEntityPosition(ID entityId);
+
+    /** Cached world bounds of the entity, or {@code null} for point entities. */
+    EntityBounds getCachedEntityBounds(ID entityId);
+
+    /** Whether the spanning policy is enabled — drives the bounded-entity sweep in ray queries. */
+    boolean isSpanningEnabled();
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/cull/Culler.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/cull/Culler.java
@@ -1,0 +1,689 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.cull;
+
+import com.hellblazer.luciferase.lucien.Frustum3D;
+import com.hellblazer.luciferase.lucien.FrustumIntersection;
+import com.hellblazer.luciferase.lucien.Plane3D;
+import com.hellblazer.luciferase.lucien.PlaneIntersection;
+import com.hellblazer.luciferase.lucien.Ray3D;
+import com.hellblazer.luciferase.lucien.SpatialDistanceCalculator;
+import com.hellblazer.luciferase.lucien.SpatialIndex.RayIntersection;
+import com.hellblazer.luciferase.lucien.SpatialIndexCore;
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.entity.EntityBounds;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+import com.hellblazer.luciferase.lucien.internal.ObjectPools;
+
+import javax.vecmath.Point3f;
+import javax.vecmath.Vector3f;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * The frustum/plane/ray cull feature object for a spatial index (RDR-008 P4).
+ *
+ * <p>Owns the bundled cull cluster — five frustum entries (inside, intersecting, visible, visible-ID, within-distance),
+ * five plane entries (all+tolerance, all, negative side, positive side, within-distance), three ray entries (all,
+ * first, within), the standard non-DSOC cull fallback {@link #frustumCullVisibleStandard}, and the cluster's twelve
+ * private geometry helpers (frustum/plane/ray AABB + point/sphere intersection, entity-intersection calculators, the
+ * two AABB-closest-point helpers, the ray-entity distance default, and the {@code getComponent} accessor used by ray-
+ * AABB slab). Bundled rather than split per RDR-008 §Decision item 2 (shared traversal hooks, high internal cohesion).
+ *
+ * <p>The cluster's seven subclass-overridden hooks (frustum / plane / ray traversal + intersect, plus ray-node
+ * intersection distance) and the two cached entity accessors and the spanning-policy flag arrive through
+ * {@link CullGeometry}; the shared sorted-node map, the read-write lock, and the entity manager arrive through
+ * {@link SpatialIndexCore}.
+ *
+ * <p>{@link FrustumCullProvider} is implemented directly: {@code DsocController} takes a {@code Culler} as its
+ * frustum-cull-provider argument and calls {@link #frustumCullVisibleStandard} as the fallback when DSOC's Z-buffer
+ * is inactive — preserving the P1-installed DSOC ↔ standard-cull seam.
+ *
+ * @param <Key>     the spatial key type
+ * @param <ID>      the entity identifier type
+ * @param <Content> the entity content type
+ * @author hal.hildebrand
+ */
+public final class Culler<Key extends SpatialKey<Key>, ID extends EntityID, Content>
+implements FrustumCullProvider<Key, ID, Content> {
+
+    private final SpatialIndexCore<Key, ID, Content> core;
+    private final CullGeometry<Key, ID, Content>     callback;
+
+    public Culler(SpatialIndexCore<Key, ID, Content> core, CullGeometry<Key, ID, Content> callback) {
+        this.core = core;
+        this.callback = callback;
+    }
+
+    // ===== Frustum culling =====
+    //
+    // Note: the public derivatives frustumCullInside / frustumCullIntersecting / frustumCullWithinDistance live on
+    // the façade and compose on top of frustumCullVisible(frustum, cameraPosition) so they inherit the DSOC routing
+    // decision. The Culler never re-implements them here — doing so would offer a path that silently bypasses DSOC.
+
+    /**
+     * Simple ID-only frustum-visibility query (no DSOC integration, no distance sorting, point-containment only).
+     * Verbatim preservation of the pre-extraction single-arg variant. Distinct from the camera-position-aware
+     * {@link #frustumCullVisibleStandard}: this variant has no DSOC equivalent on the façade because the pre-
+     * extraction {@code frustumCullVisible(Frustum3D)} was always non-DSOC.
+     */
+    public List<ID> frustumCullVisibleIds(Frustum3D frustum) {
+        if (frustum == null) {
+            throw new NullPointerException("Frustum cannot be null");
+        }
+        core.lock().readLock().lock();
+        try {
+            var visibleEntities = new ArrayList<ID>();
+            var visitedEntities = new HashSet<ID>();
+            core.spatialIndex().forEach((nodeIndex, node) -> {
+                if (node == null || node.isEmpty()) {
+                    return;
+                }
+                if (!callback.doesFrustumIntersectNode(nodeIndex, frustum)) {
+                    return;
+                }
+                for (ID entityId : node.getEntityIds()) {
+                    if (visitedEntities.add(entityId)) {
+                        var entityPos = callback.getCachedEntityPosition(entityId);
+                        if (entityPos != null && frustum.containsPoint(entityPos)) {
+                            visibleEntities.add(entityId);
+                        }
+                    }
+                }
+            });
+            return visibleEntities;
+        } finally {
+            core.lock().readLock().unlock();
+        }
+    }
+
+    /** Standard (non-DSOC) frustum cull — the P1-introduced fallback. Verbatim preservation. */
+    @Override
+    public List<FrustumIntersection<ID, Content>> frustumCullVisibleStandard(Frustum3D frustum,
+                                                                             Point3f cameraPosition) {
+        if (frustum == null) {
+            throw new NullPointerException("Frustum cannot be null");
+        }
+        core.lock().readLock().lock();
+        try {
+            var intersections = ObjectPools.<FrustumIntersection<ID, Content>>borrowArrayList();
+            var visitedEntities = ObjectPools.<ID>borrowHashSet();
+            try {
+                callback.getFrustumTraversalOrder(frustum, cameraPosition).forEach(nodeIndex -> {
+                    var node = core.spatialIndex().get(nodeIndex);
+                    if (node == null || node.isEmpty()) {
+                        return;
+                    }
+                    if (!callback.doesFrustumIntersectNode(nodeIndex, frustum)) {
+                        return;
+                    }
+                    for (ID entityId : node.getEntityIds()) {
+                        if (!visitedEntities.add(entityId)) {
+                            continue;
+                        }
+                        var content = core.entityManager().getEntityContent(entityId);
+                        if (content == null) {
+                            continue;
+                        }
+                        var entityPos = callback.getCachedEntityPosition(entityId);
+                        var bounds = callback.getCachedEntityBounds(entityId);
+                        var intersection = calculateFrustumEntityIntersection(frustum, cameraPosition, entityId,
+                                                                              content, entityPos, bounds);
+                        if (intersection != null && intersection.isVisible()) {
+                            intersections.add(intersection);
+                        }
+                    }
+                });
+                Collections.sort(intersections);
+                return new ArrayList<>(intersections);
+            } finally {
+                ObjectPools.returnArrayList(intersections);
+                ObjectPools.returnHashSet(visitedEntities);
+            }
+        } finally {
+            core.lock().readLock().unlock();
+        }
+    }
+
+    // ===== Plane intersection =====
+
+    /** Find all entities intersecting the plane within {@code tolerance} of it. */
+    public List<PlaneIntersection<ID, Content>> planeIntersectAll(Plane3D plane, float tolerance) {
+        core.lock().readLock().lock();
+        try {
+            var intersections = new ArrayList<PlaneIntersection<ID, Content>>();
+            callback.getPlaneTraversalOrder(plane).forEach(nodeIndex -> {
+                var node = core.spatialIndex().get(nodeIndex);
+                if (node == null || node.isEmpty()) {
+                    return;
+                }
+                if (!callback.doesPlaneIntersectNode(nodeIndex, plane)) {
+                    return;
+                }
+                for (ID entityId : node.getEntityIds()) {
+                    var content = core.entityManager().getEntityContent(entityId);
+                    if (content == null) {
+                        continue;
+                    }
+                    var entityPos = callback.getCachedEntityPosition(entityId);
+                    var bounds = core.entityManager().getEntityBounds(entityId);
+                    var intersection = calculatePlaneEntityIntersection(plane, entityId, content, entityPos, bounds,
+                                                                        tolerance);
+                    if (intersection != null) {
+                        intersections.add(intersection);
+                    }
+                }
+            });
+            Collections.sort(intersections);
+            return intersections;
+        } finally {
+            core.lock().readLock().unlock();
+        }
+    }
+
+    /** Find all entities exactly intersecting the plane (tolerance 0). */
+    public List<PlaneIntersection<ID, Content>> planeIntersectAll(Plane3D plane) {
+        return planeIntersectAll(plane, 0.0f);
+    }
+
+    /** Find all entities on the negative side of the plane (opposite to normal). */
+    public List<PlaneIntersection<ID, Content>> planeIntersectNegativeSide(Plane3D plane) {
+        return planeIntersectAll(plane, Float.MAX_VALUE).stream()
+                                                        .filter(PlaneIntersection::isOnNegativeSide)
+                                                        .collect(Collectors.toList());
+    }
+
+    /** Find all entities on the positive side of the plane (in direction of normal). */
+    public List<PlaneIntersection<ID, Content>> planeIntersectPositiveSide(Plane3D plane) {
+        return planeIntersectAll(plane, Float.MAX_VALUE).stream()
+                                                        .filter(PlaneIntersection::isOnPositiveSide)
+                                                        .collect(Collectors.toList());
+    }
+
+    /** Find all entities within {@code maxDistance} of the plane (on either side). */
+    public List<PlaneIntersection<ID, Content>> planeIntersectWithinDistance(Plane3D plane, float maxDistance) {
+        return planeIntersectAll(plane, maxDistance).stream()
+                                                    .filter(i -> Math.abs(i.distanceFromPlane()) <= maxDistance)
+                                                    .collect(Collectors.toList());
+    }
+
+    // ===== Ray intersection =====
+
+    /** Find all entities the ray intersects, sorted by ray-distance. */
+    public List<RayIntersection<ID, Content>> rayIntersectAll(Ray3D ray) {
+        core.lock().readLock().lock();
+        try {
+            var intersections = new ArrayList<RayIntersection<ID, Content>>();
+            var visitedEntities = new HashSet<ID>();
+            callback.getRayTraversalOrder(ray).forEach(nodeIndex -> {
+                var node = core.spatialIndex().get(nodeIndex);
+                if (node == null || node.isEmpty()) {
+                    return;
+                }
+                if (!callback.doesRayIntersectNode(nodeIndex, ray)) {
+                    return;
+                }
+                for (ID entityId : node.getEntityIds()) {
+                    if (!visitedEntities.add(entityId)) {
+                        continue;
+                    }
+                    var entityPos = callback.getCachedEntityPosition(entityId);
+                    if (entityPos == null) {
+                        continue;
+                    }
+                    var distance = getRayEntityDistance(ray, entityId, entityPos);
+                    if (distance >= 0 && ray.isWithinDistance(distance)) {
+                        var content = core.entityManager().getEntityContent(entityId);
+                        var bounds = callback.getCachedEntityBounds(entityId);
+                        var intersectionPoint = ray.pointAt(distance);
+                        var normal = new Vector3f();
+                        normal.sub(ray.origin(), intersectionPoint);
+                        normal.normalize();
+                        intersections.add(
+                        new RayIntersection<>(entityId, content, distance, intersectionPoint, normal, bounds));
+                    }
+                }
+            });
+            // Spanning sweep — spanning entities can live in nodes outside the ray's path but still have bounds the
+            // ray hits. Verbatim preservation from the pre-extraction façade.
+            if (callback.isSpanningEnabled()) {
+                for (var entry : core.spatialIndex().entrySet()) {
+                    for (var entityId : entry.getValue().getEntityIds()) {
+                        if (!visitedEntities.contains(entityId)) {
+                            var entityBounds = core.entityManager().getEntityBounds(entityId);
+                            if (entityBounds != null) {
+                                var distance = SpatialDistanceCalculator.rayIntersectsAABB(ray, entityBounds.getMinX(),
+                                                                                           entityBounds.getMinY(),
+                                                                                           entityBounds.getMinZ(),
+                                                                                           entityBounds.getMaxX(),
+                                                                                           entityBounds.getMaxY(),
+                                                                                           entityBounds.getMaxZ());
+                                if (distance >= 0 && ray.isWithinDistance(distance)) {
+                                    visitedEntities.add(entityId);
+                                    var content = core.entityManager().getEntityContent(entityId);
+                                    var intersectionPoint = ray.pointAt(distance);
+                                    var normal = new Vector3f();
+                                    normal.sub(ray.origin(), intersectionPoint);
+                                    normal.normalize();
+                                    intersections.add(new RayIntersection<>(entityId, content, distance,
+                                                                            intersectionPoint, normal, entityBounds));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Collections.sort(intersections);
+            return intersections;
+        } finally {
+            core.lock().readLock().unlock();
+        }
+    }
+
+    /** Find the closest entity the ray hits (with early termination). */
+    public Optional<RayIntersection<ID, Content>> rayIntersectFirst(Ray3D ray) {
+        core.lock().readLock().lock();
+        try {
+            var visitedEntities = new HashSet<ID>();
+            RayIntersection<ID, Content> closest = null;
+            var closestDistance = Float.MAX_VALUE;
+            var nodeIterator = callback.getRayTraversalOrder(ray).iterator();
+            while (nodeIterator.hasNext()) {
+                var nodeIndex = nodeIterator.next();
+                var nodeDistance = callback.getRayNodeIntersectionDistance(nodeIndex, ray);
+                if (nodeDistance > closestDistance) {
+                    break;
+                }
+                var node = core.spatialIndex().get(nodeIndex);
+                if (node == null || node.isEmpty()) {
+                    continue;
+                }
+                if (!callback.doesRayIntersectNode(nodeIndex, ray)) {
+                    continue;
+                }
+                for (ID entityId : node.getEntityIds()) {
+                    if (!visitedEntities.add(entityId)) {
+                        continue;
+                    }
+                    var entityPos = callback.getCachedEntityPosition(entityId);
+                    if (entityPos == null) {
+                        continue;
+                    }
+                    var distance = getRayEntityDistance(ray, entityId, entityPos);
+                    if (distance >= 0 && distance < closestDistance && ray.isWithinDistance(distance)) {
+                        var content = core.entityManager().getEntityContent(entityId);
+                        var bounds = callback.getCachedEntityBounds(entityId);
+                        var intersectionPoint = ray.pointAt(distance);
+                        var normal = new Vector3f();
+                        normal.sub(ray.origin(), intersectionPoint);
+                        normal.normalize();
+                        closest = new RayIntersection<>(entityId, content, distance, intersectionPoint, normal, bounds);
+                        closestDistance = distance;
+                    }
+                }
+            }
+            // Spanning sweep (mirrors rayIntersectAll). Verbatim preservation.
+            if (callback.isSpanningEnabled()) {
+                for (var entry : core.spatialIndex().entrySet()) {
+                    for (var entityId : entry.getValue().getEntityIds()) {
+                        if (!visitedEntities.contains(entityId)) {
+                            var entityBounds = core.entityManager().getEntityBounds(entityId);
+                            if (entityBounds != null) {
+                                var distance = SpatialDistanceCalculator.rayIntersectsAABB(ray, entityBounds.getMinX(),
+                                                                                           entityBounds.getMinY(),
+                                                                                           entityBounds.getMinZ(),
+                                                                                           entityBounds.getMaxX(),
+                                                                                           entityBounds.getMaxY(),
+                                                                                           entityBounds.getMaxZ());
+                                if (distance >= 0 && distance < closestDistance && ray.isWithinDistance(distance)) {
+                                    visitedEntities.add(entityId);
+                                    var content = core.entityManager().getEntityContent(entityId);
+                                    var intersectionPoint = ray.pointAt(distance);
+                                    var normal = new Vector3f();
+                                    normal.sub(ray.origin(), intersectionPoint);
+                                    normal.normalize();
+                                    closest = new RayIntersection<>(entityId, content, distance, intersectionPoint,
+                                                                    normal, entityBounds);
+                                    closestDistance = distance;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            return Optional.ofNullable(closest);
+        } finally {
+            core.lock().readLock().unlock();
+        }
+    }
+
+    /** Find all entities the ray intersects within {@code maxDistance}, sorted by ray-distance. */
+    public List<RayIntersection<ID, Content>> rayIntersectWithin(Ray3D ray, float maxDistance) {
+        if (maxDistance <= 0) {
+            return Collections.emptyList();
+        }
+        var boundedRay = ray.withMaxDistance(Math.min(ray.maxDistance(), maxDistance));
+        core.lock().readLock().lock();
+        try {
+            var intersections = new ArrayList<RayIntersection<ID, Content>>();
+            var visitedEntities = new HashSet<ID>();
+            callback.getRayTraversalOrder(boundedRay).forEach(nodeIndex -> {
+                float nodeDistance = callback.getRayNodeIntersectionDistance(nodeIndex, boundedRay);
+                if (nodeDistance > maxDistance) {
+                    return;
+                }
+                var node = core.spatialIndex().get(nodeIndex);
+                if (node == null || node.isEmpty()) {
+                    return;
+                }
+                if (!callback.doesRayIntersectNode(nodeIndex, boundedRay)) {
+                    return;
+                }
+                for (ID entityId : node.getEntityIds()) {
+                    if (!visitedEntities.add(entityId)) {
+                        continue;
+                    }
+                    var entityPos = callback.getCachedEntityPosition(entityId);
+                    if (entityPos == null) {
+                        continue;
+                    }
+                    float distance = getRayEntityDistance(boundedRay, entityId, entityPos);
+                    if (distance >= 0 && distance <= maxDistance) {
+                        var content = core.entityManager().getEntityContent(entityId);
+                        var bounds = callback.getCachedEntityBounds(entityId);
+                        var intersectionPoint = boundedRay.pointAt(distance);
+                        var normal = new Vector3f();
+                        normal.sub(boundedRay.origin(), intersectionPoint);
+                        normal.normalize();
+                        intersections.add(
+                        new RayIntersection<>(entityId, content, distance, intersectionPoint, normal, bounds));
+                    }
+                }
+            });
+            // Spanning sweep within the bounded distance (mirrors rayIntersectAll). Verbatim preservation.
+            if (callback.isSpanningEnabled()) {
+                for (var entry : core.spatialIndex().entrySet()) {
+                    for (var entityId : entry.getValue().getEntityIds()) {
+                        if (!visitedEntities.contains(entityId)) {
+                            var entityBounds = core.entityManager().getEntityBounds(entityId);
+                            if (entityBounds != null) {
+                                var distance = SpatialDistanceCalculator.rayIntersectsAABB(boundedRay,
+                                                                                           entityBounds.getMinX(),
+                                                                                           entityBounds.getMinY(),
+                                                                                           entityBounds.getMinZ(),
+                                                                                           entityBounds.getMaxX(),
+                                                                                           entityBounds.getMaxY(),
+                                                                                           entityBounds.getMaxZ());
+                                if (distance >= 0 && distance <= maxDistance) {
+                                    visitedEntities.add(entityId);
+                                    var content = core.entityManager().getEntityContent(entityId);
+                                    var intersectionPoint = boundedRay.pointAt(distance);
+                                    var normal = new Vector3f();
+                                    normal.sub(boundedRay.origin(), intersectionPoint);
+                                    normal.normalize();
+                                    intersections.add(new RayIntersection<>(entityId, content, distance,
+                                                                            intersectionPoint, normal, entityBounds));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Collections.sort(intersections);
+            return intersections;
+        } finally {
+            core.lock().readLock().unlock();
+        }
+    }
+
+    // ===== Frustum geometry helpers =====
+
+    private FrustumIntersection<ID, Content> calculateFrustumEntityIntersection(Frustum3D frustum,
+                                                                                Point3f cameraPosition, ID entityId,
+                                                                                Content content, Point3f entityPos,
+                                                                                EntityBounds bounds) {
+        if (bounds != null) {
+            return frustumAABBIntersection(frustum, cameraPosition, entityId, content, bounds);
+        }
+        return frustumPointIntersection(frustum, cameraPosition, entityId, content, entityPos);
+    }
+
+    private FrustumIntersection<ID, Content> frustumAABBIntersection(Frustum3D frustum, Point3f cameraPosition,
+                                                                     ID entityId, Content content,
+                                                                     EntityBounds bounds) {
+        var minX = bounds.getMinX();
+        var minY = bounds.getMinY();
+        var minZ = bounds.getMinZ();
+        var maxX = bounds.getMaxX();
+        var maxY = bounds.getMaxY();
+        var maxZ = bounds.getMaxZ();
+        var completelyInside = frustum.containsAABB(minX, minY, minZ, maxX, maxY, maxZ);
+        var intersects = frustum.intersectsAABB(minX, minY, minZ, maxX, maxY, maxZ);
+        if (!intersects) {
+            return null;
+        }
+        var visibilityType = completelyInside ? FrustumIntersection.VisibilityType.INSIDE
+                                              : FrustumIntersection.VisibilityType.INTERSECTING;
+        var entityCenter = bounds.getCenter();
+        var distanceFromCamera = cameraPosition.distance(entityCenter);
+        var closestPoint = findClosestPointOnAABBToCamera(cameraPosition, bounds);
+        return new FrustumIntersection<>(entityId, content, distanceFromCamera, closestPoint, visibilityType, bounds);
+    }
+
+    private FrustumIntersection<ID, Content> frustumPointIntersection(Frustum3D frustum, Point3f cameraPosition,
+                                                                      ID entityId, Content content, Point3f point) {
+        if (!frustum.containsPoint(point)) {
+            return null;
+        }
+        var distanceFromCamera = cameraPosition.distance(point);
+        return new FrustumIntersection<>(entityId, content, distanceFromCamera, new Point3f(point),
+                                         FrustumIntersection.VisibilityType.INSIDE, null);
+    }
+
+    private Point3f findClosestPointOnAABBToCamera(Point3f cameraPosition, EntityBounds bounds) {
+        var x = Math.max(bounds.getMinX(), Math.min(cameraPosition.x, bounds.getMaxX()));
+        var y = Math.max(bounds.getMinY(), Math.min(cameraPosition.y, bounds.getMaxY()));
+        var z = Math.max(bounds.getMinZ(), Math.min(cameraPosition.z, bounds.getMaxZ()));
+        return new Point3f(x, y, z);
+    }
+
+    // ===== Plane geometry helpers =====
+
+    private PlaneIntersection<ID, Content> calculatePlaneEntityIntersection(Plane3D plane, ID entityId, Content content,
+                                                                            Point3f entityPos, EntityBounds bounds,
+                                                                            float tolerance) {
+        if (bounds != null) {
+            return planeAABBIntersection(plane, entityId, content, bounds, tolerance);
+        }
+        return planePointIntersection(plane, entityId, content, entityPos, tolerance);
+    }
+
+    private PlaneIntersection<ID, Content> planeAABBIntersection(Plane3D plane, ID entityId, Content content,
+                                                                 EntityBounds bounds, float tolerance) {
+        var minX = bounds.getMinX();
+        var minY = bounds.getMinY();
+        var minZ = bounds.getMinZ();
+        var maxX = bounds.getMaxX();
+        var maxY = bounds.getMaxY();
+        var maxZ = bounds.getMaxZ();
+        var corners = new Point3f[] { new Point3f(minX, minY, minZ), new Point3f(maxX, minY, minZ),
+                                      new Point3f(minX, maxY, minZ), new Point3f(maxX, maxY, minZ),
+                                      new Point3f(minX, minY, maxZ), new Point3f(maxX, minY, maxZ),
+                                      new Point3f(minX, maxY, maxZ), new Point3f(maxX, maxY, maxZ) };
+        var minDistance = Float.POSITIVE_INFINITY;
+        var maxDistance = Float.NEGATIVE_INFINITY;
+        var closestPoint = new Point3f();
+        for (var corner : corners) {
+            var distance = plane.distanceToPoint(corner);
+            if (distance < minDistance) {
+                minDistance = distance;
+                closestPoint.set(corner);
+            }
+            if (distance > maxDistance) {
+                maxDistance = distance;
+            }
+        }
+        PlaneIntersection.IntersectionType intersectionType;
+        float resultDistance;
+        if (Math.abs(minDistance) <= tolerance && Math.abs(maxDistance) <= tolerance) {
+            intersectionType = PlaneIntersection.IntersectionType.ON_PLANE;
+            resultDistance = (minDistance + maxDistance) / 2.0f;
+        } else if (minDistance * maxDistance <= 0) {
+            intersectionType = PlaneIntersection.IntersectionType.INTERSECTING;
+            resultDistance = Math.abs(minDistance) < Math.abs(maxDistance) ? minDistance : maxDistance;
+        } else if (minDistance > 0) {
+            intersectionType = PlaneIntersection.IntersectionType.POSITIVE_SIDE;
+            resultDistance = minDistance;
+        } else {
+            intersectionType = PlaneIntersection.IntersectionType.NEGATIVE_SIDE;
+            resultDistance = maxDistance;
+        }
+        if (tolerance > 0 && Math.abs(resultDistance) > tolerance) {
+            return null;
+        }
+        if (intersectionType == PlaneIntersection.IntersectionType.INTERSECTING) {
+            closestPoint = findClosestPointOnAABBToPlane(plane, bounds);
+        }
+        return new PlaneIntersection<>(entityId, content, resultDistance, closestPoint, intersectionType, bounds);
+    }
+
+    private PlaneIntersection<ID, Content> planePointIntersection(Plane3D plane, ID entityId, Content content,
+                                                                  Point3f point, float tolerance) {
+        var distance = plane.distanceToPoint(point);
+        if (tolerance > 0 && Math.abs(distance) > tolerance) {
+            return null;
+        }
+        PlaneIntersection.IntersectionType intersectionType;
+        if (Math.abs(distance) <= 1e-6f) {
+            intersectionType = PlaneIntersection.IntersectionType.ON_PLANE;
+        } else if (distance > 0) {
+            intersectionType = PlaneIntersection.IntersectionType.POSITIVE_SIDE;
+        } else {
+            intersectionType = PlaneIntersection.IntersectionType.NEGATIVE_SIDE;
+        }
+        return new PlaneIntersection<>(entityId, content, distance, new Point3f(point), intersectionType, null);
+    }
+
+    private Point3f findClosestPointOnAABBToPlane(Plane3D plane, EntityBounds bounds) {
+        var normal = plane.getNormal();
+        var x = (normal.x >= 0) ? bounds.getMinX() : bounds.getMaxX();
+        var y = (normal.y >= 0) ? bounds.getMinY() : bounds.getMaxY();
+        var z = (normal.z >= 0) ? bounds.getMinZ() : bounds.getMaxZ();
+        return new Point3f(x, y, z);
+    }
+
+    // ===== Ray geometry helpers =====
+
+    private float getRayEntityDistance(Ray3D ray, ID entityId, Point3f entityPos) {
+        EntityBounds bounds = core.entityManager().getEntityBounds(entityId);
+        if (bounds != null) {
+            return rayAABBIntersection(ray, bounds);
+        }
+        return raySphereIntersection(ray, entityPos, 0.1f);
+    }
+
+    private float rayAABBIntersection(Ray3D ray, EntityBounds bounds) {
+        var tmin = 0.0f;
+        var tmax = ray.maxDistance();
+        for (int i = 0; i < 3; i++) {
+            var origin = getComponent(ray.origin(), i);
+            var direction = getComponent(ray.direction(), i);
+            var min = getComponent(bounds, i, true);
+            var max = getComponent(bounds, i, false);
+            if (Math.abs(direction) < 1e-6f) {
+                if (origin < min || origin > max) {
+                    return -1;
+                }
+            } else {
+                var t1 = (min - origin) / direction;
+                var t2 = (max - origin) / direction;
+                if (t1 > t2) {
+                    var temp = t1;
+                    t1 = t2;
+                    t2 = temp;
+                }
+                tmin = Math.max(tmin, t1);
+                tmax = Math.min(tmax, t2);
+                if (tmin > tmax) {
+                    return -1;
+                }
+            }
+        }
+        return tmin;
+    }
+
+    private float raySphereIntersection(Ray3D ray, Point3f center, float radius) {
+        var distFromOrigin = ray.origin().distance(center);
+        if (distFromOrigin <= radius) {
+            return 0.0f;
+        }
+        var toCenter = new Vector3f();
+        toCenter.sub(center, ray.origin());
+        var t = toCenter.dot(ray.direction());
+        if (t < 0) {
+            return -1;
+        }
+        var closestPoint = new Point3f(ray.origin().x + t * ray.direction().x,
+                                       ray.origin().y + t * ray.direction().y,
+                                       ray.origin().z + t * ray.direction().z);
+        var distToCenter = closestPoint.distance(center);
+        if (distToCenter > radius) {
+            return -1;
+        }
+        var halfChordLength = (float) Math.sqrt(radius * radius - distToCenter * distToCenter);
+        var t1 = t - halfChordLength;
+        var t2 = t + halfChordLength;
+        if (t1 >= 0 && t1 <= ray.maxDistance()) {
+            return t1;
+        }
+        if (t2 >= 0 && t2 <= ray.maxDistance()) {
+            return t2;
+        }
+        return -1;
+    }
+
+    private float getComponent(Point3f point, int axis) {
+        return switch (axis) {
+            case 0 -> point.x;
+            case 1 -> point.y;
+            case 2 -> point.z;
+            default -> throw new IllegalArgumentException("Invalid axis: " + axis);
+        };
+    }
+
+    private float getComponent(Vector3f vector, int axis) {
+        return switch (axis) {
+            case 0 -> vector.x;
+            case 1 -> vector.y;
+            case 2 -> vector.z;
+            default -> throw new IllegalArgumentException("Invalid axis: " + axis);
+        };
+    }
+
+    private float getComponent(EntityBounds bounds, int axis, boolean min) {
+        return switch (axis) {
+            case 0 -> min ? bounds.getMinX() : bounds.getMaxX();
+            case 1 -> min ? bounds.getMinY() : bounds.getMaxY();
+            case 2 -> min ? bounds.getMinZ() : bounds.getMaxZ();
+            default -> throw new IllegalArgumentException("Invalid axis: " + axis);
+        };
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/cull/FrustumCullProvider.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/cull/FrustumCullProvider.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.cull;
+
+import com.hellblazer.luciferase.lucien.Frustum3D;
+import com.hellblazer.luciferase.lucien.FrustumIntersection;
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+
+import javax.vecmath.Point3f;
+import java.util.List;
+
+/**
+ * The standard (non-DSOC) frustum cull service the {@link Culler} provides to occlusion consumers (RDR-008 P4).
+ *
+ * <p>{@code DsocController} uses this as its fallback path: when DSOC is enabled but the Z-buffer is inactive (or the
+ * auto-disable heuristic skips occlusion for the frame), the controller calls {@link #frustumCullVisibleStandard} to
+ * get the baseline frustum cull result. The producer is the cull cluster, the consumer is the DSOC cluster — keeping
+ * the two surfaces separate makes the DSOC ↔ standard-cull seam explicit and prevents the {@code FrustumGeometry}
+ * DSOC consumer interface from accreting cluster-foreign methods (the P2 substantive-critic obligation).
+ *
+ * @param <Key>     the spatial key type
+ * @param <ID>      the entity identifier type
+ * @param <Content> the entity content type
+ * @author hal.hildebrand
+ */
+public interface FrustumCullProvider<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
+
+    /** The standard non-DSOC frustum cull. */
+    List<FrustumIntersection<ID, Content>> frustumCullVisibleStandard(Frustum3D frustum, Point3f cameraPosition);
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/occlusion/DsocController.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/occlusion/DsocController.java
@@ -22,6 +22,7 @@ import com.hellblazer.luciferase.lucien.FrustumIntersection;
 import com.hellblazer.luciferase.lucien.FrustumIntersection.VisibilityType;
 import com.hellblazer.luciferase.lucien.SpatialIndexCore;
 import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.cull.FrustumCullProvider;
 import com.hellblazer.luciferase.lucien.entity.EntityBounds;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.internal.ObjectPools;
@@ -50,9 +51,11 @@ import java.util.stream.Collectors;
  *
  * <p>The owning {@code AbstractSpatialIndex} façade constructs one of these when DSOC is enabled and delegates its
  * public DSOC API and three integration seams (frustum-cull entry, entity-update visibility/TBV, occlusion-aware
- * node creation) to it. Shared storage and concurrency come from {@link SpatialIndexCore}; the few façade operations
- * the cull still needs (frustum traversal order, the subclass frustum-node test, node bounds, cached entity position,
- * and the standard non-DSOC cull fallback) arrive through {@link FrustumGeometry}.
+ * node creation) to it. Shared storage and concurrency come from {@link SpatialIndexCore}; the four façade operations
+ * the DSOC machinery still needs (frustum traversal order, the subclass frustum-node test, node bounds, cached entity
+ * position) arrive through {@link FrustumGeometry}. The standard non-DSOC cull fallback — the path that runs when
+ * DSOC's Z-buffer is inactive or auto-disable engages — lives in the P4 cull cluster and arrives through a separate
+ * {@link FrustumCullProvider}, keeping the DSOC consumer surface narrow.
  *
  * @param <Key>     the spatial key type
  * @param <ID>      the entity identifier type
@@ -69,9 +72,10 @@ public final class DsocController<Key extends SpatialKey<Key>, ID extends Entity
     private static final int    EVALUATION_INTERVAL             = 50;   // Check every 50 frames
     private static final int    MIN_ENTITIES_FOR_DSOC           = 50;
 
-    private final SpatialIndexCore<Key, ID, Content> core;
-    private final FrustumGeometry<Key, ID, Content>     callback;
-    private final DSOCConfiguration                  config;
+    private final SpatialIndexCore<Key, ID, Content>     core;
+    private final FrustumGeometry<Key, ID, Content>      callback;
+    private final FrustumCullProvider<Key, ID, Content>  cullProvider;
+    private final DSOCConfiguration                      config;
 
     private final FrameManager                              frameManager;
     private final VisibilityStateManager<ID>                visibilityManager;
@@ -92,9 +96,11 @@ public final class DsocController<Key extends SpatialKey<Key>, ID extends Entity
      * Mirrors the former {@code AbstractSpatialIndex.enableDSOC(config, bufferWidth, bufferHeight)}.
      */
     public DsocController(SpatialIndexCore<Key, ID, Content> core, FrustumGeometry<Key, ID, Content> callback,
-                          DSOCConfiguration config, int bufferWidth, int bufferHeight) {
+                          FrustumCullProvider<Key, ID, Content> cullProvider, DSOCConfiguration config,
+                          int bufferWidth, int bufferHeight) {
         this.core = core;
         this.callback = callback;
+        this.cullProvider = cullProvider;
         this.config = config;
         if (config.isEnabled()) {
             this.frameManager = new FrameManager();
@@ -151,6 +157,8 @@ public final class DsocController<Key extends SpatialKey<Key>, ID extends Entity
         if (isEnabled()) {
             stats.put("dsocEnabled", true);
             stats.put("currentFrame", getCurrentFrame());
+            stats.put("dsocFrameCount", dsocFrameCount);
+            stats.put("standardFrameCount", standardFrameCount);
             if (visibilityManager != null) {
                 stats.putAll(visibilityManager.getStatistics());
             }
@@ -243,13 +251,13 @@ public final class DsocController<Key extends SpatialKey<Key>, ID extends Entity
         // Use DSOC only when still enabled and hierarchical occlusion is configured and worthwhile
         if (isEnabled() && config.isEnableHierarchicalOcclusion()) {
             if (shouldSkipDSOC()) {
-                return measureAndExecute(() -> callback.frustumCullVisibleStandard(frustum, cameraPosition), false);
+                return measureAndExecute(() -> cullProvider.frustumCullVisibleStandard(frustum, cameraPosition), false);
             }
             return measureAndExecute(() -> frustumCullVisibleWithDSOC(frustum, cameraPosition), true);
         }
 
         // Standard path, still measured so the perf comparison stays meaningful
-        return measureAndExecute(() -> callback.frustumCullVisibleStandard(frustum, cameraPosition), false);
+        return measureAndExecute(() -> cullProvider.frustumCullVisibleStandard(frustum, cameraPosition), false);
     }
 
     /** Perform frustum culling with occlusion testing. */
@@ -259,7 +267,7 @@ public final class DsocController<Key extends SpatialKey<Key>, ID extends Entity
         }
         // Early exit if Z-buffer is not activated (no occluders)
         if (!occlusionCuller.isActivated()) {
-            return callback.frustumCullVisibleStandard(frustum, cameraPosition);
+            return cullProvider.frustumCullVisibleStandard(frustum, cameraPosition);
         }
 
         core.lock().readLock().lock();

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/occlusion/FrustumGeometry.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/occlusion/FrustumGeometry.java
@@ -17,13 +17,11 @@
 package com.hellblazer.luciferase.lucien.occlusion;
 
 import com.hellblazer.luciferase.lucien.Frustum3D;
-import com.hellblazer.luciferase.lucien.FrustumIntersection;
 import com.hellblazer.luciferase.lucien.SpatialKey;
 import com.hellblazer.luciferase.lucien.entity.EntityBounds;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 
 import javax.vecmath.Point3f;
-import java.util.List;
 import java.util.stream.Stream;
 
 /**
@@ -31,10 +29,14 @@ import java.util.stream.Stream;
  *
  * <p>P3 (RDR-008) refined the seam architecture from a single unified callback (the P2 {@code SpatialGeometry}, now
  * deleted) into per-cluster sub-interfaces. {@code DsocController} depends only on what it actually uses — the
- * subclass-overridden frustum
- * traversal/intersection hooks, the node-bounds helper, the cached entity-position lookup, and the standard non-DSOC
- * cull fallback (which lives in the frustum/cull cluster and will be re-homed in P4). The façade implements this
- * through a private inner class so the underlying methods keep their original visibility.
+ * subclass-overridden frustum traversal/intersection hooks, the node-bounds helper, and the cached entity-position
+ * lookup. The façade implements this through a private inner class so the underlying methods keep their original
+ * visibility.
+ *
+ * <p>P4 (RDR-008) re-homed the standard non-DSOC cull fallback into the new {@code lucien.cull.Culler} feature object;
+ * {@code DsocController} consumes it through a separate
+ * {@link com.hellblazer.luciferase.lucien.cull.FrustumCullProvider} sub-interface so this DSOC consumer interface
+ * stays narrow.
  *
  * @param <Key>     the spatial key type
  * @param <ID>      the entity identifier type
@@ -54,7 +56,4 @@ public interface FrustumGeometry<Key extends SpatialKey<Key>, ID extends EntityI
 
     /** Cached world position of the entity, or {@code null} if unknown. */
     Point3f getCachedEntityPosition(ID entityId);
-
-    /** The standard (non-DSOC) frustum cull — the fallback when DSOC is skipped or its Z-buffer is inactive. */
-    List<FrustumIntersection<ID, Content>> frustumCullVisibleStandard(Frustum3D frustum, Point3f cameraPosition);
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/occlusion/FrustumCullDsocRoutingTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/occlusion/FrustumCullDsocRoutingTest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.occlusion;
+
+import com.hellblazer.luciferase.lucien.Frustum3D;
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.octree.Octree;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3f;
+import javax.vecmath.Vector3f;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for RDR-008 P4 Critical finding: the {@code frustumCullInside}, {@code frustumCullIntersecting},
+ * and {@code frustumCullWithinDistance} façade derivatives must compose on top of {@code frustumCullVisible} so they
+ * inherit the DSOC routing decision. An earlier P4 draft delegated each directly to {@code Culler}, silently bypassing
+ * DSOC — caught by the code-review-expert pass before merge.
+ *
+ * <p>Each test enables DSOC, calls the derivative once, and asserts that the DSOC-controller frame counter advanced
+ * (which only happens when the call reaches {@code DsocController.frustumCullVisible.measureAndExecute}, never on the
+ * direct {@code Culler.frustumCullVisibleStandard} bypass path).
+ *
+ * @author hal.hildebrand
+ */
+public class FrustumCullDsocRoutingTest {
+
+    private Octree<LongEntityID, String> octree;
+    private Frustum3D                    frustum;
+    private Point3f                      cameraPos;
+
+    @BeforeEach
+    void setUp() {
+        octree = new Octree<>(new SequentialLongIDGenerator());
+        // Populate a handful of entities so the cull path actually touches the visibility machinery.
+        for (int i = 0; i < 50; i++) {
+            octree.insert(new Point3f((i % 10) * 10, ((i / 10) % 5) * 10, (i / 50) * 10), (byte) 10, "entity-" + i);
+        }
+        var config = DSOCConfiguration.defaultConfig()
+                                      .withEnabled(true)
+                                      .withEnableHierarchicalOcclusion(true);
+        octree.enableDSOC(config, 256, 256);
+
+        // Camera looking down +Z from origin, simple perspective frustum.
+        var eye    = new Point3f(50, 25, -50);
+        var center = new Point3f(50, 25, 50);
+        var up     = new Vector3f(0, 1, 0);
+        frustum   = Frustum3D.createPerspective(eye, center, up, (float) Math.toRadians(60.0), 1.0f, 1.0f, 200.0f);
+        cameraPos = eye;
+    }
+
+    private long totalDsocCullCalls() {
+        var stats             = octree.getDSOCStatistics();
+        var dsocFrameCount    = (long) stats.getOrDefault("dsocFrameCount", 0L);
+        var standardFrameCount = (long) stats.getOrDefault("standardFrameCount", 0L);
+        return dsocFrameCount + standardFrameCount;
+    }
+
+    @Test
+    @DisplayName("frustumCullVisible (canonical) routes through DSOC — baseline assertion")
+    void frustumCullVisibleRoutesThroughDsoc() {
+        assertTrue(totalDsocCullCalls() == 0, "baseline DSOC counter should be 0");
+        var result = octree.frustumCullVisible(frustum, cameraPos);
+        assertNotNull(result);
+        assertTrue(totalDsocCullCalls() == 1, "frustumCullVisible must increment a DSOC frame counter");
+    }
+
+    @Test
+    @DisplayName("frustumCullInside routes through DSOC (regression: P4 Critical)")
+    void frustumCullInsideRoutesThroughDsoc() {
+        assertTrue(totalDsocCullCalls() == 0, "baseline DSOC counter should be 0");
+        var result = octree.frustumCullInside(frustum, cameraPos);
+        assertNotNull(result);
+        assertTrue(totalDsocCullCalls() == 1,
+                   "frustumCullInside must compose through frustumCullVisible (DSOC counter expected 1, was "
+                   + totalDsocCullCalls() + ")");
+    }
+
+    @Test
+    @DisplayName("frustumCullIntersecting routes through DSOC (regression: P4 Critical)")
+    void frustumCullIntersectingRoutesThroughDsoc() {
+        assertTrue(totalDsocCullCalls() == 0, "baseline DSOC counter should be 0");
+        var result = octree.frustumCullIntersecting(frustum, cameraPos);
+        assertNotNull(result);
+        assertTrue(totalDsocCullCalls() == 1,
+                   "frustumCullIntersecting must compose through frustumCullVisible (DSOC counter expected 1, was "
+                   + totalDsocCullCalls() + ")");
+    }
+
+    @Test
+    @DisplayName("frustumCullWithinDistance routes through DSOC (regression: P4 Critical)")
+    void frustumCullWithinDistanceRoutesThroughDsoc() {
+        assertTrue(totalDsocCullCalls() == 0, "baseline DSOC counter should be 0");
+        var result = octree.frustumCullWithinDistance(frustum, cameraPos, 1000.0f);
+        assertNotNull(result);
+        assertTrue(totalDsocCullCalls() == 1,
+                   "frustumCullWithinDistance must compose through frustumCullVisible (DSOC counter expected 1, was "
+                   + totalDsocCullCalls() + ")");
+    }
+
+    @Test
+    @DisplayName("DSOC counter does NOT advance when DSOC is disabled (sanity check on instrumentation)")
+    void counterAbsentWhenDsocDisabled() {
+        var fresh = new Octree<LongEntityID, String>(new SequentialLongIDGenerator());
+        fresh.insert(new Point3f(0, 0, 0), (byte) 10, "e0");
+        // No enableDSOC call.
+        fresh.frustumCullVisible(frustum, cameraPos);
+        var stats = fresh.getDSOCStatistics();
+        assertTrue(Boolean.FALSE.equals(stats.get("dsocEnabled")), "DSOC must be disabled");
+    }
+}


### PR DESCRIPTION
RDR-008 Phase 4: extract the bundled frustum/plane/ray cull cluster from `AbstractSpatialIndex` into a new `Culler` feature object. Bead: `Luciferase-x5i.8`. Parent epic: `Luciferase-x5i`.

## Summary

Bundles frustum (5 public entries), plane (5 public entries), and ray (3 public entries) clusters into one `Culler` per RDR-008 §Decision item 2 (shared traversal hooks, high internal cohesion). Pattern mirrors the P3 `KnnSearcher` extraction with per-cluster sub-interfaces locked at the §Decision P3 refinement note.

## What changed

- **New package `lucien.cull/`** with three files:
  - `Culler<Key,ID,Content>` — owns 13 public cull entries + 12 helpers (AABB/point/sphere intersection, entity-intersection calculators, AABB-closest-point helpers, `getRayEntityDistance` default, `frustumCullVisibleStandard`, `getComponent` slab accessor).
  - `CullGeometry<Key,ID,Content>` — consumer seam (10 methods: 7 subclass hooks + 2 cached entity accessors + spanning flag).
  - `FrustumCullProvider<Key,ID,Content>` — single-method producer seam Culler implements directly; DsocController consumes it as the standard-cull fallback.
- **`AbstractSpatialIndex.java`**: 4920 → 4109 lines (−811). 13 public cull entries become thin delegators; 12 helpers + 3 `getComponent` privates removed; new `CullGeometryImpl` inner class added; this-escape invariant comment extended to name `CullGeometryImpl`.
- **`FrustumGeometry.java`**: shrinks by one method (drops `frustumCullVisibleStandard`) — the P2 substantive-critic obligation.
- **`DsocController.java`**: ctor takes a new `FrustumCullProvider` arg; three call sites now use the provider instead of the FrustumGeometry callback. `getStatistics()` exposes `dsocFrameCount`/`standardFrameCount` to support the regression test.

## DSOC seam preservation

The P1-installed DSOC ↔ standard-cull seam is intact:

```java
public List<FrustumIntersection<ID,Content>> frustumCullVisible(Frustum3D f, Point3f cam) {
    if (frustum == null) throw new NullPointerException(...);
    if (dsoc != null) return dsoc.frustumCullVisible(f, cam);   // DSOC path
    return culler.frustumCullVisibleStandard(f, cam);            // standard path
}
```

The three composed derivatives (`frustumCullInside`, `frustumCullIntersecting`, `frustumCullWithinDistance`) compose on top of `frustumCullVisible(frustum, cameraPos)` — **never** `Culler` directly — so they inherit the DSOC routing decision. (Initial draft of this PR delegated them directly to `Culler`, silently bypassing DSOC; caught by code-review-expert pre-merge. `FrustumCullDsocRoutingTest` is the regression net for that class of bug.)

## Subclass invariant

`Octree`, `Tetree`, `Prism`, `SFCArrayIndex` are byte-for-byte unchanged. This is the **LAST** P-unchanged gate; P5 carries a bounded `Tetree` collision-override refactor per RDR-008 §Decision.

## Reviews stacked

Per the standing `feedback_review-stacking` rule:

- **code-review-expert**: 0 Critical / 0 High after the DSOC-bypass fix.
- **substantive-critic**: 0 Critical, 2 Significant (both documentation — javadoc on the ID-only `frustumCullVisible` and dual inner-class duplication markers). Both addressed in this PR.

## Tests

- Full lucien suite: **2446/0/0/22** (was 2441; +5 from the new `FrustumCullDsocRoutingTest`).
- Cull-focused (`*Cull*,*Frustum*,*Plane*,*Ray*Intersect*,DSOC*`): 169/0/0/7.

## Façade arc progress

| Phase | Lines | Δ |
| --- | --- | --- |
| P0 baseline | 5851 | — |
| After P3-main | 4916 | −935 |
| **After P4 (this)** | **4109** | **−811** |

Cumulative: −1742 (−30 %) across P0+P1+P2+P3+P4. Four of six phases done. G6 target ≈70-method residual.

## Next

- G4 phase-review-gate (bead `Luciferase-x5i.9`)
- P5 collision + bounded Tetree refactor (`Luciferase-x5i.10`)