### PR TITLE
Luciferase-ftz: cap render surefire forkCount to stop CI OOM-kill

### DIFF
--- a/render/pom.xml
+++ b/render/pom.xml
@@ -21,6 +21,14 @@
         <render.surefire.argLine></render.surefire.argLine>
         <!-- Default: no excluded groups. CI sets this to exclude memory-intensive tests. -->
         <render.excludedGroups></render.excludedGroups>
+        <!-- Cap concurrent surefire forks for render specifically (Luciferase-ftz). The root pom
+             defaults test.forks=15; render's per-fork argLine reserves -Xms1G and allows -Xmx4G, so
+             15 concurrent forks under xvfb+Mesa+LWJGL/FFM native allocations over-commit memory on a
+             ~7GB CI runner — the OOM-killer reaps a fork ("terminated without properly saying
+             goodbye") and the next fork fails to launch ("Error occurred in starting fork"). 2 forks
+             keeps committed memory bounded while preserving some parallelism. Overridable on the
+             command line (-Drender.forkCount=N) for memory-rich local machines. -->
+        <render.forkCount>2</render.forkCount>
     </properties>
 
     <dependencies>
@@ -156,6 +164,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <!-- Cap concurrent forks (Luciferase-ftz) — see render.forkCount property above.
+                         Overrides the inherited root forkCount=${test.forks} (15), which over-commits
+                         memory for render's 4G-capable forks and OOM-kills the CI batch. -->
+                    <forkCount>${render.forkCount}</forkCount>
                     <systemPropertyVariables>
                         <java.awt.headless>true</java.awt.headless>
                         <lwjgl.opencl.explicitInit>true</lwjgl.opencl.explicitInit>


### PR DESCRIPTION
## Problem

The `test-other-modules` CI batch intermittently fails with a forked-VM crash in the **render** module:

```
The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
Error occurred in starting fork, check output in log
```

This is **not** a test or GL bug. Root cause: the root pom sets `test.forks=15` (`forkCount=15`), and `render/pom.xml` overrides only the surefire `argLine` to `-Xmx4G -Xms1G` per fork — **not** `forkCount`. So the render batch launches up to **15 concurrent JVMs**, each committing 1 GB (`-Xms1G`) and able to grow to 4 GB, under `xvfb` + Mesa software GL with LWJGL/FFM native allocations, on a ~7 GB `ubuntu-latest` runner. That over-commits memory → the Linux OOM-killer reaps a fork (first message) and the next fork can't reserve its heap (second message). Non-deterministic, hence the flakiness.

## Context

- All **real GPU/LWJGL-context** render tests are already gated out of the shared CI batch (`RUN_GPU_TESTS` / `@Disabled` / CI-headless `assumeTrue(false)` skips); actual GPU runs live in the dedicated `gpu-vendor-tests.yml` workflow. The CI batch runs render's **CPU-side logic only**.
- The only tests needing 4 GB (`Phase5a5BenchmarkTest`, `@Tag("memory-intensive")`) are already CI-excluded.

## Fix

Cap render's concurrent forks to **2** via an overridable `render.forkCount` property (default 2; `-Drender.forkCount=N` for memory-rich local machines). render already overrides `argLine`, so the `forkCount` override is the same pattern. Effective-pom confirms render's build surefire now uses `forkCount=2` (vs. inherited 15).

## Verification

Full render suite (memory-intensive excluded), `forkCount=2`:

```
Tests run: 1885, Failures: 0, Errors: 0, Skipped: 181
BUILD SUCCESS
```

No VM-crash signature. Bead: Luciferase-ftz.