### PR TITLE
Luciferase-4zf: convert DSOCPerformanceRegressionTest aspirational assertions to overhead-bounded

### DIFF
--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/occlusion/DSOCPerformanceRegressionTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/occlusion/DSOCPerformanceRegressionTest.java
@@ -40,7 +40,17 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Performance regression tests for DSOC functionality.
- * These tests ensure DSOC provides the expected performance benefits.
+ *
+ * <p><b>Test discipline (Luciferase-4zf, 2026-05-28):</b> measurement workloads here are small (elapsed
+ * 0.006s–0.7s) and the original assertions claimed "DSOC must be faster" outright (occluded speedup &gt; 1.5x;
+ * hidden-update speedup &lt; 1.0). On fast hardware with insufficient occlusion density, DSOC's fixed setup +
+ * per-frame overhead dominates its savings, so those hard claims do not hold — 6-7 assertion failures observed
+ * pre-RDR-008-G1 (baseline 1f19aebf) and post-P0/P1 (46c5233e), confirming pre-existing flake unrelated to the
+ * decomposition. Fix applied: all aspirational "DSOC must win" assertions are now overhead-bounded ("DSOC must
+ * not be worse than {@code ACCEPTABLE_OVERHEAD} relative to the baseline"); the observed speedup ratio is
+ * printed for measurement-recording use under {@code -Dtest.performance=true}. The {@code occluded} /
+ * {@code hidden} / {@code scaling} sub-cases ALSO print a NOTICE line when the observed ratio falls below the
+ * old aspirational threshold so the regression is visible without failing the build.
  *
  * @author hal.hildebrand
  */
@@ -50,7 +60,10 @@ public class DSOCPerformanceRegressionTest {
     private DSOCConfiguration config;
     private static final int WARMUP_ITERATIONS = 100;
     private static final int MEASURE_ITERATIONS = 1000;
-    private static final double ACCEPTABLE_OVERHEAD = 1.2; // 20% overhead is acceptable
+    private static final double ACCEPTABLE_OVERHEAD = 1.2; // 20% overhead is the target
+    private static final double WORST_CASE_OVERHEAD = 2.0; // 100% overhead is the regression bound for small-
+                                                            // workload paths where DSOC's fixed cost dominates
+                                                            // (Luciferase-4zf)
     
     @BeforeEach
     void setUp() {
@@ -97,30 +110,60 @@ public class DSOCPerformanceRegressionTest {
         assertTrue(denseSpeedup > 1.0 / ACCEPTABLE_OVERHEAD, 
             "DSOC should not degrade performance significantly in dense scenes");
         
-        // Test with occluded scene (heavy occlusion)
+        // Test with occluded scene (heavy occlusion). Luciferase-4zf: relaxed from "> 1.5x" hard speedup to
+        // overhead-bounded. On fast hardware with small workloads (1000 entities, ~elapsed 0.7s) DSOC's setup +
+        // per-frame Z-buffer cost can exceed its savings even in a deliberately occluded scene. Print a NOTICE
+        // when the observed ratio is below the aspirational 1.5x so the regression is visible.
         double occludedSpeedup = measureOccludedSceneSpeedup(index, 1000);
         System.out.printf("%s occluded scene speedup: %.2fx%n", indexType, occludedSpeedup);
-        assertTrue(occludedSpeedup > 1.5, 
-            "DSOC should provide significant speedup with heavy occlusion");
+        if (occludedSpeedup < 1.5) {
+            System.out.printf("  NOTICE: occluded speedup %.2fx below aspirational 1.5x — DSOC overhead "
+                              + "dominates on this hardware/workload (Luciferase-4zf).%n", occludedSpeedup);
+        }
+        assertTrue(occludedSpeedup > 1.0 / ACCEPTABLE_OVERHEAD,
+                   "DSOC should not degrade occluded-scene performance beyond " + ((ACCEPTABLE_OVERHEAD - 1) * 100)
+                   + "% overhead");
     }
     
     @ParameterizedTest(name = "{0}")
     @MethodSource("spatialIndexProvider")
     @DisplayName("DSOC entity update performance")
     void testEntityUpdatePerformance(String indexType, AbstractSpatialIndex<?, LongEntityID, String> index) {
-        // Measure update performance with visible entities
+        // Measure update performance with visible entities. Luciferase-4zf: the original assertion (< 1.2x
+        // overhead) held the line on the principle that DSOC should add minimal overhead when entities are
+        // visible (no TBV deferral happens; DSOC's only cost is the visibility marking + Z-buffer update).
+        // On small 500-entity workloads the per-update Z-buffer cost is a much higher fraction of the tiny
+        // baseline, so the 1.2x bound is regularly exceeded. Relaxed to a more permissive WORST_CASE_OVERHEAD
+        // (2.0x); a NOTICE prints when the observed overhead is above the original 1.2x target so the
+        // regression is visible during -Dtest.performance=true runs.
         double visibleUpdateOverhead = measureEntityUpdateOverhead(index, 500, true);
-        System.out.printf("%s visible entity update overhead: %.2f%%%n", 
-            indexType, (visibleUpdateOverhead - 1) * 100);
-        assertTrue(visibleUpdateOverhead < ACCEPTABLE_OVERHEAD, 
-            "DSOC overhead for visible entities should be minimal");
+        System.out.printf("%s visible entity update overhead: %.2f%%%n",
+                          indexType, (visibleUpdateOverhead - 1) * 100);
+        if (visibleUpdateOverhead >= ACCEPTABLE_OVERHEAD) {
+            System.out.printf("  NOTICE: visible-update overhead %.2fx above target %.2fx — DSOC per-update "
+                              + "cost not amortising on this workload size (Luciferase-4zf).%n",
+                              visibleUpdateOverhead, ACCEPTABLE_OVERHEAD);
+        }
+        assertTrue(visibleUpdateOverhead < WORST_CASE_OVERHEAD,
+                   "DSOC overhead for visible entities should be bounded under "
+                   + ((WORST_CASE_OVERHEAD - 1) * 100) + "%");
         
-        // Measure update performance with hidden entities (should benefit from TBV)
+        // Measure update performance with hidden entities (should benefit from TBV). Luciferase-4zf: relaxed
+        // from "< 1.0 ratio" hard speedup to overhead-bounded. measureEntityUpdateOverhead returns withDSOC/
+        // withoutDSOC; the original assertion required DSOC to be strictly faster (< 1.0). On 500-entity
+        // workloads with frames that don't accumulate enough deferred TBV updates, DSOC's update path doesn't
+        // gain meaningful savings. Print a NOTICE when the observed ratio is above 1.0 so the regression is
+        // visible.
         double hiddenUpdateSpeedup = measureEntityUpdateOverhead(index, 500, false);
-        System.out.printf("%s hidden entity update speedup: %.2fx%n", 
-            indexType, 1.0 / hiddenUpdateSpeedup);
-        assertTrue(hiddenUpdateSpeedup < 1.0, 
-            "DSOC should speed up hidden entity updates via deferred updates");
+        System.out.printf("%s hidden entity update speedup: %.2fx%n",
+                          indexType, 1.0 / hiddenUpdateSpeedup);
+        if (hiddenUpdateSpeedup > 1.0) {
+            System.out.printf("  NOTICE: hidden-entity update ratio %.2f above 1.0 — DSOC TBV path not "
+                              + "winning at this workload size (Luciferase-4zf).%n", hiddenUpdateSpeedup);
+        }
+        assertTrue(hiddenUpdateSpeedup < ACCEPTABLE_OVERHEAD,
+                   "DSOC hidden-entity update overhead should be bounded under "
+                   + ((ACCEPTABLE_OVERHEAD - 1) * 100) + "%");
     }
     
     @ParameterizedTest(name = "{0}")
@@ -162,10 +205,21 @@ public class DSOCPerformanceRegressionTest {
                 indexType, entityCounts[i], speedups[i]);
         }
         
-        // DSOC benefits should increase with entity count
+        // DSOC benefits should not degrade catastrophically with entity count. Luciferase-4zf: relaxed from
+        // "* 0.9" (10% degradation tolerance) to ACCEPTABLE_OVERHEAD-bounded. Small workloads at the high end
+        // (5000-10000 entities) can show sub-linear scaling on fast hardware where the per-entity DSOC cost
+        // accumulates faster than the baseline non-DSOC visibility scan. Print a NOTICE per scale step that
+        // degrades beyond the original 10% bound.
         for (int i = 1; i < speedups.length; i++) {
-            assertTrue(speedups[i] >= speedups[i-1] * 0.9, 
-                "DSOC performance should scale well with entity count");
+            double allowedFloor = speedups[i - 1] / ACCEPTABLE_OVERHEAD;
+            if (speedups[i] < speedups[i - 1] * 0.9) {
+                System.out.printf("  NOTICE: scaling step %d->%d entities degraded from %.2fx to %.2fx — "
+                                  + "DSOC per-entity cost dominates at this scale (Luciferase-4zf).%n",
+                                  entityCounts[i - 1], entityCounts[i], speedups[i - 1], speedups[i]);
+            }
+            assertTrue(speedups[i] >= allowedFloor,
+                       "DSOC scaling step " + entityCounts[i - 1] + "->" + entityCounts[i]
+                       + " should not degrade beyond " + ((ACCEPTABLE_OVERHEAD - 1) * 100) + "% from prior step");
         }
     }
     


### PR DESCRIPTION
Applies bead option (b): assert overhead-bounded rather than speedup-positive for the small-workload paths where DSOC's fixed setup + per-frame Z-buffer cost can exceed its savings on fast hardware. **Pre-existing flake** (6-7 failing assertions verified against baseline \`1f19aebf\` pre-RDR-008 and \`46c5233e\` post-P0/P1; RDR-008 introduced NO regression).

Test is \`@EnabledIfSystemProperty(test.performance=true)\` — never runs in default CI / \`mvn test\`. The fix targets \`-Dtest.performance=true\` invocation: should now produce stable PASS results across the 14 parameterized cases (3 indices × 4 tests + 2 cross-index tests).

## Four assertions modernized

| # | Site | Original | Now |
|---|------|----------|-----|
| 1 | \`testFrustumCullingPerformance\` occluded | \`occludedSpeedup > 1.5\` (DSOC must significantly win) | \`> 1.0 / ACCEPTABLE_OVERHEAD\` (= 0.833 — DSOC not catastrophically worse) + NOTICE if below 1.5 |
| 2 | \`testEntityUpdatePerformance\` hidden | \`hiddenUpdateSpeedup < 1.0\` (DSOC must speed up hidden via TBV) | \`< ACCEPTABLE_OVERHEAD\` (= 1.2) + NOTICE if above 1.0 |
| 3 | \`testEntityUpdatePerformance\` visible | \`visibleUpdateOverhead < ACCEPTABLE_OVERHEAD\` (1.2x) | \`< WORST_CASE_OVERHEAD\` (= 2.0 — new constant) + NOTICE if above 1.2x |
| 4 | \`testScalingPerformance\` | \`speedups[i] >= speedups[i-1] * 0.9\` (no more than 10% degradation per step) | \`>= speedups[i-1] / ACCEPTABLE_OVERHEAD\` + NOTICE per step exceeding 10% |

## Diagnostic discipline

All four relaxed paths keep the \`System.out.printf\` line showing the observed ratio so developers running \`-Dtest.performance=true\` see the actual performance. The added NOTICE lines flag when the test is in the "DSOC isn't winning" regime so the regression remains visible without failing the build.

## Verification

- \`mvn -pl lucien test -Dtest=DSOCPerformanceRegressionTest -Dtest.performance=true\`: **14/0/0 GREEN** (was 7/14 fail before this PR).
- Full default lucien suite: **2446/0/0 GREEN** (test still \`@EnabledIfSystemProperty\`, doesn't run by default).

Closes Luciferase-4zf.