### PR TITLE
Luciferase-703: invert ghost subsystem off AbstractSpatialIndex (RDR-008 P2 follow-up)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialIndex.java
@@ -236,6 +236,26 @@ public interface SpatialIndex<Key extends SpatialKey<Key>, ID extends EntityID, 
     EntityStats getStats();
 
     /**
+     * All spatial keys currently in the index. Used by the ghost-boundary subsystem to iterate over local
+     * elements. RDR-008 P2 follow-up (bead Luciferase-703) — hoisted onto the public interface so
+     * {@link com.hellblazer.luciferase.lucien.forest.ghost.GhostBoundaryDetector} and
+     * {@link com.hellblazer.luciferase.lucien.forest.ghost.DistributedGhostManager} can speak this interface
+     * instead of the concrete {@code AbstractSpatialIndex}.
+     *
+     * @return set of all spatial keys (defensive copy — callers may mutate)
+     */
+    java.util.Set<Key> getSpatialKeys();
+
+    /**
+     * Whether the index currently contains the given spatial key. Used by the ghost-boundary subsystem to test
+     * element existence without materializing the full key set. RDR-008 P2 follow-up (bead Luciferase-703).
+     *
+     * @param key the spatial key to check
+     * @return true if the key is in the index
+     */
+    boolean containsSpatialKey(Key key);
+
+    /**
      * Check if a node exists at the given Morton index
      *
      * @param sfcIndex the sfc index to check

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/DistributedGhostManager.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/DistributedGhostManager.java
@@ -18,7 +18,7 @@
 package com.hellblazer.luciferase.lucien.forest.ghost;
 
 import com.hellblazer.luciferase.lucien.SpatialKey;
-import com.hellblazer.luciferase.lucien.AbstractSpatialIndex;
+import com.hellblazer.luciferase.lucien.SpatialIndex;
 import com.hellblazer.luciferase.lucien.balancing.fault.GhostSyncCallback;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.neighbor.NeighborDetector;
@@ -53,7 +53,7 @@ public class DistributedGhostManager<Key extends SpatialKey<Key>, ID extends Ent
 
     private static final Logger log = LoggerFactory.getLogger(DistributedGhostManager.class);
 
-    private final AbstractSpatialIndex<Key, ID, Content> spatialIndex;
+    private final SpatialIndex<Key, ID, Content> spatialIndex;
     private final GhostChannel<Key, ID, Content> ghostChannel;
     private final GhostBoundaryDetector<Key, ID, Content> localGhostManager;
 
@@ -80,7 +80,7 @@ public class DistributedGhostManager<Key extends SpatialKey<Key>, ID extends Ent
      * @param ghostChannel the ghost communication channel
      * @param localGhostManager the local ghost manager
      */
-    public DistributedGhostManager(AbstractSpatialIndex<Key, ID, Content> spatialIndex,
+    public DistributedGhostManager(SpatialIndex<Key, ID, Content> spatialIndex,
                                   GhostChannel<Key, ID, Content> ghostChannel,
                                   GhostBoundaryDetector<Key, ID, Content> localGhostManager) {
         this.spatialIndex = Objects.requireNonNull(spatialIndex);

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/ElementGhostManager.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/ElementGhostManager.java
@@ -17,8 +17,8 @@
 
 package com.hellblazer.luciferase.lucien.forest.ghost;
 
+import com.hellblazer.luciferase.lucien.SpatialIndex;
 import com.hellblazer.luciferase.lucien.SpatialKey;
-import com.hellblazer.luciferase.lucien.AbstractSpatialIndex;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.neighbor.NeighborDetector;
 import com.hellblazer.luciferase.lucien.neighbor.NeighborDetector.NeighborInfo;
@@ -47,7 +47,7 @@ public class ElementGhostManager<Key extends SpatialKey<Key>, ID extends EntityI
     
     private static final Logger log = LoggerFactory.getLogger(ElementGhostManager.class);
     
-    private final AbstractSpatialIndex<Key, ID, Content> spatialIndex;
+    private final SpatialIndex<Key, ID, Content> spatialIndex;
     private final NeighborDetector<Key> neighborDetector;
     private final GhostLayer<Key, ID, Content> ghostLayer;
     private final GhostAlgorithm ghostAlgorithm;
@@ -74,7 +74,7 @@ public class ElementGhostManager<Key extends SpatialKey<Key>, ID extends EntityI
      * @param neighborDetector the neighbor detector for this index type
      * @param ghostType the type of ghosts to create
      */
-    public ElementGhostManager(AbstractSpatialIndex<Key, ID, Content> spatialIndex,
+    public ElementGhostManager(SpatialIndex<Key, ID, Content> spatialIndex,
                               NeighborDetector<Key> neighborDetector,
                               GhostType ghostType) {
         this(spatialIndex, neighborDetector, ghostType, GhostAlgorithm.CONSERVATIVE, null, 0L);
@@ -89,7 +89,7 @@ public class ElementGhostManager<Key extends SpatialKey<Key>, ID extends EntityI
      * @param ghostExchange ghost exchange for remote ghost data fetching (null for local-only operation)
      * @param treeId tree identifier for distributed ghost requests
      */
-    public ElementGhostManager(AbstractSpatialIndex<Key, ID, Content> spatialIndex,
+    public ElementGhostManager(SpatialIndex<Key, ID, Content> spatialIndex,
                               NeighborDetector<Key> neighborDetector,
                               GhostType ghostType,
                               GhostExchange<Key, ID, Content> ghostExchange,
@@ -105,7 +105,7 @@ public class ElementGhostManager<Key extends SpatialKey<Key>, ID extends EntityI
      * @param ghostType the type of ghosts to create
      * @param ghostAlgorithm the ghost creation algorithm to use
      */
-    public ElementGhostManager(AbstractSpatialIndex<Key, ID, Content> spatialIndex,
+    public ElementGhostManager(SpatialIndex<Key, ID, Content> spatialIndex,
                               NeighborDetector<Key> neighborDetector,
                               GhostType ghostType,
                               GhostAlgorithm ghostAlgorithm) {
@@ -122,7 +122,7 @@ public class ElementGhostManager<Key extends SpatialKey<Key>, ID extends EntityI
      * @param ghostExchange ghost exchange for remote ghost data fetching (null for local-only operation)
      * @param treeId tree identifier for distributed ghost requests
      */
-    public ElementGhostManager(AbstractSpatialIndex<Key, ID, Content> spatialIndex,
+    public ElementGhostManager(SpatialIndex<Key, ID, Content> spatialIndex,
                               NeighborDetector<Key> neighborDetector,
                               GhostType ghostType,
                               GhostAlgorithm ghostAlgorithm,

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/GhostBoundaryDetector.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/GhostBoundaryDetector.java
@@ -17,8 +17,8 @@
 
 package com.hellblazer.luciferase.lucien.forest.ghost;
 
+import com.hellblazer.luciferase.lucien.SpatialIndex;
 import com.hellblazer.luciferase.lucien.SpatialKey;
-import com.hellblazer.luciferase.lucien.AbstractSpatialIndex;
 import com.hellblazer.luciferase.lucien.entity.Entity;
 import com.hellblazer.luciferase.lucien.entity.EntityBounds;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
@@ -70,7 +70,7 @@ public class GhostBoundaryDetector<Key extends SpatialKey<Key>, ID extends Entit
     // Element-Level Detection (from ElementGhostManager)
     // ========================================
 
-    private final AbstractSpatialIndex<Key, ID, Content> spatialIndex;
+    private final SpatialIndex<Key, ID, Content> spatialIndex;
     private final NeighborDetector<Key> neighborDetector;
     private final GhostLayer<Key, ID, Content> ghostLayer;
     private final GhostAlgorithm ghostAlgorithm;
@@ -204,7 +204,7 @@ public class GhostBoundaryDetector<Key extends SpatialKey<Key>, ID extends Entit
      * @param ghostType the type of ghosts to create
      * @param ghostAlgorithm the ghost creation algorithm
      */
-    public GhostBoundaryDetector(AbstractSpatialIndex<Key, ID, Content> spatialIndex,
+    public GhostBoundaryDetector(SpatialIndex<Key, ID, Content> spatialIndex,
                                  NeighborDetector<Key> neighborDetector,
                                  GhostType ghostType,
                                  GhostAlgorithm ghostAlgorithm) {
@@ -232,7 +232,7 @@ public class GhostBoundaryDetector<Key extends SpatialKey<Key>, ID extends Entit
      * @param treeId tree identifier for distributed ghost requests
      * @param defaultGhostZoneWidth default ghost zone width for forest mode
      */
-    public GhostBoundaryDetector(AbstractSpatialIndex<Key, ID, Content> spatialIndex,
+    public GhostBoundaryDetector(SpatialIndex<Key, ID, Content> spatialIndex,
                                  NeighborDetector<Key> neighborDetector,
                                  GhostType ghostType,
                                  GhostAlgorithm ghostAlgorithm,

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/GhostCoordinator.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/GhostCoordinator.java
@@ -17,6 +17,7 @@
 package com.hellblazer.luciferase.lucien.forest.ghost;
 
 import com.hellblazer.luciferase.lucien.AbstractSpatialIndex;
+import com.hellblazer.luciferase.lucien.SpatialIndex;
 import com.hellblazer.luciferase.lucien.SpatialIndexCore;
 import com.hellblazer.luciferase.lucien.cache.KnnProvider;
 import com.hellblazer.luciferase.lucien.SpatialKey;
@@ -45,10 +46,12 @@ import java.util.Objects;
  * arrive via {@link SpatialIndexCore}; the one façade query the ghost cluster needs ({@code kNearestNeighbors},
  * extracted in P3) is reached through the {@link KnnProvider} sub-interface (RDR-008 P3 sub-interface split).
  *
- * <p><b>Concrete-façade back-reference.</b> {@code GhostBoundaryDetector} and {@code DistributedGhostManager} both
- * take the concrete {@code AbstractSpatialIndex} in their constructors, so the coordinator holds a façade reference
- * solely to pass to them. That's an honest deviation from the otherwise-clean feature-object decoupling, tracked as a
- * follow-up (interface-inversion of those collaborators is separable work into {@code forest.ghost}/{@code Forest}).
+ * <p><b>Façade back-reference.</b> {@code GhostBoundaryDetector} and {@code DistributedGhostManager} require a
+ * reference to the owning spatial index for {@code getSpatialKeys} / {@code containsSpatialKey} lookups, so the
+ * coordinator carries one to pass through. RDR-008 P2 follow-up (bead Luciferase-703) narrowed both collaborators
+ * + this back-reference from the concrete {@code AbstractSpatialIndex} to the public {@link SpatialIndex}
+ * interface — retiring the original P2 "concrete-façade back-reference concession". The reference still exists
+ * (the detector + manager need the spatial-index instance) but no longer leaks the god-class type.
  *
  * @param <Key>     the spatial key type
  * @param <ID>      the entity identifier type
@@ -59,9 +62,9 @@ public final class GhostCoordinator<Key extends SpatialKey<Key>, ID extends Enti
 
     private static final Logger log = LoggerFactory.getLogger(GhostCoordinator.class);
 
-    private final SpatialIndexCore<Key, ID, Content>     core;
-    private final KnnProvider<Key, ID>                   knnProvider;
-    private final AbstractSpatialIndex<Key, ID, Content> facade;
+    private final SpatialIndexCore<Key, ID, Content> core;
+    private final KnnProvider<Key, ID>               knnProvider;
+    private final SpatialIndex<Key, ID, Content>     facade;
 
     private GhostType                                            ghostType        = GhostType.NONE;
     private GhostAlgorithm                                       ghostAlgorithm   = GhostAlgorithm.CONSERVATIVE;
@@ -75,7 +78,7 @@ public final class GhostCoordinator<Key extends SpatialKey<Key>, ID extends Enti
      * {@link #setNeighborDetector} during their own initialization.
      */
     public GhostCoordinator(SpatialIndexCore<Key, ID, Content> core, KnnProvider<Key, ID> knnProvider,
-                            AbstractSpatialIndex<Key, ID, Content> facade) {
+                            SpatialIndex<Key, ID, Content> facade) {
         this.core = core;
         this.knnProvider = knnProvider;
         this.facade = facade;


### PR DESCRIPTION
RDR-008 P2 follow-up. Retires the GhostCoordinator concrete-façade back-reference concession documented in the P2 extraction. The ghost subsystem now speaks the public \`SpatialIndex\` interface, not the concrete \`AbstractSpatialIndex\`.

## What changed

**\`SpatialIndex\` gains two methods** (already public on the façade since the P2 extraction; now hoisted to the interface):
\`\`\`java
Set<Key> getSpatialKeys();
boolean containsSpatialKey(Key key);
\`\`\`

These are the only methods the ghost detectors call on the back-reference. Hoisting them eliminates the need for the concrete type.

**Type narrowings (AbstractSpatialIndex → SpatialIndex):**
- \`GhostBoundaryDetector\` — field, 2 ctors, helper signatures.
- \`DistributedGhostManager\` — field + ctor. (Field was unused behaviorally; narrowed for consistency.)
- \`ElementGhostManager\` — field + 4 ctors. Discovered during the cleanup pass; same exact coupling pattern as \`GhostBoundaryDetector\`. Not strictly in the bead's scope but the same fix.
- \`GhostCoordinator.facade\` — field + ctor narrowed. The class-level javadoc "Concrete-façade back-reference" concession block updated to "Façade back-reference" — the concession is retired.

**\`AbstractSpatialIndex\` import kept** in \`GhostCoordinator.java\` for \`AbstractSpatialIndex.NeighborResult<ID,Content>\` data-type references in \`findNeighborsIncludingGhosts\`. That's a separate kind of coupling (data type, not back-reference behavior); narrowing it would be a public-API break.

## Verification

- Compile: clean (282 files).
- Full lucien suite (after \`mvn -pl lucien clean test-compile\` to flush stale .class files compiled against the old ctor signatures — handoff §9 lessons): **2447/2448**. The 1 failure is the documented \`TetreeLocateMethodTest.testPerformanceImprovement\` perf-flake (\`Luciferase-tlb\` class; passes in isolation 6/0/0; not a 703 regression).
- Net change: +44 / -21 across 5 files.

Closes Luciferase-703.