### PR TITLE
Luciferase-va5: active-only MembershipView.activeMembers() accessor (RDR-005 prep)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/delos/MembershipView.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/delos/MembershipView.java
@@ -32,11 +32,36 @@ import java.util.stream.Stream;
 public interface MembershipView<M> {
 
     /**
-     * Get a stream of current cluster members.
+     * Get a stream of all known cluster members.
+     * <p>
+     * Backed by the view's full membership (e.g. {@code DynamicContext.allMembers()}), which may
+     * include members that have been evicted from the active view but not yet garbage-collected.
+     *
+     * @return stream of all known members
+     */
+    Stream<M> getMembers();
+
+    /**
+     * Get a stream of the <em>active</em> cluster members only.
+     * <p>
+     * Distinct from {@link #getMembers()}: this excludes members that are present in the view's
+     * full membership set but no longer active (e.g. evicted-but-not-yet-GC'd). Backed by
+     * {@code DynamicContext.active()} in the Fireflies implementation.
+     * <p>
+     * <b>Security-critical (RDR-005 / Luciferase-ah3).</b> Peer-identity authorization — e.g. the
+     * {@code inCurrentView} predicate that gates gRPC mTLS peer verification — MUST be built from
+     * this active-only set, never from {@link #getMembers()}. An evicted-but-not-GC'd node still
+     * holds a cryptographically valid, KERL-committed certificate; admitting it via the full
+     * membership set would let a node the view has already removed continue to authenticate.
+     * <p>
+     * <b>Production implementations backed by a real view MUST NOT delegate this to
+     * {@link #getMembers()}</b> — they must consult the view's active-only set. Test doubles that
+     * do not exercise the active/all distinction may return the same set as {@link #getMembers()},
+     * but MUST document that the equivalence is intentional.
      *
      * @return stream of active members
      */
-    Stream<M> getMembers();
+    Stream<M> activeMembers();
 
     /**
      * Register a listener for membership change events.

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/delos/fireflies/FirefliesMembershipView.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/delos/fireflies/FirefliesMembershipView.java
@@ -68,6 +68,16 @@ public class FirefliesMembershipView implements MembershipView<Member> {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
+    public Stream<Member> activeMembers() {
+        // active() excludes evicted-but-not-yet-GC'd members that allMembers() still returns.
+        // Authorization gates MUST use this set, not getMembers() — see MembershipView javadoc
+        // (RDR-005 / Luciferase-ah3). Same Participant-extends-Member cast as getMembers().
+        var context = view.getContext();
+        return (Stream<Member>) (Stream<? extends Member>) context.active();
+    }
+
+    @Override
     public void addListener(Consumer<ViewChange<Member>> listener) {
         listeners.add(listener);
     }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/delos/mock/MockFirefliesView.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/delos/mock/MockFirefliesView.java
@@ -39,6 +39,7 @@ import java.util.stream.Stream;
 public class MockFirefliesView<M> implements MembershipView<M> {
 
     private final Set<M>                          members   = ConcurrentHashMap.newKeySet();
+    private final Set<M>                          inactive  = ConcurrentHashMap.newKeySet();
     private final List<Consumer<ViewChange<M>>>  listeners = new CopyOnWriteArrayList<>();
 
     /**
@@ -47,6 +48,7 @@ public class MockFirefliesView<M> implements MembershipView<M> {
      * @param member the member to add
      */
     public void addMember(M member) {
+        inactive.remove(member);
         if (members.add(member)) {
             notifyListeners(new ViewChange<>(List.of(member), List.of()));
         }
@@ -58,14 +60,37 @@ public class MockFirefliesView<M> implements MembershipView<M> {
      * @param member the member to remove
      */
     public void removeMember(M member) {
+        inactive.remove(member);
         if (members.remove(member)) {
             notifyListeners(new ViewChange<>(List.of(), List.of(member)));
         }
     }
 
+    /**
+     * Mark a member as inactive without removing it from the known-membership set, modelling the
+     * "evicted-but-not-yet-GC'd" state: the member is still returned by {@link #getMembers()} but
+     * excluded from {@link #activeMembers()}. Lets tests exercise the active-vs-all authorization
+     * distinction (RDR-005 / Luciferase-ah3). No listener notification — eviction signalling is the
+     * job of {@link #removeMember}.
+     *
+     * @param member the member to mark inactive (must already be known via {@link #addMember})
+     */
+    public void markInactive(M member) {
+        if (!members.contains(member)) {
+            throw new IllegalArgumentException(
+                "Cannot mark unknown member inactive (call addMember first): " + member);
+        }
+        inactive.add(member);
+    }
+
     @Override
     public Stream<M> getMembers() {
         return members.stream();
+    }
+
+    @Override
+    public Stream<M> activeMembers() {
+        return members.stream().filter(m -> !inactive.contains(m));
     }
 
     @Override

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/causality/GhostPhysicsIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/causality/GhostPhysicsIntegrationTest.java
@@ -473,6 +473,12 @@ class GhostPhysicsIntegrationTest {
         }
 
         @Override
+        public java.util.stream.Stream<Object> activeMembers() {
+            // active==all intentionally: this test does not exercise the active/all auth distinction.
+            return new HashSet<>(members).stream();
+        }
+
+        @Override
         public void addListener(java.util.function.Consumer<MembershipView.ViewChange<Object>> listener) {
             listeners.add(listener);
         }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/causality/ViewChangeReconciliationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/causality/ViewChangeReconciliationTest.java
@@ -471,6 +471,12 @@ class ViewChangeReconciliationTest {
         }
 
         @Override
+        public java.util.stream.Stream<Object> activeMembers() {
+            // active==all intentionally: this test does not exercise the active/all auth distinction.
+            return new HashSet<>(members).stream();
+        }
+
+        @Override
         public void addListener(java.util.function.Consumer<ViewChange<Object>> listener) {
             listeners.add(listener);
         }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeP2PIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeP2PIntegrationTest.java
@@ -346,5 +346,10 @@ public class CommitteeP2PIntegrationTest {
         public java.util.stream.Stream<com.hellblazer.delos.membership.Member> getMembers() {
             return java.util.stream.Stream.empty();
         }
+
+        @Override
+        public java.util.stream.Stream<com.hellblazer.delos.membership.Member> activeMembers() {
+            return java.util.stream.Stream.empty();
+        }
     }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/OptimisticMigratorIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/OptimisticMigratorIntegrationTest.java
@@ -230,5 +230,10 @@ public class OptimisticMigratorIntegrationTest {
         public Stream<Member> getMembers() {
             return Stream.empty();
         }
+
+        @Override
+        public Stream<Member> activeMembers() {
+            return Stream.empty();
+        }
     }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeConsensusTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeConsensusTest.java
@@ -540,5 +540,10 @@ public class ViewCommitteeConsensusTest {
         public Stream<Member> getMembers() {
             return Stream.empty();
         }
+
+        @Override
+        public Stream<Member> activeMembers() {
+            return Stream.empty();
+        }
     }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewIdRaceConditionTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewIdRaceConditionTest.java
@@ -334,5 +334,10 @@ public class ViewIdRaceConditionTest {
         public Stream<Member> getMembers() {
             return Stream.empty();
         }
+
+        @Override
+        public Stream<Member> activeMembers() {
+            return Stream.empty();
+        }
     }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/VirtualSynchronyTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/VirtualSynchronyTest.java
@@ -281,5 +281,10 @@ public class VirtualSynchronyTest {
         public Stream<Member> getMembers() {
             return Stream.empty();
         }
+
+        @Override
+        public Stream<Member> activeMembers() {
+            return Stream.empty();
+        }
     }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ByzantineRobustnessIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ByzantineRobustnessIntegrationTest.java
@@ -258,5 +258,10 @@ public class ByzantineRobustnessIntegrationTest {
         public Stream<Member> getMembers() {
             return Stream.empty();
         }
+
+        @Override
+        public Stream<Member> activeMembers() {
+            return Stream.empty();
+        }
     }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/EndToEndMigrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/EndToEndMigrationTest.java
@@ -375,5 +375,10 @@ public class EndToEndMigrationTest {
         public Stream<Member> getMembers() {
             return Stream.empty();
         }
+
+        @Override
+        public Stream<Member> activeMembers() {
+            return Stream.empty();
+        }
     }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/FiveNodeIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/FiveNodeIntegrationTest.java
@@ -353,5 +353,10 @@ public class FiveNodeIntegrationTest {
         public Stream<Member> getMembers() {
             return Stream.empty();
         }
+
+        @Override
+        public Stream<Member> activeMembers() {
+            return Stream.empty();
+        }
     }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ThreeNodeIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ThreeNodeIntegrationTest.java
@@ -297,5 +297,10 @@ public class ThreeNodeIntegrationTest {
         public Stream<Member> getMembers() {
             return Stream.empty();
         }
+
+        @Override
+        public Stream<Member> activeMembers() {
+            return Stream.empty();
+        }
     }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/TwoNodeIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/TwoNodeIntegrationTest.java
@@ -303,5 +303,10 @@ public class TwoNodeIntegrationTest {
         public Stream<Member> getMembers() {
             return Stream.empty();
         }
+
+        @Override
+        public Stream<Member> activeMembers() {
+            return Stream.empty();
+        }
     }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ViewChangeIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ViewChangeIntegrationTest.java
@@ -298,5 +298,10 @@ public class ViewChangeIntegrationTest {
         public Stream<Member> getMembers() {
             return Stream.empty();
         }
+
+        @Override
+        public Stream<Member> activeMembers() {
+            return Stream.empty();
+        }
     }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/delos/fireflies/FirefliesMembershipViewTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/delos/fireflies/FirefliesMembershipViewTest.java
@@ -91,6 +91,36 @@ class FirefliesMembershipViewTest {
     }
 
     /**
+     * Test 1b: Verify activeMembers() is backed by context.active(), NOT allMembers().
+     * <p>
+     * Security-critical (RDR-005 / Luciferase-ah3): an evicted-but-not-yet-GC'd member is still
+     * returned by allMembers() but excluded from active(). activeMembers() must reflect active().
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testActiveMembersUsesActiveNotAllMembers() {
+        var active1  = mock(Member.class);
+        var active2  = mock(Member.class);
+        var evicted  = mock(Member.class);
+
+        // allMembers() includes the evicted node; active() does not.
+        when(mockContext.allMembers()).thenReturn(Stream.of(active1, active2, evicted));
+        when(mockContext.active()).thenReturn(Stream.of(active1, active2));
+
+        adapter = new FirefliesMembershipView(mockView);
+
+        var activeList = adapter.activeMembers().collect(Collectors.toList());
+
+        assertThat(activeList)
+            .as("activeMembers() must exclude the evicted-but-not-GC'd member")
+            .containsExactly(active1, active2)
+            .doesNotContain(evicted);
+
+        verify(mockContext).active();
+        verify(mockContext, never()).allMembers();
+    }
+
+    /**
      * Test 2: Verify listener receives notifications when members join/leave
      */
     @Test

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/delos/mock/MockFirefliesViewTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/delos/mock/MockFirefliesViewTest.java
@@ -83,6 +83,40 @@ class MockFirefliesViewTest {
     }
 
     @Test
+    void testActiveMembersExcludesInactive() {
+        var active  = UUID.randomUUID();
+        var evicted = UUID.randomUUID();
+
+        view.addMember(active);
+        view.addMember(evicted);
+        view.markInactive(evicted);
+
+        // getMembers() still returns the evicted-but-not-GC'd member...
+        assertThat(view.getMembers().collect(Collectors.toList()))
+            .as("getMembers() returns all known members including inactive")
+            .containsExactlyInAnyOrder(active, evicted);
+
+        // ...but activeMembers() excludes it (RDR-005 / Luciferase-ah3 distinction).
+        assertThat(view.activeMembers().collect(Collectors.toList()))
+            .as("activeMembers() excludes inactive members")
+            .containsExactly(active)
+            .doesNotContain(evicted);
+    }
+
+    @Test
+    void testReAddingClearsInactive() {
+        var member = UUID.randomUUID();
+
+        view.addMember(member);
+        view.markInactive(member);
+        assertThat(view.activeMembers().collect(Collectors.toList())).isEmpty();
+
+        // Re-adding a previously-inactive member restores it to active.
+        view.addMember(member);
+        assertThat(view.activeMembers().collect(Collectors.toList())).containsExactly(member);
+    }
+
+    @Test
     void testListenerNotifications() throws InterruptedException {
         var latch = new CountDownLatch(2);
         var changes = new ArrayList<MembershipView.ViewChange<UUID>>();


### PR DESCRIPTION
## What

Adds `MembershipView.activeMembers()` — an **active-only** membership accessor, distinct from `getMembers()` (full membership / `allMembers()`).

- `FirefliesMembershipView` backs it by Delos `DynamicContext.active()` (filters on `Tracked.isActive`); `getMembers()` uses `allMembers()` with no such filter. Confirmed via Delos bytecode disassembly during review.
- Made **abstract** (not a default delegating to `getMembers()`) to prevent a silent-unsafe default — exactly the hazard `Luciferase-ah3` is about.
- `MockFirefliesView` gains `markInactive()` to model the evicted-but-not-GC'd state (still in `getMembers()`, excluded from `activeMembers()`); `markInactive` on an unknown member fails fast.
- 13 test-double `MembershipView` impls updated; the two stateful doubles document their intentional `active==all` equivalence.

## Why (RDR-005 / Luciferase-ah3)

Future gRPC mTLS peer verification must gate the `inCurrentView` predicate on the **active-only** set. An evicted-but-not-GC'd node still holds a cryptographically valid, KERL-committed certificate, so authorizing via the full membership set would let a removed node continue to authenticate.

## Scope (deliberately narrow — "now-safe scaffolding")

Purely additive, **zero behavior change**. No production caller is rewired to `activeMembers()` here. Wiring `FirefliesPeerVerifier.inCurrentView` to it is **deferred Inc-7+ work** (it activates remote-exposure-relevant auth, which `ah3` gates). **This PR does NOT satisfy or close `ah3`.**

## Tests

- `FirefliesMembershipViewTest.testActiveMembersUsesActiveNotAllMembers` — stubs divergent `active()`/`allMembers()`, asserts `verify(never()).allMembers()`.
- `MockFirefliesViewTest` — inactive exclusion + re-add restoration.
- Full simulation module compiles; targeted suites green (10 tests).

Reviewed by code-review-expert and substantive-critic (0 critical; clarity findings addressed).