### PR TITLE
Luciferase-x5i.10: extract CollisionEngine + scoped Tetree collision-override refactor (RDR-008 P5)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
@@ -145,6 +145,10 @@ implements SpatialIndex<Key, ID, Content> {
     // ctor). Culler implements FrustumCullProvider — DsocController takes it as the standard-cull fallback so the
     // FrustumGeometry consumer surface stays narrow.
     protected final Culler<Key, ID, Content>                                 culler;
+    // RDR-008 P5: collision-detection cluster, encapsulated in CollisionEngine (always present; eager init in
+    // ctor). Takes the lockingStrategy field via a supplier — findCollisionsFineGrained needs the late-bound
+    // mutable reference (configureFineGrainedLocking may replace it), mirroring the KnnSearcher pattern.
+    protected final com.hellblazer.luciferase.lucien.collision.CollisionEngine<Key, ID, Content> collisions;
     // Tree balancing support
     private         TreeBalancingStrategy<ID>                        balancingStrategy;
     private         boolean                                          autoBalancingEnabled     = false;
@@ -187,15 +191,24 @@ implements SpatialIndex<Key, ID, Content> {
         // it (storage-only).
         this.culler = new Culler<>(core, new CullGeometryImpl());
 
+        // RDR-008 P5: collision-detection cluster lives in CollisionEngine. The CollisionGeometryImpl callback
+        // stores `this` but the ctor doesn't dispatch through it (storage-only). The lockingStrategy supplier is
+        // late-bound — configureFineGrainedLocking can replace the field — and findCollisionsFineGrained reads it
+        // at call time, mirroring KnnSearcher.
+        this.collisions = new com.hellblazer.luciferase.lucien.collision.CollisionEngine<>(core,
+                                                                                            new CollisionGeometryImpl(),
+                                                                                            () -> this.lockingStrategy);
+
         // RDR-008 P2: distributed-ghost cluster lives in GhostCoordinator; constructed eagerly so subclasses can
         // call setNeighborDetector during their own initialization.
         // INVARIANT for future phases: GhostCoordinator's ctor (and the ctors of any other feature object created
-        // here — including KnnSearcher above and Culler immediately above) MUST NOT invoke any method on the
-        // supplied FrustumGeometryImpl / KnnGeometryImpl / CullGeometryImpl, on the KnnProvider /
-        // FrustumCullProvider, or on `this` directly — `this` is still partially constructed at this point, and any
-        // virtual dispatch into a not-yet-initialized subclass is a classic this-escape hazard. Storing the
-        // references is fine; calling through them is not.  (KnnSearcher's and Culler's ctors store only; the
-        // lockingStrategy supplier captures `this` but is invoked post-construction.)
+        // here — including KnnSearcher, Culler, and CollisionEngine above) MUST NOT invoke any method on the
+        // supplied FrustumGeometryImpl / KnnGeometryImpl / CullGeometryImpl / CollisionGeometryImpl, on the
+        // KnnProvider / FrustumCullProvider, or on `this` directly — `this` is still partially constructed at this
+        // point, and any virtual dispatch into a not-yet-initialized subclass is a classic this-escape hazard.
+        // Storing the references is fine; calling through them is not.  (KnnSearcher's, Culler's, and
+        // CollisionEngine's ctors store only; the lockingStrategy supplier captures `this` but is invoked
+        // post-construction.)
         // The `knn` argument below satisfies KnnProvider<Key,ID> (P3-main moved this role off the façade); the
         // second `this` is the façade back-reference the ghost subsystem (GhostBoundaryDetector +
         // DistributedGhostManager) needs in their ctors.
@@ -275,42 +288,7 @@ implements SpatialIndex<Key, ID, Content> {
 
     @Override
     public Optional<CollisionPair<ID, Content>> checkCollision(ID entityId1, ID entityId2) {
-        if (entityId1.equals(entityId2)) {
-            return Optional.empty();
-        }
-
-        lock.readLock().lock();
-        try {
-            var bounds1 = getCachedEntityBounds(entityId1);
-            var bounds2 = getCachedEntityBounds(entityId2);
-
-            // Quick early rejection check
-            if (bounds1 != null && bounds2 != null) {
-                // Both have bounds - quick AABB check
-                if (!boundsIntersect(bounds1, bounds2)) {
-                    return Optional.empty();
-                }
-            } else if (bounds1 == null && bounds2 == null) {
-                // Both are points - check distance
-                var pos1 = getCachedEntityPosition(entityId1);
-                var pos2 = getCachedEntityPosition(entityId2);
-
-                if (pos1 == null || pos2 == null) {
-                    return Optional.empty();
-                }
-
-                var threshold = 0.1f; // Small threshold for point entities
-                if (pos1.distance(pos2) > threshold) {
-                    return Optional.empty();
-                }
-            }
-            // For mixed types (one bounded, one point), skip early rejection and go to detailed check
-
-            // Perform detailed collision check
-            return performDetailedCollisionCheck(entityId1, entityId2);
-        } finally {
-            lock.readLock().unlock();
-        }
+        return collisions.checkCollision(entityId1, entityId2);
     }
 
     /**
@@ -585,160 +563,27 @@ implements SpatialIndex<Key, ID, Content> {
 
     @Override
     public List<CollisionPair<ID, Content>> findAllCollisions() {
-        lock.readLock().lock();
-        try {
-            var collisions = ObjectPools.<CollisionPair<ID, Content>>borrowArrayList();
-            var checkedPairs = ObjectPools.<UnorderedPair<ID>>borrowHashSet();
-            try {
-                // Perform four phases of collision detection
-                findIntraNodeCollisions(collisions, checkedPairs);
-                findBoundedEntityCollisions(collisions, checkedPairs);
-                findAdjacentNodeCollisions(collisions, checkedPairs);
-                findPointBoundedCollisions(collisions, checkedPairs);
-
-                // Sort by penetration depth (deepest first)
-                Collections.sort(collisions);
-
-                // Return a copy to avoid returning pooled object
-                return new ArrayList<>(collisions);
-            } finally {
-                ObjectPools.returnArrayList(collisions);
-                ObjectPools.returnHashSet(checkedPairs);
-            }
-        } finally {
-            lock.readLock().unlock();
-        }
+        return collisions.findAllCollisions();
     }
 
+    @Override
     public List<CollisionPair<ID, Content>> findCollisions(ID entityId) {
-        lock.readLock().lock();
-        try {
-            var locations = entityManager.getEntityLocations(entityId);
-            if (locations.isEmpty()) {
-                return Collections.emptyList();
-            }
-
-            var collisions = ObjectPools.<CollisionPair<ID, Content>>borrowArrayList();
-            var checkedEntities = ObjectPools.<ID>borrowHashSet();
-            try {
-                checkedEntities.add(entityId);
-
-                var entityBounds = entityManager.getEntityBounds(entityId);
-                if (entityBounds != null) {
-                    findBoundedEntityCollisions(entityId, entityBounds, checkedEntities, collisions);
-                } else {
-                    findPointEntityCollisions(entityId, locations, checkedEntities, collisions);
-                }
-
-                Collections.sort(collisions);
-                // Return a copy to avoid returning pooled object
-                return new ArrayList<>(collisions);
-            } finally {
-                ObjectPools.returnArrayList(collisions);
-                ObjectPools.returnHashSet(checkedEntities);
-            }
-        } finally {
-            lock.readLock().unlock();
-        }
+        return collisions.findCollisions(entityId);
     }
 
     // ===== Common Insert Operations =====
 
     /**
-     * Find collisions using fine-grained locking for better concurrency This is an alternative to findCollisions that
-     * can be used when high read concurrency is needed
+     * Find collisions using fine-grained locking for better concurrency. Alternative to {@link #findCollisions}
+     * when high read concurrency is needed.
      */
     public List<CollisionPair<ID, Content>> findCollisionsFineGrained(ID entityId) {
-        var locations = entityManager.getEntityLocations(entityId);
-        if (locations.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        // Use fine-grained locking for each node access
-        return lockingStrategy.executeRead(0L, () -> {
-            var collisions = ObjectPools.<CollisionPair<ID, Content>>borrowArrayList();
-            var checkedEntities = ObjectPools.<ID>borrowHashSet();
-            try {
-                checkedEntities.add(entityId);
-
-                var entityBounds = getCachedEntityBounds(entityId);
-                if (entityBounds != null) {
-                    findBoundedEntityCollisions(entityId, entityBounds, checkedEntities, collisions);
-                } else {
-                    findPointEntityCollisions(entityId, locations, checkedEntities, collisions);
-                }
-
-                Collections.sort(collisions);
-                return new ArrayList<>(collisions);
-            } finally {
-                ObjectPools.returnArrayList(collisions);
-                ObjectPools.returnHashSet(checkedEntities);
-            }
-        });
+        return collisions.findCollisionsFineGrained(entityId);
     }
 
     @Override
     public List<CollisionPair<ID, Content>> findCollisionsInRegion(Spatial region) {
-        lock.readLock().lock();
-        try {
-            var collisions = new ArrayList<CollisionPair<ID, Content>>();
-            var checkedPairs = new HashSet<UnorderedPair<ID>>();
-
-            // Find all nodes intersecting the region
-            var bounds = getVolumeBounds(region);
-            if (bounds == null) {
-                return collisions;
-            }
-
-            var nodesInRegion = spatialRangeQuery(bounds, true);
-            var nodeList = nodesInRegion.collect(Collectors.toList());
-
-            // Check entities within and between nodes
-            for (int i = 0; i < nodeList.size(); i++) {
-                List<ID> nodeEntities = new ArrayList<>(nodeList.get(i).getValue().getEntityIds());
-
-                // Check within node
-                for (int j = 0; j < nodeEntities.size(); j++) {
-                    for (int k = j + 1; k < nodeEntities.size(); k++) {
-                        var id1 = nodeEntities.get(j);
-                        var id2 = nodeEntities.get(k);
-
-                        // Check if both entities are actually in the region
-                        if (isEntityInRegion(id1, region) && isEntityInRegion(id2, region)) {
-                            var pair = new UnorderedPair<>(id1, id2);
-                            if (checkedPairs.add(pair)) {
-                                checkAndAddCollision(id1, id2, collisions);
-                            }
-                        }
-                    }
-                }
-
-                // Check between nodes
-                for (int j = i + 1; j < nodeList.size(); j++) {
-                    for (ID id1 : nodeEntities) {
-                        if (!isEntityInRegion(id1, region)) {
-                            continue;
-                        }
-
-                        for (ID id2 : nodeList.get(j).getValue().getEntityIds()) {
-                            if (!isEntityInRegion(id2, region)) {
-                                continue;
-                            }
-
-                            var pair = new UnorderedPair<>(id1, id2);
-                            if (checkedPairs.add(pair)) {
-                                checkAndAddCollision(id1, id2, collisions);
-                            }
-                        }
-                    }
-                }
-            }
-
-            Collections.sort(collisions);
-            return collisions;
-        } finally {
-            lock.readLock().unlock();
-        }
+        return collisions.findCollisionsInRegion(region);
     }
 
     /**
@@ -881,12 +726,7 @@ implements SpatialIndex<Key, ID, Content> {
 
     @Override
     public CollisionShape getCollisionShape(ID entityId) {
-        lock.readLock().lock();
-        try {
-            return entityManager.getEntityCollisionShape(entityId);
-        } finally {
-            lock.readLock().unlock();
-        }
+        return collisions.getCollisionShape(entityId);
     }
 
     /**
@@ -1740,14 +1580,7 @@ implements SpatialIndex<Key, ID, Content> {
 
     @Override
     public void setCollisionShape(ID entityId, CollisionShape shape) {
-        lock.writeLock().lock();
-        try {
-            entityManager.setEntityCollisionShape(entityId, shape);
-            // Invalidate cache as bounds may have changed
-            entityCache.remove(entityId);
-        } finally {
-            lock.writeLock().unlock();
-        }
+        collisions.setCollisionShape(entityId, shape);
     }
 
     /**
@@ -2055,10 +1888,11 @@ implements SpatialIndex<Key, ID, Content> {
      * {@code FrustumCullProvider} seam.
      *
      * <p>NOTE: {@link CullGeometryImpl} mirrors three method signatures defined here — {@code getFrustumTraversalOrder},
-     * {@code doesFrustumIntersectNode}, {@code getCachedEntityPosition}. The two interfaces are intentionally
-     * independent (cluster-scoped) so they cannot share a base type without crossing the cull/occlusion package
-     * boundary. If any of these three signatures changes, BOTH inner classes need the same change — neither compiler
-     * nor IDE will warn of the asymmetry.
+     * {@code doesFrustumIntersectNode}, {@code getCachedEntityPosition}; {@link KnnGeometryImpl},
+     * {@link CollisionGeometryImpl}, and {@link CullGeometryImpl} additionally share {@code getCachedEntityPosition}.
+     * Each cluster's sub-interface is intentionally independent (cluster-scoped) so they cannot share a base type
+     * without crossing package boundaries. If any of these signatures changes, every mirroring inner class needs
+     * the same change — neither compiler nor IDE will warn of the asymmetry.
      */
     private final class FrustumGeometryImpl implements FrustumGeometry<Key, ID, Content> {
         @Override
@@ -2087,11 +1921,12 @@ implements SpatialIndex<Key, ID, Content> {
      * seven subclass-overridden traversal/intersect/distance hooks, the two cached entity accessors, and the
      * spanning-policy flag. Private inner class preserves the underlying methods' original visibility.
      *
-     * <p>NOTE: this class duplicates three method signatures from {@link FrustumGeometryImpl} —
-     * {@code getFrustumTraversalOrder}, {@code doesFrustumIntersectNode}, {@code getCachedEntityPosition} — because
-     * each cluster's sub-interface is intentionally independent (P3 refinement) and cannot share a base type without
-     * crossing the cull/occlusion package boundary. Update BOTH inner classes if any of these three signatures
-     * changes.
+     * <p>NOTE: this class duplicates method signatures with sibling inner classes — three with
+     * {@link FrustumGeometryImpl} ({@code getFrustumTraversalOrder}, {@code doesFrustumIntersectNode},
+     * {@code getCachedEntityPosition}) and one with {@link CollisionGeometryImpl}
+     * ({@code getCachedEntityBounds}). Each cluster's sub-interface is intentionally independent (P3 refinement)
+     * and cannot share a base type without crossing package boundaries. Update every mirroring inner class if any
+     * of these signatures changes.
      */
     private final class CullGeometryImpl implements CullGeometry<Key, ID, Content> {
         @Override
@@ -2142,6 +1977,49 @@ implements SpatialIndex<Key, ID, Content> {
         @Override
         public boolean isSpanningEnabled() {
             return AbstractSpatialIndex.this.spanningPolicy.isSpanningEnabled();
+        }
+    }
+
+    /**
+     * Façade implementation of the {@link com.hellblazer.luciferase.lucien.collision.CollisionGeometry} seam
+     * (RDR-008 P5): supplies {@code CollisionEngine} the collision-cluster façade operations it needs (two
+     * subclass-overridden traversal hooks + the façade-resident range query + the two cached entity accessors).
+     * Private inner class preserves the underlying methods' original visibility.
+     *
+     * <p>NOTE: this class duplicates the cached-entity accessor signatures with {@link FrustumGeometryImpl},
+     * {@link CullGeometryImpl}, and {@link KnnGeometryImpl}, and the {@code findNodesIntersectingBounds(VolumeBounds)}
+     * and {@code addNeighboringNodes} signatures with {@link KnnGeometryImpl}. Each cluster's sub-interface is
+     * intentionally independent (P3 refinement) and cannot share a base type without crossing package boundaries.
+     * Update sibling inner classes if any of these duplicated signatures changes — neither compiler nor IDE will
+     * warn of the asymmetry.
+     */
+    private final class CollisionGeometryImpl
+    implements com.hellblazer.luciferase.lucien.collision.CollisionGeometry<Key, ID, Content> {
+
+        @Override
+        public java.util.Set<Key> findNodesIntersectingBounds(VolumeBounds bounds) {
+            return AbstractSpatialIndex.this.findNodesIntersectingBounds(bounds);
+        }
+
+        @Override
+        public void addNeighboringNodes(Key nodeIndex, java.util.Queue<Key> toVisit, java.util.Set<Key> visitedNodes) {
+            AbstractSpatialIndex.this.addNeighboringNodes(nodeIndex, toVisit, visitedNodes);
+        }
+
+        @Override
+        public java.util.stream.Stream<java.util.Map.Entry<Key, SpatialNodeImpl<ID>>> spatialRangeQuery(
+        VolumeBounds bounds, boolean includeIntersecting) {
+            return AbstractSpatialIndex.this.spatialRangeQuery(bounds, includeIntersecting);
+        }
+
+        @Override
+        public Point3f getCachedEntityPosition(ID entityId) {
+            return AbstractSpatialIndex.this.getCachedEntityPosition(entityId);
+        }
+
+        @Override
+        public EntityBounds getCachedEntityBounds(ID entityId) {
+            return AbstractSpatialIndex.this.getCachedEntityBounds(entityId);
         }
     }
 
@@ -2762,277 +2640,7 @@ implements SpatialIndex<Key, ID, Content> {
 
     // ===== Bulk Operations Implementation =====
 
-    /**
-     * Check if two bounds intersect
-     */
-    private boolean boundsIntersect(EntityBounds b1, EntityBounds b2) {
-        return b1.getMaxX() >= b2.getMinX() && b1.getMinX() <= b2.getMaxX() && b1.getMaxY() >= b2.getMinY()
-        && b1.getMinY() <= b2.getMaxY() && b1.getMaxZ() >= b2.getMinZ() && b1.getMinZ() <= b2.getMaxZ();
-    }
-
-    /**
-     * Check if bounds intersect with a volume
-     */
-    private boolean boundsIntersectVolume(EntityBounds bounds, Spatial volume) {
-        return switch (volume) {
-            case Spatial.Cube cube ->
-            bounds.getMaxX() >= cube.originX() && bounds.getMinX() <= cube.originX() + cube.extent()
-            && bounds.getMaxY() >= cube.originY() && bounds.getMinY() <= cube.originY() + cube.extent()
-            && bounds.getMaxZ() >= cube.originZ() && bounds.getMinZ() <= cube.originZ() + cube.extent();
-
-            case Spatial.Sphere sphere -> {
-                // Find closest point on bounds to sphere center
-                var closestX = Math.max(bounds.getMinX(), Math.min(sphere.centerX(), bounds.getMaxX()));
-                var closestY = Math.max(bounds.getMinY(), Math.min(sphere.centerY(), bounds.getMaxY()));
-                var closestZ = Math.max(bounds.getMinZ(), Math.min(sphere.centerZ(), bounds.getMaxZ()));
-
-                var dx = closestX - sphere.centerX();
-                var dy = closestY - sphere.centerY();
-                var dz = closestZ - sphere.centerZ();
-                yield (dx * dx + dy * dy + dz * dz) <= (sphere.radius() * sphere.radius());
-            }
-
-            default -> true;
-        };
-    }
-
-    /**
-     * Calculate contact normal between two AABBs
-     */
-    private Vector3f calculateContactNormal(EntityBounds b1, EntityBounds b2) {
-        // Find the axis with minimum penetration
-        var penetrations = new float[6];
-        penetrations[0] = b1.getMaxX() - b2.getMinX(); // +X
-        penetrations[1] = b2.getMaxX() - b1.getMinX(); // -X
-        penetrations[2] = b1.getMaxY() - b2.getMinY(); // +Y
-        penetrations[3] = b2.getMaxY() - b1.getMinY(); // -Y
-        penetrations[4] = b1.getMaxZ() - b2.getMinZ(); // +Z
-        penetrations[5] = b2.getMaxZ() - b1.getMinZ(); // -Z
-
-        var minAxis = 0;
-        var minPenetration = penetrations[0];
-        for (int i = 1; i < 6; i++) {
-            if (penetrations[i] < minPenetration) {
-                minPenetration = penetrations[i];
-                minAxis = i;
-            }
-        }
-
-        // Return normal based on minimum penetration axis
-        return switch (minAxis) {
-            case 0 -> new Vector3f(1, 0, 0);   // +X
-            case 1 -> new Vector3f(-1, 0, 0);  // -X
-            case 2 -> new Vector3f(0, 1, 0);   // +Y
-            case 3 -> new Vector3f(0, -1, 0);  // -Y
-            case 4 -> new Vector3f(0, 0, 1);   // +Z
-            case 5 -> new Vector3f(0, 0, -1);  // -Z
-            default -> new Vector3f(1, 0, 0);
-        };
-    }
-
-    /**
-     * Calculate contact point between two AABBs
-     */
-    private Point3f calculateContactPoint(EntityBounds b1, EntityBounds b2) {
-        // Use the center of the intersection volume
-        var minX = Math.max(b1.getMinX(), b2.getMinX());
-        var minY = Math.max(b1.getMinY(), b2.getMinY());
-        var minZ = Math.max(b1.getMinZ(), b2.getMinZ());
-        var maxX = Math.min(b1.getMaxX(), b2.getMaxX());
-        var maxY = Math.min(b1.getMaxY(), b2.getMaxY());
-        var maxZ = Math.min(b1.getMaxZ(), b2.getMaxZ());
-
-        return new Point3f((minX + maxX) / 2, (minY + maxY) / 2, (minZ + maxZ) / 2);
-    }
-
-    /**
-     * Calculate penetration depth between two AABBs
-     */
-    private float calculatePenetrationDepth(EntityBounds b1, EntityBounds b2) {
-        var xPenetration = Math.min(b1.getMaxX() - b2.getMinX(), b2.getMaxX() - b1.getMinX());
-        var yPenetration = Math.min(b1.getMaxY() - b2.getMinY(), b2.getMaxY() - b1.getMinY());
-        var zPenetration = Math.min(b1.getMaxZ() - b2.getMinZ(), b2.getMaxZ() - b1.getMinZ());
-
-        return Math.min(Math.min(xPenetration, yPenetration), zPenetration);
-    }
-
-    /**
-     * Calculate contact normal between a point and bounds
-     */
-    private Vector3f calculatePointBoundsNormal(Point3f point, EntityBounds bounds) {
-        var boundsCenter = new Point3f((bounds.getMinX() + bounds.getMaxX()) / 2,
-                                       (bounds.getMinY() + bounds.getMaxY()) / 2,
-                                       (bounds.getMinZ() + bounds.getMaxZ()) / 2);
-
-        Vector3f contactNormal = new Vector3f();
-        contactNormal.sub(point, boundsCenter);
-        if (contactNormal.length() > 0) {
-            contactNormal.normalize();
-        } else {
-            contactNormal.set(1, 0, 0); // Default normal
-        }
-        return contactNormal;
-    }
-
-    /**
-     * Calculate penetration depth between a point and bounds
-     */
-    private float calculatePointBoundsPenetration(Point3f point, EntityBounds bounds, float threshold) {
-        if (bounds.getMinX() == bounds.getMaxX() && bounds.getMinY() == bounds.getMaxY()
-        && bounds.getMinZ() == bounds.getMaxZ()) {
-            // Zero-size bounds - use distance
-            Point3f boundsPoint = new Point3f(bounds.getMinX(), bounds.getMinY(), bounds.getMinZ());
-            float distance = point.distance(boundsPoint);
-            return (distance == 0) ? 0 : Math.max(0, threshold - distance);
-        } else {
-            // Regular bounds - distance from point to nearest surface
-            return Math.min(Math.min(point.x - bounds.getMinX(), bounds.getMaxX() - point.x),
-                            Math.min(Math.min(point.y - bounds.getMinY(), bounds.getMaxY() - point.y),
-                                     Math.min(point.z - bounds.getMinZ(), bounds.getMaxZ() - point.z)));
-        }
-    }
-
-    /**
-     * Check collision between two entities with AABB bounds
-     */
-    private Optional<CollisionPair<ID, Content>> checkAABBCollision(ID id1, Content content1, EntityBounds bounds1,
-                                                                    ID id2, Content content2, EntityBounds bounds2) {
-        if (boundsIntersect(bounds1, bounds2)) {
-            var contactPoint = calculateContactPoint(bounds1, bounds2);
-            var contactNormal = calculateContactNormal(bounds1, bounds2);
-            var penetrationDepth = calculatePenetrationDepth(bounds1, bounds2);
-
-            return Optional.of(
-            CollisionPair.create(id1, content1, bounds1, id2, content2, bounds2, contactPoint, contactNormal,
-                                 penetrationDepth));
-        }
-        return Optional.empty();
-    }
-
-    /**
-     * Check two entities for collision and add to list if colliding
-     */
-    private void checkAndAddCollision(ID id1, ID id2, List<CollisionPair<ID, Content>> collisions) {
-        if (id1.equals(id2)) {
-            return;
-        }
-
-        var collision = performDetailedCollisionCheck(id1, id2);
-        collision.ifPresent(collisions::add);
-    }
-
-    /**
-     * Check collision between a bounded entity and a point entity
-     */
-    private Optional<CollisionPair<ID, Content>> checkMixedCollision(ID id1, Content content1, EntityBounds bounds1,
-                                                                     ID id2, Content content2, EntityBounds bounds2) {
-        var bounds = bounds1 != null ? bounds1 : bounds2;
-        var pointEntityId = bounds1 != null ? id2 : id1;
-        var pointPos = entityManager.getEntityPosition(pointEntityId);
-
-        if (pointPos == null) {
-            return Optional.empty();
-        }
-
-        float threshold = 0.1f;
-        if (isPointInBoundsWithThreshold(pointPos, bounds, threshold)) {
-            var contactPoint = new Point3f(pointPos);
-            var contactNormal = calculatePointBoundsNormal(pointPos, bounds);
-            var penetrationDepth = calculatePointBoundsPenetration(pointPos, bounds, threshold);
-
-            return Optional.of(
-            CollisionPair.create(id1, content1, bounds1, id2, content2, bounds2, contactPoint, contactNormal,
-                                 penetrationDepth));
-        }
-        return Optional.empty();
-    }
-
-    /**
-     * Check neighboring nodes for collisions
-     */
-    private void checkNeighborNodesForCollisions(ID entityId, Key nodeIndex, Set<ID> checkedEntities,
-                                                 List<CollisionPair<ID, Content>> collisions) {
-        var neighbors = new LinkedList<Key>();
-        var visitedNeighbors = new HashSet<Key>();
-        addNeighboringNodes(nodeIndex, neighbors, visitedNeighbors);
-
-        while (!neighbors.isEmpty()) {
-            var neighborIndex = neighbors.poll();
-            checkNodeEntitiesForCollisions(entityId, neighborIndex, checkedEntities, collisions);
-        }
-    }
-
-    /**
-     * Check all entities in a node for collisions
-     */
-    private void checkNodeEntitiesForCollisions(ID entityId, Key nodeIndex, Set<ID> checkedEntities,
-                                                List<CollisionPair<ID, Content>> collisions) {
-        var node = spatialIndex.get(nodeIndex);
-        if (node == null || node.isEmpty()) {
-            return;
-        }
-
-        for (ID otherId : node.getEntityIds()) {
-            if (!checkedEntities.add(otherId)) {
-                continue;
-            }
-            checkAndAddCollision(entityId, otherId, collisions);
-        }
-    }
-
     // ===== Parallel Operations API =====
-
-    /**
-     * Check collision between two point entities
-     */
-    private Optional<CollisionPair<ID, Content>> checkPointCollision(ID id1, Content content1, EntityBounds bounds1,
-                                                                     ID id2, Content content2, EntityBounds bounds2) {
-        var pos1 = entityManager.getEntityPosition(id1);
-        var pos2 = entityManager.getEntityPosition(id2);
-
-        if (pos1 == null || pos2 == null) {
-            return Optional.empty();
-        }
-
-        var distance = pos1.distance(pos2);
-        var threshold = 0.1f;
-
-        if (distance <= threshold) {
-            var contactPoint = new Point3f();
-            contactPoint.interpolate(pos1, pos2, 0.5f);
-
-            Vector3f contactNormal = new Vector3f();
-            contactNormal.sub(pos2, pos1);
-            if (contactNormal.length() > 0) {
-                contactNormal.normalize();
-            } else {
-                contactNormal.set(1, 0, 0); // Default normal for identical positions
-            }
-
-            // For identical positions, penetration depth is 0
-            // Otherwise it's the overlap amount
-            var penetrationDepth = (distance == 0) ? 0 : Math.max(0, threshold - distance);
-
-            return Optional.of(
-            CollisionPair.create(id1, content1, bounds1, id2, content2, bounds2, contactPoint, contactNormal,
-                                 penetrationDepth));
-        }
-        return Optional.empty();
-    }
-
-    /**
-     * Check collision between two entities with custom collision shapes
-     */
-    private Optional<CollisionPair<ID, Content>> checkShapeCollision(ID id1, Content content1, EntityBounds bounds1,
-                                                                     CollisionShape shape1, ID id2, Content content2,
-                                                                     EntityBounds bounds2, CollisionShape shape2) {
-        var result = shape1.collidesWith(shape2);
-        if (result.collides) {
-            return Optional.of(CollisionPair.create(id1, content1, bounds1, id2, content2, bounds2, result.contactPoint,
-                                                    result.contactNormal, result.penetrationDepth));
-        }
-        return Optional.empty();
-    }
 
     /**
      * Determine the effective level for batch insertion
@@ -3061,191 +2669,7 @@ implements SpatialIndex<Key, ID, Content> {
         return shouldUseMortonSort;
     }
 
-    /**
-     * Phase 3: Find collisions between adjacent nodes
-     */
-    private void findAdjacentNodeCollisions(List<CollisionPair<ID, Content>> collisions,
-                                            Set<UnorderedPair<ID>> checkedPairs) {
-        for (var nodeIndex : spatialIndex.keySet()) {
-            var node = spatialIndex.get(nodeIndex);
-            if (node == null || node.isEmpty()) {
-                continue;
-            }
-
-            var nodeEntities = new ArrayList<>(node.getEntityIds());
-
-            // Find neighboring nodes
-            var neighbors = new LinkedList<Key>();
-            var visitedNeighbors = new HashSet<Key>();
-            addNeighboringNodes(nodeIndex, neighbors, visitedNeighbors);
-
-            // Check entities between this node and its neighbors
-            while (!neighbors.isEmpty()) {
-                var neighborIndex = neighbors.poll();
-
-                // Skip already processed nodes (SFC ordering optimization)
-                if (neighborIndex.compareTo(nodeIndex) < 0) {
-                    continue;
-                }
-
-                var neighborNode = spatialIndex.get(neighborIndex);
-                if (neighborNode == null || neighborNode.isEmpty()) {
-                    continue;
-                }
-
-                // Check entities between adjacent nodes
-                for (ID id1 : nodeEntities) {
-                    // Skip bounded entities (already handled)
-                    if (entityManager.getEntityBounds(id1) != null) {
-                        continue;
-                    }
-
-                    for (ID id2 : neighborNode.getEntityIds()) {
-                        var pair = new UnorderedPair<>(id1, id2);
-                        if (checkedPairs.add(pair)) {
-                            checkAndAddCollision(id1, id2, collisions);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     // ===== Memory Pre-allocation Methods =====
-
-    /**
-     * Find collisions for a bounded entity
-     */
-    private void findBoundedEntityCollisions(ID entityId, EntityBounds entityBounds, Set<ID> checkedEntities,
-                                             List<CollisionPair<ID, Content>> collisions) {
-        var nodesToCheck = findNodesIntersectingBounds(entityBounds);
-
-        for (var nodeIndex : nodesToCheck) {
-            checkNodeEntitiesForCollisions(entityId, nodeIndex, checkedEntities, collisions);
-        }
-    }
-
-    /**
-     * Phase 2: Find collisions for bounded entities that span multiple nodes
-     */
-    private void findBoundedEntityCollisions(List<CollisionPair<ID, Content>> collisions,
-                                             Set<UnorderedPair<ID>> checkedPairs) {
-        var boundedEntities = new ArrayList<ID>();
-        for (var entityId : entityManager.getAllEntityIds()) {
-            if (entityManager.getEntityBounds(entityId) != null) {
-                boundedEntities.add(entityId);
-            }
-        }
-
-        // Check bounded entities against each other
-        for (int i = 0; i < boundedEntities.size() - 1; i++) {
-            for (int j = i + 1; j < boundedEntities.size(); j++) {
-                var id1 = boundedEntities.get(i);
-                var id2 = boundedEntities.get(j);
-                var pair = new UnorderedPair<>(id1, id2);
-                if (checkedPairs.add(pair)) {
-                    checkAndAddCollision(id1, id2, collisions);
-                }
-            }
-        }
-    }
-
-    /**
-     * Phase 1: Find collisions between entities within the same node
-     */
-    private void findIntraNodeCollisions(List<CollisionPair<ID, Content>> collisions,
-                                         Set<UnorderedPair<ID>> checkedPairs) {
-        for (var nodeIndex : spatialIndex.keySet()) {
-            var node = spatialIndex.get(nodeIndex);
-            if (node == null || node.isEmpty()) {
-                continue;
-            }
-
-            var nodeEntities = new ArrayList<>(node.getEntityIds());
-            if (nodeEntities.size() < 2) {
-                continue;
-            }
-
-            // Check all pairs within this node
-            for (int i = 0; i < nodeEntities.size() - 1; i++) {
-                for (int j = i + 1; j < nodeEntities.size(); j++) {
-                    var id1 = nodeEntities.get(i);
-                    var id2 = nodeEntities.get(j);
-                    var pair = new UnorderedPair<>(id1, id2);
-                    if (checkedPairs.add(pair)) {
-                        checkAndAddCollision(id1, id2, collisions);
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Phase 4: Find collisions between point entities and bounded entities
-     */
-    private void findPointBoundedCollisions(List<CollisionPair<ID, Content>> collisions,
-                                            Set<UnorderedPair<ID>> checkedPairs) {
-        // First, collect all bounded entities and their expanded search regions
-        var boundedEntitySearchNodes = new HashMap<ID, Set<Key>>();
-
-        for (var nodeIndex : spatialIndex.keySet()) {
-            var node = spatialIndex.get(nodeIndex);
-            if (node == null || node.isEmpty()) {
-                continue;
-            }
-
-            for (ID entityId : node.getEntityIds()) {
-                var bounds = entityManager.getEntityBounds(entityId);
-                if (bounds != null) {
-                    // Calculate nodes that could contain point entities that might collide
-                    var threshold = 0.1f; // Collision threshold for point entities
-                    var expandedBounds = new EntityBounds(
-                    new Point3f(bounds.getMinX() - threshold, bounds.getMinY() - threshold,
-                                bounds.getMinZ() - threshold),
-                    new Point3f(bounds.getMaxX() + threshold, bounds.getMaxY() + threshold,
-                                bounds.getMaxZ() + threshold));
-                    var searchNodes = findNodesIntersectingBounds(expandedBounds);
-                    boundedEntitySearchNodes.put(entityId, searchNodes);
-                }
-            }
-        }
-
-        // Now check point entities against bounded entities in their search regions
-        for (var entry : boundedEntitySearchNodes.entrySet()) {
-            var boundedId = entry.getKey();
-            var searchNodes = entry.getValue();
-
-            for (var searchNodeIndex : searchNodes) {
-                var searchNode = spatialIndex.get(searchNodeIndex);
-                if (searchNode == null || searchNode.isEmpty()) {
-                    continue;
-                }
-
-                for (ID pointId : searchNode.getEntityIds()) {
-                    if (entityManager.getEntityBounds(pointId) == null) { // Only check point entities
-                        var pair = new UnorderedPair<>(boundedId, pointId);
-                        if (checkedPairs.add(pair)) {
-                            checkAndAddCollision(boundedId, pointId, collisions);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Find collisions for a point entity
-     */
-    private void findPointEntityCollisions(ID entityId, Set<Key> locations, Set<ID> checkedEntities,
-                                           List<CollisionPair<ID, Content>> collisions) {
-        for (var nodeIndex : locations) {
-            // Check entities in the same node
-            checkNodeEntitiesForCollisions(entityId, nodeIndex, checkedEntities, collisions);
-
-            // Check entities in neighboring nodes
-            checkNeighborNodesForCollisions(entityId, nodeIndex, checkedEntities, collisions);
-        }
-    }
 
     /**
      * Internal method to get entity bounds with caching
@@ -3322,64 +2746,6 @@ implements SpatialIndex<Key, ID, Content> {
     }
 
     /**
-     * Check if an entity is within a region
-     */
-    private boolean isEntityInRegion(ID entityId, Spatial region) {
-        var pos = entityManager.getEntityPosition(entityId);
-        if (pos == null) {
-            return false;
-        }
-
-        EntityBounds bounds = entityManager.getEntityBounds(entityId);
-        if (bounds != null) {
-            // Check if bounds intersect region
-            return boundsIntersectVolume(bounds, region);
-        } else {
-            // Check if point is in region
-            return isPointInVolume(pos, region);
-        }
-    }
-
-    /**
-     * Check if a point is inside bounds with a threshold
-     */
-    private boolean isPointInBoundsWithThreshold(Point3f point, EntityBounds bounds, float threshold) {
-        var inBounds = point.x >= bounds.getMinX() && point.x <= bounds.getMaxX() && point.y >= bounds.getMinY()
-        && point.y <= bounds.getMaxY() && point.z >= bounds.getMinZ() && point.z <= bounds.getMaxZ();
-
-        // For zero-size bounds, check distance to bounds center
-        if (!inBounds && bounds.getMinX() == bounds.getMaxX() && bounds.getMinY() == bounds.getMaxY()
-        && bounds.getMinZ() == bounds.getMaxZ()) {
-            Point3f boundsPoint = new Point3f(bounds.getMinX(), bounds.getMinY(), bounds.getMinZ());
-            float distance = point.distance(boundsPoint);
-            inBounds = distance <= threshold;
-        }
-
-        return inBounds;
-    }
-
-    /**
-     * Check if a point is inside a volume
-     */
-    private boolean isPointInVolume(Point3f point, Spatial volume) {
-        return switch (volume) {
-            case Spatial.Cube cube ->
-            point.x >= cube.originX() && point.x <= cube.originX() + cube.extent() && point.y >= cube.originY()
-            && point.y <= cube.originY() + cube.extent() && point.z >= cube.originZ()
-            && point.z <= cube.originZ() + cube.extent();
-
-            case Spatial.Sphere sphere -> {
-                var dx = point.x - sphere.centerX();
-                var dy = point.y - sphere.centerY();
-                var dz = point.z - sphere.centerZ();
-                yield (dx * dx + dy * dy + dz * dz) <= (sphere.radius() * sphere.radius());
-            }
-
-            default -> true; // Conservative for unknown types
-        };
-    }
-
-    /**
      * Log batch insertion performance metrics
      */
     private void logBatchPerformance(int batchSize, long startTime) {
@@ -3388,35 +2754,6 @@ implements SpatialIndex<Key, ID, Content> {
             var rate = batchSize * 1_000_000_000.0 / elapsedTime;
             log.debug("Bulk inserted {} entities in {}ms ({} entities/sec)", batchSize,
                       String.format("%.2f", elapsedTime / 1_000_000.0), String.format("%.0f", rate));
-        }
-    }
-
-    // Collision Detection Helper Methods
-
-    /**
-     * Perform detailed collision check between two entities
-     */
-    private Optional<CollisionPair<ID, Content>> performDetailedCollisionCheck(ID id1, ID id2) {
-        var bounds1 = entityManager.getEntityBounds(id1);
-        var bounds2 = entityManager.getEntityBounds(id2);
-        var content1 = entityManager.getEntityContent(id1);
-        var content2 = entityManager.getEntityContent(id2);
-
-        // Check if we have collision shapes for narrow-phase detection
-        var shape1 = entityManager.getEntityCollisionShape(id1);
-        var shape2 = entityManager.getEntityCollisionShape(id2);
-
-        if (shape1 != null && shape2 != null) {
-            return checkShapeCollision(id1, content1, bounds1, shape1, id2, content2, bounds2, shape2);
-        }
-
-        // Fall back to AABB collision detection
-        if (bounds1 != null && bounds2 != null) {
-            return checkAABBCollision(id1, content1, bounds1, id2, content2, bounds2);
-        } else if (bounds1 != null || bounds2 != null) {
-            return checkMixedCollision(id1, content1, bounds1, id2, content2, bounds2);
-        } else {
-            return checkPointCollision(id1, content1, bounds1, id2, content2, bounds2);
         }
     }
 

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/collision/CollisionEngine.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/collision/CollisionEngine.java
@@ -1,0 +1,793 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.collision;
+
+import com.hellblazer.luciferase.lucien.FineGrainedLockingStrategy;
+import com.hellblazer.luciferase.lucien.Spatial;
+import com.hellblazer.luciferase.lucien.SpatialIndex.CollisionPair;
+import com.hellblazer.luciferase.lucien.SpatialIndexCore;
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.SpatialNodeImpl;
+import com.hellblazer.luciferase.lucien.VolumeBounds;
+import com.hellblazer.luciferase.lucien.entity.EntityBounds;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+import com.hellblazer.luciferase.lucien.internal.ObjectPools;
+import com.hellblazer.luciferase.lucien.internal.UnorderedPair;
+
+import javax.vecmath.Point3f;
+import javax.vecmath.Vector3f;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * The collision-detection feature object for a spatial index (RDR-008 P5).
+ *
+ * <p>Owns the collision cluster — seven public entries
+ * ({@link #checkCollision}, {@link #findAllCollisions}, {@link #findCollisions}, {@link #findCollisionsFineGrained},
+ * {@link #findCollisionsInRegion}, {@link #getCollisionShape}, {@link #setCollisionShape}) and the cluster's ~22
+ * private helpers (AABB/point/mixed/shape collision checks, contact normal/point/penetration calculation, the
+ * four-phase {@code findAllCollisions} sweep, the bounded/point entity collision finders, region-membership and
+ * point-in-volume helpers). Verbatim preservation of the pre-extraction behavior.
+ *
+ * <p>The two subclass-overridden hooks ({@link CollisionGeometry#findNodesIntersectingBounds} and
+ * {@link CollisionGeometry#addNeighboringNodes}), the façade-resident range-query
+ * ({@link CollisionGeometry#spatialRangeQuery}), and the two cached entity accessors
+ * ({@link CollisionGeometry#getCachedEntityPosition}, {@link CollisionGeometry#getCachedEntityBounds}) arrive
+ * through the callback; the sorted node map, the read-write lock, and the entity manager arrive through
+ * {@link SpatialIndexCore}; the fine-grained locking strategy arrives via a supplier so the late-bound mutable
+ * façade field is read at call time, mirroring the {@code KnnSearcher} pattern.
+ *
+ * @param <Key>     the spatial key type
+ * @param <ID>      the entity identifier type
+ * @param <Content> the entity content type
+ * @author hal.hildebrand
+ */
+public final class CollisionEngine<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
+
+    private final SpatialIndexCore<Key, ID, Content>             core;
+    private final CollisionGeometry<Key, ID, Content>            callback;
+    private final Supplier<FineGrainedLockingStrategy<ID, Content>> lockingStrategy;
+
+    public CollisionEngine(SpatialIndexCore<Key, ID, Content> core, CollisionGeometry<Key, ID, Content> callback,
+                           Supplier<FineGrainedLockingStrategy<ID, Content>> lockingStrategy) {
+        this.core = core;
+        this.callback = callback;
+        this.lockingStrategy = lockingStrategy;
+    }
+
+    // ===== Public API =====
+
+    /** Check whether two entities collide (verbatim preservation of the pre-extraction behavior). */
+    public Optional<CollisionPair<ID, Content>> checkCollision(ID entityId1, ID entityId2) {
+        if (entityId1.equals(entityId2)) {
+            return Optional.empty();
+        }
+
+        core.lock().readLock().lock();
+        try {
+            var bounds1 = callback.getCachedEntityBounds(entityId1);
+            var bounds2 = callback.getCachedEntityBounds(entityId2);
+
+            // Quick early rejection check
+            if (bounds1 != null && bounds2 != null) {
+                // Both have bounds - quick AABB check
+                if (!boundsIntersect(bounds1, bounds2)) {
+                    return Optional.empty();
+                }
+            } else if (bounds1 == null && bounds2 == null) {
+                // Both are points - check distance
+                var pos1 = callback.getCachedEntityPosition(entityId1);
+                var pos2 = callback.getCachedEntityPosition(entityId2);
+
+                if (pos1 == null || pos2 == null) {
+                    return Optional.empty();
+                }
+
+                var threshold = 0.1f; // Small threshold for point entities
+                if (pos1.distance(pos2) > threshold) {
+                    return Optional.empty();
+                }
+            }
+            // For mixed types (one bounded, one point), skip early rejection and go to detailed check
+
+            // Perform detailed collision check
+            return performDetailedCollisionCheck(entityId1, entityId2);
+        } finally {
+            core.lock().readLock().unlock();
+        }
+    }
+
+    /** Find all collisions in the spatial index (four-phase sweep). */
+    public List<CollisionPair<ID, Content>> findAllCollisions() {
+        core.lock().readLock().lock();
+        try {
+            var collisions = ObjectPools.<CollisionPair<ID, Content>>borrowArrayList();
+            var checkedPairs = ObjectPools.<UnorderedPair<ID>>borrowHashSet();
+            try {
+                // Perform four phases of collision detection
+                findIntraNodeCollisions(collisions, checkedPairs);
+                findBoundedEntityCollisions(collisions, checkedPairs);
+                findAdjacentNodeCollisions(collisions, checkedPairs);
+                findPointBoundedCollisions(collisions, checkedPairs);
+
+                // Sort by penetration depth (deepest first)
+                Collections.sort(collisions);
+
+                return new ArrayList<>(collisions);
+            } finally {
+                ObjectPools.returnArrayList(collisions);
+                ObjectPools.returnHashSet(checkedPairs);
+            }
+        } finally {
+            core.lock().readLock().unlock();
+        }
+    }
+
+    /** Find collisions involving a specific entity. */
+    public List<CollisionPair<ID, Content>> findCollisions(ID entityId) {
+        var locations = core.entityManager().getEntityLocations(entityId);
+        if (locations.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        core.lock().readLock().lock();
+        try {
+            var collisions = ObjectPools.<CollisionPair<ID, Content>>borrowArrayList();
+            var checkedEntities = ObjectPools.<ID>borrowHashSet();
+            try {
+                checkedEntities.add(entityId);
+
+                var entityBounds = callback.getCachedEntityBounds(entityId);
+                if (entityBounds != null) {
+                    findBoundedEntityCollisions(entityId, entityBounds, checkedEntities, collisions);
+                } else {
+                    findPointEntityCollisions(entityId, locations, checkedEntities, collisions);
+                }
+
+                Collections.sort(collisions);
+                return new ArrayList<>(collisions);
+            } finally {
+                ObjectPools.returnArrayList(collisions);
+                ObjectPools.returnHashSet(checkedEntities);
+            }
+        } finally {
+            core.lock().readLock().unlock();
+        }
+    }
+
+    /**
+     * Find collisions using fine-grained locking for better concurrency. Alternative to {@link #findCollisions}
+     * when high read concurrency is needed.
+     */
+    public List<CollisionPair<ID, Content>> findCollisionsFineGrained(ID entityId) {
+        var locations = core.entityManager().getEntityLocations(entityId);
+        if (locations.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // Use fine-grained locking for each node access
+        return lockingStrategy.get().executeRead(0L, () -> {
+            var collisions = ObjectPools.<CollisionPair<ID, Content>>borrowArrayList();
+            var checkedEntities = ObjectPools.<ID>borrowHashSet();
+            try {
+                checkedEntities.add(entityId);
+
+                var entityBounds = callback.getCachedEntityBounds(entityId);
+                if (entityBounds != null) {
+                    findBoundedEntityCollisions(entityId, entityBounds, checkedEntities, collisions);
+                } else {
+                    findPointEntityCollisions(entityId, locations, checkedEntities, collisions);
+                }
+
+                Collections.sort(collisions);
+                return new ArrayList<>(collisions);
+            } finally {
+                ObjectPools.returnArrayList(collisions);
+                ObjectPools.returnHashSet(checkedEntities);
+            }
+        });
+    }
+
+    /** Find all collisions in the given region. */
+    public List<CollisionPair<ID, Content>> findCollisionsInRegion(Spatial region) {
+        core.lock().readLock().lock();
+        try {
+            var collisions = new ArrayList<CollisionPair<ID, Content>>();
+            var checkedPairs = new HashSet<UnorderedPair<ID>>();
+
+            // Find all nodes intersecting the region. Uses the static VolumeBounds.from rather than the
+            // façade's protected getVolumeBounds wrapper; the wrapper today is a pure pass-through to the
+            // same static, but a future subclass that overrides getVolumeBounds to normalize/clamp the
+            // bounds would diverge here. Audited as low-risk for P5 (no subclass overrides exist); revisit
+            // if such an override is introduced. P5 code-review-expert Important#3.
+            var bounds = VolumeBounds.from(region);
+            if (bounds == null) {
+                return collisions;
+            }
+
+            var nodesInRegion = callback.spatialRangeQuery(bounds, true);
+            var nodeList = nodesInRegion.collect(Collectors.toList());
+
+            // Check entities within and between nodes
+            for (int i = 0; i < nodeList.size(); i++) {
+                List<ID> nodeEntities = new ArrayList<>(nodeList.get(i).getValue().getEntityIds());
+
+                // Check within node
+                for (int j = 0; j < nodeEntities.size(); j++) {
+                    for (int k = j + 1; k < nodeEntities.size(); k++) {
+                        var id1 = nodeEntities.get(j);
+                        var id2 = nodeEntities.get(k);
+
+                        // Check if both entities are actually in the region
+                        if (isEntityInRegion(id1, region) && isEntityInRegion(id2, region)) {
+                            var pair = new UnorderedPair<>(id1, id2);
+                            if (checkedPairs.add(pair)) {
+                                checkAndAddCollision(id1, id2, collisions);
+                            }
+                        }
+                    }
+                }
+
+                // Check between nodes
+                for (int j = i + 1; j < nodeList.size(); j++) {
+                    for (ID id1 : nodeEntities) {
+                        if (!isEntityInRegion(id1, region)) {
+                            continue;
+                        }
+
+                        for (ID id2 : nodeList.get(j).getValue().getEntityIds()) {
+                            if (!isEntityInRegion(id2, region)) {
+                                continue;
+                            }
+
+                            var pair = new UnorderedPair<>(id1, id2);
+                            if (checkedPairs.add(pair)) {
+                                checkAndAddCollision(id1, id2, collisions);
+                            }
+                        }
+                    }
+                }
+            }
+
+            Collections.sort(collisions);
+            return collisions;
+        } finally {
+            core.lock().readLock().unlock();
+        }
+    }
+
+    /** Get the entity's collision shape, or {@code null} if unset. */
+    public CollisionShape getCollisionShape(ID entityId) {
+        core.lock().readLock().lock();
+        try {
+            return core.entityManager().getEntityCollisionShape(entityId);
+        } finally {
+            core.lock().readLock().unlock();
+        }
+    }
+
+    /** Set the entity's collision shape, invalidating the cached entity bounds. */
+    public void setCollisionShape(ID entityId, CollisionShape shape) {
+        core.lock().writeLock().lock();
+        try {
+            core.entityManager().setEntityCollisionShape(entityId, shape);
+            // Invalidate cache as bounds may have changed (verbatim preservation of the pre-extraction
+            // façade behavior)
+            core.entityCache().remove(entityId);
+        } finally {
+            core.lock().writeLock().unlock();
+        }
+    }
+
+    // ===== Collision check helpers (verbatim preservation) =====
+
+    private boolean boundsIntersect(EntityBounds b1, EntityBounds b2) {
+        return b1.getMaxX() >= b2.getMinX() && b1.getMinX() <= b2.getMaxX() && b1.getMaxY() >= b2.getMinY()
+        && b1.getMinY() <= b2.getMaxY() && b1.getMaxZ() >= b2.getMinZ() && b1.getMinZ() <= b2.getMaxZ();
+    }
+
+    private boolean boundsIntersectVolume(EntityBounds bounds, Spatial volume) {
+        return switch (volume) {
+            case Spatial.Cube cube ->
+            bounds.getMaxX() >= cube.originX() && bounds.getMinX() <= cube.originX() + cube.extent()
+            && bounds.getMaxY() >= cube.originY() && bounds.getMinY() <= cube.originY() + cube.extent()
+            && bounds.getMaxZ() >= cube.originZ() && bounds.getMinZ() <= cube.originZ() + cube.extent();
+
+            case Spatial.Sphere sphere -> {
+                // Find closest point on bounds to sphere center
+                var closestX = Math.max(bounds.getMinX(), Math.min(sphere.centerX(), bounds.getMaxX()));
+                var closestY = Math.max(bounds.getMinY(), Math.min(sphere.centerY(), bounds.getMaxY()));
+                var closestZ = Math.max(bounds.getMinZ(), Math.min(sphere.centerZ(), bounds.getMaxZ()));
+
+                var dx = closestX - sphere.centerX();
+                var dy = closestY - sphere.centerY();
+                var dz = closestZ - sphere.centerZ();
+                yield (dx * dx + dy * dy + dz * dz) <= (sphere.radius() * sphere.radius());
+            }
+
+            default -> true;
+        };
+    }
+
+    private Vector3f calculateContactNormal(EntityBounds b1, EntityBounds b2) {
+        // Find the axis with minimum penetration
+        var penetrations = new float[6];
+        penetrations[0] = b1.getMaxX() - b2.getMinX(); // +X
+        penetrations[1] = b2.getMaxX() - b1.getMinX(); // -X
+        penetrations[2] = b1.getMaxY() - b2.getMinY(); // +Y
+        penetrations[3] = b2.getMaxY() - b1.getMinY(); // -Y
+        penetrations[4] = b1.getMaxZ() - b2.getMinZ(); // +Z
+        penetrations[5] = b2.getMaxZ() - b1.getMinZ(); // -Z
+
+        var minAxis = 0;
+        var minPenetration = penetrations[0];
+        for (int i = 1; i < 6; i++) {
+            if (penetrations[i] < minPenetration) {
+                minPenetration = penetrations[i];
+                minAxis = i;
+            }
+        }
+
+        // Return normal based on minimum penetration axis
+        return switch (minAxis) {
+            case 0 -> new Vector3f(1, 0, 0);
+            case 1 -> new Vector3f(-1, 0, 0);
+            case 2 -> new Vector3f(0, 1, 0);
+            case 3 -> new Vector3f(0, -1, 0);
+            case 4 -> new Vector3f(0, 0, 1);
+            case 5 -> new Vector3f(0, 0, -1);
+            default -> new Vector3f(1, 0, 0);
+        };
+    }
+
+    private Point3f calculateContactPoint(EntityBounds b1, EntityBounds b2) {
+        // Use the center of the intersection volume
+        var minX = Math.max(b1.getMinX(), b2.getMinX());
+        var minY = Math.max(b1.getMinY(), b2.getMinY());
+        var minZ = Math.max(b1.getMinZ(), b2.getMinZ());
+        var maxX = Math.min(b1.getMaxX(), b2.getMaxX());
+        var maxY = Math.min(b1.getMaxY(), b2.getMaxY());
+        var maxZ = Math.min(b1.getMaxZ(), b2.getMaxZ());
+
+        return new Point3f((minX + maxX) / 2, (minY + maxY) / 2, (minZ + maxZ) / 2);
+    }
+
+    private float calculatePenetrationDepth(EntityBounds b1, EntityBounds b2) {
+        var xPenetration = Math.min(b1.getMaxX() - b2.getMinX(), b2.getMaxX() - b1.getMinX());
+        var yPenetration = Math.min(b1.getMaxY() - b2.getMinY(), b2.getMaxY() - b1.getMinY());
+        var zPenetration = Math.min(b1.getMaxZ() - b2.getMinZ(), b2.getMaxZ() - b1.getMinZ());
+
+        return Math.min(Math.min(xPenetration, yPenetration), zPenetration);
+    }
+
+    private Vector3f calculatePointBoundsNormal(Point3f point, EntityBounds bounds) {
+        var boundsCenter = new Point3f((bounds.getMinX() + bounds.getMaxX()) / 2,
+                                       (bounds.getMinY() + bounds.getMaxY()) / 2,
+                                       (bounds.getMinZ() + bounds.getMaxZ()) / 2);
+
+        Vector3f contactNormal = new Vector3f();
+        contactNormal.sub(point, boundsCenter);
+        if (contactNormal.length() > 0) {
+            contactNormal.normalize();
+        } else {
+            contactNormal.set(1, 0, 0); // Default normal
+        }
+        return contactNormal;
+    }
+
+    private float calculatePointBoundsPenetration(Point3f point, EntityBounds bounds, float threshold) {
+        if (bounds.getMinX() == bounds.getMaxX() && bounds.getMinY() == bounds.getMaxY()
+        && bounds.getMinZ() == bounds.getMaxZ()) {
+            // Zero-size bounds - use distance
+            Point3f boundsPoint = new Point3f(bounds.getMinX(), bounds.getMinY(), bounds.getMinZ());
+            float distance = point.distance(boundsPoint);
+            return (distance == 0) ? 0 : Math.max(0, threshold - distance);
+        } else {
+            // Regular bounds - distance from point to nearest surface
+            return Math.min(Math.min(point.x - bounds.getMinX(), bounds.getMaxX() - point.x),
+                            Math.min(Math.min(point.y - bounds.getMinY(), bounds.getMaxY() - point.y),
+                                     Math.min(point.z - bounds.getMinZ(), bounds.getMaxZ() - point.z)));
+        }
+    }
+
+    private Optional<CollisionPair<ID, Content>> checkAABBCollision(ID id1, Content content1, EntityBounds bounds1,
+                                                                    ID id2, Content content2, EntityBounds bounds2) {
+        if (boundsIntersect(bounds1, bounds2)) {
+            var contactPoint = calculateContactPoint(bounds1, bounds2);
+            var contactNormal = calculateContactNormal(bounds1, bounds2);
+            var penetrationDepth = calculatePenetrationDepth(bounds1, bounds2);
+
+            return Optional.of(
+            CollisionPair.create(id1, content1, bounds1, id2, content2, bounds2, contactPoint, contactNormal,
+                                 penetrationDepth));
+        }
+        return Optional.empty();
+    }
+
+    private void checkAndAddCollision(ID id1, ID id2, List<CollisionPair<ID, Content>> collisions) {
+        if (id1.equals(id2)) {
+            return;
+        }
+
+        var collision = performDetailedCollisionCheck(id1, id2);
+        collision.ifPresent(collisions::add);
+    }
+
+    private Optional<CollisionPair<ID, Content>> checkMixedCollision(ID id1, Content content1, EntityBounds bounds1,
+                                                                     ID id2, Content content2, EntityBounds bounds2) {
+        var bounds = bounds1 != null ? bounds1 : bounds2;
+        var pointEntityId = bounds1 != null ? id2 : id1;
+        var pointPos = core.entityManager().getEntityPosition(pointEntityId);
+
+        if (pointPos == null) {
+            return Optional.empty();
+        }
+
+        float threshold = 0.1f;
+        if (isPointInBoundsWithThreshold(pointPos, bounds, threshold)) {
+            var contactPoint = new Point3f(pointPos);
+            var contactNormal = calculatePointBoundsNormal(pointPos, bounds);
+            var penetrationDepth = calculatePointBoundsPenetration(pointPos, bounds, threshold);
+
+            return Optional.of(
+            CollisionPair.create(id1, content1, bounds1, id2, content2, bounds2, contactPoint, contactNormal,
+                                 penetrationDepth));
+        }
+        return Optional.empty();
+    }
+
+    private void checkNeighborNodesForCollisions(ID entityId, Key nodeIndex, Set<ID> checkedEntities,
+                                                 List<CollisionPair<ID, Content>> collisions) {
+        var neighbors = new LinkedList<Key>();
+        var visitedNeighbors = new HashSet<Key>();
+        callback.addNeighboringNodes(nodeIndex, neighbors, visitedNeighbors);
+
+        while (!neighbors.isEmpty()) {
+            var neighborIndex = neighbors.poll();
+            checkNodeEntitiesForCollisions(entityId, neighborIndex, checkedEntities, collisions);
+        }
+    }
+
+    private void checkNodeEntitiesForCollisions(ID entityId, Key nodeIndex, Set<ID> checkedEntities,
+                                                List<CollisionPair<ID, Content>> collisions) {
+        var node = core.spatialIndex().get(nodeIndex);
+        if (node == null || node.isEmpty()) {
+            return;
+        }
+
+        for (ID otherId : node.getEntityIds()) {
+            if (!checkedEntities.add(otherId)) {
+                continue;
+            }
+            checkAndAddCollision(entityId, otherId, collisions);
+        }
+    }
+
+    private Optional<CollisionPair<ID, Content>> checkPointCollision(ID id1, Content content1, EntityBounds bounds1,
+                                                                     ID id2, Content content2, EntityBounds bounds2) {
+        var pos1 = core.entityManager().getEntityPosition(id1);
+        var pos2 = core.entityManager().getEntityPosition(id2);
+
+        if (pos1 == null || pos2 == null) {
+            return Optional.empty();
+        }
+
+        var distance = pos1.distance(pos2);
+        var threshold = 0.1f;
+
+        if (distance <= threshold) {
+            var contactPoint = new Point3f();
+            contactPoint.interpolate(pos1, pos2, 0.5f);
+
+            Vector3f contactNormal = new Vector3f();
+            contactNormal.sub(pos2, pos1);
+            if (contactNormal.length() > 0) {
+                contactNormal.normalize();
+            } else {
+                contactNormal.set(1, 0, 0); // Default normal for identical positions
+            }
+
+            // For identical positions, penetration depth is 0
+            // Otherwise it's the overlap amount
+            var penetrationDepth = (distance == 0) ? 0 : Math.max(0, threshold - distance);
+
+            return Optional.of(
+            CollisionPair.create(id1, content1, bounds1, id2, content2, bounds2, contactPoint, contactNormal,
+                                 penetrationDepth));
+        }
+        return Optional.empty();
+    }
+
+    private Optional<CollisionPair<ID, Content>> checkShapeCollision(ID id1, Content content1, EntityBounds bounds1,
+                                                                     CollisionShape shape1, ID id2, Content content2,
+                                                                     EntityBounds bounds2, CollisionShape shape2) {
+        var result = shape1.collidesWith(shape2);
+        if (result.collides) {
+            return Optional.of(CollisionPair.create(id1, content1, bounds1, id2, content2, bounds2, result.contactPoint,
+                                                    result.contactNormal, result.penetrationDepth));
+        }
+        return Optional.empty();
+    }
+
+    // ===== Four-phase findAllCollisions sweep =====
+
+    private void findAdjacentNodeCollisions(List<CollisionPair<ID, Content>> collisions,
+                                            Set<UnorderedPair<ID>> checkedPairs) {
+        for (var nodeIndex : core.spatialIndex().keySet()) {
+            var node = core.spatialIndex().get(nodeIndex);
+            if (node == null || node.isEmpty()) {
+                continue;
+            }
+
+            var nodeEntities = new ArrayList<>(node.getEntityIds());
+
+            // Find neighboring nodes
+            var neighbors = new LinkedList<Key>();
+            var visitedNeighbors = new HashSet<Key>();
+            callback.addNeighboringNodes(nodeIndex, neighbors, visitedNeighbors);
+
+            // Check entities between this node and its neighbors
+            while (!neighbors.isEmpty()) {
+                var neighborIndex = neighbors.poll();
+
+                // Skip already processed nodes (SFC ordering optimization)
+                if (neighborIndex.compareTo(nodeIndex) < 0) {
+                    continue;
+                }
+
+                var neighborNode = core.spatialIndex().get(neighborIndex);
+                if (neighborNode == null || neighborNode.isEmpty()) {
+                    continue;
+                }
+
+                // Check entities between adjacent nodes
+                for (ID id1 : nodeEntities) {
+                    // Skip bounded entities (already handled)
+                    if (core.entityManager().getEntityBounds(id1) != null) {
+                        continue;
+                    }
+
+                    for (ID id2 : neighborNode.getEntityIds()) {
+                        var pair = new UnorderedPair<>(id1, id2);
+                        if (checkedPairs.add(pair)) {
+                            checkAndAddCollision(id1, id2, collisions);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private void findBoundedEntityCollisions(ID entityId, EntityBounds entityBounds, Set<ID> checkedEntities,
+                                             List<CollisionPair<ID, Content>> collisions) {
+        var nodesToCheck = findNodesIntersectingBounds(entityBounds);
+
+        for (var nodeIndex : nodesToCheck) {
+            checkNodeEntitiesForCollisions(entityId, nodeIndex, checkedEntities, collisions);
+        }
+    }
+
+    private void findBoundedEntityCollisions(List<CollisionPair<ID, Content>> collisions,
+                                             Set<UnorderedPair<ID>> checkedPairs) {
+        var boundedEntities = new ArrayList<ID>();
+        for (var entityId : core.entityManager().getAllEntityIds()) {
+            if (core.entityManager().getEntityBounds(entityId) != null) {
+                boundedEntities.add(entityId);
+            }
+        }
+
+        // Check bounded entities against each other
+        for (int i = 0; i < boundedEntities.size() - 1; i++) {
+            for (int j = i + 1; j < boundedEntities.size(); j++) {
+                var id1 = boundedEntities.get(i);
+                var id2 = boundedEntities.get(j);
+                var pair = new UnorderedPair<>(id1, id2);
+                if (checkedPairs.add(pair)) {
+                    checkAndAddCollision(id1, id2, collisions);
+                }
+            }
+        }
+    }
+
+    private void findIntraNodeCollisions(List<CollisionPair<ID, Content>> collisions,
+                                         Set<UnorderedPair<ID>> checkedPairs) {
+        for (var nodeIndex : core.spatialIndex().keySet()) {
+            var node = core.spatialIndex().get(nodeIndex);
+            if (node == null || node.isEmpty()) {
+                continue;
+            }
+
+            var nodeEntities = new ArrayList<>(node.getEntityIds());
+            if (nodeEntities.size() < 2) {
+                continue;
+            }
+
+            // Check all pairs within this node
+            for (int i = 0; i < nodeEntities.size() - 1; i++) {
+                for (int j = i + 1; j < nodeEntities.size(); j++) {
+                    var id1 = nodeEntities.get(i);
+                    var id2 = nodeEntities.get(j);
+                    var pair = new UnorderedPair<>(id1, id2);
+                    if (checkedPairs.add(pair)) {
+                        checkAndAddCollision(id1, id2, collisions);
+                    }
+                }
+            }
+        }
+    }
+
+    private void findPointBoundedCollisions(List<CollisionPair<ID, Content>> collisions,
+                                            Set<UnorderedPair<ID>> checkedPairs) {
+        // First, collect all bounded entities and their expanded search regions
+        var boundedEntitySearchNodes = new HashMap<ID, Set<Key>>();
+
+        for (var nodeIndex : core.spatialIndex().keySet()) {
+            var node = core.spatialIndex().get(nodeIndex);
+            if (node == null || node.isEmpty()) {
+                continue;
+            }
+
+            for (ID entityId : node.getEntityIds()) {
+                var bounds = core.entityManager().getEntityBounds(entityId);
+                if (bounds != null) {
+                    // Calculate nodes that could contain point entities that might collide
+                    var threshold = 0.1f; // Collision threshold for point entities
+                    var expandedBounds = new EntityBounds(
+                    new Point3f(bounds.getMinX() - threshold, bounds.getMinY() - threshold,
+                                bounds.getMinZ() - threshold),
+                    new Point3f(bounds.getMaxX() + threshold, bounds.getMaxY() + threshold,
+                                bounds.getMaxZ() + threshold));
+                    var searchNodes = findNodesIntersectingBounds(expandedBounds);
+                    boundedEntitySearchNodes.put(entityId, searchNodes);
+                }
+            }
+        }
+
+        // Now check point entities against bounded entities in their search regions
+        for (var entry : boundedEntitySearchNodes.entrySet()) {
+            var boundedId = entry.getKey();
+            var searchNodes = entry.getValue();
+
+            for (var searchNodeIndex : searchNodes) {
+                var searchNode = core.spatialIndex().get(searchNodeIndex);
+                if (searchNode == null || searchNode.isEmpty()) {
+                    continue;
+                }
+
+                for (ID pointId : searchNode.getEntityIds()) {
+                    if (core.entityManager().getEntityBounds(pointId) == null) { // Only check point entities
+                        var pair = new UnorderedPair<>(boundedId, pointId);
+                        if (checkedPairs.add(pair)) {
+                            checkAndAddCollision(boundedId, pointId, collisions);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private void findPointEntityCollisions(ID entityId, Set<Key> locations, Set<ID> checkedEntities,
+                                           List<CollisionPair<ID, Content>> collisions) {
+        for (var nodeIndex : locations) {
+            // Check entities in the same node
+            checkNodeEntitiesForCollisions(entityId, nodeIndex, checkedEntities, collisions);
+
+            // Check entities in neighboring nodes
+            checkNeighborNodesForCollisions(entityId, nodeIndex, checkedEntities, collisions);
+        }
+    }
+
+    // ===== Volume/region helpers =====
+
+    /**
+     * Find all nodes intersecting the bounds of a bounded entity. Verbatim port of the pre-extraction protected
+     * façade overload — composes over {@link CollisionGeometry#spatialRangeQuery}, NOT the raw subclass
+     * {@code findNodesIntersectingBounds(VolumeBounds)} hook, so the precise {@code doesNodeIntersectVolume}
+     * filter the range query applies is preserved. A direct call to the {@code VolumeBounds} hook skips that
+     * filter and returns false-positive candidate nodes, which silently dropped multi-entity collisions
+     * (caught by {@code OctreeCollisionAccuracyTest.testMultipleCollisionAccuracy} on the first P5 verification
+     * pass).
+     */
+    private Set<Key> findNodesIntersectingBounds(EntityBounds bounds) {
+        var volumeBounds = new VolumeBounds(bounds.getMinX(), bounds.getMinY(), bounds.getMinZ(), bounds.getMaxX(),
+                                            bounds.getMaxY(), bounds.getMaxZ());
+        var intersectingNodes = new HashSet<Key>();
+        callback.spatialRangeQuery(volumeBounds, true).forEach(entry -> intersectingNodes.add(entry.getKey()));
+        return intersectingNodes;
+    }
+
+    private boolean isEntityInRegion(ID entityId, Spatial region) {
+        var pos = core.entityManager().getEntityPosition(entityId);
+        if (pos == null) {
+            return false;
+        }
+
+        EntityBounds bounds = core.entityManager().getEntityBounds(entityId);
+        if (bounds != null) {
+            // Check if bounds intersect region
+            return boundsIntersectVolume(bounds, region);
+        } else {
+            // Check if point is in region
+            return isPointInVolume(pos, region);
+        }
+    }
+
+    private boolean isPointInBoundsWithThreshold(Point3f point, EntityBounds bounds, float threshold) {
+        var inBounds = point.x >= bounds.getMinX() && point.x <= bounds.getMaxX() && point.y >= bounds.getMinY()
+        && point.y <= bounds.getMaxY() && point.z >= bounds.getMinZ() && point.z <= bounds.getMaxZ();
+
+        // For zero-size bounds, check distance to bounds center
+        if (!inBounds && bounds.getMinX() == bounds.getMaxX() && bounds.getMinY() == bounds.getMaxY()
+        && bounds.getMinZ() == bounds.getMaxZ()) {
+            Point3f boundsPoint = new Point3f(bounds.getMinX(), bounds.getMinY(), bounds.getMinZ());
+            float distance = point.distance(boundsPoint);
+            inBounds = distance <= threshold;
+        }
+
+        return inBounds;
+    }
+
+    private boolean isPointInVolume(Point3f point, Spatial volume) {
+        return switch (volume) {
+            case Spatial.Cube cube ->
+            point.x >= cube.originX() && point.x <= cube.originX() + cube.extent() && point.y >= cube.originY()
+            && point.y <= cube.originY() + cube.extent() && point.z >= cube.originZ()
+            && point.z <= cube.originZ() + cube.extent();
+
+            case Spatial.Sphere sphere -> {
+                var dx = point.x - sphere.centerX();
+                var dy = point.y - sphere.centerY();
+                var dz = point.z - sphere.centerZ();
+                yield (dx * dx + dy * dy + dz * dz) <= (sphere.radius() * sphere.radius());
+            }
+
+            default -> true; // Conservative for unknown types
+        };
+    }
+
+    private Optional<CollisionPair<ID, Content>> performDetailedCollisionCheck(ID id1, ID id2) {
+        var bounds1 = core.entityManager().getEntityBounds(id1);
+        var bounds2 = core.entityManager().getEntityBounds(id2);
+        var content1 = core.entityManager().getEntityContent(id1);
+        var content2 = core.entityManager().getEntityContent(id2);
+
+        // Check if we have collision shapes for narrow-phase detection
+        var shape1 = core.entityManager().getEntityCollisionShape(id1);
+        var shape2 = core.entityManager().getEntityCollisionShape(id2);
+
+        if (shape1 != null && shape2 != null) {
+            return checkShapeCollision(id1, content1, bounds1, shape1, id2, content2, bounds2, shape2);
+        }
+
+        // Fall back to AABB collision detection
+        if (bounds1 != null && bounds2 != null) {
+            return checkAABBCollision(id1, content1, bounds1, id2, content2, bounds2);
+        } else if (bounds1 != null || bounds2 != null) {
+            return checkMixedCollision(id1, content1, bounds1, id2, content2, bounds2);
+        } else {
+            return checkPointCollision(id1, content1, bounds1, id2, content2, bounds2);
+        }
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/collision/CollisionGeometry.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/collision/CollisionGeometry.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.collision;
+
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.SpatialNodeImpl;
+import com.hellblazer.luciferase.lucien.VolumeBounds;
+import com.hellblazer.luciferase.lucien.entity.EntityBounds;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+
+import javax.vecmath.Point3f;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * Façade operations the {@link CollisionEngine} consumes (RDR-008 P5).
+ *
+ * <p>Following the P3 per-cluster sub-interface refinement (RDR-008 §Decision item 1 P3 refinement), each feature
+ * object depends only on the narrow surface it actually uses — for the collision cluster that surface is the two
+ * subclass-overridden traversal hooks ({@link #findNodesIntersectingBounds} and {@link #addNeighboringNodes}), the
+ * façade-resident range-query composed of the same two hooks, and the two cached entity accessors. The façade
+ * implements this through a private inner class so the underlying methods keep their original visibility.
+ *
+ * <p><b>Naming-discipline exception.</b> Sibling sub-interfaces {@code FrustumGeometry}, {@code CullGeometry}, and
+ * {@code KnnGeometry} expose only bare spatial predicates and subclass hooks; this interface additionally exposes
+ * {@link #spatialRangeQuery} (a composed query) and the two entity-cache accessors. The composed query is required
+ * because a direct call to the {@code findNodesIntersectingBounds(VolumeBounds)} subclass hook skips the
+ * {@code doesNodeIntersectVolume} filter that {@code spatialRangeQuery} applies — a regression caught on the first
+ * P5 verification pass (Octree spanning-entity collision tests dropped silently). The entity-cache accessors are
+ * included to avoid a separate two-method seam. The P5 review noted the resulting label drift; future cluster
+ * extractions should hold the line and only add composed queries when an equivalent regression makes the case.
+ *
+ * @param <Key>     the spatial key type
+ * @param <ID>      the entity identifier type
+ * @param <Content> the entity content type
+ * @author hal.hildebrand
+ */
+public interface CollisionGeometry<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
+
+    // ===== Subclass hooks =====
+
+    /**
+     * Spatial keys of nodes potentially intersecting the given volume bounds (subclass-specific spatial query).
+     */
+    Set<Key> findNodesIntersectingBounds(VolumeBounds bounds);
+
+    /**
+     * Expand the neighbor frontier from the given node into {@code toVisit}, tracking visited keys in
+     * {@code visitedNodes} (subclass-specific topology).
+     */
+    void addNeighboringNodes(Key nodeIndex, Queue<Key> toVisit, Set<Key> visitedNodes);
+
+    // ===== Façade-resident composed query =====
+
+    /**
+     * Stream of (key, node) entries in the spatial index that match the volume bounds. The façade composes this
+     * over {@link #findNodesIntersectingBounds} and the subclass-specific containment/intersection predicates;
+     * the collision cluster consumes it for {@code findCollisionsInRegion} and several internal sweeps.
+     */
+    Stream<Map.Entry<Key, SpatialNodeImpl<ID>>> spatialRangeQuery(VolumeBounds bounds, boolean includeIntersecting);
+
+    // ===== Cached accessors =====
+
+    /** Cached world position of the entity, or {@code null} if unknown. */
+    Point3f getCachedEntityPosition(ID entityId);
+
+    /** Cached world bounds of the entity, or {@code null} for point entities. */
+    EntityBounds getCachedEntityBounds(ID entityId);
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/Tetree.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/Tetree.java
@@ -150,24 +150,38 @@ extends AbstractSpatialIndex<TetreeKey<? extends TetreeKey<?>>, ID, Content> {
      */
     @Override
     public List<CollisionPair<ID, Content>> findAllCollisions() {
-        // Use the base class implementation but with additional logic
-        // for checking other tetrahedra in the same grid cell
-        var baseCollisions = super.findAllCollisions();
-
-        lock.readLock().lock();
+        // RDR-008 P5: nucleus access (lock, spatial index map) routes through the SpatialIndexCore protected
+        // re-exposure path. Verbatim behavioral preservation — the override still scans the five non-self
+        // characteristic tetrahedra of every populated cell and reports any cross-tet collisions the base
+        // four-phase sweep misses (the same-cell-different-type case is invisible to neighbor traversal).
+        //
+        // The read lock is acquired BEFORE super.findAllCollisions() and held through the cross-tet sweep
+        // (RDR-008 P5 substantive-critic S2): the base sweep acquires the same read lock internally, but
+        // ReentrantReadWriteLock permits re-entrant read acquisitions from the same thread, so we hold the
+        // lock continuously across both sections. Without this, a concurrent writer could mutate the index
+        // in the window between the base sweep releasing the lock and the override re-acquiring it, leading
+        // to semantically inconsistent results (pair-set seeded from stale base data, etc.).
+        //
+        // Pair deduplication uses HashSet<UnorderedPair<ID>> (P5 code-review-expert Important#2 / substantive-
+        // critic S1): the base sweep deduplicates via UnorderedPair (compareTo-based total order). The
+        // pre-P5 override used a String key built from hashCode-ordering of the two IDs, which can disagree
+        // with compareTo when hashCode collides — producing duplicate CollisionPair entries for those pairs.
+        // Switching to UnorderedPair aligns the override with the base's deduplication contract.
+        core.lock().readLock().lock();
         try {
+            var baseCollisions = super.findAllCollisions();
             var collisions = new ArrayList<>(baseCollisions);
-            var checkedPairs = new HashSet<String>(); // Use String for pair keys
+            var checkedPairs = new HashSet<UnorderedPair<ID>>();
 
-            // Add all base collision pairs to checked set
+            // Add all base collision pairs to checked set, keyed by UnorderedPair to match the base sweep's
+            // total-ordered pair deduplication.
             for (var collision : baseCollisions) {
-                var key = createPairKey(collision.entityId1(), collision.entityId2());
-                checkedPairs.add(key);
+                checkedPairs.add(new UnorderedPair<>(collision.entityId1(), collision.entityId2()));
             }
 
             // Check entities in different tetrahedra of the same grid cell
-            for (var nodeIndex : spatialIndex.keySet()) {
-                var node = spatialIndex.get(nodeIndex);
+            for (var nodeIndex : core.spatialIndex().keySet()) {
+                var node = core.spatialIndex().get(nodeIndex);
                 if (node == null || node.isEmpty()) {
                     continue;
                 }
@@ -184,12 +198,12 @@ extends AbstractSpatialIndex<TetreeKey<? extends TetreeKey<?>>, ID, Content> {
 
                         var sameCellTet = new Tet(currentTet.x(), currentTet.y(), currentTet.z(), currentTet.l(), type);
                         var sameCellIndex = sameCellTet.tmIndex();
-                        var sameCellNode = spatialIndex.get(sameCellIndex);
+                        var sameCellNode = core.spatialIndex().get(sameCellIndex);
 
                         if (sameCellNode != null && !sameCellNode.isEmpty()) {
                             for (ID otherId : sameCellNode.getEntityIds()) {
-                                var key = createPairKey(entityId, otherId);
-                                if (checkedPairs.add(key)) {
+                                var pair = new UnorderedPair<>(entityId, otherId);
+                                if (checkedPairs.add(pair)) {
                                     // Check if these entities actually collide
                                     var collision = checkCollision(entityId, otherId);
                                     if (collision.isPresent()) {
@@ -204,7 +218,7 @@ extends AbstractSpatialIndex<TetreeKey<? extends TetreeKey<?>>, ID, Content> {
 
             return collisions;
         } finally {
-            lock.readLock().unlock();
+            core.lock().readLock().unlock();
         }
     }
 
@@ -245,17 +259,21 @@ extends AbstractSpatialIndex<TetreeKey<? extends TetreeKey<?>>, ID, Content> {
      */
     @Override
     public List<CollisionPair<ID, Content>> findCollisions(ID entityId) {
-        lock.readLock().lock();
+        // RDR-008 P5: nucleus access (lock, entity manager, spatial index map) routes through the
+        // SpatialIndexCore protected re-exposure path. Façade-protected operations (findNodesIntersectingBounds,
+        // spatialRangeQuery) and the public checkCollision delegator stay called by name — they remain on the
+        // façade and are the sanctioned re-entry points for the override.
+        core.lock().readLock().lock();
         try {
             List<CollisionPair<ID, Content>> collisions = new ArrayList<>();
 
             // Get entity position for spatial range query
-            Point3f entityPos = entityManager.getEntityPosition(entityId);
+            Point3f entityPos = core.entityManager().getEntityPosition(entityId);
             if (entityPos == null) {
                 return collisions;
             }
 
-            EntityBounds entityBounds = entityManager.getEntityBounds(entityId);
+            EntityBounds entityBounds = core.entityManager().getEntityBounds(entityId);
             float searchRadius = 0.1f; // Standard collision threshold for point entities
 
             if (entityBounds != null) {
@@ -265,7 +283,7 @@ extends AbstractSpatialIndex<TetreeKey<? extends TetreeKey<?>>, ID, Content> {
                 checkedEntities.add(entityId);
 
                 for (var nodeIndex : nodesToCheck) {
-                    SpatialNodeImpl<ID> node = spatialIndex.get(nodeIndex);
+                    SpatialNodeImpl<ID> node = core.spatialIndex().get(nodeIndex);
                     if (node == null || node.isEmpty()) {
                         continue;
                     }
@@ -308,7 +326,7 @@ extends AbstractSpatialIndex<TetreeKey<? extends TetreeKey<?>>, ID, Content> {
             Collections.sort(collisions);
             return collisions;
         } finally {
-            lock.readLock().unlock();
+            core.lock().readLock().unlock();
         }
     }
 
@@ -932,8 +950,9 @@ extends AbstractSpatialIndex<TetreeKey<? extends TetreeKey<?>>, ID, Content> {
             return super.findCollisionsInRegion(region);
         }
 
-        // Tet-shaped query: Phase 1 uses AABB+SAT post-filter to reduce candidate nodes
-        lock.readLock().lock();
+        // Tet-shaped query: Phase 1 uses AABB+SAT post-filter to reduce candidate nodes.
+        // RDR-008 P5: nucleus access (lock) routes through the SpatialIndexCore protected re-exposure path.
+        core.lock().readLock().lock();
         try {
             var collisions = new ArrayList<SpatialIndex.CollisionPair<ID, Content>>();
             var checkedPairs = new HashSet<UnorderedPair<ID>>();
@@ -979,7 +998,7 @@ extends AbstractSpatialIndex<TetreeKey<? extends TetreeKey<?>>, ID, Content> {
             Collections.sort(collisions);
             return collisions;
         } finally {
-            lock.readLock().unlock();
+            core.lock().readLock().unlock();
         }
     }
 
@@ -988,11 +1007,13 @@ extends AbstractSpatialIndex<TetreeKey<? extends TetreeKey<?>>, ID, Content> {
      * Used by {@link #findCollisionsInRegion(Spatial)} when the region is a {@link Spatial.aabt}.
      */
     private boolean isEntityInAabt(ID entityId, Spatial.aabt queryBound) {
-        var pos = entityManager.getEntityPosition(entityId);
+        // RDR-008 P5: nucleus access (entity manager) routes through the SpatialIndexCore protected
+        // re-exposure path for consistency with the findCollisions*/findAllCollisions overrides.
+        var pos = core.entityManager().getEntityPosition(entityId);
         if (pos == null) {
             return false;
         }
-        var bounds = entityManager.getEntityBounds(entityId);
+        var bounds = core.entityManager().getEntityBounds(entityId);
         if (bounds == null) {
             // Point entity: check containment
             return queryBound.contains(pos.x, pos.y, pos.z);
@@ -2347,18 +2368,6 @@ extends AbstractSpatialIndex<TetreeKey<? extends TetreeKey<?>>, ID, Content> {
         return candidates;
     }
 
-
-    /**
-     * Create a unique key for an entity pair (order-independent).
-     */
-    private String createPairKey(ID id1, ID id2) {
-        // Create order-independent key
-        if (id1.hashCode() < id2.hashCode()) {
-            return id1 + ":" + id2;
-        } else {
-            return id2 + ":" + id1;
-        }
-    }
 
     /**
      * Determine which of the 6 characteristic tetrahedra contains a point within a cube.

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeCrossTetrahedraCollisionTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeCrossTetrahedraCollisionTest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.tetree;
+
+import com.hellblazer.luciferase.lucien.SpatialIndex;
+import com.hellblazer.luciferase.lucien.SpatialIndex.CollisionPair;
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3f;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for the Tetree-specific same-grid-cell cross-tetrahedron collision path (RDR-008 P5).
+ *
+ * <p>{@code Tetree.findAllCollisions()} overrides the base implementation to scan, for each populated node, the
+ * other five characteristic tetrahedra (S0..S5) in the same grid cell — collisions between entities that share a
+ * grid cell but live in different tet types are invisible to the generic neighbor-traversal path the
+ * {@code AbstractSpatialIndex} base implementation uses. The generic lucien collision suite cannot exercise this
+ * path (its assumptions are octree-shaped), so without this test the override's behavior is unverified.
+ *
+ * <p>P5 (Luciferase-x5i.10) refactors {@code Tetree.findAllCollisions} to reach the nucleus through the
+ * façade-sanctioned protected re-exposure path; this test pins the same-cell cross-tetrahedron semantics so any
+ * regression in the refactor surfaces immediately. The test must be GREEN both before and after the P5 refactor.
+ *
+ * @author hal.hildebrand
+ */
+public class TetreeCrossTetrahedraCollisionTest {
+
+    /**
+     * Two point entities placed inside the same grid cell at the deepest refinement level (cellSize=1) but
+     * intentionally on opposite sides of the S0/S4 type boundary, within the point-collision threshold (0.1f
+     * default). The base {@code findAllCollisions} sees them in different SFC nodes (different tet types) and
+     * does not consider them neighbors; only the Tetree override's same-cell sweep can find their collision.
+     *
+     * <p>S0 contains {@code x>=y>=z}; S4 contains {@code x>=z>=y} (per {@link Tet#contains12DOP}). Positions
+     * (0.5, 0.45, 0.4) and (0.5, 0.4, 0.45) land in S0 and S4 respectively and are sqrt(0.0025+0.0025) ≈ 0.071
+     * apart — under the 0.1f point-collision threshold {@code AbstractSpatialIndex#checkPointCollision} uses.
+     */
+    @Test
+    void sameGridCellDifferentTetTypesCollide() {
+        var tetree = new Tetree<LongEntityID, String>(new SequentialLongIDGenerator());
+
+        // Use the deepest level so cellSize=1 — at coarser levels the centroids of different tet types in a
+        // single cell are spread well beyond the 0.1f point-collision threshold and we cannot exercise the
+        // cross-tet path with point entities.
+        byte level = 21;
+        var p1 = new Point3f(0.5f, 0.45f, 0.4f);   // S0: x>=y>=z
+        var p2 = new Point3f(0.5f, 0.4f, 0.45f);   // S4: x>=z>=y
+
+        var id1 = tetree.insert(p1, level, "A");
+        var id2 = tetree.insert(p2, level, "B");
+
+        // Sanity: the two entities must actually land in different tet types of the same grid cell. Without
+        // this preflight a future change to locate()/contains12DOP could silently collapse the entities into
+        // the same tet and make the test pass for the wrong reason.
+        var tet1 = tetree.locate(p1, level);
+        var tet2 = tetree.locate(p2, level);
+        assertEquals(tet1.x(), tet2.x(), "Both entities must occupy the same grid cell (x)");
+        assertEquals(tet1.y(), tet2.y(), "Both entities must occupy the same grid cell (y)");
+        assertEquals(tet1.z(), tet2.z(), "Both entities must occupy the same grid cell (z)");
+        assertEquals(tet1.l(), tet2.l(), "Both entities must occupy the same level");
+        assertNotEquals(tet1.type(), tet2.type(),
+                        "Test requires entities in DIFFERENT tet types of the SAME cell — fixture is broken");
+        assertNotEquals(tet1.tmIndex(), tet2.tmIndex(),
+                        "Different tet types must yield different SFC keys — fixture is broken");
+
+        // The Tetree override of findAllCollisions must surface this cross-tet pair. With point entities under
+        // the 0.1f threshold and distinct SFC keys, this collision is invisible to the generic intra-node and
+        // neighbor-traversal paths the base findAllCollisions uses; only the override's same-cell sweep finds
+        // it.
+        List<CollisionPair<LongEntityID, String>> collisions = tetree.findAllCollisions();
+        assertEquals(1, collisions.size(),
+                     "Tetree.findAllCollisions must find the cross-tet pair via the same-grid-cell sweep");
+        var pair = collisions.get(0);
+        assertTrue(pair.involves(id1), "Collision must involve entity A");
+        assertTrue(pair.involves(id2), "Collision must involve entity B");
+    }
+
+    /**
+     * Same-cell cross-tetrahedron collisions for all 15 unordered pairs across the six S0..S5 types. Places one
+     * entity inside each of the six characteristic tetrahedra of the same grid cell, all within mutual
+     * point-collision threshold. Confirms the override's loop over the five non-self types per node yields
+     * symmetric coverage — every pair fires exactly once.
+     *
+     * <p>The six positions hug a tight neighborhood around (0.5, 0.5, 0.5) at level 21 (cellSize=1) with
+     * coordinate ordering chosen so each lands in exactly one S-type per {@link Tet#contains12DOP}. Pairwise
+     * distances stay under the 0.1f threshold.
+     */
+    @Test
+    void sameGridCellAllSixTetTypesCollidePairwise() {
+        var tetree = new Tetree<LongEntityID, String>(new SequentialLongIDGenerator());
+
+        byte level = 21;
+        // Six positions inside the unit cell at (0,0,0,21). Each ordering hits exactly one S-type, derived from
+        // Tet.contains12DOP: S0=x>=y>=z, S1=y>=x>=z, S2=z>=x>=y, S3=z>=y>=x, S4=x>=z>=y, S5=y>=z>=x. We use
+        // (a, a+δ, a+2δ) permutations with a=0.5 and δ=0.02 so all six points stay inside the cell, hit the
+        // intended type, and lie within sqrt(2)·2δ ≈ 0.057 of each other (under the 0.1f threshold).
+        float a = 0.5f, d = 0.02f;
+        var positions = new Point3f[]{ new Point3f(a + 2 * d, a + d, a),         // S0: x>y>z
+                                       new Point3f(a + d, a + 2 * d, a),         // S1: y>x>z
+                                       new Point3f(a + d, a, a + 2 * d),         // S2: z>x>y
+                                       new Point3f(a, a + d, a + 2 * d),         // S3: z>y>x
+                                       new Point3f(a + 2 * d, a, a + d),         // S4: x>z>y
+                                       new Point3f(a, a + 2 * d, a + d) };       // S5: y>z>x
+
+        var ids = new LongEntityID[6];
+        for (int i = 0; i < 6; i++) {
+            ids[i] = tetree.insert(positions[i], level, "T" + i);
+        }
+
+        // Sanity: each entity must land in the expected unique S-type.
+        var seenTypes = new boolean[6];
+        for (int i = 0; i < 6; i++) {
+            var tet = tetree.locate(positions[i], level);
+            assertEquals(0, tet.x(), "Entity " + i + " must be in the (0,0,0) grid cell (x)");
+            assertEquals(0, tet.y(), "Entity " + i + " must be in the (0,0,0) grid cell (y)");
+            assertEquals(0, tet.z(), "Entity " + i + " must be in the (0,0,0) grid cell (z)");
+            assertEquals(level, tet.l(), "Entity " + i + " must be at the test level");
+            assertEquals((byte) i, tet.type(),
+                         "Entity " + i + " must land in tet type S" + i + " — fixture is broken");
+            seenTypes[tet.type()] = true;
+        }
+        for (byte t = 0; t < 6; t++) {
+            assertTrue(seenTypes[t], "Fixture must populate tet type S" + t);
+        }
+
+        List<SpatialIndex.CollisionPair<LongEntityID, String>> collisions = tetree.findAllCollisions();
+        // C(6,2) = 15 unordered pairs, every pair within collision threshold.
+        assertEquals(15, collisions.size(),
+                     "Override must surface every cross-tet pair across all 6 same-cell types (15 = C(6,2))");
+    }
+}


### PR DESCRIPTION
RDR-008 Phase 5 — extracts the collision-detection cluster from `AbstractSpatialIndex` into a `CollisionEngine` feature object and performs the §Decision-locked **bounded** Tetree collision-override refactor.

## Architecture

Follows the locked pattern (RDR-008 §Decision item 1 with the P3 refinement):
- **`collision.CollisionGeometry`** — 5-method sub-interface (2 subclass hooks + composed `spatialRangeQuery` + 2 cached entity accessors). Naming-discipline exception for `spatialRangeQuery` is documented (the composed query is required because a direct call to the `findNodesIntersectingBounds(VolumeBounds)` subclass hook bypasses the `doesNodeIntersectVolume` filter — caught on the first P5 verification pass).
- **`collision.CollisionEngine`** — 7 public + ~22 private migrated verbatim. Holds `SpatialIndexCore` + `CollisionGeometry` callback + `Supplier<FineGrainedLockingStrategy>` (late-bound for `findCollisionsFineGrained`, mirroring `KnnSearcher`).
- **Façade** adds `protected final CollisionEngine collisions` + eager ctor construction (this-escape invariant preserved) + `CollisionGeometryImpl` private inner class with bidirectional NOTE blocks. 7 public collision methods reduced to delegators.

## Scoped Tetree refactor (BOUNDED)

Phase 5 is the **first** phase that breaks the "subclasses byte-for-byte unchanged" invariant, per RDR §Decision item 2 phase 5. The three Tetree collision overrides (`findAllCollisions`, `findCollisions(ID)`, `findCollisionsInRegion`) and the `isEntityInAabt` private helper now route nucleus access through `core.lock()`, `core.spatialIndex()`, `core.entityManager()` — the §Decision-sanctioned protected re-exposure path.

**Octree, Prism, SFCArrayIndex are byte-for-byte unchanged** (\`git diff --stat -- octree/ prism/ sfc/\` empty).

## New Tetree-specific cross-tetrahedra collision test

RDR §Decision item 2 phase 5 mandates this — the same-cell-different-type collision path is unique to Tetree's S0-S5 subdivision and invisible to the generic neighbor-traversal sweep the base \`findAllCollisions\` uses. Two cases:
1. Single S0/S4 pair at level 21 (cellSize=1) within the 0.1f point-collision threshold.
2. All 15 C(6,2) pairs across S0-S5 with one entity per type in the same cell.

## Bugs caught and fixed during stacked review (\`mem:feedback_review-stacking\`)

- **\`createPairKey\` hash-collision deduplication divergence** (code-review-expert Important#2 / substantive-critic S1) — the pre-P5 override used \`HashSet<String>\` keyed by hashCode-ordering of the two IDs, while the base sweep uses \`HashSet<UnorderedPair<ID>>\` (compareTo-ordering). On hash collisions these orderings disagree and the override would emit duplicate \`CollisionPair\` entries. Switched to \`UnorderedPair\` to align with the base contract; removed dead \`createPairKey\` helper.
- **TOCTOU window between super and cross-tet sweep** (substantive-critic S2) — \`super.findAllCollisions()\` released the read lock before the override re-acquired it. A concurrent writer could mutate the index in the gap. Fixed by acquiring the read lock BEFORE calling \`super.findAllCollisions()\` and holding it across both sections; \`ReentrantReadWriteLock\` allows the re-entrant read acquisition inside \`CollisionEngine.findAllCollisions\`.

Other review items addressed: missing \`@Override\` on the \`findCollisions(ID)\` facade delegator (#1/S4), \`CollisionGeometry\` naming-discipline doc note (S3), \`getVolumeBounds\` future-compat doc note (#3).

## First verification pass also caught a Critical

CollisionEngine's initial \`findNodesIntersectingBounds(EntityBounds)\` wrapper routed directly to the subclass \`VolumeBounds\` hook, bypassing \`spatialRangeQuery\`'s \`doesNodeIntersectVolume\` filter. \`OctreeCollisionAccuracyTest.testMultipleCollisionAccuracy\`, \`OctreeCollisionDetectionTest.testCollisionDetectionWithSpanningEntities\`, and \`OctreeCollisionShapeIntegrationTest.testFindCollisionsWithCustomShapes\` flagged the regression on spanning-entity paths. Fix re-routed through \`callback.spatialRangeQuery\` to match the pre-extraction facade wrapper.

## Verification

- Full lucien suite (post-clean): **2455 / 0 / 0**.
- Collision-cluster sweep (Octree + Tetree + Prism + cross-tet): **106 / 0 / 0**.
- \`git diff --stat -- octree/ prism/ sfc/\` empty → subclass invariant holds for the other three.

## Arc progress

Façade cumulative: **5851 → 3450 lines (−2401, 41% reduction; 5 of 6 phases done)**. G5 (\`Luciferase-x5i.11\`) is next; P6 (EntityLifecycleManager, \`Luciferase-x5i.12\`) remains, which will additionally move \`lockingStrategy\` into \`SpatialIndexCore\` and replace \`CollisionEngine\`'s \`Supplier\` with \`core.lockingStrategy()\` (P3 substantive-critic Significant#1 obligation).

Bead: \`Luciferase-x5i.10\`  
RDR: RDR-008 (§Decision item 1 P3 refinement + item 2 phase 5)