### PR TITLE
RDR-010 P1: PyramidKey + Pyramid primitive (128-bit 6D-Morton SFC)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/Pyramid.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/Pyramid.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.pyramid;
+
+import com.hellblazer.luciferase.lucien.Constants;
+
+import javax.vecmath.Point3f;
+import javax.vecmath.Point3i;
+import java.util.Objects;
+
+/**
+ * Pyramid element of the hybrid pyramid/tetrahedron space-filling curve (RDR-010, Knapp 2026,
+ * "A Morton-Type SFC for Pyramid Subdivision and Hybrid AMR"). A pyramid is the square-based
+ * element that, together with a 180&deg;-rotated sibling and two tetrahedra, tiles a cube and
+ * closes the documented t8code tetrahedral partition gap.
+ *
+ * <p>Analogous to {@link com.hellblazer.luciferase.lucien.tetree.Tet}: an element is identified by
+ * its anchor coordinate (the lower-left-back corner of its surrounding cube), its refinement level,
+ * and its type. Pyramids carry type {@link #TYPE_6} or {@link #TYPE_7}; the four tetrahedral
+ * children of a pyramid are represented by {@code Tet} (types 0-5).
+ *
+ * <p>Vertex construction follows the t8code reference implementation
+ * ({@code t8_dpyramid_compute_coords}, t8_default_pyramid scheme), the executable ground truth for
+ * Knapp 2026 &sect;3:
+ * <ul>
+ *   <li><b>Type 6</b> (FIRST_TYPE): square base on the bottom face (z), apex at the
+ *       (+x,+y,+z) cube corner.</li>
+ *   <li><b>Type 7</b> (SECOND_TYPE): square base on the top face (z+L), apex at the anchor
+ *       corner. A 180&deg; rotation of type 6.</li>
+ * </ul>
+ *
+ * <p>The mandatory {@code minTetLevel} field (Knapp Algorithm 4.1) records the smallest level at
+ * which an ancestor is a tetrahedron; it is required to keep parent/child/face-neighbor O(1) for
+ * tetrahedra descending from pyramidal roots. Pure pyramids carry the sentinel
+ * {@link #NO_TET_ANCESTOR} (-1).
+ *
+ * @author hal.hildebrand
+ */
+public final class Pyramid {
+
+    /** Pyramid type 6 (t8code FIRST_TYPE): base on bottom face, apex at the far cube corner. */
+    public static final byte TYPE_6 = 6;
+    /** Pyramid type 7 (t8code SECOND_TYPE): base on top face, apex at the anchor corner. */
+    public static final byte TYPE_7 = 7;
+    /** {@code minTetLevel} sentinel: no tetrahedral ancestor (pure pyramid). */
+    public static final byte NO_TET_ANCESTOR = -1;
+    /** Number of corners of a pyramid (4 base + 1 apex). */
+    public static final int  CORNERS         = 5;
+
+    private final int  x;
+    private final int  y;
+    private final int  z;
+    private final byte level;
+    private final byte type;
+    private final byte minTetLevel;
+
+    /**
+     * Create a pure pyramid (no tetrahedral ancestor).
+     */
+    public Pyramid(int x, int y, int z, byte level, byte type) {
+        this(x, y, z, level, type, NO_TET_ANCESTOR);
+    }
+
+    /**
+     * Create a pyramid with an explicit {@code minTetLevel}.
+     *
+     * @param x           anchor x (lower-left-back corner, non-negative)
+     * @param y           anchor y (non-negative)
+     * @param z           anchor z (non-negative)
+     * @param level       refinement level, 0..{@link Constants#getMaxRefinementLevel()}
+     * @param type        {@link #TYPE_6} or {@link #TYPE_7}
+     * @param minTetLevel smallest level at which an ancestor is a tetrahedron, or
+     *                    {@link #NO_TET_ANCESTOR}
+     */
+    public Pyramid(int x, int y, int z, byte level, byte type, byte minTetLevel) {
+        if (type != TYPE_6 && type != TYPE_7) {
+            throw new IllegalArgumentException("Pyramid type must be 6 or 7, got: " + type);
+        }
+        if (level < 0 || level > Constants.getMaxRefinementLevel()) {
+            throw new IllegalArgumentException(
+            "Level must be between 0 and " + Constants.getMaxRefinementLevel() + ", got: " + level);
+        }
+        if (x < 0 || y < 0 || z < 0) {
+            throw new IllegalArgumentException(
+            String.format("Negative anchor coordinates not supported: (%d,%d,%d)", x, y, z));
+        }
+        if (minTetLevel != NO_TET_ANCESTOR && (minTetLevel < 0 || minTetLevel > level)) {
+            throw new IllegalArgumentException(
+            "minTetLevel must be -1 or in [0, level], got: " + minTetLevel + " (level " + level + ")");
+        }
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.level = level;
+        this.type = type;
+        this.minTetLevel = minTetLevel;
+    }
+
+    /**
+     * The edge length of this pyramid's surrounding cube at its level.
+     *
+     * @return {@code 2^(maxRefinementLevel - level)}
+     */
+    public int length() {
+        return Constants.lengthAtLevel(level);
+    }
+
+    /**
+     * The five integer vertex coordinates of this pyramid, indexed by corner 0..4 (corners 0-3 are
+     * the square base, corner 4 is the apex; Knapp Fig 4.1 / t8code {@code t8_dpyramid_compute_coords}).
+     *
+     * @return a 5-element array of vertices
+     */
+    public Point3i[] coordinates() {
+        var h = length();
+        var c = new Point3i[CORNERS];
+        if (type == TYPE_6) {
+            c[0] = new Point3i(x, y, z);
+            c[1] = new Point3i(x + h, y, z);
+            c[2] = new Point3i(x, y + h, z);
+            c[3] = new Point3i(x + h, y + h, z);
+            c[4] = new Point3i(x + h, y + h, z + h);
+        } else { // TYPE_7 — 180-degree rotation of type 6
+            c[0] = new Point3i(x, y, z + h);
+            c[1] = new Point3i(x + h, y, z + h);
+            c[2] = new Point3i(x, y + h, z + h);
+            c[3] = new Point3i(x + h, y + h, z + h);
+            c[4] = new Point3i(x, y, z);
+        }
+        return c;
+    }
+
+    /**
+     * The centroid of this pyramid (arithmetic mean of its five vertices). Note this is the vertex
+     * centroid, not the volume centroid; pyramids are not symmetric about it (the volume centroid
+     * lies at 1/4 of the height above the base). Do not use for volume-weighted operations.
+     *
+     * @return the vertex centroid
+     */
+    public Point3f centroid() {
+        var verts = coordinates();
+        float sx = 0, sy = 0, sz = 0;
+        for (var v : verts) {
+            sx += v.x;
+            sy += v.y;
+            sz += v.z;
+        }
+        return new Point3f(sx / CORNERS, sy / CORNERS, sz / CORNERS);
+    }
+
+    public int x() {
+        return x;
+    }
+
+    public int y() {
+        return y;
+    }
+
+    public int z() {
+        return z;
+    }
+
+    public byte level() {
+        return level;
+    }
+
+    public byte type() {
+        return type;
+    }
+
+    public byte minTetLevel() {
+        return minTetLevel;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Pyramid p)) {
+            return false;
+        }
+        return x == p.x && y == p.y && z == p.z && level == p.level && type == p.type
+        && minTetLevel == p.minTetLevel;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(x, y, z, level, type, minTetLevel);
+    }
+
+    @Override
+    public String toString() {
+        return "Pyramid[type=" + type + ",L" + level + ",@(" + x + "," + y + "," + z + ")"
+        + (minTetLevel == NO_TET_ANCESTOR ? "" : ",minTet=" + minTetLevel) + "]";
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKey.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.pyramid;
+
+import com.hellblazer.luciferase.lucien.Constants;
+import com.hellblazer.luciferase.lucien.SpatialKey;
+
+import javax.vecmath.Point3f;
+import java.util.Objects;
+
+/**
+ * 128-bit spatial key for the pyramid space-filling curve (RDR-010, Knapp 2026). The key encodes
+ * the pyramid index {@code m_P(P) = Z &darr; Y &darr; X &darr; B&sup2; &darr; B&sup1; &darr; B&sup0;}
+ * (Knapp Eq 3.4), a 6-dimensional Morton interleaving of three anchor-coordinate tuples
+ * {@code (Z,Y,X)} and three type-representing tuples {@code (B&sup2;,B&sup1;,B&sup0;)}. Per refinement
+ * step the six interleaved bits form a contiguous group laid out MSB&rarr;LSB as
+ * {@code [Z,Y,X,B&sup2;,B&sup1;,B&sup0;]} = 3 coordinate bits followed by 3 type bits. The type bits
+ * are the binary digits of the element type {@code 0..7}; the per-step bit budget matches the Tetree
+ * extended-key layout, but the underlying mathematics (a bijection with the 6D cube Morton index;
+ * Knapp Theorem 3.5) is distinct.
+ *
+ * <p>{@code PyramidKey} is a sibling of {@code TetreeKey}, not a subclass: it implements
+ * {@link SpatialKey} directly and inherits the default {@link SpatialKey#sfcRangesForKNN} (empty
+ * &mdash; k-NN falls back to breadth-first search until a {@code locate} primitive lands in a later
+ * phase).
+ *
+ * <h3>Bit layout &mdash; canonical (coarse-dominant) ordering</h3>
+ * The index is built MortonKey-style: each deeper refinement step is appended at the least
+ * significant end (the shallowest step migrates to the most significant bits). The full index is a
+ * uniform {@code 6 * level}-bit value held across two longs &mdash; {@code lowBits} are bits 0..63,
+ * {@code highBits} bits 64..125. With {@code 6 * 21 = 126} bits, all 21 refinement levels fit in two
+ * longs with no special split-bit encoding. {@link #compareTo} compares {@code level} first, then the
+ * 128-bit value as {@code (highBits, lowBits)} unsigned &mdash; so the shallowest (coarsest) step
+ * dominates, reproducing the {@code m_P} total order.
+ *
+ * @author hal.hildebrand
+ */
+public final class PyramidKey implements SpatialKey<PyramidKey> {
+
+    /** Bits per refinement step (3 coordinate + 3 type). */
+    public static final  int  BITS_PER_LEVEL    = 6;
+    /** Highest level supported (21 * 6 = 126 bits, fits two longs). */
+    public static final  byte MAX_PYRAMID_LEVEL = 21;
+    private static final long GROUP_MASK        = 0x3FL;
+
+    private final byte level;
+    private final long lowBits;
+    private final long highBits;
+
+    /**
+     * Construct a key directly from its packed bits.
+     *
+     * @param level    refinement level, 0..{@value #MAX_PYRAMID_LEVEL}
+     * @param lowBits  index bits 0..63
+     * @param highBits index bits 64..125
+     */
+    public PyramidKey(byte level, long lowBits, long highBits) {
+        if (level < 0 || level > MAX_PYRAMID_LEVEL) {
+            throw new IllegalArgumentException(
+            "PyramidKey level must be between 0 and " + MAX_PYRAMID_LEVEL + ", got: " + level);
+        }
+        this.level = level;
+        this.lowBits = lowBits;
+        this.highBits = highBits;
+    }
+
+    /**
+     * Build a key from per-step coordinate and type bits. Both arrays are indexed by refinement step
+     * {@code 1..level} (index 0 is unused; the root contributes no bits). Step 1 is the shallowest
+     * (coarsest) refinement; it is appended first and ends in the most significant bits.
+     *
+     * @param level      refinement level
+     * @param coordBits  per-step 3-bit coordinate value {@code (Z<<2)|(Y<<1)|X}, length &gt; level
+     * @param typeBits   per-step 3-bit type value {@code 0..7}, length &gt; level
+     * @return the packed key
+     */
+    public static PyramidKey fromLevels(byte level, int[] coordBits, int[] typeBits) {
+        if (level < 0 || level > MAX_PYRAMID_LEVEL) {
+            throw new IllegalArgumentException("level out of range: " + level);
+        }
+        Objects.requireNonNull(coordBits, "coordBits");
+        Objects.requireNonNull(typeBits, "typeBits");
+        if (coordBits.length <= level || typeBits.length <= level) {
+            throw new IllegalArgumentException("coordBits/typeBits must have length > level");
+        }
+        long low = 0L;
+        long high = 0L;
+        for (int l = 1; l <= level; l++) {
+            // Append this step's group at the LSB (shift the running value left by 6, then OR in).
+            high = (high << BITS_PER_LEVEL) | (low >>> (64 - BITS_PER_LEVEL));
+            low = low << BITS_PER_LEVEL;
+            long group = ((coordBits[l] & 0x7L) << 3) | (typeBits[l] & 0x7L);
+            low |= group;
+        }
+        return new PyramidKey(level, low, high);
+    }
+
+    public static PyramidKey getRoot() {
+        return new PyramidKey((byte) 0, 0L, 0L);
+    }
+
+    public long getLowBits() {
+        return lowBits;
+    }
+
+    public long getHighBits() {
+        return highBits;
+    }
+
+    /**
+     * The 3-bit type value at refinement step {@code l} (1..level).
+     */
+    public byte getTypeAtLevel(int l) {
+        return (byte) (rawGroup(l) & 0x7);
+    }
+
+    /**
+     * The 3-bit coordinate value {@code (Z<<2)|(Y<<1)|X} at refinement step {@code l} (1..level).
+     */
+    public byte getCoordBitsAtLevel(int l) {
+        return (byte) ((rawGroup(l) >> 3) & 0x7);
+    }
+
+    /**
+     * The 6-bit group for step {@code l}. Step {@code level} (deepest) is at bit offset 0; step 1
+     * (shallowest) is at offset {@code (level-1)*6}. May straddle the low/high long boundary.
+     */
+    private long rawGroup(int l) {
+        if (l < 1 || l > level) {
+            throw new IllegalArgumentException("step must be in [1, " + level + "], got: " + l);
+        }
+        int bit = (level - l) * BITS_PER_LEVEL; // offset from LSB
+        if (bit >= 64) {
+            return (highBits >>> (bit - 64)) & GROUP_MASK;
+        }
+        if (bit + BITS_PER_LEVEL <= 64) {
+            return (lowBits >>> bit) & GROUP_MASK;
+        }
+        // Straddles the boundary: low part from lowBits, high part from highBits.
+        long lowPart = lowBits >>> bit;
+        long highPart = highBits << (64 - bit);
+        return (lowPart | highPart) & GROUP_MASK;
+    }
+
+    @Override
+    public byte getLevel() {
+        return level;
+    }
+
+    @Override
+    public int compareTo(PyramidKey other) {
+        Objects.requireNonNull(other, "Cannot compare to null PyramidKey");
+        int levelCmp = Byte.compare(this.level, other.level);
+        if (levelCmp != 0) {
+            return levelCmp;
+        }
+        // (highBits, lowBits) as a 128-bit unsigned value. The shallowest step occupies the most
+        // significant bits, so this reproduces the coarse-dominant m_P total order (Knapp Eq 3.4).
+        int highCmp = Long.compareUnsigned(this.highBits, other.highBits);
+        if (highCmp != 0) {
+            return highCmp;
+        }
+        return Long.compareUnsigned(this.lowBits, other.lowBits);
+    }
+
+    @Override
+    public PyramidKey parent() {
+        if (level == 0) {
+            return null;
+        }
+        // Drop the deepest step (the LSB group): shift the 128-bit value right by 6.
+        long parentLow = (lowBits >>> BITS_PER_LEVEL) | (highBits << (64 - BITS_PER_LEVEL));
+        long parentHigh = highBits >>> BITS_PER_LEVEL;
+        return new PyramidKey((byte) (level - 1), parentLow, parentHigh);
+    }
+
+    @Override
+    public PyramidKey root() {
+        return getRoot();
+    }
+
+    @Override
+    public boolean isValid() {
+        if (level < 0 || level > MAX_PYRAMID_LEVEL) {
+            return false;
+        }
+        int usedBits = level * BITS_PER_LEVEL;
+        if (usedBits <= 64) {
+            long lowMask = (usedBits == 64) ? -1L : (1L << usedBits) - 1;
+            return (lowBits & ~lowMask) == 0L && highBits == 0L;
+        }
+        int usedHigh = usedBits - 64;
+        long highMask = (usedHigh >= 64) ? -1L : (1L << usedHigh) - 1;
+        return (highBits & ~highMask) == 0L;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PyramidKey pk)) {
+            return false;
+        }
+        return level == pk.level && lowBits == pk.lowBits && highBits == pk.highBits;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(level, lowBits, highBits);
+    }
+
+    @Override
+    public String toString() {
+        return "PyramidKey[L" + level + ",lo:" + Long.toHexString(lowBits)
+        + (highBits != 0 ? ",hi:" + Long.toHexString(highBits) : "") + "]";
+    }
+
+    // ===== SFC Range Estimation (parity with MortonKey/TetreeKey) =====
+
+    /**
+     * A range of pyramid keys for pruning spatial queries via
+     * {@code ConcurrentSkipListMap.subMap(lower, upper)}.
+     */
+    public record SFCRange(PyramidKey lower, PyramidKey upper) {
+        public SFCRange {
+            Objects.requireNonNull(lower, "lower");
+            Objects.requireNonNull(upper, "upper");
+        }
+    }
+
+    /**
+     * Estimate the level whose cell diagonal first covers {@code radius} (coarse cells for large
+     * radii), mirroring {@code MortonKey.estimateSFCDepth} / {@code TetreeKey.estimateSFCDepth}.
+     */
+    public static byte estimateSFCDepth(float radius) {
+        if (radius <= 0) {
+            throw new IllegalArgumentException("Search radius must be positive, got: " + radius);
+        }
+        for (byte l = MAX_PYRAMID_LEVEL; l >= 0; l--) {
+            float cellSize = Constants.lengthAtLevel(l);
+            float diagonal = (float) (cellSize * Math.sqrt(3.0));
+            if (diagonal >= radius) {
+                return l;
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Conservative SFC range covering a query sphere. Until a {@code locate(point)} primitive exists
+     * (a later RDR-010 phase), this returns the full key band at the radius-derived level
+     * {@code [(level,0,0), (level,maxLow,maxHigh)]} &mdash; correctly ordered and inclusive of every
+     * key at that level, so callers may scan it and filter by actual distance. Mirrors the static
+     * {@code estimateSFCRange} entry point on {@code MortonKey}/{@code TetreeKey}.
+     *
+     * @param center query centre (non-negative coordinates)
+     * @param radius search radius (positive)
+     * @return a conservative, correctly ordered range
+     */
+    public static SFCRange estimateSFCRange(Point3f center, float radius) {
+        Objects.requireNonNull(center, "center");
+        if (radius <= 0) {
+            throw new IllegalArgumentException("Search radius must be positive, got: " + radius);
+        }
+        if (center.x < 0 || center.y < 0 || center.z < 0) {
+            throw new IllegalArgumentException("Negative center coordinates not supported: " + center);
+        }
+        byte level = estimateSFCDepth(radius);
+        var lower = new PyramidKey(level, 0L, 0L);
+        int usedBits = level * BITS_PER_LEVEL;
+        long maxLow;
+        long maxHigh;
+        if (usedBits <= 64) {
+            maxLow = (usedBits == 64) ? -1L : (1L << usedBits) - 1;
+            maxHigh = 0L;
+        } else {
+            maxLow = -1L;
+            int usedHigh = usedBits - 64;
+            maxHigh = (usedHigh >= 64) ? -1L : (1L << usedHigh) - 1;
+        }
+        var upper = new PyramidKey(level, maxLow, maxHigh);
+        return new SFCRange(lower, upper);
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeySerde.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeySerde.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.pyramid;
+
+import com.hellblazer.luciferase.lucien.SpatialKeySerde;
+
+import java.nio.ByteBuffer;
+
+/**
+ * {@link SpatialKeySerde} for {@link PyramidKey} (RDR-010). Registers under type-id {@code "pyramid"}
+ * and serialises the key as a fixed 17-byte payload: {@code level} (1 byte) followed by
+ * {@code lowBits} and {@code highBits} (8 bytes each, big-endian). Register the singleton with
+ * {@code SpatialKeySerdeRegistry.register(PyramidKeySerde.INSTANCE)} (or via the ServiceLoader SPI
+ * in the transport module) before pyramid ghost exchange.
+ *
+ * @author hal.hildebrand
+ */
+public final class PyramidKeySerde implements SpatialKeySerde<PyramidKey> {
+
+    public static final PyramidKeySerde INSTANCE = new PyramidKeySerde();
+
+    private static final int PAYLOAD_BYTES = Byte.BYTES + 2 * Long.BYTES;
+
+    private PyramidKeySerde() {
+    }
+
+    @Override
+    public String typeId() {
+        return "pyramid";
+    }
+
+    @Override
+    public Class<PyramidKey> keyClass() {
+        return PyramidKey.class;
+    }
+
+    @Override
+    public byte[] serialize(PyramidKey key) {
+        return ByteBuffer.allocate(PAYLOAD_BYTES)
+                         .put(key.getLevel())
+                         .putLong(key.getLowBits())
+                         .putLong(key.getHighBits())
+                         .array();
+    }
+
+    @Override
+    public PyramidKey deserialize(byte[] payload) {
+        if (payload == null || payload.length != PAYLOAD_BYTES) {
+            throw new IllegalArgumentException(
+            "PyramidKey payload must be " + PAYLOAD_BYTES + " bytes, got: "
+            + (payload == null ? "null" : payload.length));
+        }
+        var buf = ByteBuffer.wrap(payload);
+        byte level = buf.get();
+        long low = buf.getLong();
+        long high = buf.getLong();
+        return new PyramidKey(level, low, high);
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeyTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeyTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.pyramid;
+
+import com.hellblazer.luciferase.lucien.SpatialKeySerdeRegistry;
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3f;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validates the {@link PyramidKey} 6D-Morton encoding (Knapp Eq 3.4), the parent walk, the level-first
+ * SFC ordering, and {@link PyramidKeySerde} round-tripping (RDR-010 pi1.1).
+ *
+ * @author hal.hildebrand
+ */
+class PyramidKeyTest {
+
+    @Test
+    void perStepCoordAndTypeBitsRoundTrip() {
+        var rng = new Random(42);
+        for (int trial = 0; trial < 1000; trial++) {
+            byte level = (byte) (1 + rng.nextInt(PyramidKey.MAX_PYRAMID_LEVEL));
+            int[] coord = new int[level + 1];
+            int[] type = new int[level + 1];
+            for (int l = 1; l <= level; l++) {
+                coord[l] = rng.nextInt(8);
+                type[l] = rng.nextInt(8);
+            }
+            var key = PyramidKey.fromLevels(level, coord, type);
+            assertEquals(level, key.getLevel());
+            for (int l = 1; l <= level; l++) {
+                assertEquals(coord[l], key.getCoordBitsAtLevel(l), "coord bits at step " + l);
+                assertEquals(type[l], key.getTypeAtLevel(l), "type bits at step " + l);
+            }
+            assertTrue(key.isValid(), "freshly built key must be valid");
+        }
+    }
+
+    @Test
+    void parentDropsDeepestStepAndWalksToRoot() {
+        var rng = new Random(7);
+        byte level = (byte) PyramidKey.MAX_PYRAMID_LEVEL;
+        int[] coord = new int[level + 1];
+        int[] type = new int[level + 1];
+        for (int l = 1; l <= level; l++) {
+            coord[l] = rng.nextInt(8);
+            type[l] = rng.nextInt(8);
+        }
+        var key = PyramidKey.fromLevels(level, coord, type);
+
+        PyramidKey cur = key;
+        for (int expectedLevel = level; expectedLevel >= 1; expectedLevel--) {
+            assertEquals(expectedLevel, cur.getLevel());
+            var parent = cur.parent();
+            assertNotNull(parent);
+            assertEquals(expectedLevel - 1, parent.getLevel());
+            // Parent preserves all shallower steps unchanged.
+            for (int l = 1; l < expectedLevel; l++) {
+                assertEquals(key.getCoordBitsAtLevel(l), parent.getCoordBitsAtLevel(l));
+                assertEquals(key.getTypeAtLevel(l), parent.getTypeAtLevel(l));
+            }
+            cur = parent;
+        }
+        assertEquals(0, cur.getLevel());
+        assertNull(cur.parent(), "root has no parent");
+        assertEquals(PyramidKey.getRoot(), cur);
+    }
+
+    @Test
+    void orderingIsLevelFirst() {
+        var deepLow = PyramidKey.fromLevels((byte) 2, new int[] { 0, 0, 0 }, new int[] { 0, 0, 0 });
+        var shallowHigh = PyramidKey.fromLevels((byte) 1, new int[] { 0, 7 }, new int[] { 0, 7 });
+        assertTrue(shallowHigh.compareTo(deepLow) < 0, "lower level sorts first regardless of bits");
+        assertTrue(deepLow.compareTo(shallowHigh) > 0);
+        assertEquals(0, deepLow.compareTo(deepLow));
+    }
+
+    @Test
+    void orderingIsCoarseDominantAcrossLongBoundary() {
+        // Canonical m_P order (Knapp Eq 3.4): the shallowest (coarsest) step dominates. At level 15
+        // step 1 lives in the high long (bit (15-1)*6 = 84) and the deepest step lives in the low long.
+        // A difference at the shallow step must outweigh any difference at deeper steps.
+        byte level = 15;
+        int[] cA = new int[level + 1];
+        int[] cB = new int[level + 1];
+        int[] type = new int[level + 1];
+        // A: shallow step small, deepest step maximal.   B: shallow step large, deepest step zero.
+        cA[1] = 0;
+        cA[level] = 7;
+        type[level] = 7; // any
+        cB[1] = 1;
+        cB[level] = 0;
+        var a = PyramidKey.fromLevels(level, cA, type);
+        var b = PyramidKey.fromLevels(level, cB, type);
+        assertTrue(a.compareTo(b) < 0, "shallow step must dominate ordering over deeper steps");
+        assertTrue(b.compareTo(a) > 0);
+
+        // Differing only at the deepest step orders by that step (the tiebreaker).
+        int[] cC = new int[level + 1];
+        int[] cD = new int[level + 1];
+        cC[level] = 0;
+        cD[level] = 1;
+        assertTrue(PyramidKey.fromLevels(level, cC, type).compareTo(PyramidKey.fromLevels(level, cD, type)) < 0);
+    }
+
+    @Test
+    void isValidRejectsBitsAboveOccupiedGroups() {
+        // Level 5: usedBits = 30; low bits >= 30 must be zero, high must be zero.
+        assertTrue(new PyramidKey((byte) 5, (1L << 30) - 1, 0L).isValid());
+        assertTrue(!new PyramidKey((byte) 5, 1L << 30, 0L).isValid(), "low bits above level-5 groups invalid");
+        assertTrue(!new PyramidKey((byte) 5, 0L, 1L).isValid(), "high bits must be zero for shallow levels");
+        // Level 11: usedBits = 66; low fully used, high bits >= 2 must be zero.
+        assertTrue(new PyramidKey((byte) 11, -1L, 0x3L).isValid());
+        assertTrue(!new PyramidKey((byte) 11, -1L, 0x4L).isValid(), "high bits above level-11 groups invalid");
+        // Level 21 (max): usedBits = 126; high bits >= 62 must be zero.
+        assertTrue(new PyramidKey((byte) 21, -1L, (1L << 62) - 1).isValid());
+        assertTrue(!new PyramidKey((byte) 21, -1L, 1L << 62).isValid(), "high bits above level-21 groups invalid");
+    }
+
+    @Test
+    void rootIsZeroAndValid() {
+        var root = PyramidKey.getRoot();
+        assertEquals(0, root.getLevel());
+        assertEquals(0L, root.getLowBits());
+        assertEquals(0L, root.getHighBits());
+        assertTrue(root.isValid());
+        assertNull(root.parent());
+        assertSame(PyramidKey.class, root.root().getClass());
+    }
+
+    @Test
+    void rejectsOutOfRangeLevel() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> new PyramidKey((byte) (PyramidKey.MAX_PYRAMID_LEVEL + 1), 0L, 0L));
+        assertThrows(IllegalArgumentException.class, () -> new PyramidKey((byte) -1, 0L, 0L));
+    }
+
+    @Test
+    void serdeRoundTrips() {
+        var rng = new Random(99);
+        for (int trial = 0; trial < 500; trial++) {
+            byte level = (byte) rng.nextInt(PyramidKey.MAX_PYRAMID_LEVEL + 1);
+            int[] coord = new int[level + 1];
+            int[] type = new int[level + 1];
+            for (int l = 1; l <= level; l++) {
+                coord[l] = rng.nextInt(8);
+                type[l] = rng.nextInt(8);
+            }
+            var key = PyramidKey.fromLevels(level, coord, type);
+            var bytes = PyramidKeySerde.INSTANCE.serialize(key);
+            assertEquals(17, bytes.length);
+            var back = PyramidKeySerde.INSTANCE.deserialize(bytes);
+            assertEquals(key, back);
+            assertEquals(0, key.compareTo(back));
+        }
+    }
+
+    @Test
+    void serdeRegistersWithRegistry() {
+        SpatialKeySerdeRegistry.register(PyramidKeySerde.INSTANCE);
+        assertSame(PyramidKeySerde.INSTANCE, SpatialKeySerdeRegistry.forKey(PyramidKey.getRoot()));
+        assertEquals("pyramid", PyramidKeySerde.INSTANCE.typeId());
+    }
+
+    @Test
+    void serdeRejectsMalformedPayload() {
+        assertThrows(IllegalArgumentException.class, () -> PyramidKeySerde.INSTANCE.deserialize(new byte[5]));
+        assertThrows(IllegalArgumentException.class, () -> PyramidKeySerde.INSTANCE.deserialize(null));
+    }
+
+    @Test
+    void estimateSFCRangeIsOrderedAndLevelConsistent() {
+        var center = new Point3f(1000, 2000, 3000);
+        for (float radius : new float[] { 1f, 16f, 256f, 4096f, 65536f }) {
+            var range = PyramidKey.estimateSFCRange(center, radius);
+            assertTrue(range.lower().compareTo(range.upper()) <= 0, "range must be ordered for radius " + radius);
+            assertEquals(range.lower().getLevel(), range.upper().getLevel(), "bounds share a level");
+        }
+        assertThrows(IllegalArgumentException.class, () -> PyramidKey.estimateSFCRange(center, 0f));
+        assertThrows(IllegalArgumentException.class,
+                     () -> PyramidKey.estimateSFCRange(new Point3f(-1, 0, 0), 5f));
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidS0S7SubdivisionTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidS0S7SubdivisionTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.pyramid;
+
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3i;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validates that a cube is exactly tiled by two pyramids (types 6 and 7) plus two tetrahedra, with
+ * no gaps and no overlaps (RDR-010, Knapp 2026 Fig 3.1c). This is the foundational correctness proof
+ * for {@link Pyramid#coordinates()} and the pyramid/tet hybrid partition.
+ *
+ * <p>Geometry derived from t8code {@code t8_dpyramid_compute_coords}: at height {@code z} the type-6
+ * pyramid occupies {@code [z,L]x[z,L]} and the type-7 pyramid occupies {@code [0,z]x[0,z]}, leaving
+ * two tetrahedral gaps {@code conv{V0,V1,V5,V7}} and {@code conv{V0,V2,V6,V7}}. Volume identity:
+ * {@code 2*(L^3/3) + 2*(L^3/6) = L^3}.
+ *
+ * <p>A high level (small edge length L=8) keeps the {@code orient3d} determinants well inside double
+ * precision. Monte Carlo sampling is seeded for determinism.
+ *
+ * @author hal.hildebrand
+ */
+class PyramidS0S7SubdivisionTest {
+
+    private static final double EPS = 1e-9;
+
+    // Cube under test: anchor (0,0,0), level 18 => edge length L = 2^(21-18) = 8.
+    private static final byte LEVEL = 18;
+    private static final int  L     = 8;
+
+    @Test
+    void type6VertexCoordinatesMatchT8code() {
+        var p = new Pyramid(0, 0, 0, LEVEL, Pyramid.TYPE_6);
+        var expected = new Point3i[] { new Point3i(0, 0, 0), new Point3i(L, 0, 0), new Point3i(0, L, 0),
+                                       new Point3i(L, L, 0), new Point3i(L, L, L) };
+        assertArrayEquals(expected, p.coordinates(),
+                          "Type-6 base on bottom face, apex at far (+x,+y,+z) corner");
+    }
+
+    @Test
+    void type7VertexCoordinatesMatchT8code() {
+        var p = new Pyramid(0, 0, 0, LEVEL, Pyramid.TYPE_7);
+        var expected = new Point3i[] { new Point3i(0, 0, L), new Point3i(L, 0, L), new Point3i(0, L, L),
+                                       new Point3i(L, L, L), new Point3i(0, 0, 0) };
+        assertArrayEquals(expected, p.coordinates(),
+                          "Type-7 base on top face, apex at anchor corner (180-deg rotation of type 6)");
+    }
+
+    @Test
+    void typesAreDistinctAndAnchorShared() {
+        var p6 = new Pyramid(0, 0, 0, LEVEL, Pyramid.TYPE_6);
+        var p7 = new Pyramid(0, 0, 0, LEVEL, Pyramid.TYPE_7);
+        // Both share the anchor corner as a vertex (apex of 7 == base corner of 6, and vice-versa).
+        assertEquals(new Point3i(0, 0, 0), p6.coordinates()[0]);
+        assertEquals(new Point3i(0, 0, 0), p7.coordinates()[4]);
+    }
+
+    @Test
+    void cubeIsTiledWithNoGapsNoOverlaps() {
+        double[][] p6 = toDoubles(new Pyramid(0, 0, 0, LEVEL, Pyramid.TYPE_6).coordinates());
+        double[][] p7 = toDoubles(new Pyramid(0, 0, 0, LEVEL, Pyramid.TYPE_7).coordinates());
+        // Two tetrahedral gaps. These corner sets are derived purely from the geometry: at height z
+        // the pyramids occupy [z,L]^2 (type 6) and [0,z]^2 (type 7), leaving conv{V0,V1,V5,V7} and
+        // conv{V0,V2,V6,V7}. They happen to coincide with Luciferase tet types S4 and S5. NOTE: these
+        // are NOT the tet *child* types of a refined pyramid -- Knapp Table 3.2 / t8code
+        // parenttype_Iloc_to_type row 6 gives child tet types 0 and 3. That is a different partition
+        // (pyramid refinement, not the root cube tiling); this test validates coordinates() and the
+        // cube tiling only. Child-type correctness is exercised in a later phase (pi1.2/pi1.3).
+        double[][] gapA = { v(0, 0, 0), v(L, 0, 0), v(L, 0, L), v(L, L, L) }; // conv{V0,V1,V5,V7}
+        double[][] gapB = { v(0, 0, 0), v(0, L, 0), v(0, L, L), v(L, L, L) }; // conv{V0,V2,V6,V7}
+
+        // Volume conservation: 2 pyramids + 2 tets == cube.
+        double cubeVol = (double) L * L * L;
+        double sum = pyramidVolume(p6) + pyramidVolume(p7) + tetVolume(gapA) + tetVolume(gapB);
+        assertEquals(cubeVol, sum, EPS * cubeVol, "Element volumes must sum to the cube volume");
+        assertEquals(cubeVol / 3.0, pyramidVolume(p6), EPS * cubeVol, "Each pyramid is L^3/3");
+        assertEquals(cubeVol / 6.0, tetVolume(gapA), EPS * cubeVol, "Each gap tet is L^3/6");
+
+        // Monte Carlo coverage (no gaps) and disjointness (no overlaps).
+        var rng = new Random(0xC0FFEEL);
+        int samples = 200_000;
+        for (int i = 0; i < samples; i++) {
+            double[] q = { rng.nextDouble() * L, rng.nextDouble() * L, rng.nextDouble() * L };
+            int strictly = 0;
+            if (strictInsidePyramid(p6, q)) {
+                strictly++;
+            }
+            if (strictInsidePyramid(p7, q)) {
+                strictly++;
+            }
+            if (strictInsideTet(gapA, q)) {
+                strictly++;
+            }
+            if (strictInsideTet(gapB, q)) {
+                strictly++;
+            }
+            final int overlap = strictly;
+            final double[] pt = q;
+            assertTrue(overlap <= 1, () -> "Overlap: point " + java.util.Arrays.toString(pt) + " in " + overlap
+            + " elements");
+
+            boolean covered = insideOrOnPyramid(p6, q) || insideOrOnPyramid(p7, q) || insideOrOnTet(gapA, q)
+            || insideOrOnTet(gapB, q);
+            assertTrue(covered, () -> "Gap: point " + java.util.Arrays.toString(pt) + " covered by no element");
+        }
+    }
+
+    // ===== geometry helpers =====
+
+    private static double[] v(double x, double y, double z) {
+        return new double[] { x, y, z };
+    }
+
+    private static double[][] toDoubles(Point3i[] pts) {
+        var out = new double[pts.length][];
+        for (int i = 0; i < pts.length; i++) {
+            out[i] = v(pts[i].x, pts[i].y, pts[i].z);
+        }
+        return out;
+    }
+
+    /** Six times the signed volume of tetrahedron (a,b,c,d). */
+    private static double orient3d(double[] a, double[] b, double[] c, double[] d) {
+        double[] ad = { a[0] - d[0], a[1] - d[1], a[2] - d[2] };
+        double[] bd = { b[0] - d[0], b[1] - d[1], b[2] - d[2] };
+        double[] cd = { c[0] - d[0], c[1] - d[1], c[2] - d[2] };
+        double cx = bd[1] * cd[2] - bd[2] * cd[1];
+        double cy = bd[2] * cd[0] - bd[0] * cd[2];
+        double cz = bd[0] * cd[1] - bd[1] * cd[0];
+        return ad[0] * cx + ad[1] * cy + ad[2] * cz;
+    }
+
+    private static double tetVolume(double[][] t) {
+        return Math.abs(orient3d(t[0], t[1], t[2], t[3])) / 6.0;
+    }
+
+    private static double pyramidVolume(double[][] p) {
+        // p = [c0,c1,c2,c3,apex]; base square loop is c0,c1,c3,c2.
+        double[][] a = { p[0], p[1], p[3], p[4] };
+        double[][] b = { p[0], p[3], p[2], p[4] };
+        return tetVolume(a) + tetVolume(b);
+    }
+
+    /** Barycentric coordinates of q w.r.t. tet t (relative to the tet's signed volume). */
+    private static double[] bary(double[][] t, double[] q) {
+        double vol = orient3d(t[0], t[1], t[2], t[3]);
+        double b0 = orient3d(q, t[1], t[2], t[3]) / vol;
+        double b1 = orient3d(t[0], q, t[2], t[3]) / vol;
+        double b2 = orient3d(t[0], t[1], q, t[3]) / vol;
+        double b3 = orient3d(t[0], t[1], t[2], q) / vol;
+        return new double[] { b0, b1, b2, b3 };
+    }
+
+    private static boolean insideOrOnTet(double[][] t, double[] q) {
+        for (double b : bary(t, q)) {
+            if (b < -EPS) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean strictInsideTet(double[][] t, double[] q) {
+        for (double b : bary(t, q)) {
+            if (b <= EPS) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean insideOrOnPyramid(double[][] p, double[] q) {
+        double[][] a = { p[0], p[1], p[3], p[4] };
+        double[][] b = { p[0], p[3], p[2], p[4] };
+        return insideOrOnTet(a, q) || insideOrOnTet(b, q);
+    }
+
+    private static boolean strictInsidePyramid(double[][] p, double[] q) {
+        // Strictly inside the pyramid: strictly inside either half-tet, OR on their shared internal
+        // diagonal face but inside the pyramid body. Approximate by "inside-or-on either half AND not
+        // on the pyramid's outer boundary"; for disjointness testing it suffices to treat a point as
+        // strictly inside if it is strictly inside either half-tet.
+        double[][] a = { p[0], p[1], p[3], p[4] };
+        double[][] b = { p[0], p[3], p[2], p[4] };
+        return strictInsideTet(a, q) || strictInsideTet(b, q);
+    }
+}


### PR DESCRIPTION
## Summary
First phase of the RDR-010 Pyramid Spatial Index epic (`Luciferase-pi1.1`). Adds the element-level foundation for a hybrid pyramid/tetrahedron spatial index per Knapp 2026 ("A Morton-Type SFC for Pyramid Subdivision and Hybrid AMR"), closing the documented t8code tetrahedral cube-partition gap.

- **`Pyramid`** — type-6/7 element primitive. Vertex `coordinates()` verified against t8code `t8_dpyramid_compute_coords` (the executable ground truth for Knapp §3); carries the mandatory `min_tet_level` field (Algorithm 4.1).
- **`PyramidKey`** — 128-bit 6D-Morton key (Eq 3.4). Uniform 126-bit layout with coarse-dominant canonical SFC ordering, full 21-level support (no split-bit encoding needed), parent walk, and a conservative `estimateSFCRange`. Sibling of `TetreeKey` (implements `SpatialKey` directly); inherits the empty `sfcRangesForKNN` default until a `locate` primitive lands in a later phase.
- **`PyramidKeySerde`** — 17-byte registry-compatible serde.

Purely additive (new `pyramid` package); no existing code path modified.

## Test plan
- [x] `PyramidS0S7SubdivisionTest` — 200k-point Monte Carlo proof that `pyramid6 + pyramid7 + 2 tets` tiles the cube with no gaps/overlaps; volume identity; t8code-exact vertex spot checks.
- [x] `PyramidKeyTest` — 6D-Morton encode/decode round-trip, parent chain to root, coarse-dominant ordering across the long boundary, level-boundary validity, serde round-trip + registry registration.
- [x] Full lucien suite green (2461 tests, 0 failures); `-Pperformance` parity structural (no existing hot path touched).
- [x] Dual review (code-review-expert + substantive-critic) — findings resolved (canonical SFC ordering, full 21-level support, `isValid` boundary checks).
- [x] `/conexus:phase-review-gate RDR-010 --phase 1` PASSED.