### PR TITLE
chore: address code-review findings on RDR-008 P6 follow-ups

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
@@ -156,6 +156,10 @@ implements SpatialIndex<Key, ID, Content> {
     // hook). The host interface is the principled middle ground after P3 refinement; it's narrower than the
     // concrete-facade back-reference GhostCoordinator carries from P2 (see GhostCoordinator's P2-concession note).
     protected final com.hellblazer.luciferase.lucien.entity.EntityLifecycleManager<Key, ID, Content> entityLifecycle;
+    // RDR-008 P6 follow-up (Luciferase-ts8) review cleanup: cache the stack-builder host as a final field instead
+    // of allocating a fresh StackBuilderHostImpl at every call site (bulk-insert paths + EntityLifecycleHostImpl.
+    // stackBuilderTarget()). The wrapper is stateless and identity-stable, so a single instance suffices.
+    private final   StackBuilderHostImpl                                     stackBuilderHost         = new StackBuilderHostImpl();
     // Tree balancing support
     private         TreeBalancingStrategy<ID>                        balancingStrategy;
     private         boolean                                          autoBalancingEnabled     = false;
@@ -295,8 +299,9 @@ implements SpatialIndex<Key, ID, Content> {
             }
 
             // Build tree (RDR-008 P6 follow-up Luciferase-ts8: builder takes StackBuilderHost, not the concrete
-            // facade — protect against the god-class type leak)
-            return treeBuilder.buildTree(new StackBuilderHostImpl(), positions, contents, startLevel);
+            // facade — protect against the god-class type leak; cached stackBuilderHost field, not a per-call
+            // allocation, per the review-cleanup pass)
+            return treeBuilder.buildTree(stackBuilderHost, positions, contents, startLevel);
         } finally {
             lock.writeLock().unlock();
         }
@@ -1759,7 +1764,7 @@ implements SpatialIndex<Key, ID, Content> {
 
         @Override
         public com.hellblazer.luciferase.lucien.StackBuilderHost<Key, ID, Content> stackBuilderTarget() {
-            return new StackBuilderHostImpl();
+            return stackBuilderHost;
         }
     }
 

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialIndex.java
@@ -242,18 +242,33 @@ public interface SpatialIndex<Key extends SpatialKey<Key>, ID extends EntityID, 
      * {@link com.hellblazer.luciferase.lucien.forest.ghost.DistributedGhostManager} can speak this interface
      * instead of the concrete {@code AbstractSpatialIndex}.
      *
+     * <p>Default throws {@link UnsupportedOperationException}; the in-tree {@code AbstractSpatialIndex} override
+     * returns a defensive {@code HashSet} copy of the underlying skip-list keyset. The default exists so external
+     * implementors of {@code SpatialIndex} that pre-date the P2 ghost extraction continue to compile; only code
+     * paths that actually invoke ghost operations through such an implementation hit the throw.
+     *
      * @return set of all spatial keys (defensive copy — callers may mutate)
      */
-    java.util.Set<Key> getSpatialKeys();
+    default java.util.Set<Key> getSpatialKeys() {
+        throw new UnsupportedOperationException(
+            "getSpatialKeys() is not implemented for " + getClass().getName()
+            + "; required for ghost-subsystem integration (RDR-008 P2 follow-up, bead Luciferase-703).");
+    }
 
     /**
      * Whether the index currently contains the given spatial key. Used by the ghost-boundary subsystem to test
      * element existence without materializing the full key set. RDR-008 P2 follow-up (bead Luciferase-703).
      *
+     * <p>Default delegates to {@link #getSpatialKeys()}: implementations that override either method get a
+     * correct {@code containsSpatialKey} for free, but should override both for efficiency (the default
+     * materialises the full key set per call).
+     *
      * @param key the spatial key to check
      * @return true if the key is in the index
      */
-    boolean containsSpatialKey(Key key);
+    default boolean containsSpatialKey(Key key) {
+        return getSpatialKeys().contains(key);
+    }
 
     /**
      * Check if a node exists at the given Morton index

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/DistributedGhostManager.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/DistributedGhostManager.java
@@ -53,6 +53,12 @@ public class DistributedGhostManager<Key extends SpatialKey<Key>, ID extends Ent
 
     private static final Logger log = LoggerFactory.getLogger(DistributedGhostManager.class);
 
+    // Reserved: SpatialIndex back-reference retained for prospective incremental-sync paths (per-key existence
+    // checks during distributed reconciliation). Currently unused by any method on this class — the null-check
+    // in the constructor still serves as a contract guard. RDR-008 P2 follow-up (Luciferase-703) narrowed the
+    // type from AbstractSpatialIndex to SpatialIndex without removing the field, on the rationale that an
+    // upcoming distributed-ghost-sync arc will need it; flagged in code review and intentionally retained.
+    @SuppressWarnings("unused")
     private final SpatialIndex<Key, ID, Content> spatialIndex;
     private final GhostChannel<Key, ID, Content> ghostChannel;
     private final GhostBoundaryDetector<Key, ID, Content> localGhostManager;

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/octree/MortonKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/octree/MortonKey.java
@@ -20,6 +20,10 @@ import com.hellblazer.luciferase.lucien.Constants;
 import com.hellblazer.luciferase.lucien.SpatialKey;
 
 import javax.vecmath.Point3f;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.NavigableSet;
 import java.util.Objects;
 
 /**
@@ -537,17 +541,16 @@ public final class MortonKey implements SpatialKey<MortonKey> {
      * follow-up (bead Luciferase-vpl).
      */
     @Override
-    public Iterable<com.hellblazer.luciferase.lucien.SpatialKey.SFCRange<MortonKey>> sfcRangesForKNN(
-        Point3f center, float radius, java.util.NavigableSet<MortonKey> indexKeys) {
-        var levels = new java.util.LinkedHashSet<Byte>();
+    public Iterable<SpatialKey.SFCRange<MortonKey>> sfcRangesForKNN(Point3f center, float radius,
+                                                                    NavigableSet<MortonKey> indexKeys) {
+        var levels = new LinkedHashSet<Byte>();
         for (var key : indexKeys) {
             levels.add(key.getLevel());
         }
-        var ranges = new java.util.ArrayList<com.hellblazer.luciferase.lucien.SpatialKey.SFCRange<MortonKey>>(
-            levels.size());
+        List<SpatialKey.SFCRange<MortonKey>> ranges = new ArrayList<>(levels.size());
         for (var level : levels) {
             var range = estimateSFCRange(center, radius, level);
-            ranges.add(new com.hellblazer.luciferase.lucien.SpatialKey.SFCRange<>(range.lower(), range.upper()));
+            ranges.add(new SpatialKey.SFCRange<>(range.lower(), range.upper()));
         }
         return ranges;
     }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeKey.java
@@ -21,6 +21,8 @@ import com.hellblazer.luciferase.lucien.Constants;
 import com.hellblazer.luciferase.lucien.SpatialKey;
 
 import javax.vecmath.Point3f;
+import java.util.List;
+import java.util.NavigableSet;
 import java.util.Objects;
 
 /**
@@ -583,12 +585,10 @@ public abstract class TetreeKey<K extends TetreeKey<K>> implements SpatialKey<Te
      * follow-up (bead Luciferase-vpl).
      */
     @Override
-    public Iterable<com.hellblazer.luciferase.lucien.SpatialKey.SFCRange<TetreeKey<? extends TetreeKey<?>>>> sfcRangesForKNN(
-        Point3f center, float radius,
-        java.util.NavigableSet<TetreeKey<? extends TetreeKey<?>>> indexKeys) {
+    public Iterable<SpatialKey.SFCRange<TetreeKey<? extends TetreeKey<?>>>> sfcRangesForKNN(
+        Point3f center, float radius, NavigableSet<TetreeKey<? extends TetreeKey<?>>> indexKeys) {
         var range = estimateSFCRange(center, radius);
-        return java.util.List.of(
-            new com.hellblazer.luciferase.lucien.SpatialKey.SFCRange<TetreeKey<? extends TetreeKey<?>>>(range.lower(),
-                                                                                                       range.upper()));
+        return List.of(
+            new SpatialKey.SFCRange<TetreeKey<? extends TetreeKey<?>>>(range.lower(), range.upper()));
     }
 }


### PR DESCRIPTION
Retrospective stacked review on the three RDR-008 follow-up PRs (#141 ts8, #142 vpl, #143 703) that landed without pre-push stacked-review discipline surfaced **1 Important** and **3 Suggestion** findings. This PR addresses all four in priority order.

## Findings addressed

### ISSUE-703-A (Important): `SpatialIndex` non-default abstract method additions

\`SpatialIndex.getSpatialKeys()\` and \`SpatialIndex.containsSpatialKey(Key)\` were added by PR #143 as non-default abstract methods — a binary-compat break for any external \`SpatialIndex\` implementor pre-dating the P2 ghost extraction.

**Fix:** Both methods now have defaults.
- \`getSpatialKeys()\` default throws \`UnsupportedOperationException\` with a message naming the calling class + the bead reference. External implementors that don't use ghost operations keep compiling; the throw only fires when ghost code paths actually run against a non-overriding impl.
- \`containsSpatialKey(Key)\` default delegates to \`getSpatialKeys().contains(key)\`. Implementors overriding only \`getSpatialKeys()\` get a correct (but O(n)) \`containsSpatialKey\` for free; the doc recommends overriding both for efficiency.

### ISSUE-ts8-A (Suggestion): `StackBuilderHostImpl` per-call allocation

PR #141's \`StackBuilderHostImpl\` (stateless inner class wrapping facade-internal methods) was allocated twice per stack-builder path. Cached as a final field on \`AbstractSpatialIndex\`; both call sites (\`performStackBasedBulkInsert\` facade dispatch + \`EntityLifecycleHostImpl.stackBuilderTarget()\`) now read the field. Wrapper is identity-stable.

### ISSUE-703-B (Suggestion): `DistributedGhostManager.spatialIndex` dead field

Stored but never read. Retained per the upcoming distributed-ghost-sync arc that will need it, but now explicitly documented with a comment + \`@SuppressWarnings(\"unused\")\` so the intent is visible. The null-check in the constructor still serves as a contract guard.

### ISSUE-vpl-C (Suggestion): FQN noise in `MortonKey` / `TetreeKey` overrides

PR #142's \`sfcRangesForKNN\` overrides used \`java.util.NavigableSet\`, \`java.util.LinkedHashSet\`, \`java.util.ArrayList\`, \`java.util.List\` fully-qualified despite the files already importing other \`java.util\` types. Added proper imports per file.

## Verification

- Compile: clean (282 files).
- Full lucien suite: **2448/0/0 GREEN** (22 skipped). The \`Luciferase-tlb\` perf-flake didn't fire this run.

## Net change

+46 / -17 across 5 files.