### PR TITLE
RDR-010 P2 (narrowed): Tet.minTetLevel field + pyramid connectivity tables

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/Tet.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/Tet.java
@@ -76,13 +76,39 @@ public class Tet implements Spatial.aabt {
                                                         { 0, 3, 5, 7, 1, 2, 4, 6 }, // Parent type 4
                                                         { 0, 3, 6, 7, 2, 1, 4, 5 }  // Parent type 5
     };
+    /**
+     * Sentinel for {@link #minTetLevel}: this tetrahedron has no pyramidal ancestor (pure-Tetree, or
+     * a tet whose whole ancestor chain is tetrahedral). RDR-010 pi1.2 / Knapp 2026 Algorithm 4.1.
+     */
+    public static final  byte         NO_TET_ANCESTOR = -1;
     public final         int          x;
     public final         int          y;
     public final         int          z;
     public final         byte         l;
     public final         byte         type;
+    /**
+     * Smallest level at which an ancestor is a tetrahedron; {@link #NO_TET_ANCESTOR} (-1) for
+     * pure-Tetree elements. Contextual tree metadata for the hybrid pyramid/tet SFC (RDR-010);
+     * excluded from geometric identity ({@link #equals}/{@link #hashCode}).
+     */
+    public final         byte         minTetLevel;
 
     public Tet(int x, int y, int z, byte l, byte type) {
+        this(x, y, z, l, type, NO_TET_ANCESTOR);
+    }
+
+    /**
+     * Create a Tet carrying an explicit {@code minTetLevel} (RDR-010 pi1.2, Knapp 2026
+     * Algorithm 4.1). {@code minTetLevel} is the smallest level at which an ancestor is a
+     * tetrahedron; it is {@link #NO_TET_ANCESTOR} (-1) for tetrahedra in a pure-Tetree tree and for
+     * any tet whose entire ancestor chain is tetrahedral. It is non-negative only for tetrahedra
+     * descending from a pyramidal root, where it marks the tet/pyramid boundary level. This is
+     * contextual tree metadata: it is intentionally excluded from {@link #equals}/{@link #hashCode},
+     * which identify a tetrahedron by its geometry {@code (x,y,z,l,type)} alone.
+     *
+     * @param minTetLevel {@link #NO_TET_ANCESTOR} (-1), or a level in {@code [0, l]}
+     */
+    public Tet(int x, int y, int z, byte l, byte type, byte minTetLevel) {
         // Validate level range first
         assert l >= 0 && l <= MortonCurve.MAX_REFINEMENT_LEVEL : "Level " + l + " must be between 0 and "
         + MortonCurve.MAX_REFINEMENT_LEVEL;
@@ -92,11 +118,14 @@ public class Tet implements Spatial.aabt {
         assert x >= 0 && y >= 0 && z >= 0 : "Coordinates must be non-negative: (" + x + ", " + y + ", " + z + ")";
         // Validate that coordinates are correct anchor coordinates for the level and type
         assert validateAnchorCoordinates(x, y, z, l, type);
+        assert minTetLevel == NO_TET_ANCESTOR || (minTetLevel >= 0 && minTetLevel <= l)
+        : "minTetLevel must be -1 (NO_TET_ANCESTOR) or in [0, " + l + "], got: " + minTetLevel;
         this.x = x;
         this.y = y;
         this.z = z;
         this.l = l;
         this.type = type;
+        this.minTetLevel = minTetLevel;
     }
 
     /**
@@ -925,7 +954,25 @@ public class Tet implements Spatial.aabt {
 
         // Use the efficient BeySubdivision method which produces identical results
         // This is ~3x faster than the previous implementation when computing single children
-        return BeySubdivision.getMortonChild(this, childIndex);
+        var child = BeySubdivision.getMortonChild(this, childIndex);
+        // RDR-010 (Knapp Algorithm 4.2b): a tetrahedral child of a tetrahedron inherits its
+        // minTetLevel. Pure-Tetree (NO_TET_ANCESTOR) returns the child unchanged.
+        return minTetLevel == NO_TET_ANCESTOR ? child : child.withMinTetLevel(minTetLevel);
+    }
+
+    /**
+     * The smallest level at which an ancestor is a tetrahedron, or {@link #NO_TET_ANCESTOR} (-1) for
+     * pure-Tetree elements (RDR-010, Knapp Algorithm 4.1).
+     */
+    public byte minTetLevel() {
+        return minTetLevel;
+    }
+
+    /**
+     * This tetrahedron with a different {@code minTetLevel} (same geometry). RDR-010 metadata carrier.
+     */
+    public Tet withMinTetLevel(byte newMinTetLevel) {
+        return newMinTetLevel == minTetLevel ? this : new Tet(x, y, z, l, type, newMinTetLevel);
     }
 
     /**
@@ -956,6 +1003,17 @@ public class Tet implements Spatial.aabt {
      */
     public byte computeType(byte level) {
         assert (0 <= level && level <= l);
+
+        // RDR-010: for a tetrahedron descending from a pyramidal root the "trace from root type 0"
+        // assumption below is wrong above the tet/pyramid boundary (ancestor types are pyramid 6/7,
+        // determined via Knapp 2026 §4.1). Computing those requires the pyramid ancestor-type
+        // machinery deferred to the element-type unification (Luciferase-q3p). Fail loud rather than
+        // return a wrong Bey-path type. Pure-Tetree (NO_TET_ANCESTOR) is unaffected.
+        if (minTetLevel != NO_TET_ANCESTOR) {
+            throw new IllegalStateException(
+            "computeType on a pyramid-rooted tetrahedron (minTetLevel != -1) requires pyramid "
+            + "ancestor-type resolution; deferred to Luciferase-q3p");
+        }
 
         if (level == l) {
             return type;
@@ -1534,7 +1592,16 @@ public class Tet implements Spatial.aabt {
 
         // Use BeySubdivision which internally uses subdivisionCoordinates()
         // This provides subdivision-compatible vertices without changing the global coordinate system
-        return BeySubdivision.subdivide(this);
+        var children = BeySubdivision.subdivide(this);
+        // RDR-010 (Knapp Algorithm 4.2b): tetrahedral children inherit the parent's minTetLevel.
+        // BeySubdivision uses the 5-arg constructor (NO_TET_ANCESTOR), so re-apply for hybrid tets.
+        // Pure-Tetree (NO_TET_ANCESTOR) returns BeySubdivision's children unchanged.
+        if (minTetLevel != NO_TET_ANCESTOR) {
+            for (int i = 0; i < children.length; i++) {
+                children[i] = children[i].withMinTetLevel(minTetLevel);
+            }
+        }
+        return children;
     }
 
     @Override
@@ -1691,6 +1758,27 @@ public class Tet implements Spatial.aabt {
     public Tet parent() {
         if (l == 0) {
             throw new IllegalStateException("Root tetrahedron has no parent");
+        }
+
+        // RDR-010 (Knapp Algorithm 4.1): a tetrahedron descending from a pyramidal root.
+        if (minTetLevel != NO_TET_ANCESTOR) {
+            if (minTetLevel == l) {
+                // This is the shallowest tetrahedron; its parent is the pyramid that birthed it.
+                // Cross-type return (Tet -> Pyramid) is deferred to the element-type unification
+                // (Luciferase-q3p); pure-Tetree pi1.2 cannot construct or traverse such an element.
+                throw new IllegalStateException(
+                "Tet at the tet/pyramid boundary (minTetLevel == level): its parent is a pyramid; "
+                + "cross-type parent return is deferred to Luciferase-q3p");
+            }
+            // Parent is a tetrahedron; compute it directly (the TetreeLevelCache is keyed without
+            // minTetLevel, so it is bypassed here) and propagate minTetLevel unchanged.
+            int h = length(); // this tet's cell size; clearing its bit yields the parent anchor
+            int parentX = x & ~h;
+            int parentY = y & ~h;
+            int parentZ = z & ~h;
+            byte parentLevel = (byte) (l - 1);
+            byte parentType = computeParentType(parentX, parentY, parentZ, parentLevel);
+            return new Tet(parentX, parentY, parentZ, parentLevel, parentType, minTetLevel);
         }
 
         // Check if we have cached the parent of this Tet

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeConnectivity.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeConnectivity.java
@@ -73,6 +73,35 @@ public final class TetreeConnectivity {
     { 5, 5, 5, 5, 2, 3, 0, 1 } };
 
     /**
+     * Pyramid (types 6 and 7) child types by local index 0..9 (RDR-010, Knapp 2026 Table 3.2). Each
+     * pyramid refines into 10 children: 6 pyramids (types 6/7) and 4 tetrahedra (types 0/3). Held
+     * separately from {@link #PARENT_TYPE_TO_CHILD_TYPE} because pyramids have 10 children (not the
+     * Bey 8) and a parent type outside the tet 0-5 range. Row index = {@code parentType - 6}; values
+     * verified against t8code {@code t8_dpyramid_parenttype_Iloc_to_type} rows 6,7 (origin/main).
+     */
+    public static final byte[][] PYRAMID_PARENT_TO_CHILD_TYPE = {
+    // Parent type 6
+    { 6, 3, 6, 0, 6, 0, 3, 6, 7, 6 },
+    // Parent type 7
+    { 7, 0, 3, 6, 7, 3, 7, 0, 7, 7 } };
+
+    /**
+     * Pyramid (types 6 and 7) child cube-ids by local index 0..9 (RDR-010, Knapp Table 3.1). The
+     * cube-id selects the child anchor shift within the parent's surrounding cube (bit 0 -&gt; +x,
+     * bit 1 -&gt; +y, bit 2 -&gt; +z, each by half the parent edge length). Row index =
+     * {@code parentType - 6}; verified against t8code {@code t8_dpyramid_parenttype_Iloc_to_cid}
+     * rows 6,7 (origin/main).
+     */
+    public static final byte[][] PYRAMID_PARENT_TO_CHILD_CID = {
+    // Parent type 6
+    { 0, 1, 1, 2, 2, 3, 3, 3, 3, 7 },
+    // Parent type 7
+    { 0, 4, 4, 4, 4, 5, 5, 6, 6, 7 } };
+
+    /** Number of children of a pyramid (6 pyramids + 4 tetrahedra; Knapp 2026 §3). */
+    public static final int CHILDREN_PER_PYRAMID = 10;
+
+    /**
      * Face corner indices for each tetrahedron type. Given a tetrahedron type (0-5) and face index (0-3), returns the
      * vertex indices that form that face.
      *

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/PyramidConnectivityTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/PyramidConnectivityTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.tetree;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RDR-010 pi1.2: validates the pyramid child-type / child-cube-id connectivity tables against the
+ * t8code ground truth ({@code t8_dpyramid_parenttype_Iloc_to_type} / {@code _to_cid} rows 6,7) and
+ * the Knapp 2026 §3 structural invariant (10 children = 6 pyramids + 4 tetrahedra).
+ *
+ * @author hal.hildebrand
+ */
+class PyramidConnectivityTest {
+
+    @Test
+    void childTypeTableMatchesT8code() {
+        assertArrayEquals(new byte[] { 6, 3, 6, 0, 6, 0, 3, 6, 7, 6 },
+                          TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_TYPE[0], "parent type 6 child types");
+        assertArrayEquals(new byte[] { 7, 0, 3, 6, 7, 3, 7, 0, 7, 7 },
+                          TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_TYPE[1], "parent type 7 child types");
+    }
+
+    @Test
+    void childCubeIdTableMatchesT8code() {
+        assertArrayEquals(new byte[] { 0, 1, 1, 2, 2, 3, 3, 3, 3, 7 },
+                          TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_CID[0], "parent type 6 child cube-ids");
+        assertArrayEquals(new byte[] { 0, 4, 4, 4, 4, 5, 5, 6, 6, 7 },
+                          TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_CID[1], "parent type 7 child cube-ids");
+    }
+
+    @Test
+    void eachPyramidHasTenChildrenSixPyramidsFourTets() {
+        assertEquals(TetreeConnectivity.CHILDREN_PER_PYRAMID, 10);
+        for (byte[] row : TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_TYPE) {
+            assertEquals(10, row.length);
+            int pyramids = 0;
+            int tets = 0;
+            for (byte t : row) {
+                if (t == 6 || t == 7) {
+                    pyramids++;
+                } else {
+                    assertTrue(t == 0 || t == 3, "pyramid tet children are types 0 or 3 only, got: " + t);
+                    tets++;
+                }
+            }
+            assertEquals(6, pyramids, "6 pyramidal children");
+            assertEquals(4, tets, "4 tetrahedral children");
+        }
+    }
+
+    @Test
+    void cubeIdsAreInRange() {
+        for (byte[] row : TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_CID) {
+            assertEquals(10, row.length);
+            for (byte cid : row) {
+                assertTrue(cid >= 0 && cid <= 7, "cube-id in [0,7], got: " + cid);
+            }
+        }
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetMinTetLevelTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetMinTetLevelTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.tetree;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RDR-010 pi1.2: validates the {@code minTetLevel} field on {@link Tet} (Knapp 2026 Algorithm 4.1)
+ * and its propagation through {@link Tet#child(int)} / {@link Tet#parent()}, while confirming
+ * pure-Tetree behaviour is byte-for-byte unchanged (sentinel {@link Tet#NO_TET_ANCESTOR}).
+ *
+ * @author hal.hildebrand
+ */
+class TetMinTetLevelTest {
+
+    private static Tet validTetAtLevel3() {
+        return new Tet(0, 0, 0, (byte) 0, (byte) 0).child(0).child(0).child(0);
+    }
+
+    @Test
+    void defaultConstructorUsesSentinel() {
+        var t = new Tet(0, 0, 0, (byte) 0, (byte) 0);
+        assertEquals(Tet.NO_TET_ANCESTOR, t.minTetLevel());
+        assertEquals(-1, Tet.NO_TET_ANCESTOR);
+    }
+
+    @Test
+    void explicitConstructorAndWithMinTetLevelCarryTheValue() {
+        var t = validTetAtLevel3();
+        assertEquals(3, t.l);
+        var withMtl = t.withMinTetLevel((byte) 2);
+        assertEquals(2, withMtl.minTetLevel());
+        // Same geometry => equal (minTetLevel is excluded from identity).
+        assertEquals(t, withMtl);
+        assertEquals(t.hashCode(), withMtl.hashCode());
+        // withMinTetLevel of the same value is identity.
+        assertSame(t, t.withMinTetLevel(Tet.NO_TET_ANCESTOR));
+    }
+
+    @Test
+    void minTetLevelExcludedFromGeometricIdentity() {
+        var t = validTetAtLevel3();
+        var a = t.withMinTetLevel((byte) 1);
+        var b = t.withMinTetLevel((byte) 2);
+        assertEquals(a, b, "same geometry, differing minTetLevel => still equal");
+        assertNotEquals(a.minTetLevel(), b.minTetLevel());
+    }
+
+    @Test
+    void childPropagatesMinTetLevel() {
+        var t = validTetAtLevel3().withMinTetLevel((byte) 2);
+        var child = t.child(0);
+        assertEquals(2, child.minTetLevel(), "Knapp Alg 4.2b: tet child inherits parent's minTetLevel");
+        assertEquals(4, child.l);
+    }
+
+    @Test
+    void childOfPureTetStaysPure() {
+        var pure = validTetAtLevel3();
+        var child = pure.child(0);
+        assertEquals(Tet.NO_TET_ANCESTOR, child.minTetLevel());
+    }
+
+    @Test
+    void parentPropagatesMinTetLevelForTetOfTet() {
+        var t = validTetAtLevel3().withMinTetLevel((byte) 2); // boundary at level 2, this at level 3
+        var parent = t.parent();
+        assertEquals(2, parent.l);
+        assertEquals(2, parent.minTetLevel(), "Knapp Alg 4.1 else-branch: propagate minTetLevel to tet parent");
+    }
+
+    @Test
+    void parentAtBoundaryDefersToUnificationBead() {
+        // minTetLevel == level => the parent is the birthing pyramid; cross-type return is q3p.
+        var boundary = validTetAtLevel3().withMinTetLevel((byte) 3);
+        var ex = assertThrows(IllegalStateException.class, boundary::parent);
+        assertTrue(ex.getMessage().contains("q3p"), "boundary parent must point to the deferred unification bead");
+    }
+
+    @Test
+    void withMinTetLevelRejectsOutOfRange() {
+        boolean assertionsEnabled = false;
+        assert assertionsEnabled = true; // side-effect sets true only when -ea
+        if (!assertionsEnabled) {
+            return; // invariant is assert-guarded; nothing to verify without -ea
+        }
+        var t = validTetAtLevel3(); // level 3
+        assertThrows(AssertionError.class, () -> t.withMinTetLevel((byte) (t.l + 1)),
+                     "minTetLevel > level must violate the constructor invariant");
+    }
+
+    @Test
+    void geometricSubdividePropagatesMinTetLevel() {
+        var t = validTetAtLevel3().withMinTetLevel((byte) 2);
+        for (var child : t.geometricSubdivide()) {
+            assertEquals(2, child.minTetLevel(), "geometricSubdivide children inherit minTetLevel");
+        }
+        // Pure-tet geometric subdivision stays pure.
+        for (var child : validTetAtLevel3().geometricSubdivide()) {
+            assertEquals(Tet.NO_TET_ANCESTOR, child.minTetLevel());
+        }
+    }
+
+    @Test
+    void computeTypeFailsLoudOnPyramidRootedTet() {
+        var pyramidRooted = validTetAtLevel3().withMinTetLevel((byte) 2);
+        var ex = assertThrows(IllegalStateException.class, () -> pyramidRooted.computeType((byte) 1));
+        assertTrue(ex.getMessage().contains("q3p"), "computeType must defer pyramid-rooted case to q3p");
+        // Pure-tet computeType is unchanged.
+        var pure = validTetAtLevel3();
+        assertEquals(pure.type, pure.computeType(pure.l));
+    }
+
+    @Test
+    void siblingInheritsMinTetLevelTransitively() {
+        var t = validTetAtLevel3().withMinTetLevel((byte) 2);
+        var sib = t.sibling(1);
+        assertEquals(2, sib.minTetLevel(), "sibling propagates minTetLevel via parent()->child()");
+    }
+
+    @Test
+    void pureTetParentUnchanged() {
+        var pure = validTetAtLevel3();
+        var parent = pure.parent();
+        assertEquals(2, parent.l);
+        assertEquals(Tet.NO_TET_ANCESTOR, parent.minTetLevel());
+        // The pure path round-trips: a child's parent is the original tet.
+        assertEquals(pure.parent(), pure.child(0).parent().parent());
+    }
+}


### PR DESCRIPTION
## Summary
Phase 2 of the RDR-010 Pyramid Spatial Index epic (`Luciferase-pi1.2`), **narrowed** by design decision: this lands the element-level bookkeeping for the hybrid pyramid/tet SFC (Knapp 2026) without any cross-type return changes. The cross-type unification (`Tet.parent()`/`faceNeighbor()` returning a `Pyramid`, `computeType` 6/7 logic) is deferred to **`Luciferase-q3p`**, which depends on this and blocks pi1.3.

- **`Tet.minTetLevel`** field + `NO_TET_ANCESTOR` (−1) sentinel, 6-arg constructor, `minTetLevel()`/`withMinTetLevel()`. Contextual tree metadata (Knapp Algorithm 4.1), **excluded from `equals`/`hashCode`** (geometric identity = x,y,z,l,type).
- **Propagation**: `child()` and `geometricSubdivide()` inherit `minTetLevel` (Alg 4.2b); `parent()` propagates for tet-of-tet; the tet/pyramid boundary case (`minTetLevel == level`) throws → deferred to q3p. `computeType()` fails loud on pyramid-rooted tets rather than returning a wrong Bey type.
- **`TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_TYPE`/`_CID`** (`byte[2][10]`) + `CHILDREN_PER_PYRAMID`, verified against t8code `t8_dpyramid_connectivity.c` rows 6,7.

Branches off `main`, independent of #156 (no pyramid-package dependency).

## Test plan
- [x] `TetMinTetLevelTest` (12) — field default, constructor/`withMinTetLevel`, identity exclusion, child/parent/geometricSubdivide/sibling propagation, boundary + computeType fail-loud guards, pure-tet round-trip, out-of-range tripwire.
- [x] `PyramidConnectivityTest` (4) — table values vs t8code, 6-pyramid/4-tet structural invariant, cube-id range.
- [x] **Pure-Tetree byte-for-byte unchanged**: full lucien suite green (2462 tests, 0 failures).
- [x] `-Pperformance` parity by inspection (single predictable `minTetLevel` branch on the fast path; no new allocation — confirmed by code review).
- [x] Dual review (code-review-expert approved; substantive-critic findings fixed).
- [ ] `/conexus:phase-review-gate RDR-010 --phase 2` (running next).

## Deferred (tracked, not dropped)
`Luciferase-q3p` owns: cross-type `parent()`/`faceNeighbor()` returns, `computeType` pyramid 6/7 branch, and the element-type unification (revises RDR-010 invariant #7 — needs RDR amendment). Wired: pi1.2 → q3p → pi1.3.