### PR TITLE
Luciferase-opw: @Tag('performance') the two residual perf-only test methods

### DIFF
--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismVsOctreeComparisonTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/prism/PrismVsOctreeComparisonTest.java
@@ -111,6 +111,9 @@ public class PrismVsOctreeComparisonTest {
     }
     
     @Test
+    @Tag("performance")  // Luciferase-opw: 5ms perf threshold; excluded from default `mvn test`, runs under
+                         // -Pperformance. Kept @DisabledIfEnvironmentVariable for belt-and-suspenders coverage on
+                         // CI runners that selectively run perf-tagged tests.
     @DisabledIfEnvironmentVariable(
         named = "CI",
         matches = "true",

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeLocateMethodTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeLocateMethodTest.java
@@ -5,6 +5,7 @@ import com.hellblazer.luciferase.lucien.PerfMeasure;
 import com.hellblazer.luciferase.lucien.benchmark.CIEnvironmentCheck;
 import com.hellblazer.luciferase.lucien.entity.LongEntityID;
 import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import javax.vecmath.Point3f;
 import java.util.Random;
@@ -233,6 +234,9 @@ public class TetreeLocateMethodTest {
     }
 
     @Test
+    @Tag("performance")  // Luciferase-opw: pure-perf assertion (speedup ratio); flakes under load on fast hardware
+                         // even with warmup+best-of-N (Luciferase-tlb). Excluded from default `mvn test`; runs under
+                         // -Pperformance. The five functional tests in this class stay in the default suite.
     void testPerformanceImprovement() {
         // Skip if running in any CI environment
         assumeFalse(CIEnvironmentCheck.isRunningInCI(), CIEnvironmentCheck.getSkipMessage());


### PR DESCRIPTION
Narrows opw per its own bead recommendation (downgraded P3 NOTES, 2026-05-27): the root pom already excludes \`*Benchmark*.java\` and \`*PerformanceTest*.java\` + \`@Tag('performance')\` from default test cycles, so a broad build-composition change is not warranted. The residual is a small set of perf-asserting methods that slip through the filename patterns because they live in functional test classes. This PR tags those individual methods.

## Two methods tagged

### \`TetreeLocateMethodTest.testPerformanceImprovement\`
- Pure-perf assertion (speedup ratio >= 1.5x).
- **Source of the recurring flake we hit 3x this session** (default \`mvn test\` runs under load, robustification via warmup+best-of-N per \`Luciferase-tlb\` helps but doesn't eliminate).
- Now \`@Tag('performance')\` — excluded from default \`mvn test\`; runs under \`-Pperformance\`.
- The other 5 tests in the class (\`testLocateMethodAccuracy\`, \`testDeterministicBehavior\`, \`testBoundaryConditions\`, \`testCoverageAcrossAllTypes\`, \`testEdgeCaseGeometry\`) stay in the default suite — they're functional, not perf.

### \`PrismVsOctreeComparisonTest.testRangeQueryPerformanceComparison\`
- 5ms perf threshold; \`@DisabledIfEnvironmentVariable(CI=true)\` kept as belt-and-suspenders.
- Now also \`@Tag('performance')\` so it's excluded from **local** \`mvn test\` (which the CI env-var guard doesn't cover for local runs).

Both tests **still run under \`-Pperformance\`**, where the perf assertions are intended to live.

## Not tagged (intentional)

- \`testInsertionPerformanceComparison\` in \`PrismVsOctreeComparisonTest\`: 10-second threshold + functional \`assertEquals\` on entity counts → mixed perf+functional, perf assertion is generous, keep in default suite.
- \`testKNNPerformanceComparison\` in \`PrismVsOctreeComparisonTest\`: already \`@Tag('performance')\`.

## Verification

- \`mvn -pl lucien test -Dtest=TetreeLocateMethodTest\`: **5/0/0** (testPerformanceImprovement excluded; was 6 before).
- \`mvn -pl lucien test -Dtest=TetreeLocateMethodTest -Pperformance\`: **1/0/0** (only the perf-tagged method runs under the perf profile).
- Full lucien suite: **2446/0/0 GREEN** (2 fewer than pre-change 2448 — the two newly-tagged methods).

Closes Luciferase-opw.