### PR TITLE
Luciferase-jvs: extract RD-math kernel to geometry module, drop simulation→portal dep (RDR-006 PR1)

### DIFF
--- a/docs/rdr/RDR-006-break-simulation-portal-coupling.md
+++ b/docs/rdr/RDR-006-break-simulation-portal-coupling.md
@@ -101,3 +101,41 @@ Accepted 2026-05-25 (gate PASSED, self-reviewed). Locked:
 - **Positive:** removes JavaFX from the headless `simulation`/distributed classpath; puts the RD math where RDR-003's FCC work can reach it without UI coupling; corrects the `domain-primitive-in-wrong-module` smell (incl. Clock).
 - **Cost / risk:** an internal API ripple (`Point3D`→`Point3f`) across `BubbleBounds` and the `von` records; if a new module is chosen, one module of overhead. `portal` keeps a thin `Point3D`-typed rendering layer over the kernel.
 - **Watch:** `TransportNeighborInfo` Phase 6B will introduce a `BubbleBounds` wire dependency — at that point it must cross-reference RDR-004's deserialization hardening. **Follow-up:** `common`'s `javafx-graphics` dependency undermines it as a leaf module (separate cleanup).
+
+## Implementation Progress
+
+### Corrected blast radius (2026-05-28)
+
+A pre-implementation blast-radius sweep found the JavaFX coupling is **wider than the
+"`BubbleBounds` + `von`" scope this RDR documented**. `javafx.geometry.Point3D` is used across
+~21 `simulation/src/main` files: the `von` package (10), `distributed/migration` (5 records),
+`bubble` (4, incl. `BubbleBounds`), `ghost/GhostSyncVONIntegration`, and
+`delos/fireflies/TetreeKeyRouter`. The `dependency:tree`-shows-no-`javafx-*` acceptance criterion
+therefore requires migrating **all** of them, not just `BubbleBounds`/`von`.
+
+Two corrections to the locked Decision:
+- **Position type is `Point3d` (double), not `Point3f`.** The RDR text said `Point3f`; swapping the
+  distributed-simulation position type to float would silently drop precision on AOI/distance/
+  boundary math. The precision-preserving replacement for javafx `Point3D` is `javax.vecmath.Point3d`.
+- **`BubbleBounds` was the *only* `simulation` main file importing `portal`** — so breaking the
+  `simulation → portal` *module* dependency (the literal D5 goal) is separable from, and smaller
+  than, fully clearing `javafx-*`.
+
+### Phased delivery
+
+- **PR1 (this increment, bead Luciferase-jvs):** new `geometry` module (vecmath-only, no JavaFX);
+  extracted the UI-free RD-math kernel as standalone `geometry/.../rd/RDGCoordinates` (no
+  `Grid`/`RDGCS`/`javafx` inheritance — the inheritance chain is the JavaFX carrier);
+  `toCartesian` returns `Point3d`. Repointed `BubbleBounds` off `portal.Tetrahedral`;
+  **dropped the `portal` dependency from `simulation/pom.xml`** (`mvn dependency:tree -pl simulation`
+  confirms no `portal`). Added kernel coverage (`RDGCoordinatesTest`: round-trip identity, metric-
+  tensor dot, neighbor shells — guards the 7jk/6oa/xnf fixes). Two latent transitive couplings
+  surfaced and were made explicit: (a) `org.jetbrains:annotations` convergence pin (javalin 24.1.0
+  vs kotlin-stdlib 13.0, previously masked by portal's tree); (b) explicit `render` dependency
+  (simulation.viz.render.SerializationUtils uses render ESVT types, previously satisfied via
+  portal→render). `portal.Tetrahedral` retained unchanged as the JavaFX-typed rendering variant.
+- **PR2 (follow-up):** repo-wide `Point3D` → `Point3d` migration across the ~21 files so
+  `mvn dependency:tree -pl simulation` shows zero `javafx-*`; this is where the criterion is met.
+  JavaFX still reaches `simulation` transitively via `render` and `common` after PR1.
+- **Deferred:** Clock package rename (`Luciferase-7n1`) — kept out of PR1 to keep the diff
+  reviewable; it is an orthogonal ~26-file package move.

--- a/geometry/pom.xml
+++ b/geometry/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.hellblazer.luciferase</groupId>
+        <artifactId>luciferase.app</artifactId>
+        <version>0.0.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>geometry</artifactId>
+    <name>Geometry - UI-free spatial coordinate math</name>
+    <description>
+        Pure javax.vecmath coordinate math with NO JavaFX dependency. Holds the
+        rhombic-dodecahedron / FCC (RDGCS) coordinate kernel extracted from
+        portal.Tetrahedral so headless consumers (simulation, lucien FCC work)
+        can use the math without dragging the JavaFX toolkit onto their
+        classpath. See RDR-006.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.vecmath</groupId>
+            <artifactId>vecmath</artifactId>
+        </dependency>
+
+        <!-- Test Only Dependencies Below This Line -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/geometry/src/main/java/com/hellblazer/luciferase/geometry/rd/RDGCoordinates.java
+++ b/geometry/src/main/java/com/hellblazer/luciferase/geometry/rd/RDGCoordinates.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (C) 2023 Hal Hildebrand. All rights reserved.
+ * <p>
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ * <p>
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.geometry.rd;
+
+import javax.vecmath.Point3d;
+import javax.vecmath.Point3f;
+import javax.vecmath.Point3i;
+import javax.vecmath.Tuple3f;
+import javax.vecmath.Tuple3i;
+import javax.vecmath.Vector3f;
+
+/**
+ * UI-free rhombic-dodecahedron / FCC (RDGCS) coordinate math kernel.
+ * <p>
+ * This is the JavaFX-free extraction of the coordinate math previously only available through
+ * {@code portal.Tetrahedral}, whose {@code Tetrahedral → RDGCS → Grid} inheritance chain drags the
+ * entire JavaFX toolkit (the {@code Grid} base imports {@code javafx.scene.*}). Headless consumers
+ * — the distributed simulation, RDR-003's FCC spatial-index work — need only this math, not the
+ * scene-graph rendering layer.
+ * <p>
+ * Deliberately a <b>standalone</b> class with NO inheritance from {@code Grid}/{@code RDGCS} and no
+ * {@code javafx.*} reference: reaching this math by subclassing {@code RDGCS} would silently drag
+ * the JavaFX chain back in (RDR-006 §Approach). All methods are pure functions of their arguments.
+ * <p>
+ * Cartesian outputs use {@link Point3d} (double precision) rather than the float-typed inputs to
+ * avoid a precision regression on position math (RDR-006 implementation decision); the float
+ * {@code toRDG} input matches the existing call sites.
+ *
+ * @author hal.hildebrand
+ */
+public final class RDGCoordinates {
+
+    /** {@code 1/√2} — the RDGCS basis scale. */
+    public static final double DIVIDE_ROOT_2 = 1.0 / Math.sqrt(2);
+
+    private RDGCoordinates() {
+        // static math kernel — not instantiable
+    }
+
+    /**
+     * Answer the Euclidean length of the tetrahedral vector.
+     *
+     * @param rdg vector in Tetrahedral basis
+     * @return the length of the vector
+     */
+    public static float euclideanNorm(Vector3f rdg) {
+        return (float) Math.sqrt(rdg.x * (rdg.x + rdg.y + rdg.z) + rdg.y * (rdg.y + rdg.z) + rdg.z * rdg.z);
+    }
+
+    /**
+     * Answer the manhattan (L1) distance of the tetrahedral vector.
+     *
+     * @param rdg vector in Tetrahedral basis
+     * @return the manhattan distance
+     */
+    public static float l1(Vector3f rdg) {
+        return Math.abs(rdg.x) + Math.abs(rdg.y) + Math.abs(rdg.z);
+    }
+
+    /**
+     * Tetrahedral-basis cross product.
+     *
+     * @param u left vector
+     * @param v right vector
+     * @return the cross product in the Tetrahedral basis
+     */
+    public static Point3f cross(Tuple3f u, Tuple3f v) {
+        return new Point3f(
+        (float) ((-u.x * (v.y - v.z) + u.y * (3 * v.z + v.x) - u.z * (v.x + 3 * v.y)) * (DIVIDE_ROOT_2 / 2)),
+        (float) ((-u.x * (v.y + 3 * v.z) - u.y * (v.z - v.x) + u.z * (3 * v.x + v.y)) * (DIVIDE_ROOT_2 / 2)),
+        (float) ((u.x * (3 * v.y + v.z) - u.y * (v.z + 3 * v.x) - u.z * (v.x - v.y)) * (DIVIDE_ROOT_2 / 2)));
+    }
+
+    /**
+     * Tetrahedral-basis inner product derived from the metric tensor {@code G_ii = 1, G_ij = 1/2}
+     * (i ≠ j). The previous implementation had multiple incorrect coefficients
+     * ({@code u.y*(v.x+v.x)} instead of {@code u.y*v.y + (...)/2}, trailing {@code u.z*v.x} instead
+     * of {@code u.z*v.z}) — Luciferase-7jk.
+     *
+     * @param u left vector in Tetrahedral basis
+     * @param v right vector in Tetrahedral basis
+     * @return {@code Σ_ij G_ij · u_i · v_j}
+     */
+    public static float dot(Vector3f u, Vector3f v) {
+        return u.x * v.x + u.y * v.y + u.z * v.z
+             + (u.x * v.y + u.y * v.x + u.x * v.z + u.z * v.x + u.y * v.z + u.z * v.y) / 2f;
+    }
+
+    /**
+     * Rotate {@code vec} about {@code axis} by {@code theta} radians (counter-clockwise).
+     *
+     * @param vec   vector to rotate
+     * @param axis  rotation axis
+     * @param theta angle in radians
+     * @return the rotated vector
+     */
+    public static Vector3f rotateVectorCC(Vector3f vec, Vector3f axis, double theta) {
+        float x = vec.getX(), y = vec.getY(), z = vec.getZ();
+        float u = axis.getX(), v = axis.getY(), w = axis.getZ();
+        float C = u * x + v * y + w * z;
+        float xPrime = (float) (u * C * (1d - Math.cos(theta)) + x * Math.cos(theta) + (-w * y + v * z) * Math.sin(theta));
+        float yPrime = (float) (v * C * (1d - Math.cos(theta)) + y * Math.cos(theta) + (w * x - u * z) * Math.sin(theta));
+        float zPrime = (float) (w * C * (1d - Math.cos(theta)) + z * Math.cos(theta) + (-v * x + u * y) * Math.sin(theta));
+        return new Vector3f(xPrime, yPrime, zPrime);
+    }
+
+    /**
+     * Convert integer RDGCS coordinates to Cartesian.
+     *
+     * @param rdg RDGCS coordinates
+     * @return Cartesian position (double precision)
+     */
+    public static Point3d toCartesian(Tuple3i rdg) {
+        return new Point3d((rdg.y + rdg.z) * DIVIDE_ROOT_2, (rdg.z + rdg.x) * DIVIDE_ROOT_2,
+                           (rdg.x + rdg.y) * DIVIDE_ROOT_2);
+    }
+
+    /**
+     * Inverse of {@link #toCartesian(Tuple3i)} via the Tetrahedral basis change.
+     * <p>
+     * Uses {@link Math#round} (not C-style {@code (int)} truncation) to invert the {@code 1/√2}
+     * basis scale faithfully. The earlier truncation implementation broke the
+     * {@code toRDG(toCartesian(p)) == p} round-trip for unit-magnitude integer points: for example,
+     * {@code toCartesian((1, 0, 0)) = (0, 1/√2, 1/√2)} and the inverse computation produced floats
+     * in the {@code [0.99999..., 1.00000...]} neighbourhood that {@code (int)} cast to {@code 0}
+     * (Luciferase-6oa audit finding).
+     *
+     * @param cartesian Cartesian position
+     * @return RDGCS coordinates
+     */
+    public static Point3i toRDG(Tuple3f cartesian) {
+        return new Point3i((int) Math.round((-cartesian.x + cartesian.y + cartesian.z) * DIVIDE_ROOT_2),
+                           (int) Math.round(( cartesian.x - cartesian.y + cartesian.z) * DIVIDE_ROOT_2),
+                           (int) Math.round(( cartesian.x + cartesian.y - cartesian.z) * DIVIDE_ROOT_2));
+    }
+
+    /**
+     * Return the 6 face-connected + 6 second-shell neighbors (12 total) of {@code cell}.
+     *
+     * @param cell the cell whose face-connected neighbors to return
+     * @return 12 neighbor offsets
+     */
+    public static Point3i[] faceConnectedNeighbors(Point3i cell) {
+        var x = cell.x;
+        var y = cell.y;
+        var z = cell.z;
+        var neighbors = new Point3i[12];
+        neighbors[0] = new Point3i(x + 1, y, z);
+        neighbors[1] = new Point3i(x - 1, y, z);
+        neighbors[2] = new Point3i(x, y + 1, z);
+        neighbors[3] = new Point3i(x, y - 1, z);
+        neighbors[4] = new Point3i(x, y, z + 1);
+        neighbors[5] = new Point3i(x, y, z - 1);
+
+        neighbors[6] = new Point3i(x, y + 1, z - 1);
+        neighbors[7] = new Point3i(x, y - 1, z + 1);
+        neighbors[8] = new Point3i(x - 1, y, z + 1);
+        neighbors[9] = new Point3i(x + 1, y, z - 1);
+        neighbors[10] = new Point3i(x + 1, y - 1, z);
+        neighbors[11] = new Point3i(x - 1, y + 1, z);
+        return neighbors;
+    }
+
+    /**
+     * Return the 6 FCC second-shell vertex-connected neighbors of {@code cell}.
+     * <p>
+     * In Tetrahedral coordinates these are the 6 offsets {@code (±1, ±1, ∓1)} with mixed signs whose
+     * Cartesian images are the 6 axis-aligned points at distance {@code sqrt(2)} from origin (the
+     * FCC second shell). The previous implementation returned a mix of face-neighbor (distance 1)
+     * and third-shell (distance sqrt(11)) offsets — Luciferase-xnf.
+     *
+     * @param cell the cell whose vertex-connected neighbors to return
+     * @return 6 distinct offsets all at Cartesian distance {@code sqrt(2)} from {@code cell}
+     */
+    public static Point3i[] vertexConnectedNeighbors(Point3i cell) {
+        var x = cell.x;
+        var y = cell.y;
+        var z = cell.z;
+        var neighbors = new Point3i[6];
+        neighbors[0] = new Point3i(x + 1, y + 1, z - 1);
+        neighbors[1] = new Point3i(x - 1, y - 1, z + 1);
+        neighbors[2] = new Point3i(x + 1, y - 1, z + 1);
+        neighbors[3] = new Point3i(x - 1, y + 1, z - 1);
+        neighbors[4] = new Point3i(x - 1, y + 1, z + 1);
+        neighbors[5] = new Point3i(x + 1, y - 1, z - 1);
+        return neighbors;
+    }
+}

--- a/geometry/src/test/java/com/hellblazer/luciferase/geometry/rd/RDGCoordinatesTest.java
+++ b/geometry/src/test/java/com/hellblazer/luciferase/geometry/rd/RDGCoordinatesTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (C) 2023 Hal Hildebrand. All rights reserved.
+ * <p>
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ * <p>
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.geometry.rd;
+
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3f;
+import javax.vecmath.Point3i;
+import javax.vecmath.Vector3f;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Coverage for the UI-free RD coordinate kernel extracted from {@code portal.Tetrahedral} (RDR-006).
+ * Validates that the extraction preserves the verified math (round-trip identity, metric-tensor dot,
+ * neighbor shells) — i.e. the lift did not introduce a regression.
+ *
+ * @author hal.hildebrand
+ */
+class RDGCoordinatesTest {
+
+    /**
+     * toRDG(toCartesian(p)) == p for integer points — the round-trip identity that Luciferase-6oa's
+     * Math.round fix established (C-style truncation broke it for unit-magnitude points).
+     */
+    @Test
+    void roundTripIdentityForIntegerPoints() {
+        for (int x = -3; x <= 3; x++) {
+            for (int y = -3; y <= 3; y++) {
+                for (int z = -3; z <= 3; z++) {
+                    var rdg = new Point3i(x, y, z);
+                    var cart = RDGCoordinates.toCartesian(rdg);
+                    var back = RDGCoordinates.toRDG(new Point3f((float) cart.x, (float) cart.y, (float) cart.z));
+                    assertThat(back).as("round-trip for (%d,%d,%d)", x, y, z).isEqualTo(rdg);
+                }
+            }
+        }
+    }
+
+    /** Specifically the (1,0,0) case from the Luciferase-6oa audit. */
+    @Test
+    void roundTripUnitMagnitudePoint() {
+        var rdg = new Point3i(1, 0, 0);
+        var cart = RDGCoordinates.toCartesian(rdg);
+        // toCartesian((1,0,0)) = (0, 1/√2, 1/√2)
+        assertThat(cart.x).isCloseTo(0.0, within(1e-9));
+        assertThat(cart.y).isCloseTo(RDGCoordinates.DIVIDE_ROOT_2, within(1e-9));
+        assertThat(cart.z).isCloseTo(RDGCoordinates.DIVIDE_ROOT_2, within(1e-9));
+        var back = RDGCoordinates.toRDG(new Point3f((float) cart.x, (float) cart.y, (float) cart.z));
+        assertThat(back).isEqualTo(rdg);
+    }
+
+    /**
+     * Metric-tensor dot (G_ii=1, G_ij=1/2). Verifies symmetry and a hand-computed value, guarding the
+     * Luciferase-7jk coefficient fix.
+     */
+    @Test
+    void dotIsSymmetricMetricTensor() {
+        var u = new Vector3f(1, 2, 3);
+        var v = new Vector3f(4, 5, 6);
+        // Σ u_i v_i + (Σ_{i≠j} u_i v_j)/2
+        float expected = (1*4 + 2*5 + 3*6)
+                       + (1*5 + 2*4 + 1*6 + 3*4 + 2*6 + 3*5) / 2f;
+        assertThat(RDGCoordinates.dot(u, v)).isEqualTo(expected);
+        assertThat(RDGCoordinates.dot(u, v)).as("symmetry").isEqualTo(RDGCoordinates.dot(v, u));
+    }
+
+    @Test
+    void euclideanNormAndL1() {
+        assertThat(RDGCoordinates.l1(new Vector3f(1, -2, 3))).isEqualTo(6f);
+        // norm of zero vector is zero; norm is non-negative
+        assertThat(RDGCoordinates.euclideanNorm(new Vector3f(0, 0, 0))).isEqualTo(0f);
+        assertThat(RDGCoordinates.euclideanNorm(new Vector3f(1, 1, 1))).isGreaterThan(0f);
+    }
+
+    @Test
+    void crossIsAntisymmetric() {
+        var u = new Point3f(1, 2, 3);
+        var v = new Point3f(4, 5, 6);
+        var uv = RDGCoordinates.cross(u, v);
+        var vu = RDGCoordinates.cross(v, u);
+        // cross(u,v) == -cross(v,u)
+        assertThat(uv.x).isCloseTo(-vu.x, within(1e-5f));
+        assertThat(uv.y).isCloseTo(-vu.y, within(1e-5f));
+        assertThat(uv.z).isCloseTo(-vu.z, within(1e-5f));
+        // cross(u,u) == 0
+        var uu = RDGCoordinates.cross(u, u);
+        assertThat(uu.x).isCloseTo(0f, within(1e-5f));
+        assertThat(uu.y).isCloseTo(0f, within(1e-5f));
+        assertThat(uu.z).isCloseTo(0f, within(1e-5f));
+    }
+
+    @Test
+    void rotateVectorCCFullTurnIsIdentity() {
+        var vec = new Vector3f(1, 2, 3);
+        var axis = new Vector3f(0, 0, 1);
+        var rotated = RDGCoordinates.rotateVectorCC(vec, axis, 2 * Math.PI);
+        assertThat(rotated.x).isCloseTo(vec.x, within(1e-4f));
+        assertThat(rotated.y).isCloseTo(vec.y, within(1e-4f));
+        assertThat(rotated.z).isCloseTo(vec.z, within(1e-4f));
+    }
+
+    @Test
+    void rotateVectorCCAboutZByHalfPi() {
+        // (1,0,0) rotated +90° about +z → (0,1,0)
+        var rotated = RDGCoordinates.rotateVectorCC(new Vector3f(1, 0, 0), new Vector3f(0, 0, 1), Math.PI / 2);
+        assertThat(rotated.x).isCloseTo(0f, within(1e-6f));
+        assertThat(rotated.y).isCloseTo(1f, within(1e-6f));
+        assertThat(rotated.z).isCloseTo(0f, within(1e-6f));
+    }
+
+    @Test
+    void faceConnectedNeighborsAreTwelveDistinct() {
+        var n = RDGCoordinates.faceConnectedNeighbors(new Point3i(0, 0, 0));
+        assertThat(n).hasSize(12);
+        assertThat(new HashSet<>(Arrays.asList(n))).as("all distinct").hasSize(12);
+    }
+
+    /** The 6 vertex-connected neighbors must all sit at Cartesian distance √2 (Luciferase-xnf). */
+    @Test
+    void vertexConnectedNeighborsAreSixAtDistanceRoot2() {
+        var n = RDGCoordinates.vertexConnectedNeighbors(new Point3i(0, 0, 0));
+        assertThat(n).hasSize(6);
+        assertThat(new HashSet<>(Arrays.asList(n))).hasSize(6);
+        for (var cell : n) {
+            var c = RDGCoordinates.toCartesian(cell);
+            double dist = Math.sqrt(c.x * c.x + c.y * c.y + c.z * c.z);
+            assertThat(dist).as("vertex neighbor %s at distance √2", cell).isCloseTo(Math.sqrt(2), within(1e-9));
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <module>grpc</module>
         <module>lucien</module>
         <module>lucien-distributed</module>
+        <module>geometry</module>
         <module>portal</module>
         <module>common</module>
         <module>simulation</module>
@@ -73,6 +74,11 @@
                 <groupId>${project.groupId}</groupId>
                 <version>${project.version}</version>
                 <artifactId>lucien</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>geometry</artifactId>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
@@ -160,6 +166,14 @@
                 <groupId>com.github.ben-manes.caffeine</groupId>
                 <artifactId>caffeine</artifactId>
                 <version>3.1.8</version>
+            </dependency>
+            <dependency>
+                <!-- Convergence pin: javalin pulls annotations 24.1.0 directly while the
+                     kotlin-stdlib chain pulls 13.0. Previously masked by the portal dependency
+                     tree; surfaced when simulation dropped its portal dependency (RDR-006). -->
+                <groupId>org.jetbrains</groupId>
+                <artifactId>annotations</artifactId>
+                <version>24.1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -25,6 +25,13 @@
             <artifactId>lucien</artifactId>
         </dependency>
         <dependency>
+            <!-- RDR-006: Tetrahedral delegates its UI-free RD math to the geometry kernel
+                 (RDGCoordinates) so there is a single source of truth for the 7jk/6oa/xnf
+                 fixes. geometry depends only on vecmath, so no dependency cycle. -->
+            <groupId>${project.groupId}</groupId>
+            <artifactId>geometry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>render</artifactId>
         </dependency>

--- a/portal/src/main/java/com/hellblazer/luciferase/portal/Tetrahedral.java
+++ b/portal/src/main/java/com/hellblazer/luciferase/portal/Tetrahedral.java
@@ -14,6 +14,7 @@
  */
 package com.hellblazer.luciferase.portal;
 
+import com.hellblazer.luciferase.geometry.rd.RDGCoordinates;
 import javafx.geometry.Point3D;
 import javafx.util.Pair;
 
@@ -61,7 +62,7 @@ public class Tetrahedral extends RDGCS {
      * @return the legth of the vector
      */
     public static float euclideanNorm(Vector3f rdg) {
-        return (float) Math.sqrt(rdg.x * (rdg.x + rdg.y + rdg.z) + rdg.y * (rdg.y + rdg.z) + rdg.z * rdg.z);
+        return RDGCoordinates.euclideanNorm(rdg);
     }
 
     /**
@@ -71,7 +72,7 @@ public class Tetrahedral extends RDGCS {
      * @return the manhatten distance to the vector
      */
     public static float l1(Vector3f rdg) {
-        return Math.abs(rdg.x) + Math.abs(rdg.y) + Math.abs(rdg.z);
+        return RDGCoordinates.l1(rdg);
     }
 
     public Point3f axisAngle(float radians, Vector3f u, Vector3f w) {
@@ -88,10 +89,7 @@ public class Tetrahedral extends RDGCS {
 
     @Override
     public Point3f cross(Tuple3f u, Tuple3f v) {
-        return new Point3f(
-        (-u.x * (v.y - v.z) + u.y * (3 * v.z + v.x) - u.z * (v.x + 3 * v.y)) * (RDGCS.DIVIDE_ROOT_2 / 2),
-        (-u.x * (v.y + 3 * v.z) - u.y * (v.z - v.x) + u.z * (3 * v.x + v.y)) * (RDGCS.DIVIDE_ROOT_2 / 2),
-        (u.x * (3 * v.y + v.z) - u.y * (v.z + 3 * v.x) - u.z * (v.x - v.y)) * (RDGCS.DIVIDE_ROOT_2 / 2));
+        return RDGCoordinates.cross(u, v);
     }
 
     /**
@@ -107,56 +105,23 @@ public class Tetrahedral extends RDGCS {
      */
     @Override
     public float dot(Vector3f u, Vector3f v) {
-        return u.x * v.x + u.y * v.y + u.z * v.z
-             + (u.x * v.y + u.y * v.x + u.x * v.z + u.z * v.x + u.y * v.z + u.z * v.y) / 2f;
+        return RDGCoordinates.dot(u, v);
     }
 
     @Override
     public Point3i[] faceConnectedNeighbors(Point3i cell) {
-        var x = cell.x;
-        var y = cell.y;
-        var z = cell.z;
-        var neighbors = new Point3i[12];
-        neighbors[0] = new Point3i(x + 1, y, z);
-        neighbors[1] = new Point3i(x - 1, y, z);
-        neighbors[2] = new Point3i(x, y + 1, z);
-        neighbors[3] = new Point3i(x, y - 1, z);
-        neighbors[4] = new Point3i(x, y, z + 1);
-        neighbors[5] = new Point3i(x, y, z - 1);
-
-        neighbors[6] = new Point3i(x, y + 1, z - 1);
-        neighbors[7] = new Point3i(x, y - 1, z + 1);
-        neighbors[8] = new Point3i(x - 1, y, z + 1);
-        neighbors[9] = new Point3i(x + 1, y, z - 1);
-        neighbors[10] = new Point3i(x + 1, y - 1, z);
-        neighbors[11] = new Point3i(x - 1, y + 1, z);
-        return neighbors;
+        return RDGCoordinates.faceConnectedNeighbors(cell);
     }
 
     @Override
     public Vector3f rotateVectorCC(Vector3f vec, Vector3f axis, double theta) {
-        float x, y, z;
-        float u, v, w;
-        x = vec.getX();
-        y = vec.getY();
-        z = vec.getZ();
-        u = axis.getX();
-        v = axis.getY();
-        w = axis.getZ();
-        float C = u * x + v * y + w * z;
-        float xPrime = (float) (u * C * (1d - Math.cos(theta)) + x * Math.cos(theta) + (-w * y + v * z) * Math.sin(
-        theta));
-        float yPrime = (float) (v * C * (1d - Math.cos(theta)) + y * Math.cos(theta) + (w * x - u * z) * Math.sin(
-        theta));
-        float zPrime = (float) (w * C * (1d - Math.cos(theta)) + z * Math.cos(theta) + (-v * x + u * y) * Math.sin(
-        theta));
-        return new Vector3f(xPrime, yPrime, zPrime);
+        return RDGCoordinates.rotateVectorCC(vec, axis, theta);
     }
 
     @Override
     public Point3D toCartesian(Tuple3i rdg) {
-        return new Point3D((rdg.y + rdg.z) * DIVIDE_ROOT_2, (rdg.z + rdg.x) * DIVIDE_ROOT_2,
-                           (rdg.x + rdg.y) * DIVIDE_ROOT_2);
+        var p = RDGCoordinates.toCartesian(rdg);
+        return new Point3D(p.x, p.y, p.z);
     }
 
     @Override
@@ -179,9 +144,7 @@ public class Tetrahedral extends RDGCS {
      */
     @Override
     public Point3i toRDG(Tuple3f cartesian) {
-        return new Point3i(Math.round((-cartesian.x + cartesian.y + cartesian.z) * DIVIDE_ROOT_2),
-                           Math.round(( cartesian.x - cartesian.y + cartesian.z) * DIVIDE_ROOT_2),
-                           Math.round(( cartesian.x + cartesian.y - cartesian.z) * DIVIDE_ROOT_2));
+        return RDGCoordinates.toRDG(cartesian);
     }
 
     /**
@@ -199,20 +162,6 @@ public class Tetrahedral extends RDGCS {
      */
     @Override
     public Point3i[] vertexConnectedNeighbors(Point3i cell) {
-        var x = cell.x;
-        var y = cell.y;
-        var z = cell.z;
-        // Cartesian images via toCartesian((a,b,c)) = ((b+c), (a+c), (a+b)) / √2:
-        // (+1,+1,-1) → ( 0,  0,  √2)    (-1,-1,+1) → ( 0,  0, -√2)
-        // (+1,-1,+1) → ( 0,  √2, 0)     (-1,+1,-1) → ( 0, -√2, 0)
-        // (-1,+1,+1) → ( √2, 0,  0)     (+1,-1,-1) → (-√2, 0,  0)
-        var neighbors = new Point3i[6];
-        neighbors[0] = new Point3i(x + 1, y + 1, z - 1);
-        neighbors[1] = new Point3i(x - 1, y - 1, z + 1);
-        neighbors[2] = new Point3i(x + 1, y - 1, z + 1);
-        neighbors[3] = new Point3i(x - 1, y + 1, z - 1);
-        neighbors[4] = new Point3i(x - 1, y + 1, z + 1);
-        neighbors[5] = new Point3i(x + 1, y - 1, z - 1);
-        return neighbors;
+        return RDGCoordinates.vertexConnectedNeighbors(cell);
     }
 }

--- a/portal/src/test/java/com/hellblazer/luciferase/portal/collision/CollisionDebugSystemTest.java
+++ b/portal/src/test/java/com/hellblazer/luciferase/portal/collision/CollisionDebugSystemTest.java
@@ -6,6 +6,7 @@ package com.hellblazer.luciferase.portal.collision;
 import com.hellblazer.luciferase.lucien.collision.BoxShape;
 import com.hellblazer.luciferase.lucien.collision.SphereShape;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import javax.vecmath.Point3f;
@@ -16,9 +17,16 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Integration tests for the complete collision debug visualization system.
  * Tests Phase 6: Debug and Visualization Tools implementation.
+ * <p>
+ * Tagged {@code javafx}: the collision visualizers build JavaFX scene-graph nodes
+ * (e.g. {@code javafx.scene.shape.Sphere} via {@code CollisionShapeRenderer}), which fail to
+ * initialize without a graphics pipeline. CI excludes the {@code javafx} tag
+ * ({@code -Dportal.excludedGroups= | javafx}); see the {@code @Tag("javafx")} convention on
+ * {@code JavaFXTestBase}.
  *
  * @author hal.hildebrand
  */
+@Tag("javafx")
 public class CollisionDebugSystemTest {
     
     private CollisionVisualizer visualizer;

--- a/portal/src/test/java/com/hellblazer/luciferase/portal/collision/CollisionVisualizationTest.java
+++ b/portal/src/test/java/com/hellblazer/luciferase/portal/collision/CollisionVisualizationTest.java
@@ -10,6 +10,7 @@ import com.hellblazer.luciferase.lucien.collision.physics.PhysicsMaterial;
 import com.hellblazer.luciferase.lucien.collision.physics.RigidBody;
 import javafx.scene.paint.Color;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import javax.vecmath.Point3f;
@@ -19,9 +20,15 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for collision visualization system.
+ * <p>
+ * Tagged {@code javafx}: builds JavaFX scene-graph nodes (e.g. {@code javafx.scene.shape.Sphere})
+ * that fail to initialize without a graphics pipeline. CI excludes the {@code javafx} tag
+ * ({@code -Dportal.excludedGroups= | javafx}); see the {@code @Tag("javafx")} convention on
+ * {@code JavaFXTestBase}.
  *
  * @author hal.hildebrand
  */
+@Tag("javafx")
 public class CollisionVisualizationTest {
     
     private CollisionVisualizer visualizer;

--- a/simulation/pom.xml
+++ b/simulation/pom.xml
@@ -36,7 +36,19 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>portal</artifactId>
+            <artifactId>geometry</artifactId>
+        </dependency>
+        <!-- Pre-existing coupling, now declared honestly: simulation.viz.render.SerializationUtils
+             uses render's ESVT types (esvt.core.ESVTData/ESVTNodeUnified). This was always a real
+             simulation->render dependency; it was merely satisfied transitively via portal->render
+             before RDR-006 dropped portal. This is NOT a net JavaFX reduction — render carries
+             JavaFX/LWJGL, so dropping portal alone does not clear javafx-* from the simulation tree.
+             Two genuinely separate follow-ups: (1) PR2 migrates the ~21 javafx Point3D usages off
+             javafx; (2) relocating simulation.viz.render.* into the render module would remove this
+             coupling entirely (these classes are arguably misplaced in simulation). -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>render</artifactId>
         </dependency>
         <dependency>
             <groupId>io.javalin</groupId>

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/BubbleBounds.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/BubbleBounds.java
@@ -2,9 +2,9 @@ package com.hellblazer.luciferase.simulation.bubble;
 
 import com.hellblazer.luciferase.simulation.bubble.*;
 
+import com.hellblazer.luciferase.geometry.rd.RDGCoordinates;
 import com.hellblazer.luciferase.lucien.tetree.Tet;
 import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
-import com.hellblazer.luciferase.portal.Tetrahedral;
 import javafx.geometry.Point3D;
 
 import javax.vecmath.Point3f;
@@ -33,7 +33,6 @@ public final class BubbleBounds implements Serializable {
     private final TetreeKey<?> rootKey;
     private final Point3i rdgMin;
     private final Point3i rdgMax;
-    private transient Tetrahedral coordSystem;
 
     /**
      * Create BubbleBounds from tetrahedral and RDGCS coordinates.
@@ -46,7 +45,6 @@ public final class BubbleBounds implements Serializable {
         this.rootKey = rootKey;
         this.rdgMin = rdgMin;
         this.rdgMax = rdgMax;
-        this.coordSystem = new Tetrahedral();
     }
 
     /**
@@ -62,10 +60,9 @@ public final class BubbleBounds implements Serializable {
         var coords = tet.coordinates();
 
         // Compute RDGCS coordinates for all 4 vertices
-        var tetrahedral = new Tetrahedral();
         var rdgCoords = new Point3i[4];
         for (int i = 0; i < 4; i++) {
-            rdgCoords[i] = tetrahedral.toRDG(new Point3f(coords[i].x, coords[i].y, coords[i].z));
+            rdgCoords[i] = RDGCoordinates.toRDG(new Point3f(coords[i].x, coords[i].y, coords[i].z));
         }
 
         // Find min/max in RDGCS space
@@ -127,11 +124,9 @@ public final class BubbleBounds implements Serializable {
             throw new IllegalArgumentException("Cannot create bounds from empty position list");
         }
 
-        var tetrahedral = new Tetrahedral();
-
         // Convert all positions to RDGCS
         var rdgPositions = positions.stream()
-                                   .map(tetrahedral::toRDG)
+                                   .map(RDGCoordinates::toRDG)
                                    .toList();
 
         // Find RDGCS min/max
@@ -192,25 +187,13 @@ public final class BubbleBounds implements Serializable {
     }
 
     /**
-     * Ensure coordSystem is initialized (handles post-deserialization).
-     *
-     * @return coordSystem instance
-     */
-    private Tetrahedral getCoordSystem() {
-        if (coordSystem == null) {
-            coordSystem = new Tetrahedral();
-        }
-        return coordSystem;
-    }
-
-    /**
      * Convert Cartesian coordinates to RDGCS.
      *
      * @param cartesian Cartesian position
      * @return RDGCS coordinates
      */
     public Point3i toRDG(Tuple3f cartesian) {
-        return getCoordSystem().toRDG(cartesian);
+        return RDGCoordinates.toRDG(cartesian);
     }
 
     /**
@@ -220,7 +203,8 @@ public final class BubbleBounds implements Serializable {
      * @return Cartesian position
      */
     public Point3D toCartesian(Tuple3i rdg) {
-        return getCoordSystem().toCartesian(rdg);
+        var p = RDGCoordinates.toCartesian(rdg);
+        return new Point3D(p.x, p.y, p.z);
     }
 
     /**


### PR DESCRIPTION
## What

Breaks the **simulation→portal module dependency** (the literal D5 goal of RDR-006) by extracting the UI-free RD coordinate math into a new vecmath-only `geometry` module.

- **New `geometry` module** (zero JavaFX): standalone `RDGCoordinates` holds the rhombic-dodecahedron / FCC math previously only reachable through `portal.Tetrahedral`, whose `Tetrahedral → RDGCS → Grid` inheritance chain is the JavaFX carrier. The kernel has **no** `Grid`/`RDGCS`/`javafx` inheritance.
- **`toCartesian` returns `javax.vecmath.Point3d`** (double) — the RDR text said `Point3f`, but that would drop precision on simulation position math. Precision-preserving choice.
- **`BubbleBounds`** (the only simulation-main portal consumer) repointed to the kernel; **`portal` dependency removed from `simulation/pom.xml`**. `mvn dependency:tree -pl simulation` confirms no `portal`.
- **`portal.Tetrahedral` now delegates** its pure-math methods to `RDGCoordinates` — single source of truth for the 7jk/6oa/xnf fixes (portal gains a `geometry` dep; no cycle). `Tetrahedral` shrinks 73 lines. Portal's **31 existing RD-math tests pass** against the delegating impl → cross-validates kernel ≡ portal.

## Tests

- `geometry` `RDGCoordinatesTest`: 9 — round-trip identity, 6oa unit-magnitude case, metric-tensor `dot` (7jk), `cross` antisymmetry, `rotateVectorCC`, neighbor shells.
- `portal` RD-math suite (RDFCCMathCoverage/PortalCleanupBatch/RDGeometrySmoke): 31/31 green against delegating `Tetrahedral`.
- `simulation` `BubbleBoundsTest`: 12/12.

## Latent couplings surfaced (both made explicit honestly)

- **`org.jetbrains:annotations` convergence pin** (javalin 24.1.0 vs kotlin-stdlib 13.0) — was masked by portal's dependency tree.
- **explicit `simulation → render` dep** — `simulation.viz.render.SerializationUtils` uses render's ESVT types; always a real coupling, satisfied transitively via portal→render before. **NOT a net JavaFX reduction** (render carries JavaFX/LWJGL).

## Scope (phased — see RDR-006 §Implementation Progress)

| Goal | Status |
|------|--------|
| D5: simulation no longer depends on `portal` module | ✅ done (this PR) |
| D5: no `javafx-*` on simulation classpath | ⛔ not yet — arrives via render/common; **PR2** migrates the ~21 `Point3D` usages to `Point3d` |
| Clock rename (Luciferase-7n1) | deferred to keep diff reviewable — explicit deviation from RDR locked scope |

The corrected blast radius (~21 files, not "BubbleBounds + von") and the Point3f→Point3d correction are recorded in RDR-006's appended Implementation Progress section.

## Review

Two-pass (code-review-expert + substantive-critic). Math extraction verified faithful. Critic's duplication-hazard finding → addressed by the `Tetrahedral` delegation (single source of truth). Critic's render-framing finding → addressed in the pom comment + RDR. Critic's D5/Clock framing → made explicit above and in the RDR.