### PR TITLE
Luciferase-3pu: clear javafx-* from simulation classpath — Point3D→Point3d + dep exclusions (RDR-006 PR2)

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -15,10 +15,6 @@
             <groupId>javax.vecmath</groupId>
             <artifactId>vecmath</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.openjfx</groupId>
-            <artifactId>javafx-graphics</artifactId>
-        </dependency>
         <!-- grpc-api only (pure interfaces: credentials, ServerInterceptor) — no netty/Delos in the leaf.
              RDR-005: the gRPC auth mechanism lives here; the Delos/Fireflies verification policy is
              injected via PeerVerifier from modules where Delos already lives. -->

--- a/docs/rdr/RDR-006-break-simulation-portal-coupling.md
+++ b/docs/rdr/RDR-006-break-simulation-portal-coupling.md
@@ -176,3 +176,18 @@ JavaFX/LWJGL for its GPU/UI renderers). Verified common/portal/lucien/render/sim
 common + simulation dependency trees javafx-free.
 
 **Only remaining RDR-006 item:** Clock package rename (Luciferase-7n1), still deferred.
+
+### Correction: Clock rename already done; RDR-006 complete (2026-05-28)
+
+Earlier notes listed the Clock package rename (Luciferase-7n1) as a remaining
+deferred item. That is **stale** — 7n1 was already CLOSED via PR #128 (2026-05-27):
+`Clock` was moved from the split `simulation.distributed.integration` package to
+the common-owned `com.hellblazer.luciferase.common.time`, eliminating the split
+package (81 imports rewritten). The research note predated that merge.
+
+**RDR-006 is therefore functionally complete:** sim→portal module coupling broken
+(PR #149), javafx/lwjgl fully cleared from the simulation classpath including the
+common-leaf cleanup (PR #153), and the Clock rename done (PR #128). No outstanding
+items. (The residual `simulation/src/test/.../distributed/integration/` files —
+TestClock, InjectableClock, ClockTest — are simulation's own test utilities and
+correctly placed.)

--- a/docs/rdr/RDR-006-break-simulation-portal-coupling.md
+++ b/docs/rdr/RDR-006-break-simulation-portal-coupling.md
@@ -139,3 +139,27 @@ Two corrections to the locked Decision:
   JavaFX still reaches `simulation` transitively via `render` and `common` after PR1.
 - **Deferred:** Clock package rename (`Luciferase-7n1`) — kept out of PR1 to keep the diff
   reviewable; it is an orthogonal ~26-file package move.
+
+### PR2 complete — D5 javafx-free criterion met (2026-05-28)
+
+Bead Luciferase-3pu. The `mvn dependency:tree -pl simulation` shows **zero `javafx-*` and zero `lwjgl`** — the headless simulation/distributed classpath no longer carries the JavaFX toolkit. Delivered in two steps:
+
+1. **Point3D → Point3d migration** (58 files, main + test): replaced all
+   `javafx.geometry.Point3D` with `javax.vecmath.Point3d`. Mechanically safe —
+   the immutable-vs-mutable hazard (`.add`/`.subtract`/`.normalize`) never applied
+   (those calls were all on `Vector3f`, already vecmath); accessors (`getX/Y/Z`),
+   `.distance()`, and the `(double,double,double)` ctor are signature-identical;
+   wire format already decomposed to `posX/Y/Z` primitives. `BubbleBounds.toCartesian`
+   now returns the kernel's `Point3d` directly (dropped the PR1 javafx wrapper).
+
+2. **Transitive-carrier exclusions** (simulation/pom.xml): after the migration,
+   javafx/lwjgl still reached simulation's compile classpath via two deps whose
+   javafx-using classes simulation never links —
+   - `render` → javafx-controls + lwjgl (simulation.viz.render uses only render's
+     pure-data ESVT types); 65 viz.render runtime tests pass with it excluded.
+   - `common` → javafx-graphics (for `common.mesh.MeshLoader`, unused by simulation).
+   Both excluded at simulation's dependency declarations.
+
+**Remaining (separate, not blocking D5):** isolate `MeshLoader`'s javafx out of the
+`common` leaf module so common stops advertising `javafx-graphics` to all consumers
+(the original RDR follow-up). Clock package rename (Luciferase-7n1) still deferred.

--- a/docs/rdr/RDR-006-break-simulation-portal-coupling.md
+++ b/docs/rdr/RDR-006-break-simulation-portal-coupling.md
@@ -163,3 +163,16 @@ Bead Luciferase-3pu. The `mvn dependency:tree -pl simulation` shows **zero `java
 **Remaining (separate, not blocking D5):** isolate `MeshLoader`'s javafx out of the
 `common` leaf module so common stops advertising `javafx-graphics` to all consumers
 (the original RDR follow-up). Clock package rename (Luciferase-7n1) still deferred.
+
+### common-leaf javafx cleanup done (2026-05-28, Luciferase-3pu)
+
+The "isolate MeshLoader's javafx out of common" follow-up is **done** (no longer deferred).
+`common.mesh.MeshLoader` — the sole javafx user in the `common` leaf module, used only by
+`render` (`esvo.app`) — was relocated `common.mesh → render.mesh`, and `javafx-graphics` was
+removed from `common/pom.xml`. `common` is now javafx-free, which clears JavaFX from the API of
+**all** consumers, not just simulation's excluded view; the simulation-side `common` javafx
+exclusion was accordingly dropped (the `render` exclusion remains — render legitimately carries
+JavaFX/LWJGL for its GPU/UI renderers). Verified common/portal/lucien/render/simulation compile;
+common + simulation dependency trees javafx-free.
+
+**Only remaining RDR-006 item:** Clock package rename (Luciferase-7n1), still deferred.

--- a/render/src/main/java/com/hellblazer/luciferase/esvo/app/ESVOAmbientMode.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvo/app/ESVOAmbientMode.java
@@ -1,7 +1,7 @@
 package com.hellblazer.luciferase.esvo.app;
 
 import com.hellblazer.luciferase.esvo.core.*;
-import com.hellblazer.luciferase.common.mesh.MeshLoader;
+import com.hellblazer.luciferase.render.mesh.MeshLoader;
 import javafx.scene.shape.MeshView;
 import javafx.scene.shape.TriangleMesh;
 

--- a/render/src/main/java/com/hellblazer/luciferase/esvo/app/ESVOBuildMode.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvo/app/ESVOBuildMode.java
@@ -130,11 +130,11 @@ public class ESVOBuildMode {
         try {
             switch (ext) {
                 case "obj":
-                    var objMeshView = com.hellblazer.luciferase.common.mesh.MeshLoader.loadObj(inputFile);
+                    var objMeshView = com.hellblazer.luciferase.render.mesh.MeshLoader.loadObj(inputFile);
                     return convertJavaFXMeshToMeshData(objMeshView);
-                    
+
                 case "stl":
-                    var stlMeshView = com.hellblazer.luciferase.common.mesh.MeshLoader.loadStl(inputFile);
+                    var stlMeshView = com.hellblazer.luciferase.render.mesh.MeshLoader.loadStl(inputFile);
                     return convertJavaFXMeshToMeshData(stlMeshView);
                     
                 default:

--- a/render/src/main/java/com/hellblazer/luciferase/render/mesh/MeshLoader.java
+++ b/render/src/main/java/com/hellblazer/luciferase/render/mesh/MeshLoader.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
  * <http://www.gnu.org/licenses/>.
  */
-package com.hellblazer.luciferase.common.mesh;
+package com.hellblazer.luciferase.render.mesh;
 
 import javafx.scene.shape.MeshView;
 import javafx.scene.shape.TriangleMesh;

--- a/simulation/pom.xml
+++ b/simulation/pom.xml
@@ -27,18 +27,8 @@
             <artifactId>runtime</artifactId>
         </dependency>
         <dependency>
-            <!-- common pulls javafx-graphics for a single UI class (common.mesh.MeshLoader) that
-                 simulation never references. Exclude it so the headless simulation/distributed
-                 classpath carries no JavaFX (RDR-006 D5). Isolating MeshLoader's javafx out of the
-                 common leaf module proper is tracked separately. -->
             <groupId>${project.groupId}</groupId>
             <artifactId>common</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.openjfx</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/simulation/pom.xml
+++ b/simulation/pom.xml
@@ -27,8 +27,18 @@
             <artifactId>runtime</artifactId>
         </dependency>
         <dependency>
+            <!-- common pulls javafx-graphics for a single UI class (common.mesh.MeshLoader) that
+                 simulation never references. Exclude it so the headless simulation/distributed
+                 classpath carries no JavaFX (RDR-006 D5). Isolating MeshLoader's javafx out of the
+                 common leaf module proper is tracked separately. -->
             <groupId>${project.groupId}</groupId>
             <artifactId>common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.openjfx</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -38,17 +48,26 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>geometry</artifactId>
         </dependency>
-        <!-- Pre-existing coupling, now declared honestly: simulation.viz.render.SerializationUtils
-             uses render's ESVT types (esvt.core.ESVTData/ESVTNodeUnified). This was always a real
-             simulation->render dependency; it was merely satisfied transitively via portal->render
-             before RDR-006 dropped portal. This is NOT a net JavaFX reduction — render carries
-             JavaFX/LWJGL, so dropping portal alone does not clear javafx-* from the simulation tree.
-             Two genuinely separate follow-ups: (1) PR2 migrates the ~21 javafx Point3D usages off
-             javafx; (2) relocating simulation.viz.render.* into the render module would remove this
-             coupling entirely (these classes are arguably misplaced in simulation). -->
+        <!-- simulation.viz.render uses ONLY render's pure-data ESVT types
+             (esvt.core.ESVTData/ESVTNodeUnified, esvt.builder.ESVTBuilder — none of which import
+             javafx or lwjgl). render itself declares javafx-controls + lwjgl for its GPU/UI
+             renderers, which simulation's code path never touches. RDR-006 PR2 excludes those so
+             the headless simulation/distributed classpath carries no JavaFX/LWJGL via render.
+             (The remaining javafx-graphics on the compile classpath comes from common -> MeshLoader,
+             tracked separately; simulation does not use MeshLoader.) -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>render</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.openjfx</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.lwjgl</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.javalin</groupId>

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/AdaptiveSplitPolicy.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/AdaptiveSplitPolicy.java
@@ -2,7 +2,7 @@ package com.hellblazer.luciferase.simulation.bubble;
 
 import com.hellblazer.luciferase.simulation.bubble.*;
 
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 
 import javax.vecmath.Point3f;
 import java.util.*;
@@ -206,10 +206,10 @@ public class AdaptiveSplitPolicy {
 
         // Initialize centroids randomly
         var random = new Random(42); // Fixed seed for reproducibility
-        var centroids = new ArrayList<Point3D>();
+        var centroids = new ArrayList<Point3d>();
         for (int i = 0; i < k; i++) {
             var pos = positions.get(random.nextInt(n));
-            centroids.add(new Point3D(pos.x, pos.y, pos.z));
+            centroids.add(new Point3d(pos.x, pos.y, pos.z));
         }
 
         // Assignment and update (simplified - just 5 iterations)
@@ -251,7 +251,7 @@ public class AdaptiveSplitPolicy {
                 }
 
                 if (count > 0) {
-                    centroids.set(j, new Point3D(sumX / count, sumY / count, sumZ / count));
+                    centroids.set(j, new Point3d(sumX / count, sumY / count, sumZ / count));
                 }
             }
         }
@@ -307,7 +307,7 @@ public class AdaptiveSplitPolicy {
             }
 
             int totalSize = mergedIds.size();
-            var centroid = new Point3D(sumX / totalSize, sumY / totalSize, sumZ / totalSize);
+            var centroid = new Point3d(sumX / totalSize, sumY / totalSize, sumZ / totalSize);
 
             // Note: We can't easily get positions from IDs here, so we use a placeholder bounds
             // In a real implementation, we'd need to fetch positions from the bubble
@@ -352,13 +352,13 @@ public class AdaptiveSplitPolicy {
         var clusters = new ArrayList<EntityCluster>();
 
         if (!leftIds.isEmpty()) {
-            var leftCentroid = new Point3D(centroid.getX() - 10, centroid.getY(), centroid.getZ());
+            var leftCentroid = new Point3d(centroid.getX() - 10, centroid.getY(), centroid.getZ());
             // Use bubble's bounds for geometric clusters
             clusters.add(new EntityCluster(leftCentroid, null, leftIds, leftIds.size()));
         }
 
         if (!rightIds.isEmpty()) {
-            var rightCentroid = new Point3D(centroid.getX() + 10, centroid.getY(), centroid.getZ());
+            var rightCentroid = new Point3d(centroid.getX() + 10, centroid.getY(), centroid.getZ());
             // Use bubble's bounds for geometric clusters
             clusters.add(new EntityCluster(rightCentroid, null, rightIds, rightIds.size()));
         }
@@ -370,7 +370,7 @@ public class AdaptiveSplitPolicy {
      * Entity cluster record for split analysis.
      */
     public record EntityCluster(
-        Point3D centroid,
+        Point3d centroid,
         BubbleBounds bounds,
         List<String> entityIds,
         int size

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/BubbleBounds.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/BubbleBounds.java
@@ -5,7 +5,7 @@ import com.hellblazer.luciferase.simulation.bubble.*;
 import com.hellblazer.luciferase.geometry.rd.RDGCoordinates;
 import com.hellblazer.luciferase.lucien.tetree.Tet;
 import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 
 import javax.vecmath.Point3f;
 import javax.vecmath.Point3i;
@@ -202,9 +202,8 @@ public final class BubbleBounds implements Serializable {
      * @param rdg RDGCS coordinates
      * @return Cartesian position
      */
-    public Point3D toCartesian(Tuple3i rdg) {
-        var p = RDGCoordinates.toCartesian(rdg);
-        return new Point3D(p.x, p.y, p.z);
+    public Point3d toCartesian(Tuple3i rdg) {
+        return RDGCoordinates.toCartesian(rdg);
     }
 
     /**
@@ -289,7 +288,7 @@ public final class BubbleBounds implements Serializable {
      *
      * @return Centroid of the tetrahedron
      */
-    public Point3D centroid() {
+    public Point3d centroid() {
         var tet = rootKey.toTet();
         var coords = tet.coordinates();
 
@@ -298,7 +297,7 @@ public final class BubbleBounds implements Serializable {
         double cy = (coords[0].y + coords[1].y + coords[2].y + coords[3].y) / 4.0;
         double cz = (coords[0].z + coords[1].z + coords[2].z + coords[3].z) / 4.0;
 
-        return new Point3D(cx, cy, cz);
+        return new Point3d(cx, cy, cz);
     }
 
     /**

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/BubbleBoundsTracker.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/BubbleBoundsTracker.java
@@ -1,6 +1,6 @@
 package com.hellblazer.luciferase.simulation.bubble;
 
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 
 import javax.vecmath.Point3f;
 import java.util.ArrayList;
@@ -49,7 +49,7 @@ public class BubbleBoundsTracker implements EntityChangeListener {
      *
      * @return Centroid point or null if no bounds
      */
-    public Point3D centroid() {
+    public Point3d centroid() {
         if (bounds == null) {
             return null;
         }
@@ -67,7 +67,7 @@ public class BubbleBoundsTracker implements EntityChangeListener {
             }
 
             if (count > 0) {
-                return new Point3D(sumX / count, sumY / count, sumZ / count);
+                return new Point3d(sumX / count, sumY / count, sumZ / count);
             }
         }
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/EnhancedBubble.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/EnhancedBubble.java
@@ -5,7 +5,7 @@ import com.hellblazer.luciferase.simulation.entity.StringEntityID;
 import com.hellblazer.luciferase.simulation.ghost.GhostChannel;
 import com.hellblazer.luciferase.simulation.ghost.GhostStateManager;
 import com.hellblazer.luciferase.simulation.ghost.InMemoryGhostChannel;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 
 import javax.vecmath.Point3f;
 import java.util.ArrayList;
@@ -313,7 +313,7 @@ public class EnhancedBubble {
      *
      * @return Centroid point or null if no bounds
      */
-    public Point3D centroid() {
+    public Point3d centroid() {
         return boundsTracker.centroid();
     }
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/delos/fireflies/TetreeKeyRouter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/delos/fireflies/TetreeKeyRouter.java
@@ -21,7 +21,7 @@ import com.hellblazer.delos.context.DynamicContext;
 import com.hellblazer.delos.membership.Member;
 import com.hellblazer.luciferase.lucien.tetree.Tet;
 import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 
 /**
  * Routes spatial queries to cluster members based on TetreeKey hashing.
@@ -87,7 +87,7 @@ public class TetreeKeyRouter {
      * @param maxLevel        the refinement level to use for key generation
      * @return the member index (0 to context.size()-1)
      */
-    public int routeToPosition(Point3D position, float cubeSizeMeters, int maxLevel) {
+    public int routeToPosition(Point3d position, float cubeSizeMeters, int maxLevel) {
         // Normalize position to [0, 1) coordinates
         var normalizedX = (float) (position.getX() / cubeSizeMeters);
         var normalizedY = (float) (position.getY() / cubeSizeMeters);

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/BubbleReference.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/BubbleReference.java
@@ -17,7 +17,7 @@
 
 package com.hellblazer.luciferase.simulation.distributed.migration;
 
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 
 import java.util.Set;
 import java.util.UUID;
@@ -67,9 +67,9 @@ public interface BubbleReference {
     /**
      * Get the bubble's current position.
      *
-     * @return Point3D position
+     * @return Point3d position
      */
-    Point3D getPosition();
+    Point3d getPosition();
 
     /**
      * Get the bubble's current neighbors.

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/CrossProcessMigration.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/CrossProcessMigration.java
@@ -22,7 +22,7 @@ import com.hellblazer.primeMover.annotations.Entity;
 import com.hellblazer.primeMover.api.Kronos;
 import com.hellblazer.primeMover.controllers.RealTimeController;
 import com.hellblazer.primeMover.runtime.Kairos;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -803,7 +803,7 @@ public class CrossProcessMigration {
         private static EntitySnapshot createEntitySnapshot(String entityId, BubbleReference source, long timestamp) {
             // In actual implementation, would query source bubble for entity state
             // For now, create synthetic snapshot
-            return new EntitySnapshot(entityId, new Point3D(0, 0, 0), "MockContent", source.getBubbleId(), 1L, 1L,
+            return new EntitySnapshot(entityId, new Point3d(0, 0, 0), "MockContent", source.getBubbleId(), 1L, 1L,
                                       timestamp);
         }
     }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/EntitySnapshot.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/EntitySnapshot.java
@@ -17,7 +17,7 @@
 
 package com.hellblazer.luciferase.simulation.distributed.migration;
 
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 
 import java.util.UUID;
 
@@ -55,7 +55,7 @@ import java.util.UUID;
  */
 public record EntitySnapshot(
     String entityId,
-    Point3D position,
+    Point3d position,
     Object content,
     UUID authorityBubbleId,
     long epoch,

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/LocalBubbleReference.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/LocalBubbleReference.java
@@ -18,7 +18,7 @@
 package com.hellblazer.luciferase.simulation.distributed.migration;
 
 import com.hellblazer.luciferase.simulation.von.Bubble;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 
 import java.util.Objects;
 import java.util.Set;
@@ -69,7 +69,7 @@ public class LocalBubbleReference implements BubbleReference {
     }
 
     @Override
-    public Point3D getPosition() {
+    public Point3d getPosition() {
         return bubble.position();
     }
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/RemoteBubbleProxy.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/RemoteBubbleProxy.java
@@ -21,7 +21,7 @@ import com.hellblazer.luciferase.common.time.Clock;
 import com.hellblazer.luciferase.simulation.von.Message;
 import com.hellblazer.luciferase.simulation.von.MessageFactory;
 import com.hellblazer.luciferase.simulation.von.Transport;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -139,8 +139,8 @@ public class RemoteBubbleProxy implements BubbleReference {
     }
 
     @Override
-    public Point3D getPosition() {
-        return getCachedOrFetch("position", this::fetchPosition, new Point3D(0, 0, 0));
+    public Point3d getPosition() {
+        return getCachedOrFetch("position", this::fetchPosition, new Point3d(0, 0, 0));
     }
 
     @Override
@@ -188,10 +188,10 @@ public class RemoteBubbleProxy implements BubbleReference {
     /**
      * Fetch position from remote bubble.
      *
-     * @return Point3D position
+     * @return Point3d position
      * @throws RuntimeException on timeout or connection failure
      */
-    private Point3D fetchPosition() {
+    private Point3d fetchPosition() {
         // Send query message
         var query = factory.createQuery(transport.getLocalId(), bubbleId, "position");
         var future = new CompletableFuture<Message.QueryResponse>();
@@ -205,7 +205,7 @@ public class RemoteBubbleProxy implements BubbleReference {
 
             // Parse position from response data (JSON format: "x,y,z")
             var parts = response.responseData().split(",");
-            return new Point3D(
+            return new Point3d(
                 Double.parseDouble(parts[0]),
                 Double.parseDouble(parts[1]),
                 Double.parseDouble(parts[2])

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/TransactionState.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/TransactionState.java
@@ -33,7 +33,7 @@ import java.util.UUID;
  * Used by MigrationLogPersistence to record transactions in WAL.
  * On process restart, incomplete transactions are recovered and resolved.
  * <p>
- * Note: The snapshot is stored in a Jackson-serializable form (without Point3D).
+ * Note: The snapshot is stored in a Jackson-serializable form (without Point3d).
  * For full entity restoration, recovery reads from source bubble state.
  *
  * @param transactionId    Unique transaction identifier (UUID)
@@ -72,7 +72,7 @@ public record TransactionState(
     /**
      * Jackson-serializable snapshot of essential entity state for WAL storage.
      * <p>
-     * Stores only fields that Jackson can serialize (no Point3D).
+     * Stores only fields that Jackson can serialize (no Point3d).
      * Position is not persisted - recovery restores entity from source bubble state.
      *
      * @param entityId          Entity identifier

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/ghost/GhostSyncVONIntegration.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/ghost/GhostSyncVONIntegration.java
@@ -7,7 +7,7 @@ import com.hellblazer.luciferase.simulation.bubble.*;
 
 import com.hellblazer.luciferase.simulation.von.Node;
 import com.hellblazer.luciferase.simulation.von.SpatialNeighborIndex;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -136,7 +136,7 @@ public class GhostSyncVONIntegration {
      *
      * @param newPosition New bubble position
      */
-    public void onVONMove(Point3D newPosition) {
+    public void onVONMove(Point3d newPosition) {
         Objects.requireNonNull(newPosition, "newPosition must not be null");
 
         log.debug("VON MOVE: Bubble moved to {}", newPosition);

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/topology/metrics/ClusteringDetector.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/topology/metrics/ClusteringDetector.java
@@ -34,7 +34,7 @@ import java.util.UUID;
  * <b>Algorithm</b>:
  * <ul>
  *   <li>Use AdaptiveSplitPolicy.detectClusters() for K-means (k=2)</li>
- *   <li>Convert javafx.geometry.Point3D to javax.vecmath.Point3f</li>
+ *   <li>Convert javax.vecmath.Point3d to javax.vecmath.Point3f</li>
  *   <li>Calculate coherence based on intra-cluster distance</li>
  *   <li>Filter clusters below minimum size threshold</li>
  * </ul>
@@ -102,7 +102,7 @@ public class ClusteringDetector {
         // Convert AdaptiveSplitPolicy.EntityCluster to EntityClusterInfo
         var clusters = new ArrayList<EntityClusterInfo>();
         for (var raw : rawClusters) {
-            // Convert Point3D to Point3f
+            // Convert Point3d to Point3f
             var centroid = new Point3f(
                 (float) raw.centroid().getX(),
                 (float) raw.centroid().getY(),

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/viz/PredatorPreyGridDemo.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/viz/PredatorPreyGridDemo.java
@@ -359,9 +359,9 @@ public class PredatorPreyGridDemo {
     }
 
     /**
-     * Helper to convert JavaFX Point3D to vecmath Point3f.
+     * Helper to convert JavaFX Point3d to vecmath Point3f.
      */
-    private static Point3f toPoint3f(javafx.geometry.Point3D point) {
+    private static Point3f toPoint3f(javax.vecmath.Point3d point) {
         return new Point3f((float) point.getX(), (float) point.getY(), (float) point.getZ());
     }
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Bubble.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Bubble.java
@@ -20,7 +20,7 @@ package com.hellblazer.luciferase.simulation.von;
 import com.hellblazer.luciferase.simulation.bubble.BubbleBounds;
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
 import com.hellblazer.luciferase.common.time.Clock;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -160,9 +160,9 @@ public class Bubble extends EnhancedBubble implements Node {
     }
 
     @Override
-    public Point3D position() {
+    public Point3d position() {
         var centroid = centroid();
-        return centroid != null ? centroid : new Point3D(0, 0, 0);
+        return centroid != null ? centroid : new Point3d(0, 0, 0);
     }
 
     @Override
@@ -220,7 +220,7 @@ public class Bubble extends EnhancedBubble implements Node {
             var ctx = clockContext;  // Single volatile read
             neighborStates.put(neighborId, new NeighborState(
                 neighborId,
-                new Point3D(0, 0, 0),
+                new Point3d(0, 0, 0),
                 null,
                 ctx.clock.currentTimeMillis()
             ));
@@ -288,7 +288,7 @@ public class Bubble extends EnhancedBubble implements Node {
      * @param targetPosition Desired position in the network
      * @return true if JOIN was accepted, false otherwise
      */
-    public boolean initiateJoin(Point3D targetPosition) {
+    public boolean initiateJoin(Point3d targetPosition) {
         try {
             // Find the acceptor for this position
             var acceptor = findAcceptorForPosition(targetPosition);
@@ -665,7 +665,7 @@ public class Bubble extends EnhancedBubble implements Node {
         }
     }
 
-    private Transport.MemberInfo findAcceptorForPosition(Point3D position) {
+    private Transport.MemberInfo findAcceptorForPosition(Point3d position) {
         // Use transport's routing to find the member responsible for this position
         // For now, use a simple approach: get any available member
         // In production, this would use TetreeKey routing
@@ -690,7 +690,7 @@ public class Bubble extends EnhancedBubble implements Node {
      * @param bounds       Last known bounds
      * @param lastUpdateMs Timestamp of last update
      */
-    public record NeighborState(UUID nodeId, Point3D position, BubbleBounds bounds, long lastUpdateMs) {
+    public record NeighborState(UUID nodeId, Point3d position, BubbleBounds bounds, long lastUpdateMs) {
     }
 
     /**

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Event.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Event.java
@@ -1,7 +1,7 @@
 package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.BubbleBounds;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 
 import java.util.List;
 import java.util.UUID;
@@ -57,7 +57,7 @@ public sealed interface Event {
      */
     record Move(
         UUID nodeId,
-        Point3D newPosition,
+        Point3d newPosition,
         BubbleBounds newBounds
     ) implements Event {
 
@@ -67,7 +67,7 @@ public sealed interface Event {
          * @param oldPosition Previous position
          * @return Distance moved
          */
-        public double distance(Point3D oldPosition) {
+        public double distance(Point3d oldPosition) {
             return newPosition.distance(oldPosition);
         }
     }
@@ -90,7 +90,7 @@ public sealed interface Event {
      */
     record Join(
         UUID nodeId,
-        Point3D position
+        Point3d position
     ) implements Event {
     }
 
@@ -112,7 +112,7 @@ public sealed interface Event {
      */
     record Leave(
         UUID nodeId,
-        Point3D position
+        Point3d position
     ) implements Event {
     }
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/JoinProtocol.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/JoinProtocol.java
@@ -2,7 +2,7 @@ package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.*;
 
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 
 import java.util.Objects;
 import java.util.Set;
@@ -27,7 +27,7 @@ import java.util.function.Consumer;
  * - Enclosing neighbors via bounds overlap
  * - Performance target: JOIN latency < 100ms
  * <p>
- * Thread-safe: {@link #join(Node, Point3D)} runs under a per-protocol lock so
+ * Thread-safe: {@link #join(Node, Point3d)} runs under a per-protocol lock so
  * concurrent join attempts see a consistent view of the index between the
  * neighbor-discovery and self-insertion steps. Without this serialisation,
  * two joiners landing simultaneously could each call
@@ -72,7 +72,7 @@ public class JoinProtocol {
      * @param joiner   Bubble joining the overlay
      * @param position Join position (bubble centroid)
      */
-    public void join(Node joiner, Point3D position) {
+    public void join(Node joiner, Point3d position) {
         Objects.requireNonNull(joiner, "joiner cannot be null");
         Objects.requireNonNull(position, "position cannot be null");
 
@@ -123,7 +123,7 @@ public class JoinProtocol {
      * @param position Join position
      * @return Acceptor bubble (closest to position) or joiner if solo
      */
-    private Node findAcceptor(Node joiner, Point3D position) {
+    private Node findAcceptor(Node joiner, Point3d position) {
         // Find closest bubble to join position
         Node closest = index.findClosestTo(position);
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Manager.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Manager.java
@@ -22,7 +22,7 @@ import com.hellblazer.luciferase.simulation.bubble.SpatialLevelHeuristic;
 import com.hellblazer.luciferase.common.time.Clock;
 import com.hellblazer.luciferase.simulation.lifecycle.EnhancedBubbleAdapter;
 import com.hellblazer.luciferase.simulation.lifecycle.LifecycleCoordinator;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -243,7 +243,7 @@ public class Manager {
      * @param position Target position in the VON
      * @return true if join succeeded, false otherwise
      */
-    public boolean joinAt(Bubble bubble, Point3D position) {
+    public boolean joinAt(Bubble bubble, Point3d position) {
         Objects.requireNonNull(bubble, "bubble cannot be null");
         Objects.requireNonNull(position, "position cannot be null");
 
@@ -280,7 +280,7 @@ public class Manager {
      * @param timeoutMs      Maximum time to wait for join completion
      * @return true if join completed with at least one neighbor, false otherwise
      */
-    public boolean joinAndWait(Bubble bubble, Point3D position, long timeoutMs) {
+    public boolean joinAndWait(Bubble bubble, Point3d position, long timeoutMs) {
         if (bubbles.size() == 1 && bubbles.containsKey(bubble.id())) {
             // Solo join - immediate success
             return true;
@@ -318,7 +318,7 @@ public class Manager {
      * @param bubble      The bubble to move
      * @param newPosition New position
      */
-    public void move(Bubble bubble, Point3D newPosition) {
+    public void move(Bubble bubble, Point3d newPosition) {
         Objects.requireNonNull(bubble, "bubble cannot be null");
         Objects.requireNonNull(newPosition, "newPosition cannot be null");
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Message.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Message.java
@@ -18,7 +18,7 @@
 package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.BubbleBounds;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 
 import javax.vecmath.Point3f;
 import java.util.List;
@@ -64,7 +64,7 @@ public sealed interface Message
      * @param bounds    Initial spatial bounds
      * @param timestamp Message creation time
      */
-    record JoinRequest(UUID joinerId, Point3D position, BubbleBounds bounds, long timestamp) implements Message {
+    record JoinRequest(UUID joinerId, Point3d position, BubbleBounds bounds, long timestamp) implements Message {
         // Compact constructor removed - use MessageFactory instead
     }
 
@@ -91,7 +91,7 @@ public sealed interface Message
      * @param newBounds   New bounds after movement
      * @param timestamp   Message creation time
      */
-    record Move(UUID nodeId, Point3D newPosition, BubbleBounds newBounds, long timestamp) implements Message {
+    record Move(UUID nodeId, Point3d newPosition, BubbleBounds newBounds, long timestamp) implements Message {
         // Compact constructor removed - use MessageFactory instead
     }
 
@@ -247,6 +247,6 @@ public sealed interface Message
      * @param position Neighbor's current position
      * @param bounds   Neighbor's current bounds
      */
-    record NeighborInfo(UUID nodeId, Point3D position, BubbleBounds bounds) {
+    record NeighborInfo(UUID nodeId, Point3d position, BubbleBounds bounds) {
     }
 }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/MessageConverter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/MessageConverter.java
@@ -158,7 +158,7 @@ public class MessageConverter {
 
     private static Message joinRequestFromTransport(TransportVonMessage transport) {
         var joinerId = UUID.fromString(transport.sourceBubbleId());
-        var position = new javafx.geometry.Point3D(transport.posX(), transport.posY(), transport.posZ());
+        var position = new javax.vecmath.Point3d(transport.posX(), transport.posY(), transport.posZ());
 
         return new Message.JoinRequest(
             joinerId,
@@ -226,7 +226,7 @@ public class MessageConverter {
 
     private static Message moveFromTransport(TransportVonMessage transport) {
         var nodeId = UUID.fromString(transport.sourceBubbleId());
-        var newPosition = new javafx.geometry.Point3D(transport.posX(), transport.posY(), transport.posZ());
+        var newPosition = new javax.vecmath.Point3d(transport.posX(), transport.posY(), transport.posZ());
 
         return new Message.Move(
             nodeId,

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/MessageFactory.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/MessageFactory.java
@@ -20,7 +20,7 @@ package com.hellblazer.luciferase.simulation.von;
 import com.hellblazer.luciferase.simulation.bubble.BubbleBounds;
 import com.hellblazer.luciferase.common.time.Clock;
 import com.hellblazer.luciferase.simulation.von.Message.*;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 
 import java.util.List;
 import java.util.Objects;
@@ -80,7 +80,7 @@ public class MessageFactory {
      * @param bounds   initial spatial bounds
      * @return new JoinRequest with current timestamp
      */
-    public JoinRequest createJoinRequest(UUID joinerId, Point3D position, BubbleBounds bounds) {
+    public JoinRequest createJoinRequest(UUID joinerId, Point3d position, BubbleBounds bounds) {
         return new JoinRequest(joinerId, position, bounds, clock.currentTimeMillis());
     }
 
@@ -103,7 +103,7 @@ public class MessageFactory {
      * @param newBounds   new bounds after movement
      * @return new Move with current timestamp
      */
-    public Move createMove(UUID nodeId, Point3D newPosition, BubbleBounds newBounds) {
+    public Move createMove(UUID nodeId, Point3d newPosition, BubbleBounds newBounds) {
         return new Move(nodeId, newPosition, newBounds, clock.currentTimeMillis());
     }
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/MoveProtocol.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/MoveProtocol.java
@@ -2,7 +2,7 @@ package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.*;
 
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -66,7 +66,7 @@ public class MoveProtocol {
      * @param mover       Bubble that is moving
      * @param newPosition New position (centroid)
      */
-    public void move(Node mover, Point3D newPosition) {
+    public void move(Node mover, Point3d newPosition) {
         Objects.requireNonNull(mover, "mover cannot be null");
         Objects.requireNonNull(newPosition, "newPosition cannot be null");
 
@@ -140,7 +140,7 @@ public class MoveProtocol {
      * @param target Target position
      * @return true if within AOI
      */
-    private boolean isInAOI(Point3D source, Point3D target) {
+    private boolean isInAOI(Point3d source, Point3d target) {
         return distance(source, target) <= aoiRadius;
     }
 
@@ -151,7 +151,7 @@ public class MoveProtocol {
      * @param target Target position
      * @return true if in boundary zone
      */
-    private boolean isBoundaryNeighbor(Point3D source, Point3D target) {
+    private boolean isBoundaryNeighbor(Point3d source, Point3d target) {
         double dist = distance(source, target);
         return dist > aoiRadius && dist <= (aoiRadius + 10.0f); // 10.0f = BOUNDARY_BUFFER from test
     }
@@ -163,7 +163,7 @@ public class MoveProtocol {
      * @param p2 Second point
      * @return Distance
      */
-    private double distance(Point3D p1, Point3D p2) {
+    private double distance(Point3d p1, Point3d p2) {
         return p1.distance(p2);
     }
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Node.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Node.java
@@ -1,7 +1,7 @@
 package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.BubbleBounds;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 
 import java.util.Set;
 import java.util.UUID;
@@ -39,7 +39,7 @@ public interface Node {
      *
      * @return Current position (bubble centroid)
      */
-    Point3D position();
+    Point3d position();
 
     /**
      * Get the spatial bounds of this node.

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/SpatialNeighborIndex.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/SpatialNeighborIndex.java
@@ -10,7 +10,7 @@ import com.hellblazer.luciferase.lucien.entity.UUIDGenerator;
 import com.hellblazer.luciferase.lucien.tetree.Tetree;
 import com.hellblazer.luciferase.simulation.bubble.BubbleBounds;
 import com.hellblazer.luciferase.simulation.bubble.SpatialLevelHeuristic;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 
 import javax.vecmath.Point3f;
 import java.util.*;
@@ -75,7 +75,7 @@ import java.util.stream.Collectors;
  * A three-argument constructor lets deployments pin an explicit level.
  * <p>
  * <b>Behavioral contract change vs the pre-mj7 implementation.</b>
- * {@link #updatePosition(UUID, Point3D)} is no longer a no-op — it propagates
+ * {@link #updatePosition(UUID, Point3d)} is no longer a no-op — it propagates
  * the new centroid to the {@code Tetree} so the {@link #findKNearest} /
  * {@link #findClosestTo} path sees correct spatial bucketing. The flat map's
  * stored {@link Node} reference is unchanged since the {@link Node} reads
@@ -180,7 +180,7 @@ public class SpatialNeighborIndex {
      * @param nodeId      Node UUID
      * @param newPosition New centroid position (must have non-negative coordinates)
      */
-    public void updatePosition(UUID nodeId, Point3D newPosition) {
+    public void updatePosition(UUID nodeId, Point3d newPosition) {
         tetree.updateEntity(new UUIDEntityID(nodeId), toPoint3f(newPosition), spatialLevel);
     }
 
@@ -198,7 +198,7 @@ public class SpatialNeighborIndex {
      * @param position Query position
      * @return Closest Node or null if index is empty
      */
-    public Node findClosestTo(Point3D position) {
+    public Node findClosestTo(Point3d position) {
         if (nodes.isEmpty()) {
             return null;
         }
@@ -233,7 +233,7 @@ public class SpatialNeighborIndex {
      * @param k        Number of neighbors (must be {@code > 0})
      * @return List of up to k nearest nodes, sorted by ascending distance
      */
-    public List<Node> findKNearest(Point3D position, int k) {
+    public List<Node> findKNearest(Point3d position, int k) {
         if (k <= 0 || nodes.isEmpty()) {
             return List.of();
         }
@@ -299,7 +299,7 @@ public class SpatialNeighborIndex {
      * @param radius Search radius (non-negative)
      * @return List of nodes whose centroid lies within {@code radius} of {@code center}
      */
-    public List<Node> findWithinRadius(Point3D center, float radius) {
+    public List<Node> findWithinRadius(Point3d center, float radius) {
         var radiusSq = (double) radius * radius;
         var cx = center.getX();
         var cy = center.getY();
@@ -366,11 +366,11 @@ public class SpatialNeighborIndex {
     // ==================== private helpers ====================
 
     /**
-     * Convert a JavaFX double-precision {@link Point3D} to a vecmath single-precision
+     * Convert a JavaFX double-precision {@link Point3d} to a vecmath single-precision
      * {@link Point3f} for Tetree consumption. Float-mantissa precision (~7 decimal
      * digits) is sufficient for VoN's 200-unit world.
      */
-    private static Point3f toPoint3f(Point3D p) {
+    private static Point3f toPoint3f(Point3d p) {
         return new Point3f((float) p.getX(), (float) p.getY(), (float) p.getZ());
     }
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/TransportNeighborInfo.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/TransportNeighborInfo.java
@@ -18,7 +18,7 @@
 package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.BubbleBounds;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 
 import java.io.Serializable;
 import java.util.UUID;
@@ -26,7 +26,7 @@ import java.util.UUID;
 /**
  * Serializable transport representation of a neighbor's information.
  * <p>
- * Decomposes Point3D into individual components for reliable
+ * Decomposes Point3d into individual components for reliable
  * Java Serialization over network sockets. This is the wire format used in
  * TransportVonMessage for neighbor set transmission in JoinResponse messages.
  * <p>
@@ -65,12 +65,12 @@ public record TransportNeighborInfo(
      * <p>
      * Phase 6A: BubbleBounds set to null (not transmitted in wire format)
      *
-     * @return NeighborInfo with reconstructed Point3D, null bounds
+     * @return NeighborInfo with reconstructed Point3d, null bounds
      */
     public Message.NeighborInfo toNeighborInfo() {
         return new Message.NeighborInfo(
             UUID.fromString(nodeId),
-            new Point3D(posX, posY, posZ),
+            new Point3d(posX, posY, posZ),
             null  // BubbleBounds not transmitted in Phase 6A
         );
     }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/TransportVonMessage.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/TransportVonMessage.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 /**
  * Serializable wrapper for Message for network transport.
  * <p>
- * Problem: Message contains JavaFX types (Point3D) and javax.vecmath types (Point3f)
+ * Problem: Message contains JavaFX types (Point3d) and javax.vecmath types (Point3f)
  * that are not Serializable or have problematic serialization.
  * <p>
  * Solution: Decompose Point3f into 3x float (posX, posY, posZ) to ensure reliable

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/transport/VonTransportFilter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/transport/VonTransportFilter.java
@@ -33,7 +33,7 @@ import java.io.ObjectInputFilter;
  * ({@code PriorityQueue}, {@code TreeMap}, {@code LinkedList}) that appear in published ysoserial chains.
  * The actual wire payload is records of {@code String}/{@code float}/{@code double}/{@code long}/{@code Long}
  * plus {@code List} fields whose concrete type is {@code java.util.ArrayList}; there is no
- * {@code javax.vecmath} or JavaFX type on the wire (the {@code Point3f}/{@code Point3D} in the transport
+ * {@code javax.vecmath} or JavaFX type on the wire (the {@code Point3f}/{@code Point3d} in the transport
  * records are conversion-only, never serialized).
  *
  * @author hal.hildebrand

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/BubbleBoundsTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/BubbleBoundsTest.java
@@ -4,7 +4,7 @@ import com.hellblazer.luciferase.simulation.bubble.*;
 
 import com.hellblazer.luciferase.lucien.tetree.Tet;
 import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.Test;
 
 import javax.vecmath.Point3f;

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/delos/fireflies/TetreeKeyRouterTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/delos/fireflies/TetreeKeyRouterTest.java
@@ -22,7 +22,7 @@ import com.hellblazer.delos.cryptography.Digest;
 import com.hellblazer.delos.membership.Member;
 import com.hellblazer.luciferase.lucien.tetree.Tet;
 import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -108,7 +108,7 @@ class TetreeKeyRouterTest {
         // Given: A specific position
         when(mockContext.size()).thenReturn(3);
 
-        var position = new Point3D(0.5f, 0.5f, 0.5f);
+        var position = new Point3d(0.5f, 0.5f, 0.5f);
         var cubeSizeMeters = 10.0f;
         var maxLevel = 5;
 

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/CrossProcessMigrationEntityLifecycleTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/CrossProcessMigrationEntityLifecycleTest.java
@@ -17,7 +17,7 @@
 
 package com.hellblazer.luciferase.simulation.distributed.migration;
 
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -293,8 +293,8 @@ class CrossProcessMigrationEntityLifecycleTest {
         }
 
         @Override
-        public Point3D getPosition() {
-            return new Point3D(0, 0, 0);
+        public Point3d getPosition() {
+            return new Point3d(0, 0, 0);
         }
 
         @Override

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/CrossProcessMigrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/CrossProcessMigrationTest.java
@@ -17,7 +17,7 @@
 
 package com.hellblazer.luciferase.simulation.distributed.migration;
 
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -307,8 +307,8 @@ class CrossProcessMigrationTest {
             }
 
             @Override
-            public Point3D getPosition() {
-                return new Point3D(0, 0, 0);
+            public Point3d getPosition() {
+                return new Point3d(0, 0, 0);
             }
 
             @Override
@@ -542,8 +542,8 @@ class CrossProcessMigrationTest {
         }
 
         @Override
-        public Point3D getPosition() {
-            return new Point3D(0, 0, 0);
+        public Point3d getPosition() {
+            return new Point3d(0, 0, 0);
         }
 
         @Override
@@ -602,8 +602,8 @@ class CrossProcessMigrationTest {
         }
 
         @Override
-        public Point3D getPosition() {
-            return new Point3D(0, 0, 0);
+        public Point3d getPosition() {
+            return new Point3d(0, 0, 0);
         }
 
         @Override

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/MigrationProtocolMessagesTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/MigrationProtocolMessagesTest.java
@@ -19,7 +19,7 @@ package com.hellblazer.luciferase.simulation.distributed.migration;
 
 import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
 import com.hellblazer.luciferase.simulation.von.MigrationProtocolMessages;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
@@ -47,7 +47,7 @@ class MigrationProtocolMessagesTest {
         var txnId = UUID.randomUUID();
         var token = new IdempotencyToken("entity-1", UUID.randomUUID(), UUID.randomUUID(),
                                          testClock.currentTimeMillis(), UUID.randomUUID());
-        var snapshot = new EntitySnapshot("entity-1", new Point3D(0, 0, 0), "Content", UUID.randomUUID(), 1L, 1L,
+        var snapshot = new EntitySnapshot("entity-1", new Point3d(0, 0, 0), "Content", UUID.randomUUID(), 1L, 1L,
                                           testClock.currentTimeMillis());
 
         // Create request

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/MigrationTransactionTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/MigrationTransactionTest.java
@@ -19,7 +19,7 @@ package com.hellblazer.luciferase.simulation.distributed.migration;
 
 import com.hellblazer.luciferase.common.time.Clock;
 import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
@@ -63,7 +63,7 @@ class MigrationTransactionTest {
 
         var snapshot = new EntitySnapshot(
             "entity-1",
-            new Point3D(10, 20, 30),
+            new Point3d(10, 20, 30),
             "TestContent",
             mockSource.getBubbleId(),
             42L, // epoch
@@ -93,7 +93,7 @@ class MigrationTransactionTest {
                                          testClock.currentTimeMillis(), UUID.randomUUID());
         var mockSource = createMockBubbleReference(UUID.randomUUID());
         var mockDest = createMockBubbleReference(UUID.randomUUID());
-        var snapshot = new EntitySnapshot("entity-1", new Point3D(0, 0, 0), "Content",
+        var snapshot = new EntitySnapshot("entity-1", new Point3d(0, 0, 0), "Content",
                                           mockSource.getBubbleId(), 1L, 1L, testClock.currentTimeMillis());
 
         var txn = new MigrationTransaction(txnId, token, snapshot, mockSource, mockDest, testClock);
@@ -119,7 +119,7 @@ class MigrationTransactionTest {
                                          testClock.currentTimeMillis(), UUID.randomUUID());
         var mockSource = createMockBubbleReference(UUID.randomUUID());
         var mockDest = createMockBubbleReference(UUID.randomUUID());
-        var snapshot = new EntitySnapshot("entity-1", new Point3D(0, 0, 0), "Content",
+        var snapshot = new EntitySnapshot("entity-1", new Point3d(0, 0, 0), "Content",
                                           mockSource.getBubbleId(), 1L, 1L, testClock.currentTimeMillis());
 
         var txn = new MigrationTransaction(txnId, token, snapshot, mockSource, mockDest, testClock);
@@ -139,7 +139,7 @@ class MigrationTransactionTest {
                                          testClock.currentTimeMillis(), UUID.randomUUID());
         var mockSource = createMockBubbleReference(UUID.randomUUID());
         var mockDest = createMockBubbleReference(UUID.randomUUID());
-        var snapshot = new EntitySnapshot("entity-1", new Point3D(0, 0, 0), "Content",
+        var snapshot = new EntitySnapshot("entity-1", new Point3d(0, 0, 0), "Content",
                                           mockSource.getBubbleId(), 1L, 1L, testClock.currentTimeMillis());
 
         var txn = new MigrationTransaction(txnId, token, snapshot, mockSource, mockDest, testClock);
@@ -159,7 +159,7 @@ class MigrationTransactionTest {
         var testClock = new TestClock();
         testClock.setTime(1000L);
 
-        var position = new Point3D(10, 20, 30);
+        var position = new Point3d(10, 20, 30);
         var snapshot = new EntitySnapshot(
             "entity-1",
             position,
@@ -268,8 +268,8 @@ class MigrationTransactionTest {
             }
 
             @Override
-            public Point3D getPosition() {
-                return new Point3D(0, 0, 0);
+            public Point3d getPosition() {
+                return new Point3d(0, 0, 0);
             }
 
             @Override

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/RemoteBubbleProxyTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/RemoteBubbleProxyTest.java
@@ -20,7 +20,7 @@ package com.hellblazer.luciferase.simulation.distributed.migration;
 import com.hellblazer.luciferase.simulation.von.transport.ProcessAddress;
 import com.hellblazer.luciferase.simulation.von.transport.SocketTransport;
 import com.hellblazer.luciferase.simulation.von.Bubble;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/ghost/GhostSyncVONIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/ghost/GhostSyncVONIntegrationTest.java
@@ -10,7 +10,7 @@ import com.hellblazer.luciferase.simulation.ghost.GhostLayerHealth;
 import com.hellblazer.luciferase.simulation.von.BubbleNode;
 import com.hellblazer.luciferase.simulation.von.SpatialNeighborIndex;
 import com.hellblazer.luciferase.simulation.von.Event;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
@@ -191,7 +191,8 @@ class GhostSyncVONIntegrationTest {
         int initialNeighborCount = vonNode.neighbors().size();
 
         // Simulate MOVE to new position (near neighbor)
-        var newPosition = neighborNode.position().add(1.0, 1.0, 1.0);
+        var np = neighborNode.position();
+        var newPosition = new javax.vecmath.Point3d(np.x + 1.0, np.y + 1.0, np.z + 1.0);
         integration.onVONMove(newPosition);
 
         // Verify: MOVE may discover new neighbors if bounds overlap

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/integration/ClusterIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/integration/ClusterIntegrationTest.java
@@ -21,7 +21,7 @@ import com.hellblazer.luciferase.simulation.entity.StringEntityID;
 import com.hellblazer.luciferase.simulation.bubble.ExternalBubbleTracker;
 import com.hellblazer.luciferase.simulation.ghost.*;
 import com.hellblazer.luciferase.simulation.von.*;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/lifecycle/ManagerLifecycleTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/lifecycle/ManagerLifecycleTest.java
@@ -11,7 +11,7 @@ package com.hellblazer.luciferase.simulation.lifecycle;
 import com.hellblazer.luciferase.simulation.von.Bubble;
 import com.hellblazer.luciferase.simulation.von.LocalServerTransport;
 import com.hellblazer.luciferase.simulation.von.Manager;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/viz/PredatorPreyGridWebDemo.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/viz/PredatorPreyGridWebDemo.java
@@ -666,9 +666,9 @@ public class PredatorPreyGridWebDemo {
     }
 
     /**
-     * Helper to convert JavaFX Point3D to vecmath Point3f.
+     * Helper to convert JavaFX Point3d to vecmath Point3f.
      */
-    private static Point3f toPoint3f(javafx.geometry.Point3D point) {
+    private static Point3f toPoint3f(javax.vecmath.Point3d point) {
         return new Point3f((float) point.getX(), (float) point.getY(), (float) point.getZ());
     }
 

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/BubbleIntroducedToMemoryTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/BubbleIntroducedToMemoryTest.java
@@ -17,7 +17,7 @@
 
 package com.hellblazer.luciferase.simulation.von;
 
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/BubbleNode.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/BubbleNode.java
@@ -2,7 +2,7 @@ package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.BubbleBounds;
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 
 import java.util.Objects;
 import java.util.Set;
@@ -51,7 +51,7 @@ public class BubbleNode implements Node {
     }
 
     @Override
-    public Point3D position() {
+    public Point3d position() {
         return bubble.centroid();
     }
 

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/BubbleTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/BubbleTest.java
@@ -18,7 +18,7 @@
 package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.BubbleBounds;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -128,7 +128,7 @@ class BubbleTest {
         });
 
         // When: Bubble2 sends JOIN request to Bubble1
-        var joinRequest = factory.createJoinRequest(id2, new Point3D(0.6, 0.6, 0.6), bubble2.bounds());
+        var joinRequest = factory.createJoinRequest(id2, new Point3d(0.6, 0.6, 0.6), bubble2.bounds());
         transport2.sendToNeighbor(id1, joinRequest);
 
         // Then: Bubble1 should respond with JoinResponse
@@ -150,7 +150,7 @@ class BubbleTest {
         var neighborId = UUID.randomUUID();
         var neighborInfo = new Message.NeighborInfo(
             neighborId,
-            new Point3D(0.3, 0.3, 0.3),
+            new Point3d(0.3, 0.3, 0.3),
             null
         );
         var response = factory.createJoinResponse(
@@ -190,7 +190,7 @@ class BubbleTest {
         });
 
         // When: Bubble2 sends MOVE message
-        var newPosition = new Point3D(0.7, 0.7, 0.7);
+        var newPosition = new Point3d(0.7, 0.7, 0.7);
         var moveMsg = factory.createMove(id2, newPosition, null);
         transport2.sendToNeighbor(id1, moveMsg);
 
@@ -334,7 +334,7 @@ class BubbleTest {
 
         // When: Neighbor joins
         var neighborId = UUID.randomUUID();
-        bubble1.notifyJoin(new SimpleNode(neighborId, new Point3D(0.5, 0.5, 0.5)));
+        bubble1.notifyJoin(new SimpleNode(neighborId, new Point3d(0.5, 0.5, 0.5)));
 
         // Then: Event listener receives Join event
         assertThat(events).hasSize(1);
@@ -408,7 +408,7 @@ class BubbleTest {
 
         // When: Bubble2 sends JOIN request to Bubble1
         var startTime = System.currentTimeMillis();
-        var joinRequest = factory.createJoinRequest(id2, new Point3D(0.6, 0.6, 0.6), bubble2.bounds());
+        var joinRequest = factory.createJoinRequest(id2, new Point3d(0.6, 0.6, 0.6), bubble2.bounds());
 
         // Send in background thread to allow retry mechanism to work
         new Thread(() -> {
@@ -464,7 +464,7 @@ class BubbleTest {
 
         // When: Bubble2 sends JOIN request to Bubble1
         var startTime = System.currentTimeMillis();
-        var joinRequest = factory.createJoinRequest(id2, new Point3D(0.6, 0.6, 0.6), bubble2.bounds());
+        var joinRequest = factory.createJoinRequest(id2, new Point3d(0.6, 0.6, 0.6), bubble2.bounds());
         transport2.sendToNeighbor(id1, joinRequest);
 
         // Wait for all retries to complete (total: 50+100+200+400+800 = 1550ms)
@@ -557,8 +557,8 @@ class BubbleTest {
         bubble3.addEventListener(e -> { if (e instanceof Event.Move) moveCReceived.countDown(); });
 
         // Then: Send MOVE messages from A to B and C
-        var moveToB = factory.createMove(idA, new Point3D(0.35, 0.35, 0.35), bubble1.bounds());
-        var moveToC = factory.createMove(idA, new Point3D(0.75, 0.75, 0.75), bubble1.bounds());
+        var moveToB = factory.createMove(idA, new Point3d(0.35, 0.35, 0.35), bubble1.bounds());
+        var moveToC = factory.createMove(idA, new Point3d(0.75, 0.75, 0.75), bubble1.bounds());
 
         transportA.sendToNeighbor(idB, moveToB);
         transportA.sendToNeighbor(idC, moveToC);
@@ -586,12 +586,12 @@ class BubbleTest {
     /**
      * Simple Node implementation for testing.
      */
-    private record SimpleNode(UUID id, Point3D position) implements Node {
+    private record SimpleNode(UUID id, Point3d position) implements Node {
         @Override
         public UUID id() { return id; }
 
         @Override
-        public Point3D position() { return position; }
+        public Point3d position() { return position; }
 
         @Override
         public BubbleBounds bounds() { return null; }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/IntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/IntegrationTest.java
@@ -1,7 +1,7 @@
 package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
@@ -129,7 +129,7 @@ public class IntegrationTest {
         capturedEvents.clear();
 
         // Move bubble significantly but within AOI of some neighbors
-        Point3D newPosition = new Point3D(75.0, 75.0, 50.0);
+        Point3d newPosition = new Point3d(75.0, 75.0, 50.0);
         moveProtocol.move(mover, newPosition);
 
         // Verify MOVE event emitted
@@ -225,7 +225,7 @@ public class IntegrationTest {
         // Perform movements
         for (int i = 0; i < 3; i++) {
             Node mover = bubbles.get(i);
-            Point3D newPos = new Point3D(
+            Point3d newPos = new Point3d(
                 mover.position().getX() + 5.0,
                 mover.position().getY() + 5.0,
                 50.0

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/JoinErrorRecoveryTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/JoinErrorRecoveryTest.java
@@ -19,7 +19,7 @@ package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.common.time.Clock;
 import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -228,7 +228,7 @@ class JoinErrorRecoveryTest {
         });
 
         // When: A moves and broadcasts to neighbors
-        manager.move(bubbleA, new Point3D(52.0, 52.0, 50.0));
+        manager.move(bubbleA, new Point3d(52.0, 52.0, 50.0));
         Thread.sleep(300);
         testClock.advance(100);
 

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/JoinProtocolTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/JoinProtocolTest.java
@@ -1,7 +1,7 @@
 package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/LeaveProtocolTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/LeaveProtocolTest.java
@@ -1,7 +1,7 @@
 package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/LocalServerTransportTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/LocalServerTransportTest.java
@@ -18,7 +18,7 @@
 package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.BubbleBounds;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -256,7 +256,7 @@ public class LocalServerTransportTest {
             }
         });
 
-        var position = new Point3D(1.0, 2.0, 3.0);
+        var position = new Point3d(1.0, 2.0, 3.0);
         var bounds = BubbleBounds.fromEntityPositions(List.of(new Point3f(1.0f, 2.0f, 3.0f)));
         var request = factory.createJoinRequest(id1, position, bounds);
 
@@ -293,7 +293,7 @@ public class LocalServerTransportTest {
         // Send messages with sequence numbers encoded in position.x
         var bounds = BubbleBounds.fromEntityPositions(List.of(new Point3f(0.5f, 0.5f, 0.5f)));
         for (int i = 0; i < messageCount; i++) {
-            var position = new Point3D(i, 0, 0);  // Sequence number in x coordinate
+            var position = new Point3d(i, 0, 0);  // Sequence number in x coordinate
             var request = factory.createJoinRequest(id1, position, bounds);
             transport1.sendToNeighborAsync(id2, request);
         }
@@ -349,8 +349,8 @@ public class LocalServerTransportTest {
         // Both senders send messages concurrently
         var bounds = BubbleBounds.fromEntityPositions(List.of(new Point3f(0.5f, 0.5f, 0.5f)));
         for (int i = 0; i < messagesPerSender; i++) {
-            var position1 = new Point3D(i, 0, 0);
-            var position2 = new Point3D(i, 0, 0);
+            var position1 = new Point3d(i, 0, 0);
+            var position2 = new Point3d(i, 0, 0);
 
             var request1 = factory.createJoinRequest(sender1, position1, bounds);
             var request2 = factory.createJoinRequest(sender2, position2, bounds);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/ManagerTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/ManagerTest.java
@@ -17,7 +17,7 @@
 
 package com.hellblazer.luciferase.simulation.von;
 
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -184,7 +184,7 @@ class ManagerTest {
         });
 
         // When: Bubble2 moves
-        manager.move(bubble2, new Point3D(60.0, 60.0, 50.0));
+        manager.move(bubble2, new Point3d(60.0, 60.0, 50.0));
 
         // Then: Bubble1 receives move notification
         assertThat(moveReceived.await(2, TimeUnit.SECONDS)).isTrue();
@@ -492,8 +492,8 @@ class ManagerTest {
         assertThat(bubble5.neighbors()).isNotNull();
 
         // And: Can still move remaining bubbles
-        manager.move(bubble4, new Point3D(85.0, 50.0, 50.0));
-        manager.move(bubble5, new Point3D(95.0, 50.0, 50.0));
+        manager.move(bubble4, new Point3d(85.0, 50.0, 50.0));
+        manager.move(bubble5, new Point3d(95.0, 50.0, 50.0));
 
         // And: Can create new bubble after leaves
         var newBubble = manager.createBubble();

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/MessageConverterTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/MessageConverterTest.java
@@ -17,7 +17,7 @@
 
 package com.hellblazer.luciferase.simulation.von;
 
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -62,7 +62,7 @@ class MessageConverterTest {
     @Test
     void testMoveRoundTrip() {
         var nodeId = UUID.randomUUID();
-        var newPosition = new Point3D(10.5, 20.25, 30.75);
+        var newPosition = new Point3d(10.5, 20.25, 30.75);
         var originalMove = factory.createMove(nodeId, newPosition, null);
 
         // Convert to transport
@@ -107,7 +107,7 @@ class MessageConverterTest {
     @Test
     void testJoinRequestRoundTrip() {
         var joinerId = UUID.randomUUID();
-        var position = new Point3D(5.0, 10.0, 15.0);
+        var position = new Point3d(5.0, 10.0, 15.0);
         var originalJoinReq = factory.createJoinRequest(joinerId, position, null);
 
         // Convert to transport
@@ -152,17 +152,17 @@ class MessageConverterTest {
         var neighbors = java.util.Set.of(
             new Message.NeighborInfo(
                 UUID.randomUUID(),
-                new Point3D(1.5, 2.5, 3.5),
+                new Point3d(1.5, 2.5, 3.5),
                 null  // Phase 6A: bounds not transmitted
             ),
             new Message.NeighborInfo(
                 UUID.randomUUID(),
-                new Point3D(10.0, 20.0, 30.0),
+                new Point3d(10.0, 20.0, 30.0),
                 null  // Phase 6A: bounds not transmitted
             ),
             new Message.NeighborInfo(
                 UUID.randomUUID(),
-                new Point3D(100.25, 200.5, 300.75),
+                new Point3d(100.25, 200.5, 300.75),
                 null  // Phase 6A: bounds not transmitted
             )
         );

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/MessageTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/MessageTest.java
@@ -18,7 +18,7 @@
 package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.BubbleBounds;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.Test;
 
 import javax.vecmath.Point3f;
@@ -40,7 +40,7 @@ public class MessageTest {
     @Test
     void testJoinRequest_createsWithTimestamp() {
         var joinerId = UUID.randomUUID();
-        var position = new Point3D(1.0, 2.0, 3.0);
+        var position = new Point3d(1.0, 2.0, 3.0);
         var bounds = BubbleBounds.fromEntityPositions(List.of(new Point3f(1.0f, 2.0f, 3.0f)));
 
         var request = factory.createJoinRequest(joinerId, position, bounds);
@@ -55,7 +55,7 @@ public class MessageTest {
     void testJoinResponse_withNeighbors() {
         var acceptorId = UUID.randomUUID();
         var neighborId = UUID.randomUUID();
-        var position = new Point3D(1.0, 2.0, 3.0);
+        var position = new Point3d(1.0, 2.0, 3.0);
         var bounds = BubbleBounds.fromEntityPositions(List.of(new Point3f(1.0f, 2.0f, 3.0f)));
 
         var neighborInfo = new Message.NeighborInfo(neighborId, position, bounds);
@@ -70,7 +70,7 @@ public class MessageTest {
     @Test
     void testMove_withNewPositionAndBounds() {
         var nodeId = UUID.randomUUID();
-        var newPosition = new Point3D(4.0, 5.0, 6.0);
+        var newPosition = new Point3d(4.0, 5.0, 6.0);
         var newBounds = BubbleBounds.fromEntityPositions(List.of(new Point3f(4.0f, 5.0f, 6.0f)));
 
         var move = factory.createMove(nodeId, newPosition, newBounds);
@@ -119,7 +119,7 @@ public class MessageTest {
     @Test
     void testNeighborInfo_record() {
         var nodeId = UUID.randomUUID();
-        var position = new Point3D(1.0, 2.0, 3.0);
+        var position = new Point3d(1.0, 2.0, 3.0);
         var bounds = BubbleBounds.fromEntityPositions(List.of(new Point3f(1.0f, 2.0f, 3.0f)));
 
         var info = new Message.NeighborInfo(nodeId, position, bounds);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/MoveProtocolTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/MoveProtocolTest.java
@@ -1,7 +1,7 @@
 package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -79,7 +79,7 @@ public class MoveProtocolTest {
         capturedEvents.clear();
 
         // Move to new position
-        Point3D newPosition = new Point3D(55.0, 55.0, 55.0);
+        Point3d newPosition = new Point3d(55.0, 55.0, 55.0);
         moveProtocol.move(moverNode, newPosition);
 
         // Verify MOVE event was emitted
@@ -109,7 +109,7 @@ public class MoveProtocolTest {
         int initialNeighborCount = moverNode.neighbors().size();
 
         // Move mover closer to distant bubble (crossing boundary)
-        Point3D newPosition = new Point3D(80.0, 80.0, 80.0);
+        Point3d newPosition = new Point3d(80.0, 80.0, 80.0);
         moveProtocol.move(moverNode, newPosition);
 
         // Verify neighbor discovery may have occurred
@@ -137,7 +137,7 @@ public class MoveProtocolTest {
         assertEquals(0, moverNode.neighbors().size(), "Should start with no neighbors");
 
         // Move mover closer to nearby bubble (within AOI)
-        Point3D newPosition = new Point3D(35.0, 35.0, 35.0);
+        Point3d newPosition = new Point3d(35.0, 35.0, 35.0);
         moveProtocol.move(moverNode, newPosition);
 
         // Verify new neighbor discovered
@@ -169,7 +169,7 @@ public class MoveProtocolTest {
         assertEquals(1, moverNode.neighbors().size(), "Should have 1 neighbor");
 
         // Move mover far away (beyond AOI + buffer)
-        Point3D farPosition = new Point3D(200.0, 200.0, 200.0);
+        Point3d farPosition = new Point3d(200.0, 200.0, 200.0);
         moveProtocol.move(moverNode, farPosition);
 
         // Verify out-of-range neighbor was removed
@@ -203,7 +203,7 @@ public class MoveProtocolTest {
         }
 
         // Measure MOVE latency
-        Point3D newPosition = new Point3D(55.0, 55.0, 55.0);
+        Point3d newPosition = new Point3d(55.0, 55.0, 55.0);
 
         long start = System.nanoTime();
         moveProtocol.move(moverNode, newPosition);
@@ -230,7 +230,7 @@ public class MoveProtocolTest {
 
         // Perform 10 sequential moves
         for (int i = 1; i <= 10; i++) {
-            Point3D newPos = new Point3D(50.0 + i, 50.0 + i, 50.0);
+            Point3d newPos = new Point3d(50.0 + i, 50.0 + i, 50.0);
             moveProtocol.move(moverNode, newPos);
         }
 
@@ -253,13 +253,13 @@ public class MoveProtocolTest {
         var moverNode = wrapBubble(mover);
         index.insert(moverNode);
 
-        Point3D initialCentroid = moverNode.position();
+        Point3d initialCentroid = moverNode.position();
         assertNotNull(initialCentroid, "Initial centroid should exist");
 
         // Simulate entity movement causing centroid shift
         // Note: In real scenario, entities move within bubble
         // For this test, we validate the move protocol accepts position changes
-        Point3D newCentroid = new Point3D(55.0, 55.0, 55.0);
+        Point3d newCentroid = new Point3d(55.0, 55.0, 55.0);
         moveProtocol.move(moverNode, newCentroid);
 
         // Verify MOVE event contains new position
@@ -306,7 +306,7 @@ public class MoveProtocolTest {
         Node mover = cluster.get(0);
         int initialNeighborCount = mover.neighbors().size();
 
-        Point3D newPosition = new Point3D(52.0, 52.0, 50.0);
+        Point3d newPosition = new Point3d(52.0, 52.0, 50.0);
         moveProtocol.move(mover, newPosition);
 
         // Verify neighbor consistency preserved

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeTest.java
@@ -1,7 +1,7 @@
 package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -83,7 +83,7 @@ public class NodeTest {
             bubble.addEntity("entity-" + i, new Point3f(x, y, z), content);
         }
 
-        Point3D position = vonNode.position();
+        Point3d position = vonNode.position();
 
         assertNotNull(position, "VON node position should not be null");
         assertEquals(bubble.centroid(), position, "Position should match bubble centroid");

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/P2PProtocolIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/P2PProtocolIntegrationTest.java
@@ -17,7 +17,7 @@
 
 package com.hellblazer.luciferase.simulation.von;
 
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -169,7 +169,7 @@ class P2PProtocolIntegrationTest {
         });
 
         // When: Bubble2 moves
-        manager.move(bubble2, new Point3D(57.0, 57.0, 50.0));
+        manager.move(bubble2, new Point3d(57.0, 57.0, 50.0));
 
         // Then: All neighbors receive move notification
         Thread.sleep(200);
@@ -189,7 +189,7 @@ class P2PProtocolIntegrationTest {
         var initialState = bubble1.getNeighborState(bubble2.id());
 
         // When: Bubble2 moves
-        var newPosition = new Point3D(60.0, 60.0, 50.0);
+        var newPosition = new Point3d(60.0, 60.0, 50.0);
         manager.move(bubble2, newPosition);
         Thread.sleep(200);
 
@@ -296,7 +296,7 @@ class P2PProtocolIntegrationTest {
 
         // When: Measure move notification latency
         long startNs = System.nanoTime();
-        manager.move(bubble2, new Point3D(60.0, 60.0, 50.0));
+        manager.move(bubble2, new Point3d(60.0, 60.0, 50.0));
         long latencyNs = System.nanoTime() - startNs;
 
         double latencyMs = latencyNs / 1_000_000.0;

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/P42VONRecoveryIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/P42VONRecoveryIntegrationTest.java
@@ -19,7 +19,7 @@ package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.lucien.balancing.fault.*;
 import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/RecoveryIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/RecoveryIntegrationTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -85,8 +85,8 @@ class RecoveryIntegrationTest {
         var partitionB = UUID.randomUUID();
 
         // Create bubbles for each partition
-        var bubbleA = createMockBubble(UUID.randomUUID(), new Point3D(0, 0, 0));
-        var bubbleB = createMockBubble(UUID.randomUUID(), new Point3D(10, 10, 10));
+        var bubbleA = createMockBubble(UUID.randomUUID(), new Point3d(0, 0, 0));
+        var bubbleB = createMockBubble(UUID.randomUUID(), new Point3d(10, 10, 10));
 
         // Register bubbles
         integration.registerBubble(bubbleA.id(), partitionA);
@@ -147,7 +147,7 @@ class RecoveryIntegrationTest {
 
         for (int i = 0; i < 15; i++) {
             var partition = UUID.randomUUID();
-            var bubble = createMockBubble(UUID.randomUUID(), new Point3D(i * 10, 0, 0));
+            var bubble = createMockBubble(UUID.randomUUID(), new Point3d(i * 10, 0, 0));
 
             partitions.add(partition);
             bubbles.add(bubble);
@@ -194,7 +194,7 @@ class RecoveryIntegrationTest {
     void testRecoveryCooldownPreventsRapidRetrigger() throws InterruptedException {
         // Arrange: Create partition with bubble
         var partition = UUID.randomUUID();
-        var bubble = createMockBubble(UUID.randomUUID(), new Point3D(0, 0, 0));
+        var bubble = createMockBubble(UUID.randomUUID(), new Point3d(0, 0, 0));
 
         integration.registerBubble(bubble.id(), partition);
         when(vonManager.getBubble(bubble.id())).thenReturn(bubble);
@@ -258,7 +258,7 @@ class RecoveryIntegrationTest {
     /**
      * Create a mock Bubble with specified ID and position.
      */
-    private Bubble createMockBubble(UUID id, Point3D position) {
+    private Bubble createMockBubble(UUID id, Point3d position) {
         var bubble = mock(Bubble.class);
         when(bubble.id()).thenReturn(id);
         when(bubble.position()).thenReturn(position);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/SpatialNeighborIndexBaselineBenchmark.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/SpatialNeighborIndexBaselineBenchmark.java
@@ -6,7 +6,7 @@
 package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.BubbleBounds;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
  * <b>Empirical observation justifying the single-harness design:</b>
  * {@link SpatialNeighborIndex#findWithinRadius} and {@link SpatialNeighborIndex#findKNearest}
  * iterate a flat {@code ConcurrentHashMap} computing Euclidean distance between
- * {@code Point3D} positions — the spatial level never enters the query path. So
+ * {@code Point3d} positions — the spatial level never enters the query path. So
  * the {@code spatialLevel} {@code @Param} produces no expected difference in query
  * timings; identical numbers across the two levels are the empirical confirmation
  * that, for the current linear-scan implementation, the level fix in Step 0
@@ -94,7 +94,7 @@ public class SpatialNeighborIndexBaselineBenchmark {
     public float queryRadius;
 
     private SpatialNeighborIndex index;
-    private List<Point3D> queryCenters;
+    private List<Point3d> queryCenters;
     private int queryCursor;
 
     @Setup(Level.Trial)
@@ -108,7 +108,7 @@ public class SpatialNeighborIndexBaselineBenchmark {
         index = new SpatialNeighborIndex(queryRadius, BOUNDARY_BUFFER);
 
         for (int i = 0; i < entityCount; i++) {
-            var position = new Point3D(
+            var position = new Point3d(
                 positionRng.nextFloat() * WORLD_EXTENT,
                 positionRng.nextFloat() * WORLD_EXTENT,
                 positionRng.nextFloat() * WORLD_EXTENT
@@ -119,7 +119,7 @@ public class SpatialNeighborIndexBaselineBenchmark {
         var centerRng = new Random(0xC11C7E7L);
         queryCenters = new ArrayList<>(QUERY_CENTER_COUNT);
         for (int i = 0; i < QUERY_CENTER_COUNT; i++) {
-            queryCenters.add(new Point3D(
+            queryCenters.add(new Point3d(
                 centerRng.nextFloat() * WORLD_EXTENT,
                 centerRng.nextFloat() * WORLD_EXTENT,
                 centerRng.nextFloat() * WORLD_EXTENT
@@ -192,7 +192,7 @@ public class SpatialNeighborIndexBaselineBenchmark {
      * Lightweight stub Node returning only {@code id()} and {@code position()}.
      * Unused methods throw or return empty to surface accidental misuse.
      */
-    private record StubNode(UUID id, Point3D position) implements Node {
+    private record StubNode(UUID id, Point3d position) implements Node {
 
         @Override
         public BubbleBounds bounds() {

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/SpatialNeighborIndexTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/SpatialNeighborIndexTest.java
@@ -2,7 +2,7 @@ package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.luciferase.simulation.bubble.BubbleBounds;
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -100,7 +100,7 @@ public class SpatialNeighborIndexTest {
         index.insert(wrapBubble(bubble5));
 
         // Query point at origin
-        Point3D queryPoint = new Point3D(0.0, 0.0, 0.0);
+        Point3d queryPoint = new Point3d(0.0, 0.0, 0.0);
         Node closest = index.findClosestTo(queryPoint);
 
         assertNotNull(closest, "Should find closest bubble");
@@ -122,7 +122,7 @@ public class SpatialNeighborIndexTest {
         }
 
         // Query for 3 nearest to origin
-        Point3D queryPoint = new Point3D(0.0, 0.0, 0.0);
+        Point3d queryPoint = new Point3d(0.0, 0.0, 0.0);
         List<Node> nearest = index.findKNearest(queryPoint, 3);
 
         assertEquals(3, nearest.size(), "Should return exactly 3 neighbors");
@@ -233,7 +233,7 @@ public class SpatialNeighborIndexTest {
         index.insert(wrapBubble(bubble2));
         index.insert(wrapBubble(bubble3));
 
-        Point3D center = new Point3D(0.0, 0.0, 0.0);
+        Point3d center = new Point3d(0.0, 0.0, 0.0);
         var inRange = index.findWithinRadius(center, AOI_RADIUS);
 
         assertTrue(inRange.stream().anyMatch(n -> n.id().equals(bubble1.id())),
@@ -256,11 +256,11 @@ public class SpatialNeighborIndexTest {
 
         index.insert(node);
 
-        Point3D oldPosition = node.position();
+        Point3d oldPosition = node.position();
         assertNotNull(oldPosition, "Initial position should exist");
 
         // Simulate bubble moving by updating position
-        Point3D newPosition = new Point3D(50.0, 50.0, 50.0);
+        Point3d newPosition = new Point3d(50.0, 50.0, 50.0);
         index.updatePosition(node.id(), newPosition);
 
         // Note: updatePosition might be a no-op if position is tracked via node reference
@@ -274,7 +274,7 @@ public class SpatialNeighborIndexTest {
      */
     @Test
     public void testEmptyIndex() {
-        Point3D queryPoint = new Point3D(0.0, 0.0, 0.0);
+        Point3d queryPoint = new Point3d(0.0, 0.0, 0.0);
 
         // findClosestTo on empty index
         Node closest = index.findClosestTo(queryPoint);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/TetreeKNearestColdCacheBenchmark.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/TetreeKNearestColdCacheBenchmark.java
@@ -9,7 +9,7 @@ import com.hellblazer.luciferase.lucien.entity.UUIDEntityID;
 import com.hellblazer.luciferase.lucien.entity.UUIDGenerator;
 import com.hellblazer.luciferase.lucien.tetree.Tetree;
 import com.hellblazer.luciferase.simulation.bubble.BubbleBounds;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -116,7 +116,7 @@ public class TetreeKNearestColdCacheBenchmark {
                                 positionRng.nextFloat() * WORLD_EXTENT,
                                 positionRng.nextFloat() * WORLD_EXTENT);
             tetree.insert(new UUIDEntityID(UUID.randomUUID()), p, spatialLevel,
-                          new StubNode(UUID.randomUUID(), new Point3D(p.x, p.y, p.z)));
+                          new StubNode(UUID.randomUUID(), new Point3d(p.x, p.y, p.z)));
         }
 
         var centerRng = new Random(0xC11C7E7L);
@@ -174,7 +174,7 @@ public class TetreeKNearestColdCacheBenchmark {
      * Mirrors {@code SpatialNeighborIndexBaselineBenchmark.StubNode} for
      * cross-benchmark consistency.
      */
-    private record StubNode(UUID id, Point3D position) implements Node {
+    private record StubNode(UUID id, Point3d position) implements Node {
         @Override
         public BubbleBounds bounds() {
             throw new UnsupportedOperationException("bounds() not exercised by k-NN benchmark");

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/transport/VonDeserializationHardeningTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/transport/VonDeserializationHardeningTest.java
@@ -22,7 +22,7 @@ import com.hellblazer.luciferase.simulation.von.MessageConverter;
 import com.hellblazer.luciferase.simulation.von.TransportGhostData;
 import com.hellblazer.luciferase.simulation.von.TransportNeighborInfo;
 import com.hellblazer.luciferase.simulation.von.TransportVonMessage;
-import javafx.geometry.Point3D;
+import javax.vecmath.Point3d;
 import javax.vecmath.Point3f;
 import org.junit.jupiter.api.Test;
 
@@ -127,11 +127,11 @@ class VonDeserializationHardeningTest {
     @Test
     void filterAcceptsEveryConverterProducedMessageType() throws IOException {
         var ghost = new Message.TransportGhost("e1", new Point3f(1, 2, 3), "java.lang.String", "v", "tree-1", 1L, 2L, 3L);
-        var neighbor = new Message.NeighborInfo(UUID.randomUUID(), new Point3D(1, 2, 3), null);
+        var neighbor = new Message.NeighborInfo(UUID.randomUUID(), new Point3d(1, 2, 3), null);
         List<Message> messages = List.of(
-            new Message.JoinRequest(UUID.randomUUID(), new Point3D(1, 2, 3), null, 1L),
+            new Message.JoinRequest(UUID.randomUUID(), new Point3d(1, 2, 3), null, 1L),
             new Message.JoinResponse(UUID.randomUUID(), Set.of(neighbor), 2L),
-            new Message.Move(UUID.randomUUID(), new Point3D(4, 5, 6), null, 3L),
+            new Message.Move(UUID.randomUUID(), new Point3d(4, 5, 6), null, 3L),
             new Message.Leave(UUID.randomUUID(), 4L),
             new Message.GhostSync(UUID.randomUUID(), List.of(ghost), 9L, 5L),
             new Message.Ack(UUID.randomUUID(), UUID.randomUUID(), 6L),


### PR DESCRIPTION
## What

Completes RDR-006 D5: **`mvn dependency:tree -pl simulation` now shows zero `javafx-*` and zero `lwjgl`** — headless simulation/distributed deployments no longer drag the JavaFX toolkit.

### 1. Point3D → Point3d migration (58 files, main + test)
Replaced all `javafx.geometry.Point3D` with `javax.vecmath.Point3d` (double-precision, precision-preserving). Removes all of simulation's *own* javafx usage.

Mechanically safe per pre-migration API survey:
- The immutable-vs-mutable hazard (javafx `.add/.subtract/.normalize` return new; vecmath mutates) **never applied** — those calls were all on `Vector3f` (already vecmath). The one test `.add(x,y,z)` offset was rewritten as an explicit `new Point3d`.
- Accessors signature-identical (`Tuple3d` has `getX/Y/Z`); `.distance()` returns `double` in both; `(double,double,double)` ctor matches.
- Wire format unchanged — `TransportNeighborInfo` already decomposes to `posX/Y/Z` primitives.
- Zero cross-module exposure.
- `BubbleBounds.toCartesian` now returns the kernel's `Point3d` directly (drops PR1's javafx wrapper).

### 2. Transitive-carrier exclusions (simulation/pom.xml)
After the migration, javafx/lwjgl still reached simulation's compile classpath via two deps whose javafx-using classes simulation never links:
- **`render`** → javafx-controls + lwjgl. `simulation.viz.render` uses only render's **pure-data** ESVT types (`ESVTData`/`ESVTNodeUnified`/`ESVTBuilder` — zero javafx/lwjgl imports). Excluded.
- **`common`** → javafx-graphics, for `common.mesh.MeshLoader` (unused by simulation). Excluded.

## Validation
- `dependency:tree -pl simulation`: **zero javafx, zero lwjgl** ✅
- Full simulation suite: **2636 tests**, only failure was `testMigrationWithPacketLoss` — a probabilistic packet-loss flake (0 Point3D refs; passes 3/3 on isolated rerun; CI's flaky-rerun absorbs it).
- 65 `viz.render` tests pass at runtime *with* the exclusions — confirms the ESVT serialization/streaming path needs no GPU/JavaFX.

## Remaining (separate, not blocking D5)
- Isolate `MeshLoader`'s javafx out of the `common` leaf module so common stops advertising `javafx-graphics` to *all* consumers (the original RDR follow-up; this PR only excludes it from simulation's view).
- Clock package rename (Luciferase-7n1) still deferred.