### PR TITLE
Luciferase-ts8: narrow StackBasedTreeBuilder via StackBuilderHost seam (RDR-008 P6 follow-up)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
@@ -294,8 +294,9 @@ implements SpatialIndex<Key, ID, Content> {
                 entityManager.clear();
             }
 
-            // Build tree
-            return treeBuilder.buildTree(this, positions, contents, startLevel);
+            // Build tree (RDR-008 P6 follow-up Luciferase-ts8: builder takes StackBuilderHost, not the concrete
+            // facade — protect against the god-class type leak)
+            return treeBuilder.buildTree(new StackBuilderHostImpl(), positions, contents, startLevel);
         } finally {
             lock.writeLock().unlock();
         }
@@ -1757,8 +1758,48 @@ implements SpatialIndex<Key, ID, Content> {
         }
 
         @Override
-        public AbstractSpatialIndex<Key, ID, Content> stackBuilderTarget() {
-            return AbstractSpatialIndex.this;
+        public com.hellblazer.luciferase.lucien.StackBuilderHost<Key, ID, Content> stackBuilderTarget() {
+            return new StackBuilderHostImpl();
+        }
+    }
+
+    /**
+     * Façade implementation of the {@link com.hellblazer.luciferase.lucien.StackBuilderHost} seam (RDR-008 P6
+     * follow-up, bead {@code Luciferase-ts8}): supplies {@link StackBasedTreeBuilder} the six facade-internal
+     * methods it consumes ({@code calculateSpatialIndex}, {@code createNode}, {@code getEntityManager},
+     * {@code getSpatialIndex}, {@code getMaxDepth}, {@code getMaxEntitiesPerNode}). Private inner class preserves
+     * each underlying method's original visibility.
+     */
+    private final class StackBuilderHostImpl implements com.hellblazer.luciferase.lucien.StackBuilderHost<Key, ID, Content> {
+
+        @Override
+        public Key calculateSpatialIndex(Point3f position, byte level) {
+            return AbstractSpatialIndex.this.calculateSpatialIndex(position, level);
+        }
+
+        @Override
+        public SpatialNodeImpl<ID> createNode() {
+            return AbstractSpatialIndex.this.createNode();
+        }
+
+        @Override
+        public com.hellblazer.luciferase.lucien.entity.EntityManager<Key, ID, Content> getEntityManager() {
+            return AbstractSpatialIndex.this.getEntityManager();
+        }
+
+        @Override
+        public java.util.Map<Key, SpatialNodeImpl<ID>> getSpatialIndex() {
+            return AbstractSpatialIndex.this.getSpatialIndex();
+        }
+
+        @Override
+        public byte getMaxDepth() {
+            return AbstractSpatialIndex.this.getMaxDepth();
+        }
+
+        @Override
+        public int getMaxEntitiesPerNode() {
+            return AbstractSpatialIndex.this.getMaxEntitiesPerNode();
         }
     }
 

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/StackBasedTreeBuilder.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/StackBasedTreeBuilder.java
@@ -74,7 +74,7 @@ public class StackBasedTreeBuilder<Key extends SpatialKey<Key>, ID extends Entit
     /**
      * Build tree using stack-based approach
      */
-    public BuildResult buildTree(AbstractSpatialIndex<Key, ID, Content> index, List<Point3f> positions,
+    public BuildResult buildTree(StackBuilderHost<Key, ID, Content> index, List<Point3f> positions,
                                  List<Content> contents, byte startLevel) {
         var startTime = System.currentTimeMillis();
         var phaseTimes = new HashMap<String, Long>();
@@ -125,7 +125,7 @@ public class StackBasedTreeBuilder<Key extends SpatialKey<Key>, ID extends Entit
     /**
      * Build tree bottom-up: create all leaf nodes first, then merge upwards
      */
-    private void buildBottomUp(AbstractSpatialIndex<Key, ID, Content> index,
+    private void buildBottomUp(StackBuilderHost<Key, ID, Content> index,
                                List<BulkOperationProcessor.SfcEntity<Key, Content>> entities, byte startLevel) {
         if (entities.isEmpty()) {
             return;
@@ -214,7 +214,7 @@ public class StackBasedTreeBuilder<Key extends SpatialKey<Key>, ID extends Entit
     /**
      * Build tree using hybrid approach: bulk load at a specific level, then build internal nodes
      */
-    private void buildHybrid(AbstractSpatialIndex<Key, ID, Content> index,
+    private void buildHybrid(StackBuilderHost<Key, ID, Content> index,
                              List<BulkOperationProcessor.SfcEntity<Key, Content>> entities, byte startLevel) {
         if (entities.isEmpty()) {
             return;
@@ -268,7 +268,7 @@ public class StackBasedTreeBuilder<Key extends SpatialKey<Key>, ID extends Entit
     /**
      * Build internal nodes from a set of child nodes up to the root level
      */
-    private void buildInternalNodesUpward(AbstractSpatialIndex<Key, ID, Content> index, Set<Key> childNodes,
+    private void buildInternalNodesUpward(StackBuilderHost<Key, ID, Content> index, Set<Key> childNodes,
                                           byte fromLevel, byte toLevel) {
         var currentLevelNodes = new HashSet<>(childNodes);
         var currentLevel = fromLevel;
@@ -300,7 +300,7 @@ public class StackBasedTreeBuilder<Key extends SpatialKey<Key>, ID extends Entit
     /**
      * Build tree top-down using iterative stack approach
      */
-    private void buildTopDown(AbstractSpatialIndex<Key, ID, Content> index,
+    private void buildTopDown(StackBuilderHost<Key, ID, Content> index,
                               List<BulkOperationProcessor.SfcEntity<Key, Content>> entities, byte startLevel) {
 
         if (entities.isEmpty()) {
@@ -354,7 +354,7 @@ public class StackBasedTreeBuilder<Key extends SpatialKey<Key>, ID extends Entit
     /**
      * Create and populate a node with entities
      */
-    private void createAndPopulateNode(AbstractSpatialIndex<Key, ID, Content> index, Key nodeIndex,
+    private void createAndPopulateNode(StackBuilderHost<Key, ID, Content> index, Key nodeIndex,
                                        List<BulkOperationProcessor.SfcEntity<Key, Content>> entities) {
         var node = index.getSpatialIndex().computeIfAbsent(nodeIndex, k -> {
             nodesCreated.incrementAndGet();
@@ -378,7 +378,7 @@ public class StackBasedTreeBuilder<Key extends SpatialKey<Key>, ID extends Entit
     /**
      * Create child nodes for subdivision
      */
-    private void createChildren(AbstractSpatialIndex<Key, ID, Content> index,
+    private void createChildren(StackBuilderHost<Key, ID, Content> index,
                                 BuildStackFrame<Key, ID, Content> frame,
                                 Deque<BuildStackFrame<Key, ID, Content>> stack) {
 
@@ -415,7 +415,7 @@ public class StackBasedTreeBuilder<Key extends SpatialKey<Key>, ID extends Entit
     /**
      * Determine the appropriate level for an entity based on spatial density
      */
-    private byte determineEntityLevel(AbstractSpatialIndex<Key, ID, Content> index, Point3f position,
+    private byte determineEntityLevel(StackBuilderHost<Key, ID, Content> index, Point3f position,
                                       byte startLevel) {
         // Start at the given level and potentially go deeper based on density
         var level = startLevel;
@@ -432,7 +432,7 @@ public class StackBasedTreeBuilder<Key extends SpatialKey<Key>, ID extends Entit
     /**
      * Finalize a node after children have been created
      */
-    private void finalizeNode(AbstractSpatialIndex<Key, ID, Content> index,
+    private void finalizeNode(StackBuilderHost<Key, ID, Content> index,
                               BuildStackFrame<Key, ID, Content> frame) {
         // Mark node as having children if applicable
         var node = index.getSpatialIndex().get(frame.nodeIndex);
@@ -445,7 +445,7 @@ public class StackBasedTreeBuilder<Key extends SpatialKey<Key>, ID extends Entit
      * Group entities by their child node
      */
     private Map<Key, List<BulkOperationProcessor.SfcEntity<Key, Content>>> groupByChildNode(
-        AbstractSpatialIndex<Key, ID, Content> index, BuildStackFrame<Key, ID, Content> frame) {
+        StackBuilderHost<Key, ID, Content> index, BuildStackFrame<Key, ID, Content> frame) {
 
         var groups = new HashMap<Key, List<BulkOperationProcessor.SfcEntity<Key, Content>>>();
         var childLevel = (byte) (frame.level + 1);
@@ -465,7 +465,7 @@ public class StackBasedTreeBuilder<Key extends SpatialKey<Key>, ID extends Entit
     /**
      * Insert entities directly into a node
      */
-    private void insertEntitiesIntoNode(AbstractSpatialIndex<Key, ID, Content> index,
+    private void insertEntitiesIntoNode(StackBuilderHost<Key, ID, Content> index,
                                         BuildStackFrame<Key, ID, Content> frame) {
         // Get or create node
         SpatialNodeImpl<ID> node = index.getSpatialIndex().computeIfAbsent(frame.nodeIndex, k -> {
@@ -504,7 +504,7 @@ public class StackBasedTreeBuilder<Key extends SpatialKey<Key>, ID extends Entit
      * Prepare entities with Morton codes
      */
     private List<BulkOperationProcessor.SfcEntity<Key, Content>> prepareEntities(
-        AbstractSpatialIndex<Key, ID, Content> index, List<Point3f> positions, List<Content> contents,
+        StackBuilderHost<Key, ID, Content> index, List<Point3f> positions, List<Content> contents,
         byte level) {
 
         var entities = new ArrayList<BulkOperationProcessor.SfcEntity<Key, Content>>(positions.size());
@@ -530,7 +530,7 @@ public class StackBasedTreeBuilder<Key extends SpatialKey<Key>, ID extends Entit
     /**
      * Process a node - decide whether to subdivide or insert entities
      */
-    private void processNode(AbstractSpatialIndex<Key, ID, Content> index,
+    private void processNode(StackBuilderHost<Key, ID, Content> index,
                              BuildStackFrame<Key, ID, Content> frame, Deque<BuildStackFrame<Key, ID, Content>> stack) {
 
         var entityCount = frame.getEntityCount();
@@ -570,7 +570,7 @@ public class StackBasedTreeBuilder<Key extends SpatialKey<Key>, ID extends Entit
     /**
      * Process a single frame (helper method for batch processing)
      */
-    private void processSingleFrame(AbstractSpatialIndex<Key, ID, Content> index,
+    private void processSingleFrame(StackBuilderHost<Key, ID, Content> index,
                                     BuildStackFrame<Key, ID, Content> frame,
                                     Deque<BuildStackFrame<Key, ID, Content>> stack) {
         switch (frame.phase) {
@@ -591,7 +591,7 @@ public class StackBasedTreeBuilder<Key extends SpatialKey<Key>, ID extends Entit
     /**
      * Process stack frames for subdivision
      */
-    private void processStackFrames(AbstractSpatialIndex<Key, ID, Content> index,
+    private void processStackFrames(StackBuilderHost<Key, ID, Content> index,
                                     Deque<BuildStackFrame<Key, ID, Content>> stack, int totalEntities) {
         while (!stack.isEmpty()) {
             if (stack.size() > config.getMaxStackDepth()) {

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/StackBuilderHost.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/StackBuilderHost.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien;
+
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+import com.hellblazer.luciferase.lucien.entity.EntityManager;
+
+import javax.vecmath.Point3f;
+import java.util.Map;
+
+/**
+ * Façade operations the {@link StackBasedTreeBuilder} consumes (RDR-008 P6 follow-up — bead {@code Luciferase-ts8}).
+ *
+ * <p>Pre-extraction, {@code StackBasedTreeBuilder.buildTree} accepted {@code AbstractSpatialIndex<Key,ID,Content>}
+ * directly because the builder reaches into the subclass-overridden geometry hook
+ * ({@link #calculateSpatialIndex}), the DSOC-aware pool-aware {@link #createNode}, the {@link EntityManager} for
+ * id generation and entity registration, the underlying spatial-index map for direct put/get/computeIfAbsent
+ * access, plus the {@link #maxDepth} and {@link #maxEntitiesPerNode} sizing constants. None of those are on the
+ * public {@link SpatialIndex} interface, so the original god-class type leaked into every caller — including
+ * {@link com.hellblazer.luciferase.lucien.entity.EntityLifecycleHost} after the P6 entity-lifecycle extraction.
+ *
+ * <p>This host interface is the narrow named seam (P3 per-cluster sub-interface pattern applied here): the
+ * façade implements it via a private inner class so the underlying methods keep their original visibility, and
+ * the builder + {@link com.hellblazer.luciferase.lucien.entity.EntityLifecycleHost#stackBuilderTarget()} both
+ * speak this interface instead of the concrete {@code AbstractSpatialIndex}. Removes the
+ * {@code AbstractSpatialIndex} import from {@code lucien.entity}.
+ *
+ * @param <Key>     the spatial key type
+ * @param <ID>      the entity identifier type
+ * @param <Content> the entity content type
+ * @author hal.hildebrand
+ */
+public interface StackBuilderHost<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
+
+    /** Calculate the spatial key for a position at a given level (subclass-specific SFC encoding). */
+    Key calculateSpatialIndex(Point3f position, byte level);
+
+    /**
+     * Acquire a new spatial node — pool-aware. Returns an occlusion-aware node when DSOC is enabled, mirroring
+     * the façade's {@code createNode} behavior.
+     */
+    SpatialNodeImpl<ID> createNode();
+
+    /** The entity manager — exposed for id generation, entity registration, and entity-location tracking. */
+    EntityManager<Key, ID, Content> getEntityManager();
+
+    /** The underlying spatial-index storage map (for direct put / get / computeIfAbsent access in the builder). */
+    Map<Key, SpatialNodeImpl<ID>> getSpatialIndex();
+
+    /** Maximum subdivision depth allowed by the index. */
+    byte getMaxDepth();
+
+    /** Maximum entities per node before subdivision triggers. */
+    int getMaxEntitiesPerNode();
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/entity/EntityLifecycleHost.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/entity/EntityLifecycleHost.java
@@ -16,7 +16,6 @@
  */
 package com.hellblazer.luciferase.lucien.entity;
 
-import com.hellblazer.luciferase.lucien.AbstractSpatialIndex;
 import com.hellblazer.luciferase.lucien.BulkOperationConfig;
 import com.hellblazer.luciferase.lucien.BulkOperationProcessor;
 import com.hellblazer.luciferase.lucien.DeferredSubdivisionManager;
@@ -25,6 +24,7 @@ import com.hellblazer.luciferase.lucien.SpatialKey;
 import com.hellblazer.luciferase.lucien.SpatialNodeImpl;
 import com.hellblazer.luciferase.lucien.SpatialNodePool;
 import com.hellblazer.luciferase.lucien.StackBasedTreeBuilder;
+import com.hellblazer.luciferase.lucien.StackBuilderHost;
 import com.hellblazer.luciferase.lucien.occlusion.DsocController;
 
 import java.util.Set;
@@ -135,12 +135,11 @@ public interface EntityLifecycleHost<Key extends SpatialKey<Key>, ID extends Ent
     // ===== Stack-based tree builder target =====
 
     /**
-     * The {@link AbstractSpatialIndex} target the {@link StackBasedTreeBuilder} needs (the builder's
-     * {@code buildTree} signature takes the concrete abstract base, not the public {@code SpatialIndex} interface,
-     * because the builder relies on facade-internal helpers — auto-id generation through the entity manager and
-     * the protected lifecycle paths). The host exposes the facade through this accessor so
-     * {@code EntityLifecycleManager} avoids a direct {@code AbstractSpatialIndex} import — the coupling stays
-     * named and bounded here.
+     * The {@link StackBuilderHost} target the {@link StackBasedTreeBuilder} consumes. RDR-008 P6 follow-up (bead
+     * {@code Luciferase-ts8}): the builder's signature was previously {@code AbstractSpatialIndex<Key,ID,Content>}
+     * — the god-class concrete type leaking through this host interface. Narrowing the builder to take a
+     * {@link StackBuilderHost} (a small named seam exposing only the six facade-internal methods the builder
+     * actually uses) removes the {@code AbstractSpatialIndex} import from {@code lucien.entity}.
      */
-    AbstractSpatialIndex<Key, ID, Content> stackBuilderTarget();
+    StackBuilderHost<Key, ID, Content> stackBuilderTarget();
 }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/entity/EntityLifecycleManager.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/entity/EntityLifecycleManager.java
@@ -885,10 +885,10 @@ public final class EntityLifecycleManager<Key extends SpatialKey<Key>, ID extend
     private List<ID> performStackBasedBulkInsert(List<Point3f> positions, List<Content> contents, byte level) {
         host.configureTreeBuilder(host.bulkConfig().getStackBuilderConfig());
 
-        // The {@link StackBasedTreeBuilder#buildTree} signature requires the concrete {@link AbstractSpatialIndex}
-        // base; the host's {@link EntityLifecycleHost#stackBuilderTarget()} accessor returns it. Resolving the
-        // builder reference and the target through the host re-reads the current values, picking up any
-        // configureTreeBuilder swap that just happened above.
+        // RDR-008 P6 follow-up (Luciferase-ts8): the builder now takes a {@link
+        // com.hellblazer.luciferase.lucien.StackBuilderHost} (narrow named seam) instead of the concrete
+        // {@code AbstractSpatialIndex}. Resolving the builder reference and the target through the host re-reads
+        // the current values, picking up any configureTreeBuilder swap that just happened above.
         var buildResult = host.treeBuilder().buildTree(stackBasedBuilderTarget(), positions, contents, level);
 
         log.debug("Stack-based bulk insertion completed: {} entities in {}ms, {} nodes created",
@@ -903,11 +903,12 @@ public final class EntityLifecycleManager<Key extends SpatialKey<Key>, ID extend
     }
 
     /**
-     * Resolves the {@code AbstractSpatialIndex<Key,ID,Content>} target the stack-based builder needs (its
-     * {@code buildTree} signature requires the concrete abstract base). Routed through the host so this class
-     * doesn't import {@code AbstractSpatialIndex} directly.
+     * Resolves the {@link com.hellblazer.luciferase.lucien.StackBuilderHost} target the stack-based builder
+     * needs. RDR-008 P6 follow-up (bead Luciferase-ts8) narrowed the builder's signature from the concrete
+     * {@code AbstractSpatialIndex<Key,ID,Content>} to this named seam, removing the {@code AbstractSpatialIndex}
+     * import from the {@code lucien.entity} package.
      */
-    private com.hellblazer.luciferase.lucien.AbstractSpatialIndex<Key, ID, Content> stackBasedBuilderTarget() {
+    private com.hellblazer.luciferase.lucien.StackBuilderHost<Key, ID, Content> stackBasedBuilderTarget() {
         return host.stackBuilderTarget();
     }
 


### PR DESCRIPTION
RDR-008 P6 follow-up. Substantive-critic at the P6 review flagged that `EntityLifecycleHost.stackBuilderTarget()` returned `AbstractSpatialIndex<Key,ID,Content>` — the concrete god-class type leaking through the host interface. Root cause: `StackBasedTreeBuilder.buildTree` accepted `AbstractSpatialIndex` directly because the builder reaches into protected/package-internal methods (`calculateSpatialIndex`, `createNode`, `getEntityManager`, `getSpatialIndex`, `getMaxDepth`, `getMaxEntitiesPerNode`) — none of those are on the public `SpatialIndex` interface.

## What changed

- New `lucien.StackBuilderHost<Key,ID,Content>` interface — narrow named seam (P3 per-cluster sub-interface pattern) exposing the six methods the builder actually uses.
- New `AbstractSpatialIndex.StackBuilderHostImpl` private inner class — façade implementation of the seam (delegates to the underlying methods, preserving their original visibility so subclass overrides of `calculateSpatialIndex` and `createNode` still fire via virtual dispatch).
- `StackBasedTreeBuilder` — every `AbstractSpatialIndex<Key,ID,Content>` parameter narrowed to `StackBuilderHost<Key,ID,Content>` (16 occurrences across `buildTree` + 13 private helpers).
- `EntityLifecycleHost.stackBuilderTarget()` — return type narrowed from `AbstractSpatialIndex` to `StackBuilderHost`; the `AbstractSpatialIndex` import is **removed** from the `lucien.entity` package (the bead's primary goal).
- `EntityLifecycleManager.stackBasedBuilderTarget()` + stale comment updated to match.

## Acceptance criterion revision (called out for transparency)

The bead originally specified \"`stackBuilderTarget()` returns `SpatialIndex<Key,ID,Content>`\". Investigation showed this was unworkable: the builder uses methods that aren't on the public `SpatialIndex` interface, and lifting them there would either pollute the public API or force visibility expansion on the four subclasses' overrides (breaking the RDR-008 byte-for-byte-unchanged invariant). The `StackBuilderHost` seam achieves the bead's **intent** — decouple `lucien.entity` from the concrete god-class — via the same P3 sub-interface pattern P4/P5/P6 already use.

## Verification

- Compile: clean (282 source files).
- Suite: **2448/0/0 GREEN** (22 skipped, matches pre-change baseline).
- Subclass diff: \`git diff --stat origin/main..HEAD -- octree/ tetree/ prism/ sfc/\` is **empty** — Octree, Tetree, Prism, SFCArrayIndex byte-for-byte unchanged.
- `AbstractSpatialIndex` import removed from `lucien.entity` package (verified — only doc references remain).

Closes Luciferase-ts8.