### PR TITLE
docs(rdr): add Last Updated header to RDR README (fix doc-validation)

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -1,5 +1,8 @@
 # Recommendation Decisioning Records (RDRs)
 
+**Last Updated**: 2026-05-28
+**Status**: Current
+
 RDRs are specification prompts built through iterative research and refinement.
 
 See the [RDR process documentation](https://github.com/cwensel/rdr) for the full workflow.


### PR DESCRIPTION
## Summary

Fixes the **Documentation Checks** failure on `main` introduced by #150. `scripts/validate-documentation.sh` test 1 hard-fails any `README.md` lacking a `Last Updated` header. The RDR index README (#150) followed the nexus template, which omits this Luciferase-local requirement — so the doc workflow went red on the #150 and #151 main-push runs.

Adds the `**Last Updated**` / `**Status**` block under the H1, matching `CLAUDE.md`'s format. One-line content fix.

## Test plan
- [x] `grep "Last Updated" docs/rdr/README.md` → present
- [ ] **Documentation Checks** green on this PR (the gating check — will verify before merge this time)