### PR TITLE
Luciferase-vpl: hoist estimateSFCRange to SpatialKey.sfcRangesForKNN (RDR-008 P3 follow-up)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialKey.java
@@ -16,6 +16,10 @@
  */
 package com.hellblazer.luciferase.lucien;
 
+import javax.vecmath.Point3f;
+import java.util.List;
+import java.util.NavigableSet;
+
 /**
  * Base interface for all spatial index keys.
  *
@@ -29,6 +33,43 @@ package com.hellblazer.luciferase.lucien;
  * @author hal.hildebrand
  */
 public interface SpatialKey<K extends SpatialKey<K>> extends Comparable<K> {
+
+    /**
+     * Generic SFC range covering a query region in the spatial-key total order. The {@code (lower, upper)} pair is
+     * fed directly into {@code ConcurrentSkipListMap.subMap(lower, upper)} to prune k-NN search to the candidate
+     * keys that could contain entities within the search radius. RDR-008 P3 follow-up (bead Luciferase-vpl).
+     *
+     * @param lower the lower bound (inclusive) of the SFC range
+     * @param upper the upper bound (exclusive) of the SFC range
+     * @param <K>   the spatial key type
+     */
+    record SFCRange<K extends SpatialKey<K>>(K lower, K upper) {}
+
+    /**
+     * Build the SFC ranges {@link KnnSearcher KnnSearcher} should scan for a k-NN query centered at {@code center}
+     * with search radius {@code radius}. RDR-008 P3 follow-up (bead Luciferase-vpl) — hoisted from the per-class
+     * static methods {@code MortonKey.estimateSFCRange} / {@code TetreeKey.estimateSFCRange} so {@code KnnSearcher}
+     * can dispatch through the interface instead of {@code instanceof}.
+     *
+     * <p>Implementations decide how many ranges to return:
+     * <ul>
+     *     <li>{@code MortonKey} returns one range per distinct storage level present in the index — required
+     *         because {@code MortonKey.compareTo} orders keys by level first, so a subMap query at level L only
+     *         returns keys at level L. The level set is collected from {@code indexKeys}.</li>
+     *     <li>{@code TetreeKey} returns a single range and ignores {@code indexKeys} — its ordering is not
+     *         level-scoped.</li>
+     *     <li>Implementations without an SFC range estimator (e.g. {@code PrismKey}) return the default empty
+     *         iterable, signaling {@code KnnSearcher} to fall back to the breadth-first search path.</li>
+     * </ul>
+     *
+     * @param center     k-NN query point
+     * @param radius     k-NN search radius
+     * @param indexKeys  current key set of the spatial index (used by {@code MortonKey} for level collection)
+     * @return iterable of SFC ranges, or empty iterable for "no SFC pruning support"
+     */
+    default Iterable<SFCRange<K>> sfcRangesForKNN(Point3f center, float radius, NavigableSet<K> indexKeys) {
+        return List.of();
+    }
 
     /**
      * Get the level of this key in the spatial hierarchy. Level 0 represents the root, with increasing levels

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/cache/KnnSearcher.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/cache/KnnSearcher.java
@@ -25,16 +25,12 @@ import com.hellblazer.luciferase.lucien.VolumeBounds;
 import com.hellblazer.luciferase.lucien.entity.EntityDistance;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.internal.ObjectPools;
-import com.hellblazer.luciferase.lucien.octree.MortonKey;
-import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.vecmath.Point3f;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -69,15 +65,14 @@ import java.util.concurrent.atomic.AtomicLong;
  * substantive-critic Significant#1 by relocating the field into the core, so this class no longer carries a
  * {@code Supplier<FineGrainedLockingStrategy>} ctor argument.
  *
- * <h2>Subclass-coupled dispatch</h2>
+ * <h2>SFC-range pruning via the SpatialKey interface</h2>
  *
- * <p>{@link #performKNNSFCRangePruning} dispatches on the concrete spatial-key type via
- * {@code instanceof MortonKey / TetreeKey} to use each subclass's SFC range estimator. This couples
- * {@code lucien.cache} to {@code lucien.octree} and {@code lucien.tetree}; the dispatch was present before
- * extraction (in the façade) and the alternative — pushing the range estimator into a method on the key type —
- * is out of scope for the no-behavior-change extraction phase. The unknown-key-type branch and the catch-all
- * exception fallback both route to the legacy breadth-first {@link #performKNNSFCBasedSearch}, so the dispatch is
- * forward-compatible with future key types.
+ * <p>{@link #performKNNSFCRangePruning} delegates to {@link SpatialKey#sfcRangesForKNN} on the index's first key,
+ * which returns the iterable of SFC ranges this implementation should scan ({@code MortonKey} returns one range
+ * per distinct storage level; {@code TetreeKey} returns a single range; key types without an estimator return
+ * the default empty iterable, which signals a fall back to the legacy breadth-first
+ * {@link #performKNNSFCBasedSearch}). RDR-008 P3 follow-up (bead Luciferase-vpl) replaced the prior
+ * {@code instanceof MortonKey / TetreeKey} dispatch that coupled this class to the concrete key packages.
  *
  * @param <Key>     the spatial key type
  * @param <ID>      the entity identifier type
@@ -216,10 +211,15 @@ implements KnnProvider<Key, ID> {
     // ---- SFC range pruning (Paper 4: 4-6× speedup) ----------------------------------------------------------------
 
     /**
-     * Optimized SFC range-based k-NN search using range pruning. Dispatches on the concrete spatial-key type to use
-     * each subclass's SFC range estimator; unknown key types and any thrown exception fall back to the legacy
-     * breadth-first search.
+     * Optimized SFC range-based k-NN search using range pruning. RDR-008 P3 follow-up (bead Luciferase-vpl)
+     * removed the per-key-type {@code instanceof MortonKey / TetreeKey} dispatch by hoisting the per-key SFC range
+     * estimator to {@link SpatialKey#sfcRangesForKNN}. Each {@code SpatialKey} implementation returns the
+     * appropriate iterable of SFC ranges (Morton returns one per distinct storage level; Tetree returns a single
+     * range; PrismKey or any other implementation without an estimator returns the default empty iterable,
+     * signaling a fallback to the legacy breadth-first search). Any exception raised during range estimation also
+     * falls back.
      */
+    @SuppressWarnings("unchecked")
     private void performKNNSFCRangePruning(Point3f queryPoint, int k, float maxDistance,
                                            PriorityQueue<EntityDistance<ID>> candidates, Set<ID> addedToCandidates) {
         var spatialIndex = core.spatialIndex();
@@ -227,97 +227,40 @@ implements KnnProvider<Key, ID> {
             return;
         }
 
-        // Get the root key to determine key type
+        // When maxDistance is very large, SFC range pruning won't work properly because entities are stored at
+        // finer levels; fall back to a full scan that doesn't rely on bounding the search via subMap.
+        if (maxDistance >= Constants.MAX_COORD) {
+            performFullScanKNN(queryPoint, k, maxDistance, candidates, addedToCandidates);
+            return;
+        }
+
         var rootKey = spatialIndex.firstKey();
 
         try {
-            // Use appropriate SFC range estimation based on key type
-            if (rootKey instanceof MortonKey) {
-                performKNNSFCRangePruningMorton(queryPoint, k, maxDistance, candidates, addedToCandidates);
-            } else if (rootKey instanceof TetreeKey) {
-                performKNNSFCRangePruningTetree(queryPoint, k, maxDistance, candidates, addedToCandidates);
-            } else {
-                // Fallback to old breadth-first search for unknown key types
+            var sfcRanges = rootKey.sfcRangesForKNN(queryPoint, maxDistance, spatialIndex.navigableKeySet());
+            var iterator = sfcRanges.iterator();
+            if (!iterator.hasNext()) {
+                // Default empty iterable — no SFC pruning supported for this key type; fall back to legacy
+                // breadth-first search (matches the pre-extraction PrismKey path).
                 performKNNSFCBasedSearch(queryPoint, k, maxDistance, candidates, addedToCandidates);
+                return;
             }
+
+            do {
+                var sfcRange = iterator.next();
+                var rangeMap = spatialIndex.subMap((Key) sfcRange.lower(), (Key) sfcRange.upper());
+
+                for (var entry : rangeMap.entrySet()) {
+                    var node = entry.getValue();
+                    if (node == null) {
+                        continue;
+                    }
+                    collectCandidatesFromNode(node, queryPoint, k, maxDistance, candidates, addedToCandidates);
+                }
+            } while (iterator.hasNext());
         } catch (Exception e) {
             log.warn("SFC range pruning failed, falling back to breadth-first search: {}", e.getMessage());
             performKNNSFCBasedSearch(queryPoint, k, maxDistance, candidates, addedToCandidates);
-        }
-    }
-
-    /**
-     * SFC range-based k-NN search for MortonKey (Octree).
-     *
-     * <p>Because {@link MortonKey#compareTo} orders keys first by level then by Morton code, a {@code subMap} call
-     * whose bounds are at level L will only return keys that are also stored at level L. Entities can be inserted at
-     * different levels, so we collect the set of distinct storage levels present in the index and issue one
-     * {@code subMap} query per unique level, using bounds computed at that same level.
-     */
-    @SuppressWarnings("unchecked")
-    private void performKNNSFCRangePruningMorton(Point3f queryPoint, int k, float maxDistance,
-                                                 PriorityQueue<EntityDistance<ID>> candidates,
-                                                 Set<ID> addedToCandidates) {
-        var spatialIndex = core.spatialIndex();
-        // When maxDistance is very large, SFC range pruning at level 0 won't work properly
-        // because entities are stored at a finer level. Fall back to full scan.
-        if (maxDistance >= Constants.MAX_COORD) {
-            performFullScanKNN(queryPoint, k, maxDistance, candidates, addedToCandidates);
-            return;
-        }
-
-        // Collect the distinct levels at which keys are stored so we can issue a correctly-levelled
-        // subMap query for each one.  In the common single-level case this is a single pass.
-        var storageLevels = new LinkedHashSet<Byte>();
-        for (var key : spatialIndex.keySet()) {
-            storageLevels.add(((MortonKey) key).getLevel());
-        }
-
-        for (byte storageLevel : storageLevels) {
-            // Compute SFC range bounds at the same level as the stored keys so that
-            // subMap() returns the correct entries with level-aware compareTo.
-            var sfcRange = MortonKey.estimateSFCRange(queryPoint, maxDistance, storageLevel);
-
-            var rangeMap = spatialIndex.subMap((Key) sfcRange.lower(), (Key) sfcRange.upper());
-
-            for (var entry : rangeMap.entrySet()) {
-                var node = entry.getValue();
-                if (node == null) {
-                    continue;
-                }
-
-                collectCandidatesFromNode(node, queryPoint, k, maxDistance, candidates, addedToCandidates);
-            }
-        }
-    }
-
-    /** SFC range-based k-NN search for TetreeKey (Tetree). */
-    @SuppressWarnings("unchecked")
-    private void performKNNSFCRangePruningTetree(Point3f queryPoint, int k, float maxDistance,
-                                                 PriorityQueue<EntityDistance<ID>> candidates,
-                                                 Set<ID> addedToCandidates) {
-        var spatialIndex = core.spatialIndex();
-        // When maxDistance is very large, SFC range pruning at level 0 won't work properly
-        // because entities are stored at a finer level. Fall back to full scan.
-        if (maxDistance >= Constants.MAX_COORD) {
-            performFullScanKNN(queryPoint, k, maxDistance, candidates, addedToCandidates);
-            return;
-        }
-
-        // Estimate SFC range covering the search sphere
-        var sfcRange = TetreeKey.estimateSFCRange(queryPoint, maxDistance);
-
-        // Use subMap to iterate only over keys in the SFC range (this is the optimization!)
-        var rangeMap = spatialIndex.subMap((Key) sfcRange.lower(), (Key) sfcRange.upper());
-
-        // Process entities in nodes within the SFC range
-        for (var entry : rangeMap.entrySet()) {
-            var node = entry.getValue();
-            if (node == null) {
-                continue;
-            }
-
-            collectCandidatesFromNode(node, queryPoint, k, maxDistance, candidates, addedToCandidates);
         }
     }
 

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/octree/MortonKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/octree/MortonKey.java
@@ -526,4 +526,29 @@ public final class MortonKey implements SpatialKey<MortonKey> {
 
         return new SFCRange(lowerBound, upperBound);
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>{@code MortonKey} returns one range per distinct storage level in {@code indexKeys}. Because
+     * {@link #compareTo} orders keys first by level then by Morton code, a {@code subMap} call whose bounds are at
+     * level L only returns keys at level L — entities can be inserted at different levels, so {@code KnnSearcher}
+     * issues one {@code subMap} query per unique level using bounds computed at that same level. RDR-008 P3
+     * follow-up (bead Luciferase-vpl).
+     */
+    @Override
+    public Iterable<com.hellblazer.luciferase.lucien.SpatialKey.SFCRange<MortonKey>> sfcRangesForKNN(
+        Point3f center, float radius, java.util.NavigableSet<MortonKey> indexKeys) {
+        var levels = new java.util.LinkedHashSet<Byte>();
+        for (var key : indexKeys) {
+            levels.add(key.getLevel());
+        }
+        var ranges = new java.util.ArrayList<com.hellblazer.luciferase.lucien.SpatialKey.SFCRange<MortonKey>>(
+            levels.size());
+        for (var level : levels) {
+            var range = estimateSFCRange(center, radius, level);
+            ranges.add(new com.hellblazer.luciferase.lucien.SpatialKey.SFCRange<>(range.lower(), range.upper()));
+        }
+        return ranges;
+    }
 }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeKey.java
@@ -575,4 +575,20 @@ public abstract class TetreeKey<K extends TetreeKey<K>> implements SpatialKey<Te
         return create(level, Long.MAX_VALUE, Long.MAX_VALUE);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>{@code TetreeKey} returns a single range and ignores {@code indexKeys}. The TM-index ordering is not
+     * level-scoped, so one {@code subMap} query suffices regardless of the storage levels present. RDR-008 P3
+     * follow-up (bead Luciferase-vpl).
+     */
+    @Override
+    public Iterable<com.hellblazer.luciferase.lucien.SpatialKey.SFCRange<TetreeKey<? extends TetreeKey<?>>>> sfcRangesForKNN(
+        Point3f center, float radius,
+        java.util.NavigableSet<TetreeKey<? extends TetreeKey<?>>> indexKeys) {
+        var range = estimateSFCRange(center, radius);
+        return java.util.List.of(
+            new com.hellblazer.luciferase.lucien.SpatialKey.SFCRange<TetreeKey<? extends TetreeKey<?>>>(range.lower(),
+                                                                                                       range.upper()));
+    }
 }


### PR DESCRIPTION
RDR-008 P3 follow-up. Removes the \`instanceof MortonKey / instanceof TetreeKey\` dispatch in \`KnnSearcher.performKNNSFCRangePruning\` by hoisting the per-key SFC range estimator to the \`SpatialKey\` interface.

## What changed

**`SpatialKey` gains** a nested generic record and a default method:
```java
record SFCRange<K extends SpatialKey<K>>(K lower, K upper) {}

default Iterable<SFCRange<K>> sfcRangesForKNN(
        Point3f center, float radius, NavigableSet<K> indexKeys) {
    return List.of();  // empty = no SFC pruning support; fall back
}
```

**`MortonKey`** overrides — returns one `SFCRange` per distinct storage level in `indexKeys`. Required because `compareTo` orders keys by level-then-Morton-code, so a `subMap` at level L only returns keys at level L; entities can be inserted at different levels. Each per-level computation delegates to the existing static `MortonKey.estimateSFCRange(center, radius, level)`.

**`TetreeKey`** overrides — returns a single `SFCRange`. TetreeKey ordering is not level-scoped, so one subMap query suffices. Delegates to the existing static `TetreeKey.estimateSFCRange(center, radius)`. Ignores `indexKeys`.

**`PrismKey`** (third SpatialKey implementation) gets the default — preserves its existing pre-extraction behavior of falling through the `instanceof` chain to `performKNNSFCBasedSearch`.

**`KnnSearcher.performKNNSFCRangePruning`** collapses from a 3-branch instanceof + two ~50-LOC helper methods (Morton/Tetree-specific) to a single unified method (~50 LOC) that calls `rootKey.sfcRangesForKNN(...)` and iterates the returned ranges. Removes the `MortonKey` + `TetreeKey` imports + `LinkedHashSet` import from `lucien.cache`. The exception-based fallback path remains.

## Verification

- Compile: clean (282 source files).
- Suite: **2448/0/0 GREEN** (22 skipped, matches baseline).
- The static methods (`MortonKey.estimateSFCRange`, `TetreeKey.estimateSFCRange`) are unchanged — all their existing tests (`MortonKeyTest`, `TetreeKeyTest`, `MortonKeyEdgeCaseTest`) keep passing.

## Net change

`+122 / -97` across 4 files. `KnnSearcher.java` is the biggest delta (-87 lines after collapsing the two-helper-method dispatch).

Closes Luciferase-vpl.