### PR TITLE
docs(rdr): add RDR index README (nexus standard template)

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -1,0 +1,33 @@
+# Recommendation Decisioning Records (RDRs)
+
+RDRs are specification prompts built through iterative research and refinement.
+
+See the [RDR process documentation](https://github.com/cwensel/rdr) for the full workflow.
+
+## Index
+
+| ID | Title | Status | Type | Priority |
+|----|-------|--------|------|----------|
+| [RDR-001](RDR-001-axis-aligned-bounding-tetrahedra.md) | Axis-Aligned Bounding Tetrahedra (AABT) for Tetree Spatial Index | closed | Architecture | medium |
+| [RDR-002](RDR-002-12dop-exact-containment.md) | 12-DOP Exact Containment for Kuhn Tetrahedra — Replace containsUltraFast | closed | Architecture | high |
+| [RDR-003](RDR-003-fcc-aligned-spatial-indexing.md) | FCC-Aligned Spatial Indexing for Luciferase — VoN Spatialization, RD Overlay, and Optional TetOctree | implemented | Architecture | medium |
+| [RDR-004](RDR-004-von-socketserver-deserialization-hardening.md) | Harden Network Deserialization on the VoN SocketServer | accepted | Security | high |
+| [RDR-005](RDR-005-grpc-tls-auth-model.md) | gRPC TLS + Authentication Model for Ghost and Balancing Services | accepted | Security | high |
+| [RDR-006](RDR-006-break-simulation-portal-coupling.md) | Break the simulation→portal Coupling (BubbleBounds JavaFX Pull-In) | accepted | Architecture | medium |
+| [RDR-007](RDR-007-extract-lucien-distributed-module.md) | Extract a lucien-distributed Module (gRPC Clients out of lucien) | closed | Architecture | medium |
+| [RDR-008](RDR-008-decompose-abstractspatialindex.md) | Decompose the AbstractSpatialIndex God-Class | implemented | Architecture | medium |
+| [RDR-009](RDR-009-prism-full-cube-coverage.md) | Prism Full-Cube Coverage via Two-Prism Cover | implemented | Architecture | medium |
+| [RDR-010](RDR-010-pyramid-spatial-index.md) | Pyramid Spatial Index — Close the Hybrid Hex↔Tet Partition Gap | accepted | Architecture | medium |
+
+## Post-Mortems
+
+Closed/implemented RDRs carry a post-mortem under [`post-mortem/`](post-mortem/) capturing realized-vs-predicted outcomes.
+
+| RDR | Post-Mortem |
+|-----|-------------|
+| RDR-001 | [post-mortem/001-axis-aligned-bounding-tetrahedra.md](post-mortem/001-axis-aligned-bounding-tetrahedra.md) |
+| RDR-002 | [post-mortem/002-12dop-exact-containment.md](post-mortem/002-12dop-exact-containment.md) |
+| RDR-003 | [post-mortem/003-fcc-aligned-spatial-indexing.md](post-mortem/003-fcc-aligned-spatial-indexing.md) |
+| RDR-007 | [post-mortem/007-extract-lucien-distributed-module.md](post-mortem/007-extract-lucien-distributed-module.md) |
+| RDR-008 | [post-mortem/008-decompose-abstractspatialindex.md](post-mortem/008-decompose-abstractspatialindex.md) |
+| RDR-009 | [post-mortem/009-prism-full-cube-coverage.md](post-mortem/009-prism-full-cube-coverage.md) |


### PR DESCRIPTION
## Summary

Adds `docs/rdr/README.md` — the RDR directory index that the `/conexus:rdr-accept` and `/conexus:rdr-close` skills' "regenerate README" step expects, but which this repo never actually had. (Surfaced during RDR-010 acceptance: the skill's Step 6 assumes an index file; we confirmed via `git log --all` + `git ls-tree` that no README ever existed in `docs/rdr/`.)

Follows the **nexus standard `README-TEMPLATE.md`** format:
- Title + intro + link to the RDR process documentation
- `## Index` table: `ID | Title | Status | Type | Priority`, with the ID column linking to each RDR file
- A `## Post-Mortems` table linking the six existing post-mortem documents

## Contents

Indexes all 10 RDRs (001–010) at their current status (3 closed, 3 implemented, 3 accepted, 1 accepted=RDR-010). Lists post-mortems for RDR-001/002/003/007/008/009.

## Why

Future `rdr-accept` / `rdr-close` runs can now actually update this index per the skill's Step 6, instead of silently no-op'ing.

## Test plan

- [x] Index table matches current frontmatter (`status`/`type`/`priority`) of all 10 RDR files
- [x] All file links resolve (RDR files + 6 post-mortems verified present)
- [ ] CI green (docs-only change)