### PR TITLE
docs(rdr): sync README index with RDR-006/008/009 closures

### DIFF
--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -1,6 +1,6 @@
 # Recommendation Decisioning Records (RDRs)
 
-**Last Updated**: 2026-05-28
+**Last Updated**: 2026-05-29
 **Status**: Current
 
 RDRs are specification prompts built through iterative research and refinement.
@@ -16,10 +16,10 @@ See the [RDR process documentation](https://github.com/cwensel/rdr) for the full
 | [RDR-003](RDR-003-fcc-aligned-spatial-indexing.md) | FCC-Aligned Spatial Indexing for Luciferase — VoN Spatialization, RD Overlay, and Optional TetOctree | implemented | Architecture | medium |
 | [RDR-004](RDR-004-von-socketserver-deserialization-hardening.md) | Harden Network Deserialization on the VoN SocketServer | accepted | Security | high |
 | [RDR-005](RDR-005-grpc-tls-auth-model.md) | gRPC TLS + Authentication Model for Ghost and Balancing Services | accepted | Security | high |
-| [RDR-006](RDR-006-break-simulation-portal-coupling.md) | Break the simulation→portal Coupling (BubbleBounds JavaFX Pull-In) | accepted | Architecture | medium |
+| [RDR-006](RDR-006-break-simulation-portal-coupling.md) | Break the simulation→portal Coupling (BubbleBounds JavaFX Pull-In) | closed | Architecture | medium |
 | [RDR-007](RDR-007-extract-lucien-distributed-module.md) | Extract a lucien-distributed Module (gRPC Clients out of lucien) | closed | Architecture | medium |
-| [RDR-008](RDR-008-decompose-abstractspatialindex.md) | Decompose the AbstractSpatialIndex God-Class | implemented | Architecture | medium |
-| [RDR-009](RDR-009-prism-full-cube-coverage.md) | Prism Full-Cube Coverage via Two-Prism Cover | implemented | Architecture | medium |
+| [RDR-008](RDR-008-decompose-abstractspatialindex.md) | Decompose the AbstractSpatialIndex God-Class | closed | Architecture | medium |
+| [RDR-009](RDR-009-prism-full-cube-coverage.md) | Prism Full-Cube Coverage via Two-Prism Cover | closed | Architecture | medium |
 | [RDR-010](RDR-010-pyramid-spatial-index.md) | Pyramid Spatial Index — Close the Hybrid Hex↔Tet Partition Gap | accepted | Architecture | medium |
 
 ## Post-Mortems
@@ -31,6 +31,7 @@ Closed/implemented RDRs carry a post-mortem under [`post-mortem/`](post-mortem/)
 | RDR-001 | [post-mortem/001-axis-aligned-bounding-tetrahedra.md](post-mortem/001-axis-aligned-bounding-tetrahedra.md) |
 | RDR-002 | [post-mortem/002-12dop-exact-containment.md](post-mortem/002-12dop-exact-containment.md) |
 | RDR-003 | [post-mortem/003-fcc-aligned-spatial-indexing.md](post-mortem/003-fcc-aligned-spatial-indexing.md) |
+| RDR-006 | [post-mortem/006-break-simulation-portal-coupling.md](post-mortem/006-break-simulation-portal-coupling.md) |
 | RDR-007 | [post-mortem/007-extract-lucien-distributed-module.md](post-mortem/007-extract-lucien-distributed-module.md) |
 | RDR-008 | [post-mortem/008-decompose-abstractspatialindex.md](post-mortem/008-decompose-abstractspatialindex.md) |
 | RDR-009 | [post-mortem/009-prism-full-cube-coverage.md](post-mortem/009-prism-full-cube-coverage.md) |


### PR DESCRIPTION
## Summary

Surfaced during a 5x5 re-verification of RDR-010 against current main. PR #154 closed RDR-006/008/009 (implemented→closed) and added the RDR-006 post-mortem, but didn't update the RDR index README created in #150. This syncs the index:

- RDR-006 `accepted` → `closed`
- RDR-008 `implemented` → `closed`
- RDR-009 `implemented` → `closed`
- Add RDR-006 row to the Post-Mortems table (`post-mortem/006-*.md` now exists)
- Bump `Last Updated` 2026-05-28 → 2026-05-29

## RDR-010 verification result

RDR-010 itself is **5x5 against main HEAD `3f586318`** — no changes needed. All codebase anchors re-verified exact: Tet.java line numbers (child:918, faceNeighbor:1442, parent:1691, computeType:957, etc.), the 17 AbstractSpatialIndex abstract methods + lines, `TetreeConnectivity.PARENT_TYPE_TO_CHILD_TYPE:61`, `balancing.TwoOneBalanceChecker:127`, non-sealed `Spatial.aabt:195`, `SpatialKey.sfcRangesForKNN:70`, Forest.addTree, TreeNode.entityCount:76. RDR-010's RDR-008 cross-refs read even more accurately now (RDR-008 implemented→closed).

## Test plan
- [x] Index status column matches authoritative frontmatter for all 10 RDRs
- [ ] Documentation Checks green (README retains its Last Updated header)