### PR TITLE
RDR-010 pi1.4: PyramidNeighborDetector — same-shape topology + addNeighboringNodes graduation (Luciferase-pi1.4)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
@@ -849,18 +849,32 @@ public class PyramidIndex<ID extends EntityID, Content> extends AbstractSpatialI
     /**
      * Emit at least the SFC-adjacent same-level PyramidKeys into {@code toVisit}.
      *
-     * <p><b>Pi1.3 minimum contract</b>: this implementation emits the sibling pyramid children
-     * of the parent (i.e., the other level-N PyramidKeys that share the same parent), which
-     * are the SFC-adjacent same-level nodes. Full same/cross-shape topology (including
-     * cross-pyramid face neighbours and tet-pyramid boundaries) is deferred to pi1.4
-     * ({@link PyramidNeighborDetector}) and is explicitly out of scope for this phase.
+     * <p><b>Pi1.4 Phase C (Luciferase-3zs)</b>: emits the sibling pyramid children of the parent
+     * (the SFC-adjacent same-level nodes) <em>unioned</em> with the same-shape (quad-base, f4)
+     * face neighbour from the wired {@link PyramidNeighborDetector} — a cross-parent neighbour the
+     * sibling walk alone misses. Cross-shape topology (the four triangular tet faces, pyramid↔tet↔hex
+     * boundaries) is deferred to pi1.5; for a tet-leaf node the detector contributes nothing.
      *
-     * <p><em>Registered deferral — not silent scope reduction.</em> See bead Luciferase-pi1.4.
+     * <p><em>Registered deferral — not silent scope reduction.</em> Cross-shape: bead Luciferase-pi1.5.
      */
     @Override
     protected void addNeighboringNodes(PyramidKey nodeIndex, Queue<PyramidKey> toVisit,
                                        Set<PyramidKey> visitedNodes) {
         byte level = nodeIndex.getLevel();
+
+        // Same-shape face neighbour(s) from the wired detector (the cross-parent f4 quad base the
+        // sibling walk below cannot reach). Empty for root / tet-leaf nodes. Cross-shape → pi1.5.
+        // The detector emits geometric neighbours regardless of index occupancy; the BFS callers
+        // null-check the node map and skip absent keys (see KnnSearcher / CollisionEngine). Do NOT
+        // add occupancy filtering here — it would break BFS connectivity through empty cells.
+        var detector = getNeighborDetector();
+        if (detector != null) {
+            for (var faceKey : detector.findFaceNeighbors(nodeIndex)) {
+                if (!visitedNodes.contains(faceKey) && !faceKey.equals(nodeIndex)) {
+                    toVisit.add(faceKey);
+                }
+            }
+        }
 
         if (level == 0) {
             // Root: emit the two level-1 pyramid roots (type-6 and type-7 children of each root)

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
@@ -597,7 +597,7 @@ public class PyramidIndex<ID extends EntityID, Content> extends AbstractSpatialI
      * intersection for deep tet keys, never a false negative. This is safe for Phase D (the
      * pyramid bound encloses the tet); exact tet-geometry ray/plane tests are deferred to Phase E.
      */
-    private Pyramid pyramidFromKey(PyramidKey key) {
+    static Pyramid pyramidFromKey(PyramidKey key) {
         byte level = key.getLevel();
         if (level == 0) {
             // Virtual root — return the type-6 root cover pyramid

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
@@ -61,8 +61,9 @@ public class PyramidIndex<ID extends EntityID, Content> extends AbstractSpatialI
      * <p>Collaborator initialisation order mirrors Octree (and therefore AbstractSpatialIndex):
      * EntityManager nucleus → SpatialIndexCore → KnnSearcher → Culler → CollisionEngine →
      * EntityLifecycleManager → GhostCoordinator. After the super-constructor the neighbor detector is
-     * wired (mirroring {@code Octree}); see {@link PyramidNeighborDetector} — a Phase-A stub that fails
-     * loud against {@code Luciferase-pi1.4}.
+     * wired (mirroring {@code Octree}); see {@link PyramidNeighborDetector} — same-shape topology
+     * (RDR-010 pi1.4 Phase B, Luciferase-mu9). Cross-shape (pyramid&harr;tet&harr;hex) ghost wiring
+     * is deferred to pi1.5.
      */
     public PyramidIndex(EntityIDGenerator<ID> idGenerator, int maxEntitiesPerNode, byte maxDepth,
                         EntitySpanningPolicy spanningPolicy) {

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeyCodec.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeyCodec.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.pyramid;
+
+import com.hellblazer.luciferase.lucien.Constants;
+
+/**
+ * Encoder from a {@link Pyramid} element to its {@link PyramidKey} — the inverse of
+ * {@link PyramidIndex#pyramidFromKey(PyramidKey)} (RDR-010 pi1.4 Phase A, bead Luciferase-8zv).
+ *
+ * <p>The encoder walks the pyramid's {@link Pyramid#parent()} chain to the root, collecting at each
+ * refinement step the cube-id (from the anchor's level bit) and the element type, then assembles the
+ * key via {@link PyramidKey#fromLevels(byte, int[], int[])}. It is the same coarse-dominant bit layout
+ * the decoder consumes, so {@code pyramidFromKey(encode(p)).equals(p)} for every valid SFC pyramid.
+ *
+ * <p><b>Fail-safe contract.</b> Not every {@code (anchor, level, type)} triple is a reachable element
+ * of the pyramid SFC tree (unlike Morton, where every cube cell is valid — pyramid coverage is
+ * {@code N(ℓ) = 2·8^ℓ − 6^ℓ}). A non-SFC candidate either trips the {@code "Unreachable pyramid"}
+ * {@link IllegalStateException} in {@link Pyramid#parent()} during the walk, or assembles a key that
+ * does not decode back to the original. Both outcomes return {@code null} rather than throwing or
+ * emitting a bogus key: the internal round-trip self-check ({@code decode(key).equals(p)}) is the
+ * safety net. Callers (the neighbor enumerator, {@code addNeighboringNodes}) rely on {@code null} to
+ * filter geometric candidates down to genuine SFC elements.
+ *
+ * <p>Encoder only — this class deliberately does <em>not</em> re-home the decoder
+ * ({@code pyramidFromKey} stays on {@link PyramidIndex}); the decoder dedup is tracked separately as
+ * bead Luciferase-3y1.
+ *
+ * @author hal.hildebrand
+ */
+final class PyramidKeyCodec {
+
+    private PyramidKeyCodec() {
+    }
+
+    /**
+     * Encode a pyramid to its key, or {@code null} if the pyramid is not a reachable SFC element.
+     *
+     * @param p the pyramid element (the level-0 type-6 root encodes to {@link PyramidKey#getRoot()};
+     *          a level-0 type-7 pyramid is not a distinct SFC element and encodes to {@code null})
+     * @return the round-trip-verified key, or {@code null} for a non-SFC / unreachable pyramid
+     */
+    static PyramidKey encode(Pyramid p) {
+        if (p.minTetLevel() != Pyramid.NO_TET_ANCESTOR) {
+            // The encoder is defined only for pure-pyramid SFC elements. A hybrid-path pyramid
+            // (reached via a tet ancestor) can share geometric identity (x,y,z,level,type) with a
+            // pure-pyramid cell — and Pyramid.equals is minTetLevel-blind — so the round-trip
+            // self-check would pass against the pure-pyramid reconstruction and silently emit the
+            // wrong element's key. Reject up front rather than returning a wrong key.
+            return null;
+        }
+        byte level = p.level();
+        if (level == 0) {
+            // The SFC root is the virtual type-6 cover (pyramidFromKey returns type 6 at level 0).
+            // Route through the same round-trip guard so a type-7 level-0 pyramid — not a distinct
+            // SFC element — fails to null rather than aliasing onto the root key.
+            PyramidKey rootKey = PyramidKey.getRoot();
+            Pyramid decodedRoot = PyramidIndex.pyramidFromKey(rootKey);
+            return (decodedRoot != null && decodedRoot.equals(p)) ? rootKey : null;
+        }
+        // coordBits/typeBits are indexed by refinement step 1..level (index 0 unused; root has no bits).
+        int[] coordBits = new int[level + 1];
+        int[] typeBits = new int[level + 1];
+        Pyramid cur = p;
+        try {
+            for (int l = level; l >= 1; l--) {
+                int h = Constants.lengthAtLevel((byte) l);
+                int cubeId = ((cur.x() & h) != 0 ? 1 : 0)
+                           | ((cur.y() & h) != 0 ? 2 : 0)
+                           | ((cur.z() & h) != 0 ? 4 : 0);
+                coordBits[l] = cubeId;
+                typeBits[l] = cur.type();
+                if (l > 1) {
+                    // Stop at l == 1: cur is then the level-1 element whose bits we just took, and
+                    // its parent is the bit-less root. May throw "Unreachable pyramid" for a non-SFC
+                    // candidate, which the surrounding catch converts to null.
+                    cur = cur.parent();
+                }
+            }
+            PyramidKey key = PyramidKey.fromLevels(level, coordBits, typeBits);
+            // Round-trip self-check: the decoder is the single source of truth for SFC validity.
+            Pyramid decoded = PyramidIndex.pyramidFromKey(key);
+            if (decoded == null || !decoded.equals(p)) {
+                return null;
+            }
+            return key;
+        } catch (IllegalStateException | IllegalArgumentException | IndexOutOfBoundsException e) {
+            // Non-SFC candidate (unreachable parent step, or malformed level/bits). Fail-safe to null.
+            return null;
+        }
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborDetector.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborDetector.java
@@ -14,60 +14,211 @@
  */
 package com.hellblazer.luciferase.lucien.pyramid;
 
+import com.hellblazer.luciferase.lucien.Constants;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostType;
 import com.hellblazer.luciferase.lucien.neighbor.NeighborDetector;
 
+import javax.vecmath.Point3i;
+import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
 /**
- * Phase-A stub for the pyramid topology neighbor detector. Mirrors the Octree/Tetree construction
- * pattern where the index wires a {@link NeighborDetector} for its key type. The real implementation
- * (face/edge/vertex topology for pyramid 4-tri + 1-quad faces, Knapp §4.3-4.4 cross-shape neighbor
- * dispatch) lands in RDR-010 bead {@code Luciferase-pi1.4} (P4: PyramidNeighborDetector). Every method
- * here fails loud with the bead reference so any code path that reaches it during Phases B-E is
- * immediately surfaced rather than silently returning empty/wrong neighbor sets.
+ * Same-shape (pyramid↔pyramid) topology neighbor detector for the pyramid SFC (RDR-010 pi1.4,
+ * bead Luciferase-mu9, Knapp 2026 §4.3-4.4). Mirrors {@link com.hellblazer.luciferase.lucien.neighbor.MortonNeighborDetector}:
+ * neighbor methods return the geometric same-level neighbor keys (independent of index occupancy), and
+ * boundary/owner methods mirror the Morton peer.
+ *
+ * <p><b>Same-shape only (pi1.4 scope).</b> A pyramid's only same-shape face is the quadrilateral base
+ * (f4, type 6↔7); its four triangular faces neighbor tetrahedra, and a {@link PyramidKey} can also
+ * encode a tet leaf (type 0-5). Cross-shape neighbor finding (pyramid↔tet↔hex) and tet-leaf neighbor
+ * topology are deferred to pi1.5 (bead Luciferase-pi1.5): for a tet-leaf key this detector returns an
+ * empty result rather than throwing, so ghost/kNN wiring is not broken.
+ *
+ * <p><b>Unified enumeration.</b> All three neighbor queries share one geometric pass: for each of the
+ * 27 cube offsets {@code (dx,dy,dz) ∈ {-1,0,+1}³} and each pyramid type {@code {6,7}}, a candidate
+ * same-level pyramid is built, filtered to genuine SFC elements via {@link PyramidKeyCodec#encode}
+ * (a non-SFC candidate encodes to {@code null}), and classified by shared-vertex count against the
+ * query element. The buckets are cumulative supersets per the {@link NeighborDetector} contract:
+ * <ul>
+ *   <li>face   — shared ≥ 4 (a conforming quad base; two distinct same-level pyramids share ≥3
+ *                vertices only across the quad base, hence exactly 4)</li>
+ *   <li>edge   — shared ≥ 2 (⊇ face)</li>
+ *   <li>vertex — shared ≥ 1 (⊇ edge)</li>
+ * </ul>
+ *
+ * @author Hal Hildebrand
  */
 public final class PyramidNeighborDetector implements NeighborDetector<PyramidKey> {
+
+    private static final int FACE_SHARED_VERTICES   = 4;
+    private static final int EDGE_SHARED_VERTICES   = 2;
+    private static final int VERTEX_SHARED_VERTICES = 1;
+
+    /** Retained for the pi1.5 ghost/ownership wiring; the same-shape paths here need only geometry. */
     private final PyramidIndex<?, ?> index;
 
     public PyramidNeighborDetector(PyramidIndex<?, ?> index) {
         this.index = Objects.requireNonNull(index, "PyramidIndex cannot be null");
     }
 
-    private static UnsupportedOperationException stub(String method) {
-        return new UnsupportedOperationException(
-        "RDR-010 pi1.4: PyramidNeighborDetector." + method + " — bead Luciferase-pi1.4");
-    }
-
     @Override
     public List<PyramidKey> findFaceNeighbors(PyramidKey element) {
-        throw stub("findFaceNeighbors");
+        return sameShapeNeighbors(element, FACE_SHARED_VERTICES);
     }
 
     @Override
     public List<PyramidKey> findEdgeNeighbors(PyramidKey element) {
-        throw stub("findEdgeNeighbors");
+        return sameShapeNeighbors(element, EDGE_SHARED_VERTICES);
     }
 
     @Override
     public List<PyramidKey> findVertexNeighbors(PyramidKey element) {
-        throw stub("findVertexNeighbors");
+        return sameShapeNeighbors(element, VERTEX_SHARED_VERTICES);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Computed from the element's surrounding-cube extent. Behavior is undefined for a tet-leaf key
+     * (the anchor is the enclosing pyramid's, not the physical tet's) — that case is part of the pi1.5
+     * cross-shape work; callers with unknown keys should confirm the key is a pyramid first.
+     */
     @Override
     public boolean isBoundaryElement(PyramidKey element, Direction direction) {
-        throw stub("isBoundaryElement");
+        int[] anchor = anchorOf(element);
+        int len = Constants.lengthAtLevel(element.getLevel());
+        return switch (direction) {
+            case POSITIVE_X -> anchor[0] + len > Constants.MAX_COORD;
+            case NEGATIVE_X -> anchor[0] == 0;
+            case POSITIVE_Y -> anchor[1] + len > Constants.MAX_COORD;
+            case NEGATIVE_Y -> anchor[1] == 0;
+            case POSITIVE_Z -> anchor[2] + len > Constants.MAX_COORD;
+            case NEGATIVE_Z -> anchor[2] == 0;
+        };
     }
 
     @Override
     public Set<Direction> getBoundaryDirections(PyramidKey element) {
-        throw stub("getBoundaryDirections");
+        var dirs = EnumSet.noneOf(Direction.class);
+        for (var dir : Direction.values()) {
+            if (isBoundaryElement(element, dir)) {
+                dirs.add(dir);
+            }
+        }
+        return dirs;
     }
 
     @Override
     public List<NeighborInfo<PyramidKey>> findNeighborsWithOwners(PyramidKey element, GhostType type) {
-        throw stub("findNeighborsWithOwners");
+        var neighbors = findNeighbors(element, type);
+        var result = new ArrayList<NeighborInfo<PyramidKey>>(neighbors.size());
+        for (var neighbor : neighbors) {
+            // Same-shape, single-tree scope: all neighbors are local. Distributed ownership resolution
+            // (cross-rank, cross-tree) lands with the ghost wiring in pi1.5.
+            result.add(new NeighborInfo<>(neighbor, 0, 0, true));
+        }
+        return result;
+    }
+
+    /**
+     * Unified geometric same-shape enumeration. Returns the same-level pyramid keys that share at
+     * least {@code minSharedVertices} vertices with the query element. A tet-leaf or non-decodable key
+     * yields an empty list (pi1.5 deferral; never throws).
+     */
+    private List<PyramidKey> sameShapeNeighbors(PyramidKey element, int minSharedVertices) {
+        Pyramid self = resolvePyramid(element);
+        if (self == null) {
+            return List.of(); // tet-leaf / cross-shape — deferred to pi1.5
+        }
+        int len = self.length();
+        Point3i[] selfVerts = self.coordinates();
+        byte level = self.level();
+        var neighbors = new ArrayList<PyramidKey>();
+        for (int dx = -1; dx <= 1; dx++) {
+            for (int dy = -1; dy <= 1; dy++) {
+                for (int dz = -1; dz <= 1; dz++) {
+                    int nx = self.x() + dx * len;
+                    int ny = self.y() + dy * len;
+                    int nz = self.z() + dz * len;
+                    if (nx < 0 || ny < 0 || nz < 0 || nx > Constants.MAX_COORD || ny > Constants.MAX_COORD
+                        || nz > Constants.MAX_COORD) {
+                        continue;
+                    }
+                    for (byte candType = Pyramid.TYPE_6; candType <= Pyramid.TYPE_7; candType++) {
+                        var cand = new Pyramid(nx, ny, nz, level, candType);
+                        if (cand.equals(self)) {
+                            continue; // self
+                        }
+                        if (sharedVertexCount(selfVerts, cand.coordinates()) < minSharedVertices) {
+                            continue;
+                        }
+                        var key = PyramidKeyCodec.encode(cand);
+                        if (key != null) { // null ⇒ not a genuine SFC element
+                            neighbors.add(key);
+                        }
+                    }
+                }
+            }
+        }
+        return neighbors;
+    }
+
+    /**
+     * Decode {@code element} to its pyramid, or {@code null} if it is a tet leaf (cross-shape, pi1.5)
+     * or the root (no same-level neighbors). The key's leaf type bit is authoritative for shape —
+     * {@link PyramidIndex#pyramidFromKey} returns the enclosing parent pyramid for a deep tet-leaf
+     * key, so a {@code null} from it is not a reliable tet-leaf signal on its own.
+     */
+    private static Pyramid resolvePyramid(PyramidKey element) {
+        byte level = element.getLevel();
+        if (level == 0) {
+            return null; // root spans the domain; no same-level neighbors
+        }
+        byte leafType = element.getTypeAtLevel(level);
+        if (leafType != Pyramid.TYPE_6 && leafType != Pyramid.TYPE_7) {
+            return null; // tet leaf — deferred to pi1.5
+        }
+        Pyramid self = PyramidIndex.pyramidFromKey(element);
+        if (self == null || self.level() != level || self.type() != leafType) {
+            return null; // defensive: decode did not resolve to the leaf pyramid
+        }
+        return self;
+    }
+
+    /** Count vertices shared (by exact integer coordinate) between two pyramid vertex sets. */
+    private static int sharedVertexCount(Point3i[] a, Point3i[] b) {
+        int shared = 0;
+        for (Point3i pa : a) {
+            for (Point3i pb : b) {
+                if (pa.equals(pb)) {
+                    shared++;
+                    break;
+                }
+            }
+        }
+        return shared;
+    }
+
+    /** The surrounding-cube anchor of {@code element}, accumulated from its per-level cube-ids. */
+    private static int[] anchorOf(PyramidKey element) {
+        int ax = 0, ay = 0, az = 0;
+        byte level = element.getLevel();
+        for (int l = 1; l <= level; l++) {
+            int len = Constants.lengthAtLevel((byte) l);
+            int cubeId = element.getCoordBitsAtLevel(l);
+            if ((cubeId & 1) != 0) {
+                ax += len;
+            }
+            if ((cubeId & 2) != 0) {
+                ay += len;
+            }
+            if ((cubeId & 4) != 0) {
+                az += len;
+            }
+        }
+        return new int[] { ax, ay, az };
     }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidAddNeighboringNodesTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidAddNeighboringNodesTest.java
@@ -145,4 +145,91 @@ class PyramidAddNeighboringNodesTest {
         assertFalse(toVisit.isEmpty(),
                     "Level-1 key must produce at least one neighbor (sibling pyramid children)");
     }
+
+    @Test
+    void addNeighboringNodes_unionsTheQuadBaseFaceNeighbor() {
+        // pi1.4 Phase C graduation (Luciferase-3zs): addNeighboringNodes now unions the same-shape
+        // (quad-base, f4) face neighbor — a DIFFERENT parent's child the sibling-only walk misses —
+        // with the existing sibling set. Cross-shape (triangular tet faces) remains deferred to pi1.5.
+        var pair = firstPyramidWithSfcQuadBaseNeighbor();
+        assertNotNull(pair, "expected an interior SFC pyramid with an SFC quad-base neighbor");
+        var selfKey = PyramidKeyCodec.encode(pair[0]);
+        var f4Key = PyramidKeyCodec.encode(pair[1]);
+
+        var toVisit = new LinkedList<PyramidKey>();
+        var visited = new HashSet<PyramidKey>();
+        visited.add(selfKey);
+        index.addNeighboringNodes(selfKey, toVisit, visited);
+
+        assertTrue(toVisit.contains(f4Key),
+                   "graduated addNeighboringNodes must emit the quad-base face neighbor " + pair[1]);
+    }
+
+    @Test
+    void addNeighboringNodes_doesNotEmitTheF4NeighborWhenAlreadyVisited() {
+        var pair = firstPyramidWithSfcQuadBaseNeighbor();
+        assertNotNull(pair);
+        var selfKey = PyramidKeyCodec.encode(pair[0]);
+        var f4Key = PyramidKeyCodec.encode(pair[1]);
+
+        var toVisit = new LinkedList<PyramidKey>();
+        var visited = new HashSet<PyramidKey>();
+        visited.add(selfKey);
+        visited.add(f4Key); // already visited — must be suppressed
+        index.addNeighboringNodes(selfKey, toVisit, visited);
+
+        assertFalse(toVisit.contains(f4Key), "must not re-emit an already-visited f4 neighbor");
+    }
+
+    @Test
+    void addNeighboringNodes_f4UnionIsReciprocal() {
+        // BFS symmetry: if addNeighboringNodes(self) emits the f4 neighbor, then
+        // addNeighboringNodes(f4) must emit self back — else a kNN/range BFS could reach a cell from
+        // one side but not the other and silently miss entities.
+        var pair = firstPyramidWithSfcQuadBaseNeighbor();
+        assertNotNull(pair);
+        var selfKey = PyramidKeyCodec.encode(pair[0]);
+        var f4Key = PyramidKeyCodec.encode(pair[1]);
+
+        var toVisit = new LinkedList<PyramidKey>();
+        var visited = new HashSet<PyramidKey>();
+        visited.add(f4Key);
+        index.addNeighboringNodes(f4Key, toVisit, visited);
+
+        assertTrue(toVisit.contains(selfKey),
+                   "addNeighboringNodes(f4) must emit self back (BFS symmetry)");
+    }
+
+    private Pyramid[] firstPyramidWithSfcQuadBaseNeighbor() {
+        var roots = new Pyramid[] { new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6),
+                                    new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_7) };
+        var stack = new java.util.ArrayDeque<Pyramid>();
+        for (var r : roots) {
+            stack.push(r);
+        }
+        while (!stack.isEmpty()) {
+            var p = stack.pop();
+            if (p.level() >= 2) { // need a parent to compare against
+                var fn = p.faceNeighbor(4);
+                if (fn != null && fn.element() instanceof Pyramid pn) {
+                    var pk = PyramidKeyCodec.encode(p);
+                    var nk = PyramidKeyCodec.encode(pn);
+                    // Require the f4 neighbor to be CROSS-PARENT (not a sibling) — otherwise the
+                    // sibling-only walk already emits it and the graduation test would be vacuous.
+                    if (pk != null && nk != null && pk.parent() != null
+                        && !pk.parent().equals(nk.parent())) {
+                        return new Pyramid[] { p, pn };
+                    }
+                }
+            }
+            if (p.level() < 5) {
+                for (int i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
+                    if (p.child(i) instanceof Pyramid pc) {
+                        stack.push(pc);
+                    }
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeyCodecTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeyCodecTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.pyramid;
+
+import com.hellblazer.luciferase.lucien.Constants;
+import com.hellblazer.luciferase.lucien.HybridElement;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validates {@link PyramidKeyCodec#encode(Pyramid)} — the fail-safe, round-trip-verified inverse of
+ * {@link PyramidIndex#pyramidFromKey(PyramidKey)} (RDR-010 pi1.4 Phase A, bead Luciferase-8zv).
+ *
+ * <p>Three contracts:
+ * <ul>
+ *   <li><b>decode∘encode == identity</b> for every valid SFC pyramid (types 6 and 7, multiple levels).</li>
+ *   <li><b>encode∘decode == identity</b> (key-side bijection).</li>
+ *   <li><b>non-SFC / unreachable candidate → null</b> with no exception on the hot path.</li>
+ * </ul>
+ *
+ * @author hal.hildebrand
+ */
+class PyramidKeyCodecTest {
+
+    /**
+     * Enumerate genuine SFC pyramids by descending the two roots via {@link Pyramid#child(int)},
+     * keeping only the pyramid children, down to {@code maxLevel}.
+     */
+    private static List<Pyramid> validPyramids(int maxLevel) {
+        var out = new ArrayList<Pyramid>();
+        var roots = new Pyramid[] { new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6),
+                                    new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_7) };
+        for (var root : roots) {
+            descend(root, maxLevel, out);
+        }
+        return out;
+    }
+
+    private static void descend(Pyramid p, int maxLevel, List<Pyramid> out) {
+        if (p.level() >= 1) {
+            out.add(p); // level-0 roots are the virtual cover, not encodable SFC elements
+        }
+        if (p.level() >= maxLevel) {
+            return;
+        }
+        for (int i = 0; i < com.hellblazer.luciferase.lucien.tetree.TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
+            HybridElement child = p.child(i);
+            if (child instanceof Pyramid pc) {
+                descend(pc, maxLevel, out);
+            }
+        }
+    }
+
+    @Test
+    void decodeOfEncodeIsIdentityForValidPyramids() {
+        var pyramids = validPyramids(4);
+        assertFalse(pyramids.isEmpty(), "expected to enumerate some SFC pyramids");
+        boolean sawType6 = false, sawType7 = false;
+        for (var p : pyramids) {
+            var key = PyramidKeyCodec.encode(p);
+            assertNotNull(key, () -> "valid SFC pyramid must encode: " + p);
+            assertEquals(p.level(), key.getLevel(), () -> "encoded level must match: " + p);
+            var decoded = PyramidIndex.pyramidFromKey(key);
+            assertEquals(p, decoded, () -> "decode∘encode must be identity for " + p + " key=" + key);
+            sawType6 |= p.type() == Pyramid.TYPE_6;
+            sawType7 |= p.type() == Pyramid.TYPE_7;
+        }
+        assertTrue(sawType6 && sawType7, "coverage must include both pyramid types");
+    }
+
+    @Test
+    void encodeOfDecodeIsIdentityForValidKeys() {
+        for (var p : validPyramids(4)) {
+            var key = PyramidKeyCodec.encode(p);
+            assertNotNull(key);
+            var decoded = PyramidIndex.pyramidFromKey(key);
+            assertNotNull(decoded);
+            var key2 = PyramidKeyCodec.encode(decoded);
+            assertEquals(key, key2, () -> "encode∘decode must be identity (key-side) for " + p);
+        }
+    }
+
+    @Test
+    void rootEncodesToRootKey() {
+        var root = new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6);
+        var key = PyramidKeyCodec.encode(root);
+        assertNotNull(key);
+        assertEquals(PyramidKey.getRoot(), key);
+    }
+
+    @Test
+    void goldenKeyForKnownPyramidIndependentOfFromLevels() {
+        // Independent bit-value oracle (defends against a co-consistent error in fromLevels + decode).
+        // P = type-6 pyramid at (0,0,0) level 2 = root6.child0.child0 (both steps: cubeId 0, type 6).
+        // Per the documented coarse-dominant layout: each step's 6-bit group = (coordBits<<3)|typeBits,
+        // step 1 (shallowest) at the MSB end. group1 = (0<<3)|6 = 6; group2 = 6.
+        // lowBits = (group1 << 6) | group2 = (6 << 6) | 6 = 390; highBits = 0.
+        var p = new Pyramid(0, 0, 0, (byte) 2, Pyramid.TYPE_6);
+        var key = PyramidKeyCodec.encode(p);
+        assertNotNull(key);
+        assertEquals((byte) 2, key.getLevel());
+        assertEquals(390L, key.getLowBits(), "golden lowBits computed from the spec layout");
+        assertEquals(0L, key.getHighBits());
+        assertEquals(p, PyramidIndex.pyramidFromKey(key), "golden key must decode back to P");
+    }
+
+    @Test
+    void hybridPathPyramidEncodesToNull() {
+        // A pyramid carrying minTetLevel != -1 (reached via a tet ancestor) is not a pure-pyramid SFC
+        // element. Even when it shares geometry with a reachable pure-pyramid cell — and Pyramid.equals
+        // is minTetLevel-blind — encode must reject it (null), not emit the pure cell's key.
+        var hybrid = new Pyramid(0, 0, 0, (byte) 2, Pyramid.TYPE_6, (byte) 1); // minTetLevel = 1
+        var pure = new Pyramid(0, 0, 0, (byte) 2, Pyramid.TYPE_6);             // same geometry
+        assertEquals(hybrid, pure, "precondition: equals is minTetLevel-blind");
+        assertNotNull(PyramidKeyCodec.encode(pure), "the pure-pyramid cell does encode");
+        assertNull(PyramidKeyCodec.encode(hybrid), "the hybrid-path pyramid must encode to null");
+    }
+
+    @Test
+    void type7RootIsNotADistinctSfcElementAndEncodesToNull() {
+        // The SFC root is the virtual type-6 cover; pyramidFromKey returns type 6 at level 0. A
+        // level-0 type-7 pyramid is therefore not a distinct SFC element and must encode to null
+        // rather than aliasing onto the single root key.
+        var type7Root = new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_7);
+        assertNull(PyramidKeyCodec.encode(type7Root));
+    }
+
+    @Test
+    void unreachablePyramidReturnsNullWithoutThrowing() {
+        // PYRAMID_TYPE_CID_TO_PARENT_TYPE[type6][cubeId 5] == -1 (unreachable). A level-1 type-6
+        // pyramid at cube-id 5 (anchor bits x=1,z=1) is geometrically non-SFC: the round-trip
+        // self-check (or the parent() "Unreachable pyramid" throw on deeper variants) must funnel
+        // it to null rather than emitting a bogus key.
+        int h = Constants.lengthAtLevel((byte) 1);
+        var nonSfc = new Pyramid(h, 0, h, (byte) 1, Pyramid.TYPE_6); // cubeId 5
+        PyramidKey[] holder = new PyramidKey[1];
+        assertDoesNotThrow(() -> holder[0] = PyramidKeyCodec.encode(nonSfc),
+                           "encode must be fail-safe on the hot path (no throw)");
+        assertNull(holder[0], "non-SFC unreachable pyramid must encode to null");
+    }
+
+    @Test
+    void deepUnreachablePyramidReturnsNull() {
+        // A type-7 pyramid at cube-id 1 (anchor bit x=1) is unreachable
+        // (PYRAMID_TYPE_CID_TO_PARENT_TYPE[type7][1] == -1). Place it at level 2 so the parent()
+        // walk reaches the unreachable step and its IllegalStateException is caught.
+        int h2 = Constants.lengthAtLevel((byte) 2);
+        var nonSfc = new Pyramid(h2, 0, 0, (byte) 2, Pyramid.TYPE_7); // level-2 cubeId 1
+        assertDoesNotThrow(() -> assertNull(PyramidKeyCodec.encode(nonSfc)));
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborDetectorTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborDetectorTest.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.pyramid;
+
+import com.hellblazer.luciferase.lucien.Constants;
+import com.hellblazer.luciferase.lucien.HybridElement;
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostType;
+import com.hellblazer.luciferase.lucien.neighbor.NeighborDetector;
+import com.hellblazer.luciferase.lucien.tetree.Tet;
+import com.hellblazer.luciferase.lucien.tetree.TetreeConnectivity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3i;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Same-shape (pyramid↔pyramid) topology for {@link PyramidNeighborDetector} (RDR-010 pi1.4 Phase B,
+ * bead Luciferase-mu9). A pyramid's only same-shape face is the quadrilateral base (f4, type 6↔7);
+ * the four triangular faces neighbor tetrahedra (cross-shape, deferred to pi1.5). Validation follows
+ * the CLAUDE.md face-neighbor caveat: reciprocity/involution, plus the shared-vertex-count assertion
+ * which is valid ONLY for the conforming pyramid quad base (invariant #5).
+ *
+ * @author hal.hildebrand
+ */
+class PyramidNeighborDetectorTest {
+
+    private PyramidNeighborDetector detector;
+
+    @BeforeEach
+    void setUp() {
+        var index = new PyramidIndex<LongEntityID, String>(new SequentialLongIDGenerator());
+        detector = new PyramidNeighborDetector(index);
+    }
+
+    // ===== helpers =====
+
+    private static List<Pyramid> validPyramids(int maxLevel) {
+        var out = new ArrayList<Pyramid>();
+        for (var root : new Pyramid[] { new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6),
+                                        new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_7) }) {
+            descend(root, maxLevel, out);
+        }
+        return out;
+    }
+
+    private static void descend(Pyramid p, int maxLevel, List<Pyramid> out) {
+        if (p.level() >= 1) {
+            out.add(p);
+        }
+        if (p.level() >= maxLevel) {
+            return;
+        }
+        for (int i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
+            HybridElement child = p.child(i);
+            if (child instanceof Pyramid pc) {
+                descend(pc, maxLevel, out);
+            }
+        }
+    }
+
+    private static int sharedVertexCount(Pyramid a, Pyramid b) {
+        Point3i[] va = a.coordinates();
+        Point3i[] vb = b.coordinates();
+        int shared = 0;
+        for (Point3i pa : va) {
+            for (Point3i pb : vb) {
+                if (pa.equals(pb)) {
+                    shared++;
+                    break;
+                }
+            }
+        }
+        return shared;
+    }
+
+    /** A valid SFC pyramid whose quad-base (f4) neighbor is in-domain AND is itself an SFC element. */
+    private static Pyramid[] selfAndQuadBaseNeighbor() {
+        for (var p : validPyramids(5)) {
+            var fn = p.faceNeighbor(4);
+            if (fn == null || !(fn.element() instanceof Pyramid pn)) {
+                continue;
+            }
+            if (PyramidKeyCodec.encode(p) != null && PyramidKeyCodec.encode(pn) != null) {
+                return new Pyramid[] { p, pn };
+            }
+        }
+        return null;
+    }
+
+    // ===== tests =====
+
+    @Test
+    void quadBaseFaceNeighborIsTheSingleSameShapeFaceNeighbor() {
+        var pair = selfAndQuadBaseNeighbor();
+        assertNotNull(pair, "expected an interior SFC pyramid with an SFC quad-base neighbor");
+        var self = pair[0];
+        var neighbor = pair[1];
+        var selfKey = PyramidKeyCodec.encode(self);
+        var neighborKey = PyramidKeyCodec.encode(neighbor);
+
+        var faces = detector.findFaceNeighbors(selfKey);
+        assertEquals(1, faces.size(), "a pyramid has exactly one same-shape (quad-base) face neighbor");
+        assertEquals(neighborKey, faces.get(0));
+        // The quad base is a conforming face shared by exactly two pyramids → exactly 4 shared vertices
+        // (invariant #5; this assertion is valid ONLY for the conforming pyramid quad base).
+        assertEquals(4, sharedVertexCount(self, neighbor));
+    }
+
+    @Test
+    void faceNeighborMatchesPyramidFaceNeighbor4() {
+        var pair = selfAndQuadBaseNeighbor();
+        assertNotNull(pair);
+        var self = pair[0];
+        var selfKey = PyramidKeyCodec.encode(self);
+        var expected = PyramidKeyCodec.encode((Pyramid) self.faceNeighbor(4).element());
+        assertEquals(List.of(expected), detector.findFaceNeighbors(selfKey),
+                     "unified-enum face result must agree with Pyramid.faceNeighbor(4)");
+    }
+
+    @Test
+    void faceNeighborIsReciprocal() {
+        var pair = selfAndQuadBaseNeighbor();
+        assertNotNull(pair);
+        var selfKey = PyramidKeyCodec.encode(pair[0]);
+        var neighborKey = PyramidKeyCodec.encode(pair[1]);
+        // Involution: the f4-neighbor's same-shape face neighbor is self again.
+        assertTrue(detector.findFaceNeighbors(neighborKey).contains(selfKey),
+                   "face-neighbor relation must be reciprocal (neighbor(neighbor)==self)");
+    }
+
+    @Test
+    void triangularFacesNeighborTetsAndAreAbsentFromSameShapeResult() {
+        var pair = selfAndQuadBaseNeighbor();
+        assertNotNull(pair);
+        var self = pair[0];
+        var selfKey = PyramidKeyCodec.encode(self);
+        // The four triangular faces neighbor tetrahedra (cross-shape, pi1.5) — documented here so the
+        // single-element same-shape face result is a deliberate deferral, not silent scope reduction.
+        for (int f = 0; f < 4; f++) {
+            var fn = self.faceNeighbor(f);
+            if (fn != null) {
+                assertInstanceOf(Tet.class, fn.element(),
+                                 "triangular face " + f + " must neighbor a tetrahedron");
+            }
+        }
+        assertEquals(1, detector.findFaceNeighbors(selfKey).size(),
+                     "same-shape face result must exclude all four triangular (tet) faces");
+    }
+
+    @Test
+    void neighborBucketsAreCumulativeSupersets() {
+        var pair = selfAndQuadBaseNeighbor();
+        assertNotNull(pair);
+        var selfKey = PyramidKeyCodec.encode(pair[0]);
+        var neighborKey = PyramidKeyCodec.encode(pair[1]);
+
+        var faces = detector.findFaceNeighbors(selfKey);
+        var edges = detector.findEdgeNeighbors(selfKey);
+        var verts = detector.findVertexNeighbors(selfKey);
+
+        // Per the NeighborDetector contract: vertex ⊇ edge ⊇ face. The quad-base (f4, shared 4)
+        // neighbor must appear in ALL THREE buckets.
+        assertTrue(faces.contains(neighborKey));
+        assertTrue(edges.contains(neighborKey));
+        assertTrue(verts.contains(neighborKey));
+        assertTrue(edges.containsAll(faces), "edge set ⊇ face set");
+        assertTrue(verts.containsAll(edges), "vertex set ⊇ edge set");
+        assertTrue(verts.size() >= edges.size() && edges.size() >= faces.size());
+    }
+
+    @Test
+    void everyEnumeratedNeighborSharesAtLeastTheBucketThreshold() {
+        // Non-vacuous: each returned vertex/edge/face neighbor genuinely shares ≥1/≥2/≥4 vertices
+        // with self, and is a pyramid (same-shape), and decodes back to the level-matched element.
+        var pair = selfAndQuadBaseNeighbor();
+        assertNotNull(pair);
+        var self = pair[0];
+        var selfKey = PyramidKeyCodec.encode(self);
+
+        assertThresholds(self, detector.findVertexNeighbors(selfKey), 1);
+        assertThresholds(self, detector.findEdgeNeighbors(selfKey), 2);
+        assertThresholds(self, detector.findFaceNeighbors(selfKey), 4);
+    }
+
+    private static void assertThresholds(Pyramid self, List<PyramidKey> neighbors, int min) {
+        assertFalse(neighbors.isEmpty(), "expected at least one neighbor at threshold " + min);
+        for (var key : neighbors) {
+            var n = PyramidIndex.pyramidFromKey(key);
+            assertNotNull(n, "neighbor key must decode to a pyramid");
+            assertEquals(self.level(), n.level(), "neighbor must be at the same level");
+            assertTrue(sharedVertexCount(self, n) >= min,
+                       "neighbor " + n + " must share >= " + min + " vertices with " + self);
+        }
+    }
+
+    @Test
+    void enumerationMatchesBruteForceOverTheWholeSfcUniverse() {
+        // Independent completeness/soundness oracle: instead of the detector's ±len cube-offset trick,
+        // brute-force EVERY SFC pyramid in the level-≤5 universe and select those at self's level
+        // sharing ≥ threshold vertices. A missed cube (under-report) or a spurious candidate
+        // (over-report) makes the sets differ. This is the test that would catch ghost-holes in pi1.5.
+        var pair = selfAndQuadBaseNeighbor();
+        assertNotNull(pair);
+        var self = pair[0];
+        var selfKey = PyramidKeyCodec.encode(self);
+        var universe = validPyramids(5);
+
+        assertEquals(expectedNeighborKeys(self, universe, 4), setOf(detector.findFaceNeighbors(selfKey)));
+        assertEquals(expectedNeighborKeys(self, universe, 2), setOf(detector.findEdgeNeighbors(selfKey)));
+        assertEquals(expectedNeighborKeys(self, universe, 1), setOf(detector.findVertexNeighbors(selfKey)));
+        // And the universe genuinely contains MORE than the single face neighbor at the edge/vertex
+        // thresholds, so the oracle is not trivially equal to the 1-element face set.
+        assertTrue(expectedNeighborKeys(self, universe, 2).size() > 1,
+                   "fixture must have >1 edge neighbor for the oracle to be non-trivial");
+    }
+
+    private static java.util.Set<PyramidKey> setOf(List<PyramidKey> keys) {
+        return new java.util.HashSet<>(keys);
+    }
+
+    private static java.util.Set<PyramidKey> expectedNeighborKeys(Pyramid self, List<Pyramid> universe,
+                                                                  int minShared) {
+        var out = new java.util.HashSet<PyramidKey>();
+        for (var q : universe) {
+            if (q.level() != self.level() || q.equals(self)) {
+                continue;
+            }
+            if (sharedVertexCount(self, q) >= minShared) {
+                var key = PyramidKeyCodec.encode(q);
+                if (key != null) {
+                    out.add(key);
+                }
+            }
+        }
+        return out;
+    }
+
+    @Test
+    void positiveBoundaryDirectionsNearMaxCoord() {
+        // root6.child(9) = TYPE_6 at cube-id 7 (anchor (h,h,h), level 1, h = lengthAtLevel(1) = 2^20).
+        // anchor + len = 2^21 > MAX_COORD, so the +X/+Y/+Z faces are all domain boundaries — this is
+        // the positive-direction (anchor+len > MAX_COORD) branch the origin test cannot reach.
+        int h = Constants.lengthAtLevel((byte) 1);
+        var farCorner = new Pyramid(h, h, h, (byte) 1, Pyramid.TYPE_6);
+        var key = PyramidKeyCodec.encode(farCorner);
+        assertNotNull(key, "far-corner pyramid must be a valid SFC element");
+        var dirs = detector.getBoundaryDirections(key);
+        assertTrue(dirs.contains(NeighborDetector.Direction.POSITIVE_X));
+        assertTrue(dirs.contains(NeighborDetector.Direction.POSITIVE_Y));
+        assertTrue(dirs.contains(NeighborDetector.Direction.POSITIVE_Z));
+        assertTrue(detector.isBoundaryElement(key, NeighborDetector.Direction.POSITIVE_X));
+    }
+
+    @Test
+    void tetLeafKeyDefersToEmpty() {
+        // root6 child index 1 is a tetrahedron (cid 1, type 3). A tet-leaf PyramidKey is cross-shape
+        // territory (pi1.5): the same-shape detector returns empty, never throws.
+        var tetLeafKey = PyramidKey.fromLevels((byte) 1, new int[] { 0, 1 }, new int[] { 0, 3 });
+        assertEquals((byte) 3, tetLeafKey.getTypeAtLevel(1), "precondition: leaf type is a tet");
+        assertTrue(detector.findFaceNeighbors(tetLeafKey).isEmpty());
+        assertTrue(detector.findEdgeNeighbors(tetLeafKey).isEmpty());
+        assertTrue(detector.findVertexNeighbors(tetLeafKey).isEmpty());
+        assertTrue(detector.findNeighborsWithOwners(tetLeafKey, GhostType.FACES).isEmpty());
+    }
+
+    @Test
+    void boundaryDirectionsAtOrigin() {
+        // type-6 pyramid at the origin cube, level 2: anchor (0,0,0) → on the −X/−Y/−Z domain faces;
+        // its surrounding cube (len = lengthAtLevel(2)) is far from the +faces.
+        var origin = new Pyramid(0, 0, 0, (byte) 2, Pyramid.TYPE_6);
+        var key = PyramidKeyCodec.encode(origin);
+        assertNotNull(key);
+        var dirs = detector.getBoundaryDirections(key);
+        assertTrue(dirs.contains(NeighborDetector.Direction.NEGATIVE_X));
+        assertTrue(dirs.contains(NeighborDetector.Direction.NEGATIVE_Y));
+        assertTrue(dirs.contains(NeighborDetector.Direction.NEGATIVE_Z));
+        assertFalse(dirs.contains(NeighborDetector.Direction.POSITIVE_X));
+        assertFalse(dirs.contains(NeighborDetector.Direction.POSITIVE_Y));
+        assertFalse(dirs.contains(NeighborDetector.Direction.POSITIVE_Z));
+        assertTrue(detector.isBoundaryElement(key, NeighborDetector.Direction.NEGATIVE_X));
+        assertFalse(detector.isBoundaryElement(key, NeighborDetector.Direction.POSITIVE_X));
+    }
+
+    @Test
+    void findNeighborsWithOwnersWrapsLocalFaceNeighbors() {
+        var pair = selfAndQuadBaseNeighbor();
+        assertNotNull(pair);
+        var selfKey = PyramidKeyCodec.encode(pair[0]);
+        var neighborKey = PyramidKeyCodec.encode(pair[1]);
+        var owners = detector.findNeighborsWithOwners(selfKey, GhostType.FACES);
+        assertEquals(1, owners.size());
+        var info = owners.get(0);
+        assertEquals(neighborKey, info.neighborKey());
+        assertEquals(0, info.ownerRank());
+        assertTrue(info.isLocal());
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborParityTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborParityTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.pyramid;
+
+import com.hellblazer.luciferase.lucien.HybridElement;
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostType;
+import com.hellblazer.luciferase.lucien.neighbor.NeighborDetector;
+import com.hellblazer.luciferase.lucien.tetree.TetreeConnectivity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Dedicated parity suite for the pi1.4 PyramidNeighborDetector seam (RDR-010 pi1.4 Phase C, bead
+ * Luciferase-3zs). Follows the Prism/Pyramid convention of a peer-index dedicated suite — PyramidIndex
+ * and its detector are NOT registered in the shared {@code SpatialIndex*} parameterized providers.
+ *
+ * <p>Unlike {@link PyramidNeighborDetectorTest} (which pins specific properties on a single fixture),
+ * this suite sweeps the whole level-≤5 SFC pyramid tree to exercise face-neighbor reciprocity across
+ * many elements and levels, and verifies the {@code GhostCoordinator} seam is effectively wired (a
+ * call THROUGH {@code getNeighborDetector()} returns a real same-shape neighbor, not the Phase-A
+ * fail-loud stub).
+ *
+ * @author hal.hildebrand
+ */
+class PyramidNeighborParityTest {
+
+    private PyramidIndex<LongEntityID, String> index;
+    private PyramidNeighborDetector detector;
+
+    @BeforeEach
+    void setUp() {
+        index = new PyramidIndex<>(new SequentialLongIDGenerator());
+        detector = new PyramidNeighborDetector(index);
+    }
+
+    private static List<Pyramid> validPyramids(int maxLevel) {
+        var out = new ArrayList<Pyramid>();
+        for (var root : new Pyramid[] { new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6),
+                                        new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_7) }) {
+            descend(root, maxLevel, out);
+        }
+        return out;
+    }
+
+    private static void descend(Pyramid p, int maxLevel, List<Pyramid> out) {
+        if (p.level() >= 1) {
+            out.add(p);
+        }
+        if (p.level() >= maxLevel) {
+            return;
+        }
+        for (int i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
+            HybridElement child = p.child(i);
+            if (child instanceof Pyramid pc) {
+                descend(pc, maxLevel, out);
+            }
+        }
+    }
+
+    /** First interior SFC pyramid whose quad-base neighbor is also an in-domain SFC element. */
+    private static Pyramid[] selfAndQuadBaseNeighbor() {
+        for (var p : validPyramids(5)) {
+            var fn = p.faceNeighbor(4);
+            if (fn == null || !(fn.element() instanceof Pyramid pn)) {
+                continue;
+            }
+            if (PyramidKeyCodec.encode(p) != null && PyramidKeyCodec.encode(pn) != null) {
+                return new Pyramid[] { p, pn };
+            }
+        }
+        return null;
+    }
+
+    @Test
+    void faceNeighborReciprocityAcrossTheRefinedTree() {
+        int checked = 0;
+        int crossParent = 0;
+        for (var p : validPyramids(5)) {
+            var fn = p.faceNeighbor(4);
+            if (fn == null || !(fn.element() instanceof Pyramid pn)) {
+                continue;
+            }
+            var pk = PyramidKeyCodec.encode(p);
+            var nk = PyramidKeyCodec.encode(pn);
+            if (pk == null || nk == null) {
+                continue;
+            }
+            assertTrue(detector.findFaceNeighbors(pk).contains(nk),
+                       "detector must find the quad-base neighbor of " + p);
+            assertTrue(detector.findFaceNeighbors(nk).contains(pk),
+                       "face-neighbor relation must be reciprocal for " + p + " <-> " + pn);
+            checked++;
+            if (pk.parent() != null && nk.parent() != null && !pk.parent().equals(nk.parent())) {
+                crossParent++;
+            }
+        }
+        assertTrue(checked >= 20, "expected a broad multi-level sweep, only checked " + checked);
+        assertTrue(crossParent >= 1, "sweep must include cross-parent f4 pairs (the graduation target)");
+    }
+
+    @Test
+    void edgeNeighborReciprocityAcrossTheRefinedTree() {
+        reciprocitySweep(detector::findEdgeNeighbors, "edge");
+    }
+
+    @Test
+    void vertexNeighborReciprocityAcrossTheRefinedTree() {
+        reciprocitySweep(detector::findVertexNeighbors, "vertex");
+    }
+
+    /**
+     * Sweep the level-≤5 SFC pyramid tree and assert the chosen neighbor relation is symmetric: every
+     * neighbor {@code nk} of {@code pk} lists {@code pk} as one of its neighbors. Catches a tree-level
+     * regression (a dropped or spurious neighbor) that single-fixture tests would miss.
+     */
+    private void reciprocitySweep(java.util.function.Function<PyramidKey, List<PyramidKey>> bucket,
+                                  String label) {
+        int checked = 0;
+        for (var p : validPyramids(5)) {
+            var pk = PyramidKeyCodec.encode(p);
+            if (pk == null) {
+                continue;
+            }
+            for (var nk : bucket.apply(pk)) {
+                assertTrue(bucket.apply(nk).contains(pk),
+                           label + "-neighbor relation must be reciprocal for " + pk + " -> " + nk);
+                checked++;
+            }
+        }
+        assertTrue(checked >= 20, "expected a broad " + label + " sweep, only checked " + checked);
+    }
+
+    @Test
+    void ghostCoordinatorSeamWiresTheRealDetector() {
+        NeighborDetector<PyramidKey> wired = index.getNeighborDetector();
+        assertInstanceOf(PyramidNeighborDetector.class, wired,
+                         "the GhostCoordinator seam must hold the real pyramid detector");
+
+        var pair = selfAndQuadBaseNeighbor();
+        assertNotNull(pair);
+        var selfKey = PyramidKeyCodec.encode(pair[0]);
+        var neighborKey = PyramidKeyCodec.encode(pair[1]);
+
+        // Effective wiring: a call THROUGH the seam returns a real same-shape neighbor (the Phase-A
+        // stub would have thrown UnsupportedOperationException here).
+        var faces = wired.findFaceNeighbors(selfKey);
+        assertEquals(List.of(neighborKey), faces, "seam must yield the real f4 neighbor, not a stub");
+
+        // Pin the pi1.4 limitation: only the quad base is same-shape, so GhostType.FACES yields exactly
+        // ONE neighbor per interior pyramid. The four triangular (tet) faces produce no ghost entries
+        // until pi1.5 — this assertion makes that scope boundary visible in test output.
+        assertEquals(1, wired.findNeighbors(selfKey, GhostType.FACES).size());
+    }
+}


### PR DESCRIPTION
RDR-010 pi1.4 (Luciferase-pi1.4): same-shape (pyramid↔pyramid) neighbor topology, replacing the Phase-A fail-loud `PyramidNeighborDetector` stub and graduating `PyramidIndex.addNeighboringNodes`. Cross-shape (pyramid↔tet↔hex) ghost wiring is explicitly **pi1.5** (Luciferase-pi1.5); Forest `N_shape` weight + balance is **pi1.6**.

## Phases (one commit each)
- **A (Luciferase-8zv)** `dd24b9f0` — `PyramidKeyCodec.encode(Pyramid)→PyramidKey`: fail-safe, round-trip-verified inverse of `pyramidFromKey`. Guards `minTetLevel != -1` and the type-7 level-0 alias; non-SFC candidates → `null`. Promotes `pyramidFromKey` private→static so the codec reuses the canonical decoder.
- **B (Luciferase-mu9)** `9bda5b4d` — `PyramidNeighborDetector` via one unified geometric enumeration (27 cube offsets × {type 6,7}, filtered to SFC via the codec, classified by shared-vertex count: face≥4 / edge≥2 / vertex≥1 cumulative supersets) + boundary + local-only owners. Shape read from the key's leaf type bit (authoritative). Tet-leaf / root → empty (pi1.5 deferral; never throws).
- **C (Luciferase-3zs)** `502dbb42` — `addNeighboringNodes` unions the cross-parent f4 quad-base neighbor with siblings; dedicated `PyramidNeighborParityTest` (face/edge/vertex reciprocity tree-sweeps + GhostCoordinator seam test pinning `GhostType.FACES == 1`).

## Scope honesty
A pyramid's only same-shape face is the quad base (f4); the 4 triangular faces neighbor tetrahedra. So same-shape `findFaceNeighbors` returns ≤1, and meaningful ghost *exchange* (4/5 cross-shape faces) lands in pi1.5 — surfaced in code/javadoc/tests and confirmed by `phase-review-gate RDR-010 pi1.4` (PASSED; Item5=pi1.4, cross-shape=pi1.5, Item4=pi1.6).

## Validation
- Full `lucien` suite green: **2670, 0 failures**. pi1.3 `PyramidIndexParityTest` regression green.
- New tests: `PyramidKeyCodecTest` (8, incl. independent golden-key bit oracle), `PyramidNeighborDetectorTest` (11, incl. brute-force-over-SFC-universe completeness/soundness oracle), `PyramidNeighborParityTest` (4), `PyramidAddNeighboringNodesTest` (+3, cross-parent non-vacuous + BFS symmetry).
- Invariants preserved: #1 (no `contains12DOP` on type-6/7), #2 (no new `Spatial.aabt`), #5 (shared-vertex assertions only on conforming pyramid faces), #7 (`getNodeBounds` unchanged). Face-neighbor validation by reciprocity/involution per CLAUDE.md caveat.
- Dual review (code-review-expert + substantive-critic) at every phase; all findings actioned pre-commit.

CI note: simulation-module timing/perf tests can flake under CI contention (per pi1.3); pi1.x changes never touch simulation — a red simulation batch is almost certainly a flake, rerun `--failed`.