### PR TITLE
RDR-010 pi1.5: cross-shape neighbor finding + distributed ghost wiring (pyramid↔tet)

### DIFF
--- a/docs/rdr/RDR-010-pyramid-spatial-index.md
+++ b/docs/rdr/RDR-010-pyramid-spatial-index.md
@@ -357,3 +357,18 @@ Accepted 2026-05-28 (gate PASSED 2026-05-28, self-reviewed; T2 `Luciferase_rdr/0
 **Invariant #7 affirmed, not revised.** Invariant #7 ("`Spatial.aabt` is non-sealed; `Tet` and `aabt.Box` implement it; §3b means no new `aabt` implementor is needed") remains literally true under Option 1: `HybridElement` is orthogonal to the `aabt` hierarchy; `Pyramid` is a `HybridElement`, **not** an `aabt`; `Tet` remains the sole tetrahedral `aabt`. This addendum is a clarification of how the element model unifies, not a change to invariant #7. (Option 2 *would* have revised #7 — a further argument against it.)
 
 **Plan.** 5-phase TDD (PRE: this addendum + pi1.1/pi1.2 co-resident on the q3p branch; A: `HybridElement` + Tet/Pyramid conformance; B: `Pyramid.parent()`/`child()`; C: `Tet.parentElement()` cross-type boundary; D: `faceNeighborElement()` + `Pyramid.faceNeighbor()` + `HybridFaceNeighbor`; E: pi1.3 readiness). Full design + per-phase test invariants: T2 `Luciferase/rdr-010-q3p-element-unification-design-2026-05-29`. Per-phase gate: full lucien suite + `-Pperformance` parity + dual review + `/conexus:phase-review-gate`.
+
+## Addendum 2026-05-30 — pi1.5 close / Phase-5 §Approach cross-walk gate PASSED
+
+`/conexus:phase-review-gate RDR-010 --phase 5` PASSED 2026-05-30. §Approach cross-walk (no silent scope reduction):
+
+- **Item1** (PyramidKey + Pyramid primitive) → `Luciferase-kto` (pi1.3 Phase A skeleton; standalone primitive beads pi1.1/pi1.2 compacted).
+- **Item2** (reuse tet machinery; only tet types 0/3 pyramid-aware) → `Luciferase-9e3a` (pi1.5.B consumes `Tet.faceNeighborElement` cross-type; element-unification q3p shipped, see 2026-05-29 addendum). Per the 4pd alignment, Luciferase `Tet` type k IS t8code dtet type k — Finding #15's translation arrays were DELETED; Finding #16's deep-tet divergence is RESOLVED at the shallow boundary.
+- **Item3** (pyramid containment §3b decompose-and-reuse) → `Luciferase-ssu` (pi1.3 Phase B §3b containment + `PyramidContainmentTest`).
+- **Item4** (Forest `ShapeWeightProvider` + `TwoOneBalanceChecker` shape-router) → **DEFERRED, explicit (not silent): bead `Luciferase-pi1.6`** (RDR-010 P5). `N_pyramid(ℓ)=2·8^ℓ−6^ℓ` weight hook + PyramidKey/TetreeKey balance-router. Out of pi1.5 scope by design.
+- **Item5** (`PyramidNeighborDetector` ghost-layer integration) → `Luciferase-azwr` (pi1.5.C, this close). Built on pi1.4 same-shape (`Luciferase-8zv`/`mu9`/`3zs`) + pi1.5 cross-shape A/B/C (`uqik`/`9e3a`/`azwr`). Cross-shape face neighbors exact via element navigation; edge/vertex bounded supersets (exhaustive cross-shape edge/vertex → bead `Luciferase-0utt`); full distributed cross-rank ghost via the inverted seam with externally-assigned owners.
+- **Item6** (the gate question — three candidate directions) → **resolved at accept (2026-05-28): Direction B.** No implementation bead.
+
+**Additional registered deferrals (explicit, not silent):** deep-tet (`l > minTetLevel`) cross-shape face neighbors stay fail-loud guarded (Finding #16) → q3p Phase E / future RDR-scoped tet-tree reconciliation; exhaustive cross-shape edge/vertex topology → `Luciferase-0utt`. Both surfaced, not silently dropped.
+
+pi1.5 deliverable arc (cross-shape neighbor finding + distributed ghost wiring) is COMPLETE. Remaining RDR-010 work: pi1.6 (Forest weight + balance-router, Item4) and pi1.7 (hybrid-mesh demo + 128-bit-key/branching microbenchmarks). RDR-010 stays `accepted` (not closed) until pi1.6 + pi1.7 land.

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/DistributedGhostManager.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/DistributedGhostManager.java
@@ -244,6 +244,16 @@ public class DistributedGhostManager<Key extends SpatialKey<Key>, ID extends Ent
     /**
      * Set element ownership information for distributed ghost detection.
      *
+     * <p><b>Owner-map split (RDR-010 pi1.5 Phase C — Luciferase-azwr).</b> This populates the manager's
+     * own {@link #elementOwners} map, which is <em>separate</em> from
+     * {@link GhostBoundaryDetector#setElementOwner}'s map. The local boundary scan
+     * ({@link GhostBoundaryDetector#createGhostLayer}) — the path that decides which remote-owned
+     * neighbors become ghosts — reads the <em>detector's</em> map, not this one. To drive local
+     * cross-shape ghost creation from external (Forest-partition) ownership, set owners on the
+     * {@link GhostBoundaryDetector} (the inverted-seam owner store). This map currently backs only
+     * {@link #getElementOwner} for manager-level routing; do not assume setting it here feeds the local
+     * ghost scan.
+     *
      * @param key the spatial key
      * @param ownerRank the rank of the process that owns this element
      */

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/GhostBoundaryDetector.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/GhostBoundaryDetector.java
@@ -719,7 +719,19 @@ public class GhostBoundaryDetector<Key extends SpatialKey<Key>, ID extends Entit
         return neighbors;
     }
 
-    private void createGhostElement(Key neighborKey, int ownerRank) {
+    /**
+     * Create a ghost element for a remote-owned neighbor that is absent from the local index.
+     *
+     * <p>Placeholder hook: the actual ghost entity data arrives asynchronously via gRPC
+     * ({@link DistributedGhostManager}). This method is the single point where the local boundary scan
+     * decides "this neighbor key, owned by {@code ownerRank}, is a ghost" — {@code protected} so an
+     * integration test can observe the firing (RDR-010 pi1.5 Phase C, Luciferase-azwr), which is the
+     * only way to assert the cross-shape ghost path end-to-end given the placeholder body.
+     *
+     * @param neighborKey the spatial key of the remote-owned neighbor
+     * @param ownerRank    the owning process rank (always non-zero here)
+     */
+    protected void createGhostElement(Key neighborKey, int ownerRank) {
         // Placeholder ghost creation - actual data would come via gRPC
         log.trace("Creating placeholder ghost for key {} owned by rank {}", neighborKey, ownerRank);
     }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
@@ -921,21 +921,32 @@ public class PyramidIndex<ID extends EntityID, Content> extends AbstractSpatialI
     /**
      * Emit at least the SFC-adjacent same-level PyramidKeys into {@code toVisit}.
      *
-     * <p><b>Pi1.4 Phase C (Luciferase-3zs)</b>: emits the sibling pyramid children of the parent
-     * (the SFC-adjacent same-level nodes) <em>unioned</em> with the same-shape (quad-base, f4)
-     * face neighbour from the wired {@link PyramidNeighborDetector} — a cross-parent neighbour the
-     * sibling walk alone misses. Cross-shape topology (the four triangular tet faces, pyramid↔tet↔hex
-     * boundaries) is deferred to pi1.5; for a tet-leaf node the detector contributes nothing.
+     * <p><b>Pi1.5 Phase C (Luciferase-azwr) — cross-shape graduation.</b> Emits the sibling pyramid
+     * children of the parent (the SFC-adjacent same-level nodes) <em>unioned</em> with the full
+     * cross-shape face-neighbour set from the wired {@link PyramidNeighborDetector}. Because the detector
+     * now resolves faces by element navigation, this union includes the four triangular tet faces
+     * (pyramid→tet) as well as the quad base (f4, pyramid↔pyramid) — cross-parent neighbours the sibling
+     * walk alone misses. A <em>tet-leaf</em> {@code nodeIndex} (first-class since pi1.5) likewise emits
+     * its cross-shape face neighbours here.
      *
-     * <p><em>Registered deferral — not silent scope reduction.</em> Cross-shape: bead Luciferase-pi1.5.
+     * <p><b>Tet-sibling bound (documented, not silent).</b> The sibling walk below enqueues only the
+     * <em>Pyramid</em> children of the enclosing parent; non-face-adjacent tet siblings are intentionally
+     * not enqueued. BFS connectivity (kNN / range / collision) traverses face-adjacent cells, and every
+     * face-adjacent neighbour — including cross-shape tets — is emitted via {@code findFaceNeighbors}, so
+     * the omission cannot disconnect the BFS. Exhaustive cross-shape edge/vertex adjacency is a registered
+     * deferral (bead Luciferase-0utt).
+     *
+     * <p>Occupancy-blind: the detector emits geometric neighbours regardless of index occupancy; BFS
+     * callers null-check the node map and skip absent keys. Do NOT add occupancy filtering here.
      */
     @Override
     protected void addNeighboringNodes(PyramidKey nodeIndex, Queue<PyramidKey> toVisit,
                                        Set<PyramidKey> visitedNodes) {
         byte level = nodeIndex.getLevel();
 
-        // Same-shape face neighbour(s) from the wired detector (the cross-parent f4 quad base the
-        // sibling walk below cannot reach). Empty for root / tet-leaf nodes. Cross-shape → pi1.5.
+        // Cross-shape face neighbours from the wired detector: the f4 quad base (pyramid↔pyramid) plus
+        // the four triangular tet faces (pyramid→tet), all cross-parent neighbours the sibling walk
+        // below cannot reach. Empty for the root; for a tet-leaf node this is its cross-shape face set.
         // The detector emits geometric neighbours regardless of index occupancy; the BFS callers
         // null-check the node map and skip absent keys (see KnnSearcher / CollisionEngine). Do NOT
         // add occupancy filtering here — it would break BFS connectivity through empty cells.

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
@@ -597,6 +597,12 @@ public class PyramidIndex<ID extends EntityID, Content> extends AbstractSpatialI
      * conservative over-approximation. Ray/plane callers therefore may report a false-positive
      * intersection for deep tet keys, never a false negative. This is safe for Phase D (the
      * pyramid bound encloses the tet); exact tet-geometry ray/plane tests are deferred to Phase E.
+     *
+     * <p><b>Tet-leaf callers:</b> when the <em>actual</em> leaf element is needed (e.g. to call
+     * cross-shape navigation on a tet leaf), use {@link #elementFromKey(PyramidKey)} instead — it
+     * returns the tet itself rather than this over-approximating enclosing pyramid.
+     *
+     * @see #elementFromKey(PyramidKey)
      */
     static Pyramid pyramidFromKey(PyramidKey key) {
         byte level = key.getLevel();
@@ -654,6 +660,72 @@ public class PyramidIndex<ID extends EntityID, Content> extends AbstractSpatialI
             current = next;
         }
         return current;
+    }
+
+    /**
+     * Decode {@code key} to its actual leaf {@link HybridElement} — a {@link Pyramid} for a pyramid
+     * key, a {@link Tet} for a <em>shallowest</em> tet-leaf key (RDR-010 pi1.5 Phase A, bead
+     * Luciferase-uqik). Unlike {@link #pyramidFromKey(PyramidKey)} (which over-approximates a tet-leaf
+     * key to its enclosing parent pyramid), this returns the tet itself, so it is the validating
+     * inverse of {@link PyramidKeyCodec#encode(Tet)}.
+     *
+     * <p><b>Shallow boundary only.</b> The descent follows {@link Pyramid#child(int)} edges, so it can
+     * reconstruct a tet only at the leaf level (a tet born directly from a pyramid, {@code minTetLevel
+     * == level}). A key whose bits select a tet at a non-leaf level — a <em>deep</em> pyramid-rooted
+     * tet ({@code l > minTetLevel}) — is not reconstructible here (the tet-of-tet refinement is the
+     * q3p Phase E deferral, fail-loud elsewhere) and returns {@code null}. A key with no matching
+     * child at some level also returns {@code null}.
+     *
+     * @param key the SFC key
+     * @return the leaf element (Pyramid or Tet), or {@code null} for a non-reconstructible key
+     */
+    static HybridElement elementFromKey(PyramidKey key) {
+        byte level = key.getLevel();
+        if (level == 0) {
+            return new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6); // virtual root cover
+        }
+        // Level-1 child of one of the two roots.
+        int coordBits1 = key.getCoordBitsAtLevel(1);
+        int typeBits1 = key.getTypeAtLevel(1);
+        HybridElement currentEl = null;
+        outer:
+        for (var root : new Pyramid[] { new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6),
+                                        new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_7) }) {
+            int row = root.type() - Pyramid.TYPE_6;
+            for (int i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
+                if (TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_CID[row][i] == coordBits1
+                    && TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_TYPE[row][i] == typeBits1) {
+                    currentEl = root.child(i);
+                    break outer;
+                }
+            }
+        }
+        if (currentEl == null || level == 1) {
+            return currentEl; // level-1 leaf (Tet or Pyramid), or no match
+        }
+        // Descend levels 2..level via pyramid children. A tet at a non-leaf level cannot parent the
+        // next level here (deep-tet, out of pi1.5 scope) → null.
+        for (int l = 2; l <= level; l++) {
+            if (!(currentEl instanceof Pyramid cp)) {
+                return null; // deep tet-of-tet path: not reconstructible at the shallow boundary
+            }
+            int cb = key.getCoordBitsAtLevel(l);
+            int tb = key.getTypeAtLevel(l);
+            HybridElement next = null;
+            int row = cp.type() - Pyramid.TYPE_6;
+            for (int i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
+                if (TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_CID[row][i] == cb
+                    && TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_TYPE[row][i] == tb) {
+                    next = cp.child(i);
+                    break;
+                }
+            }
+            if (next == null) {
+                return null; // no matching child: not an SFC element
+            }
+            currentEl = next;
+        }
+        return currentEl;
     }
 
     /**

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeyCodec.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeyCodec.java
@@ -6,10 +6,14 @@
 package com.hellblazer.luciferase.lucien.pyramid;
 
 import com.hellblazer.luciferase.lucien.Constants;
+import com.hellblazer.luciferase.lucien.HybridElement;
+import com.hellblazer.luciferase.lucien.tetree.Tet;
 
 /**
- * Encoder from a {@link Pyramid} element to its {@link PyramidKey} — the inverse of
- * {@link PyramidIndex#pyramidFromKey(PyramidKey)} (RDR-010 pi1.4 Phase A, bead Luciferase-8zv).
+ * Encoder from a hybrid SFC element to its {@link PyramidKey}: {@link #encode(Pyramid)} (RDR-010 pi1.4
+ * Phase A, bead Luciferase-8zv) and {@link #encode(Tet)} for a shallowest tet leaf (RDR-010 pi1.5
+ * Phase A, bead Luciferase-uqik). Both are the inverse of the canonical decoders on {@link PyramidIndex}
+ * ({@link PyramidIndex#pyramidFromKey(PyramidKey)} / {@link PyramidIndex#elementFromKey(PyramidKey)}).
  *
  * <p>The encoder walks the pyramid's {@link Pyramid#parent()} chain to the root, collecting at each
  * refinement step the cube-id (from the anchor's level bit) and the element type, then assembles the
@@ -89,6 +93,79 @@ final class PyramidKeyCodec {
             return key;
         } catch (IllegalStateException | IllegalArgumentException | IndexOutOfBoundsException e) {
             // Non-SFC candidate (unreachable parent step, or malformed level/bits). Fail-safe to null.
+            return null;
+        }
+    }
+
+    /**
+     * Encode a <em>shallowest</em> tet leaf to its tet-leaf {@link PyramidKey}, or {@code null} if the
+     * tet is not a shallowest, reachable element of the pyramid SFC (RDR-010 pi1.5 Phase A, bead
+     * Luciferase-uqik). This is the bridge that lets {@code PyramidNeighborDetector} (Phase B) surface
+     * a pyramid's four triangular-face tet neighbors (and a tet leaf's own neighbors) as keys.
+     *
+     * <p><b>Shallow boundary only.</b> A tet whose tetrahedral branch begins at its own level
+     * ({@code minTetLevel == level}) sits directly on a pyramid face — its parent is a pyramid
+     * (recoverable via {@link Tet#parentElement()}). A deeper pyramid-rooted tet
+     * ({@code minTetLevel < level}) or a pure-Tetree tet ({@code minTetLevel == -1}) is out of pi1.5
+     * scope and returns {@code null} (deep-tet cross-shape is the q3p Phase E deferral). The level-0
+     * root is a pyramid, never a tet → {@code null}.
+     *
+     * <p><b>Fail-safe contract.</b> Mirrors {@link #encode(Pyramid)}: the {@link Tet#parentElement()}
+     * walk may throw on a non-SFC candidate; that is caught and funneled to {@code null}. The internal
+     * round-trip self-check ({@code elementFromKey(key)} must recover the same tet geometry) is the
+     * single source of truth for validity, so a co-consistent bit error never emits a bogus key.
+     *
+     * @param t the tetrahedron element
+     * @return the round-trip-verified tet-leaf key, or {@code null} for a non-shallowest / non-SFC tet
+     */
+    static PyramidKey encode(Tet t) {
+        byte level = t.level();
+        if (level < 1) {
+            return null; // the level-0 root is the pyramid cover, not a tet
+        }
+        if (t.minTetLevel() != level) {
+            // Only the shallowest tet of a pyramidal branch (parent is a pyramid) is in pi1.5 scope.
+            // Deeper pyramid-rooted tets and pure-Tetree tets (minTetLevel == -1) are not SFC pyramid
+            // leaves the codec can bridge — reject up front (fail-safe, no throw).
+            return null;
+        }
+        // coordBits/typeBits indexed by refinement step 1..level (index 0 unused; root has no bits).
+        int[] coordBits = new int[level + 1];
+        int[] typeBits = new int[level + 1];
+        int hLeaf = Constants.lengthAtLevel(level);
+        coordBits[level] = ((t.x() & hLeaf) != 0 ? 1 : 0)
+                         | ((t.y() & hLeaf) != 0 ? 2 : 0)
+                         | ((t.z() & hLeaf) != 0 ? 4 : 0);
+        typeBits[level] = t.type();
+        try {
+            // The shallowest tet's parent is the pyramid that birthed it (Tet.parentElement, the
+            // minTetLevel == level branch). Walk that pyramid chain to the root for the coarser bits.
+            HybridElement parent = t.parentElement();
+            if (!(parent instanceof Pyramid pyramidParent)) {
+                return null; // defensive: a shallowest tet must have a pyramid parent
+            }
+            Pyramid cur = pyramidParent;
+            for (int l = level - 1; l >= 1; l--) {
+                int h = Constants.lengthAtLevel((byte) l);
+                coordBits[l] = ((cur.x() & h) != 0 ? 1 : 0)
+                             | ((cur.y() & h) != 0 ? 2 : 0)
+                             | ((cur.z() & h) != 0 ? 4 : 0);
+                typeBits[l] = cur.type();
+                if (l > 1) {
+                    cur = cur.parent();
+                }
+            }
+            PyramidKey key = PyramidKey.fromLevels(level, coordBits, typeBits);
+            // Round-trip self-check against the leaf-aware decoder: the decoded leaf must be a tet of
+            // the same geometric identity (x,y,z,level,type — minTetLevel is reconstructed identically
+            // by Pyramid.child, but compare the geometric fields explicitly to stay equals-independent).
+            HybridElement decoded = PyramidIndex.elementFromKey(key);
+            if (decoded instanceof Tet dt && dt.x() == t.x() && dt.y() == t.y() && dt.z() == t.z()
+                && dt.level() == t.level() && dt.type() == t.type()) {
+                return key;
+            }
+            return null;
+        } catch (IllegalStateException | IllegalArgumentException | IndexOutOfBoundsException e) {
             return null;
         }
     }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborDetector.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborDetector.java
@@ -15,45 +15,63 @@
 package com.hellblazer.luciferase.lucien.pyramid;
 
 import com.hellblazer.luciferase.lucien.Constants;
+import com.hellblazer.luciferase.lucien.HybridElement;
+import com.hellblazer.luciferase.lucien.HybridFaceNeighbor;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostType;
 import com.hellblazer.luciferase.lucien.neighbor.NeighborDetector;
+import com.hellblazer.luciferase.lucien.tetree.Tet;
 
 import javax.vecmath.Point3i;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
 /**
- * Same-shape (pyramid↔pyramid) topology neighbor detector for the pyramid SFC (RDR-010 pi1.4,
- * bead Luciferase-mu9, Knapp 2026 §4.3-4.4). Mirrors {@link com.hellblazer.luciferase.lucien.neighbor.MortonNeighborDetector}:
- * neighbor methods return the geometric same-level neighbor keys (independent of index occupancy), and
- * boundary/owner methods mirror the Morton peer.
+ * Cross-shape (pyramid↔tet) topology neighbor detector for the pyramid SFC (RDR-010 pi1.4 same-shape /
+ * pi1.5 cross-shape, beads Luciferase-mu9 / Luciferase-9e3a, Knapp 2026 §4.3-4.4). Mirrors
+ * {@link com.hellblazer.luciferase.lucien.neighbor.MortonNeighborDetector}: neighbor methods return the
+ * geometric same-level neighbor keys (independent of index occupancy), and boundary/owner methods
+ * mirror the Morton peer.
  *
- * <p><b>Same-shape only (pi1.4 scope).</b> A pyramid's only same-shape face is the quadrilateral base
- * (f4, type 6↔7); its four triangular faces neighbor tetrahedra, and a {@link PyramidKey} can also
- * encode a tet leaf (type 0-5). Cross-shape neighbor finding (pyramid↔tet↔hex) and tet-leaf neighbor
- * topology are deferred to pi1.5 (bead Luciferase-pi1.5): for a tet-leaf key this detector returns an
- * empty result rather than throwing, so ghost/kNN wiring is not broken.
+ * <p><b>Face neighbors — exact, via element navigation (pi1.5).</b> A pyramid has five faces: the
+ * quadrilateral base (f4, same-shape type 6↔7) and four triangular faces (f0-f3, cross-shape — each
+ * neighbors a tetrahedron). {@link #findFaceNeighbors} resolves the query key to its leaf element
+ * ({@link PyramidIndex#elementFromKey}) and walks the conforming face neighbors directly via
+ * {@link Pyramid#faceNeighbor(int)} (5 faces) or {@link Tet#faceNeighborElement(int)} (4 faces),
+ * encoding each neighbor to a key (a pyramid key or a tet-leaf key) via {@link PyramidKeyCodec}. A
+ * neighbor outside the domain or outside the SFC encodes to {@code null} and is dropped. This is the
+ * reciprocity-validatable face topology (the {@link HybridFaceNeighbor#face()} reciprocal index), not a
+ * shared-vertex heuristic.
  *
- * <p><b>Unified enumeration.</b> All three neighbor queries share one geometric pass: for each of the
- * 27 cube offsets {@code (dx,dy,dz) ∈ {-1,0,+1}³} and each pyramid type {@code {6,7}}, a candidate
- * same-level pyramid is built, filtered to genuine SFC elements via {@link PyramidKeyCodec#encode}
- * (a non-SFC candidate encodes to {@code null}), and classified by shared-vertex count against the
- * query element. The buckets are cumulative supersets per the {@link NeighborDetector} contract:
- * <ul>
- *   <li>face   — shared ≥ 4 (a conforming quad base; two distinct same-level pyramids share ≥3
- *                vertices only across the quad base, hence exactly 4)</li>
- *   <li>edge   — shared ≥ 2 (⊇ face)</li>
- *   <li>vertex — shared ≥ 1 (⊇ edge)</li>
- * </ul>
+ * <p><b>Shallow boundary only.</b> Cross-shape descends to the shallowest pyramid↔tet boundary
+ * ({@code l == minTetLevel}). A deep pyramid-rooted tet ({@code l > minTetLevel}) trips
+ * {@link Tet#faceNeighborElement}'s fail-loud guard (RDR-010 Finding #16, deferred to q3p Phase E);
+ * the detector <em>catches and skips</em> that face rather than propagating — a thrown exception would
+ * break the BFS in {@code KnnSearcher}/{@code CollisionEngine}.
+ *
+ * <p><b>Edge/vertex — bounded cumulative supersets (pi1.5).</b> Edge and vertex add the same-shape
+ * (pyramid↔pyramid) geometric neighbors at shared-vertex thresholds 2 and 1 (the 27-cube enumeration
+ * below) on top of the cross-shape face set, preserving face ⊆ edge ⊆ vertex. <em>Exhaustive
+ * cross-shape edge/vertex adjacency</em> (tet-tet edge sharing, pyramid-tet vertex fans) is a
+ * registered deferral — bead Luciferase-0utt — not silent scope reduction: ghost {@code FACES}
+ * exchange needs only the face set, which is exact here.
+ *
+ * <p><b>Same-shape enumeration (edge/vertex contribution).</b> For each of the 27 cube offsets
+ * {@code (dx,dy,dz) ∈ {-1,0,+1}³} and each pyramid type {@code {6,7}}, a candidate same-level pyramid is
+ * built, filtered to genuine SFC elements via {@link PyramidKeyCodec#encode} (non-SFC → {@code null}),
+ * and classified by shared-vertex count against the query element (edge ≥ 2, vertex ≥ 1). The
+ * shared-vertex test is valid for the conforming same-shape pyramid topology; it is deliberately NOT
+ * applied to tet faces (Bey-SFC tet faces share 0-3 vertices — see CLAUDE.md face-neighbor caveat).
  *
  * @author Hal Hildebrand
  */
 public final class PyramidNeighborDetector implements NeighborDetector<PyramidKey> {
 
-    private static final int FACE_SHARED_VERTICES   = 4;
+    // Same-shape shared-vertex thresholds for the edge/vertex superset contribution. (Face neighbors
+    // are computed exactly via element navigation, not by a shared-vertex threshold.)
     private static final int EDGE_SHARED_VERTICES   = 2;
     private static final int VERTEX_SHARED_VERTICES = 1;
 
@@ -66,17 +84,92 @@ public final class PyramidNeighborDetector implements NeighborDetector<PyramidKe
 
     @Override
     public List<PyramidKey> findFaceNeighbors(PyramidKey element) {
-        return sameShapeNeighbors(element, FACE_SHARED_VERTICES);
+        // Exact conforming face topology via element navigation (pyramid: 5 faces; tet leaf: 4 faces).
+        return new ArrayList<>(crossShapeFaceNeighbors(element));
     }
 
     @Override
     public List<PyramidKey> findEdgeNeighbors(PyramidKey element) {
-        return sameShapeNeighbors(element, EDGE_SHARED_VERTICES);
+        // Bounded superset: cross-shape faces ∪ same-shape edge neighbors (shared ≥ 2). Exhaustive
+        // cross-shape edge adjacency is deferred (bead Luciferase-0utt).
+        return unionFaceWithSameShape(element, EDGE_SHARED_VERTICES);
     }
 
     @Override
     public List<PyramidKey> findVertexNeighbors(PyramidKey element) {
-        return sameShapeNeighbors(element, VERTEX_SHARED_VERTICES);
+        // Bounded superset: cross-shape faces ∪ same-shape vertex neighbors (shared ≥ 1). Exhaustive
+        // cross-shape vertex adjacency is deferred (bead Luciferase-0utt).
+        return unionFaceWithSameShape(element, VERTEX_SHARED_VERTICES);
+    }
+
+    /**
+     * Cross-shape face set unioned with the same-shape neighbors at {@code minSharedVertices},
+     * insertion-ordered and de-duplicated, preserving face ⊆ edge ⊆ vertex.
+     */
+    private List<PyramidKey> unionFaceWithSameShape(PyramidKey element, int minSharedVertices) {
+        var union = new LinkedHashSet<>(crossShapeFaceNeighbors(element));
+        union.addAll(sameShapeNeighbors(element, minSharedVertices));
+        return new ArrayList<>(union);
+    }
+
+    /**
+     * The exact conforming face neighbors of {@code element}'s leaf, as keys. Resolves the leaf via
+     * {@link PyramidIndex#elementFromKey} (a {@link Pyramid} or a shallowest {@link Tet}) and walks
+     * {@link Pyramid#faceNeighbor(int)} / {@link Tet#faceNeighborElement(int)}. A deep pyramid-rooted
+     * tet's fail-loud guard is caught and that face skipped (BFS-safe; deep cross-shape deferred to q3p
+     * Phase E). Out-of-domain / non-SFC neighbors encode to {@code null} and are dropped.
+     */
+    private Set<PyramidKey> crossShapeFaceNeighbors(PyramidKey element) {
+        HybridElement self = PyramidIndex.elementFromKey(element);
+        if (self == null || self.level() == 0) {
+            // The level-0 root is the virtual domain cover; it has no same-level face neighbors (and
+            // Pyramid.faceNeighbor on a level-0 pyramid would build an invalid level-0 element).
+            return Set.of();
+        }
+        var out = new LinkedHashSet<PyramidKey>();
+        if (self instanceof Pyramid p) {
+            for (int f = 0; f < Pyramid.FACES; f++) {
+                addFaceNeighbor(p.faceNeighbor(f), element, out);
+            }
+        } else if (self instanceof Tet t) {
+            for (int f = 0; f < 4; f++) {
+                HybridFaceNeighbor fn;
+                try {
+                    fn = t.faceNeighborElement(f);
+                } catch (IllegalStateException deepTet) {
+                    // Defensive: a deep pyramid-rooted tet (l > minTetLevel) trips Tet.faceNeighborElement's
+                    // fail-loud guard (RDR-010 Finding #16, q3p Phase E). In practice this is unreachable
+                    // via a key — encode(Tet) rejects deep tets and elementFromKey cannot reconstruct one,
+                    // so `self` here is always a SHALLOW tet (l == minTetLevel). The catch guards against
+                    // future change: propagating would break the BFS in KnnSearcher/CollisionEngine.
+                    continue;
+                }
+                addFaceNeighbor(fn, element, out);
+            }
+        }
+        return out;
+    }
+
+    /** Encode a face neighbor's element and add its key (skipping null / self / duplicates). */
+    private static void addFaceNeighbor(HybridFaceNeighbor fn, PyramidKey selfKey, Set<PyramidKey> out) {
+        if (fn == null) {
+            return;
+        }
+        PyramidKey key = encodeElement(fn.element());
+        if (key != null && !key.equals(selfKey)) {
+            out.add(key);
+        }
+    }
+
+    /** Encode a hybrid leaf element to its key via the shape-appropriate {@link PyramidKeyCodec} path. */
+    private static PyramidKey encodeElement(HybridElement e) {
+        if (e instanceof Pyramid p) {
+            return PyramidKeyCodec.encode(p);
+        }
+        if (e instanceof Tet t) {
+            return PyramidKeyCodec.encode(t);
+        }
+        return null;
     }
 
     /**
@@ -124,14 +217,16 @@ public final class PyramidNeighborDetector implements NeighborDetector<PyramidKe
     }
 
     /**
-     * Unified geometric same-shape enumeration. Returns the same-level pyramid keys that share at
-     * least {@code minSharedVertices} vertices with the query element. A tet-leaf or non-decodable key
-     * yields an empty list (pi1.5 deferral; never throws).
+     * Same-shape (pyramid↔pyramid) geometric enumeration for the edge/vertex superset contribution.
+     * Returns the same-level pyramid keys that share at least {@code minSharedVertices} vertices with
+     * the query element. A tet-leaf or non-decodable key yields an empty list (so for a tet-leaf key the
+     * edge/vertex sets equal the cross-shape face set — exhaustive cross-shape edge/vertex topology is
+     * deferred to bead Luciferase-0utt); never throws.
      */
     private List<PyramidKey> sameShapeNeighbors(PyramidKey element, int minSharedVertices) {
         Pyramid self = resolvePyramid(element);
         if (self == null) {
-            return List.of(); // tet-leaf / cross-shape — deferred to pi1.5
+            return List.of(); // tet-leaf key: same-shape edge/vertex N/A (exhaustive → bead Luciferase-0utt)
         }
         int len = self.length();
         Point3i[] selfVerts = self.coordinates();
@@ -179,7 +274,7 @@ public final class PyramidNeighborDetector implements NeighborDetector<PyramidKe
         }
         byte leafType = element.getTypeAtLevel(level);
         if (leafType != Pyramid.TYPE_6 && leafType != Pyramid.TYPE_7) {
-            return null; // tet leaf — deferred to pi1.5
+            return null; // tet leaf: same-shape enumeration N/A (cross-shape faces handled separately)
         }
         Pyramid self = PyramidIndex.pyramidFromKey(element);
         if (self == null || self.level() != level || self.type() != leafType) {

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidAddNeighboringNodesTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidAddNeighboringNodesTest.java
@@ -200,6 +200,173 @@ class PyramidAddNeighboringNodesTest {
                    "addNeighboringNodes(f4) must emit self back (BFS symmetry)");
     }
 
+    // ===== pi1.5 Phase C (Luciferase-azwr): cross-shape graduation =====
+
+    @Test
+    void addNeighboringNodes_unionsCrossShapeTetFaceNeighbor() {
+        // pi1.5 Phase C graduation (Luciferase-azwr): addNeighboringNodes consumes the now-cross-shape
+        // detector.findFaceNeighbors, so a pyramid's triangular-face TET neighbor (a tet-leaf key) must
+        // enter the BFS frontier. Non-vacuous: empty / same-shape-only would fail this.
+        var pyr = firstPyramidWithCrossShapeTetFace();
+        assertNotNull(pyr, "expected an SFC pyramid with an in-domain triangular-face tet neighbor");
+        var selfKey = PyramidKeyCodec.encode(pyr);
+        assertNotNull(selfKey);
+
+        // The cross-shape tet face neighbors surfaced by the wired detector.
+        var detector = index.getNeighborDetector();
+        var tetFaceKeys = new HashSet<PyramidKey>();
+        for (var fk : detector.findFaceNeighbors(selfKey)) {
+            if (PyramidIndex.elementFromKey(fk) instanceof com.hellblazer.luciferase.lucien.tetree.Tet) {
+                tetFaceKeys.add(fk);
+            }
+        }
+        assertFalse(tetFaceKeys.isEmpty(), "precondition: detector surfaces >=1 cross-shape tet face");
+
+        var toVisit = new LinkedList<PyramidKey>();
+        var visited = new HashSet<PyramidKey>();
+        visited.add(selfKey);
+        index.addNeighboringNodes(selfKey, toVisit, visited);
+
+        var frontier = new HashSet<>(toVisit);
+        for (var tk : tetFaceKeys) {
+            assertTrue(frontier.contains(tk),
+                       "graduated addNeighboringNodes must union the cross-shape tet face neighbor " + tk);
+        }
+    }
+
+    @Test
+    void addNeighboringNodes_tetLeafNodeIndex_emitsItsCrossShapeNeighbors() {
+        // Red-guard #1 (Phase B substantive-critic): a TET-LEAF nodeIndex was contributing nothing in
+        // pi1.4 (detector returned empty for tet-leaf keys). pi1.5 makes tet-leaf keys first-class BFS
+        // entries: addNeighboringNodes(tetLeafKey) must emit the tet's cross-shape face neighbors.
+        //
+        // Bound (documented, not silent): the sibling walk enqueues only the Pyramid children of the
+        // enclosing parent — non-face-adjacent tet siblings are intentionally NOT enqueued. BFS
+        // connectivity (kNN / range / collision) only traverses face-adjacent cells, and every
+        // face-adjacent neighbor IS emitted via findFaceNeighbors, so the omission is safe.
+        var tetLeafKey = firstCrossShapeTetLeafKey();
+        assertNotNull(tetLeafKey, "expected an in-domain shallow tet-leaf key with face neighbors");
+
+        var detector = index.getNeighborDetector();
+        var faceNeighbors = new HashSet<>(detector.findFaceNeighbors(tetLeafKey));
+        assertFalse(faceNeighbors.isEmpty(), "precondition: tet-leaf key has cross-shape face neighbors");
+
+        var toVisit = new LinkedList<PyramidKey>();
+        var visited = new HashSet<PyramidKey>();
+        visited.add(tetLeafKey);
+        index.addNeighboringNodes(tetLeafKey, toVisit, visited);
+
+        var frontier = new HashSet<>(toVisit);
+        for (var fn : faceNeighbors) {
+            assertTrue(frontier.contains(fn),
+                       "tet-leaf nodeIndex must emit its cross-shape face neighbor " + fn);
+        }
+    }
+
+    @Test
+    void addNeighboringNodes_crossShapeUnionIsReciprocal() {
+        // BFS symmetry across the cross-shape (pyramid <-> tet) seam: if addNeighboringNodes(pyramid)
+        // emits a tet face neighbor, addNeighboringNodes(tet) must emit the pyramid back — else a
+        // kNN/range BFS could reach a cell from one side but not the other and silently miss entities.
+        var pyr = firstPyramidWithCrossShapeTetFace();
+        assertNotNull(pyr);
+        var pyrKey = PyramidKeyCodec.encode(pyr);
+        var detector = index.getNeighborDetector();
+
+        PyramidKey tetKey = null;
+        for (var fk : detector.findFaceNeighbors(pyrKey)) {
+            if (PyramidIndex.elementFromKey(fk) instanceof com.hellblazer.luciferase.lucien.tetree.Tet) {
+                tetKey = fk;
+                break;
+            }
+        }
+        assertNotNull(tetKey, "precondition: pyramid has a cross-shape tet face neighbor");
+
+        // Forward: pyramid emits the tet.
+        var fwd = new LinkedList<PyramidKey>();
+        var vf = new HashSet<PyramidKey>();
+        vf.add(pyrKey);
+        index.addNeighboringNodes(pyrKey, fwd, vf);
+        assertTrue(new HashSet<>(fwd).contains(tetKey), "pyramid must emit its tet face neighbor");
+
+        // Reverse: tet emits the pyramid back.
+        var rev = new LinkedList<PyramidKey>();
+        var vr = new HashSet<PyramidKey>();
+        vr.add(tetKey);
+        index.addNeighboringNodes(tetKey, rev, vr);
+        assertTrue(new HashSet<>(rev).contains(pyrKey),
+                   "addNeighboringNodes(tet) must emit the pyramid back (cross-shape BFS symmetry)");
+    }
+
+    /** First SFC pyramid (level 2..5) whose triangular faces yield an in-domain cross-shape tet neighbor. */
+    private Pyramid firstPyramidWithCrossShapeTetFace() {
+        var detector = index.getNeighborDetector();
+        var roots = new Pyramid[] { new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6),
+                                    new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_7) };
+        var stack = new java.util.ArrayDeque<Pyramid>();
+        for (var r : roots) {
+            stack.push(r);
+        }
+        while (!stack.isEmpty()) {
+            var p = stack.pop();
+            if (p.level() >= 2) {
+                var pk = PyramidKeyCodec.encode(p);
+                if (pk != null) {
+                    for (var fk : detector.findFaceNeighbors(pk)) {
+                        if (PyramidIndex.elementFromKey(fk) instanceof com.hellblazer.luciferase.lucien.tetree.Tet) {
+                            return p;
+                        }
+                    }
+                }
+            }
+            if (p.level() < 5) {
+                for (int i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
+                    if (p.child(i) instanceof Pyramid pc) {
+                        stack.push(pc);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * First in-domain shallow tet-leaf key (level 2..5) that has at least one cross-shape face neighbor.
+     * Sourced from a pyramid's triangular-face neighbor — that tet is guaranteed to report the pyramid
+     * back (reciprocity), so its face-neighbor set is non-empty (mirrors PyramidNeighborParityTest).
+     */
+    private PyramidKey firstCrossShapeTetLeafKey() {
+        var detector = index.getNeighborDetector();
+        var roots = new Pyramid[] { new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6),
+                                    new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_7) };
+        var stack = new java.util.ArrayDeque<Pyramid>();
+        for (var r : roots) {
+            stack.push(r);
+        }
+        while (!stack.isEmpty()) {
+            var p = stack.pop();
+            if (p.level() >= 2) {
+                for (int f = 0; f < 4; f++) {
+                    var fn = p.faceNeighbor(f);
+                    if (fn != null && fn.element() instanceof com.hellblazer.luciferase.lucien.tetree.Tet t) {
+                        var tk = PyramidKeyCodec.encode(t);
+                        if (tk != null && !detector.findFaceNeighbors(tk).isEmpty()) {
+                            return tk;
+                        }
+                    }
+                }
+            }
+            if (p.level() < 5) {
+                for (int i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
+                    if (p.child(i) instanceof Pyramid pc) {
+                        stack.push(pc);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
     private Pyramid[] firstPyramidWithSfcQuadBaseNeighbor() {
         var roots = new Pyramid[] { new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6),
                                     new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_7) };

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidCrossShapeGhostTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidCrossShapeGhostTest.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.pyramid;
+
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.forest.ghost.DistributedGhostManager;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostAlgorithm;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostBoundaryDetector;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostChannel;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostElement;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostType;
+import com.hellblazer.luciferase.lucien.neighbor.NeighborDetector;
+import com.hellblazer.luciferase.lucien.tetree.Tet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3f;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * RDR-010 pi1.5 Phase C (bead Luciferase-azwr): full distributed cross-rank ghost wiring through the
+ * inverted seam, proven end-to-end for the cross-shape (pyramid↔tet) boundary.
+ *
+ * <p><b>Inverted seam (Luciferase-703 / RDR-008 P2).</b> {@link GhostBoundaryDetector} binds to the
+ * {@link NeighborDetector} interface, not a concrete index. The {@link PyramidIndex}'s wired
+ * {@link PyramidNeighborDetector} now surfaces cross-shape face neighbors (Phase B), so the ghost
+ * boundary path automatically exchanges across all four triangular tet faces — not just the f4 quad
+ * base it was limited to in pi1.4.
+ *
+ * <p><b>External ownership.</b> The detector stays geometric/local (owner rank 0). Distributed
+ * ownership is assigned externally via {@link GhostBoundaryDetector#setElementOwner}; a remote-owned
+ * neighbor that is absent from the local index becomes a ghost. This test assigns DISTINCT ranks to a
+ * boundary pyramid's cross-shape tet neighbors and asserts a ghost fires for each, with the assigned
+ * rank — non-vacuous: it fails if only the f4 same-shape face is exchanged (the pi1.4 limitation).
+ *
+ * <p><b>Observability.</b> {@link RecordingGhostBoundaryDetector} overrides the {@code createGhostElement}
+ * seam to record (key, ownerRank) firings — the placeholder production hook only logs (real ghost data
+ * arrives via gRPC), so a test subclass is the cleanest observation point for the local detection path.
+ *
+ * @author Hal Hildebrand
+ */
+class PyramidCrossShapeGhostTest {
+
+    private PyramidIndex<LongEntityID, String> index;
+
+    @BeforeEach
+    void setUp() {
+        index = new PyramidIndex<>(new SequentialLongIDGenerator());
+    }
+
+    /**
+     * A {@link GhostBoundaryDetector} that records every {@code createGhostElement} firing so a test can
+     * assert which remote-owned neighbor keys became ghosts and with what rank.
+     */
+    private static final class RecordingGhostBoundaryDetector<Key extends com.hellblazer.luciferase.lucien.SpatialKey<Key>>
+        extends GhostBoundaryDetector<Key, LongEntityID, String> {
+
+        final Map<Key, Integer> created = new LinkedHashMap<>();
+
+        RecordingGhostBoundaryDetector(com.hellblazer.luciferase.lucien.SpatialIndex<Key, LongEntityID, String> index,
+                                       NeighborDetector<Key> detector, GhostType type, GhostAlgorithm algo) {
+            super(index, detector, type, algo);
+        }
+
+        @Override
+        protected void createGhostElement(Key neighborKey, int ownerRank) {
+            created.put(neighborKey, ownerRank);
+            super.createGhostElement(neighborKey, ownerRank);
+        }
+    }
+
+    /**
+     * In-memory {@link GhostChannel} that records every queued ghost by target rank and every flush —
+     * the observation seam for the distributed fan-out path (no network).
+     */
+    private static final class RecordingGhostChannel<Key extends com.hellblazer.luciferase.lucien.SpatialKey<Key>>
+        implements GhostChannel<Key, LongEntityID, String> {
+
+        final Map<Integer, Set<Key>> queuedByRank = new LinkedHashMap<>();
+        final Set<Integer> flushedRanks = new LinkedHashSet<>();
+        int pending = 0;
+
+        @Override
+        public void queueGhost(int targetRank, GhostElement<Key, LongEntityID, String> element) {
+            queuedByRank.computeIfAbsent(targetRank, r -> new LinkedHashSet<>()).add(element.getSpatialKey());
+            pending++;
+        }
+
+        @Override
+        public CompletableFuture<Void> flushToTarget(int targetRank) {
+            flushedRanks.add(targetRank);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public int getTotalPendingCount() {
+            return pending;
+        }
+
+        @Override
+        public void clear() {
+            queuedByRank.clear();
+            pending = 0;
+        }
+
+        @Override
+        public int getCurrentRank() {
+            return 0;
+        }
+
+        @Override
+        public long getTreeId() {
+            return 0L;
+        }
+
+        @Override
+        public GhostType getGhostType() {
+            return GhostType.FACES;
+        }
+    }
+
+    @Test
+    void crossShapeGhostsFireForAllFourTriangularFacesWithAssignedRanks() {
+        // Occupy a boundary pyramid (anchored at the domain origin corner) so the ghost boundary scan
+        // processes it. Insert across the origin sub-cube at a shallow forced level to occupy real keys.
+        occupyOriginCorner();
+
+        var detector = index.getNeighborDetector();
+        var qualifying = findBoundaryKeyWithCrossShapeTetNeighbors(detector);
+        assertNotNull(qualifying,
+                      "expected an occupied boundary key with >=2 in-domain cross-shape tet neighbors");
+        var boundaryKey = qualifying.key;
+        var tetNeighbors = qualifying.tetNeighbors;
+
+        var ghostDetector = new RecordingGhostBoundaryDetector<>(index, detector, GhostType.FACES,
+                                                                 GhostAlgorithm.MINIMAL);
+
+        // Assign each cross-shape tet neighbor a DISTINCT remote rank (>0 = not local).
+        var expectedRank = new LinkedHashMap<PyramidKey, Integer>();
+        int rank = 1;
+        for (var tk : tetNeighbors) {
+            ghostDetector.setElementOwner(tk, rank);
+            expectedRank.put(tk, rank);
+            rank++;
+        }
+
+        ghostDetector.createGhostLayer();
+
+        // Every assigned cross-shape tet neighbor must have fired a ghost with its assigned rank.
+        for (var e : expectedRank.entrySet()) {
+            assertEquals(e.getValue(), ghostDetector.created.get(e.getKey()),
+                         "cross-shape tet neighbor " + e.getKey() + " must ghost with its assigned rank");
+        }
+
+        // Non-vacuous / meaningful: more than one cross-shape face exchanged (pi1.4 had only f4 == 1),
+        // and the fired ghosts are genuinely tets (the cross-shape contribution).
+        long tetGhosts = ghostDetector.created.keySet().stream()
+                                       .filter(k -> PyramidIndex.elementFromKey(k) instanceof Tet)
+                                       .count();
+        assertTrue(tetGhosts >= 2,
+                   "meaningful cross-shape exchange: >=2 triangular tet faces must ghost, got " + tetGhosts);
+    }
+
+    @Test
+    void distributedGhostManagerFansOutBoundaryGhostsAcrossMultipleRanks() {
+        // SIG-1 (Phase C substantive-critic): prove the FULL distributed path through
+        // DistributedGhostManager.createDistributedGhostLayer() — not just the local detector scan.
+        // The manager queues each local boundary element for transmission to every known remote rank
+        // through the GhostChannel (inverted seam: lucien core depends on the GhostChannel interface,
+        // not a gRPC transport). Non-vacuous: asserts cross-rank fan-out to >=2 distinct ranks.
+        occupyOriginCorner();
+
+        var detector = index.getNeighborDetector();
+        var ghostDetector = new GhostBoundaryDetector<>(index, detector, GhostType.FACES,
+                                                        GhostAlgorithm.MINIMAL);
+        var channel = new RecordingGhostChannel<PyramidKey>();
+        var manager = new DistributedGhostManager<>(index, channel, ghostDetector);
+        manager.addKnownProcess(1);
+        manager.addKnownProcess(2);
+
+        manager.createDistributedGhostLayer();
+
+        // Both remote ranks received the local boundary set (cross-rank fan-out).
+        assertTrue(channel.queuedByRank.containsKey(1) && channel.queuedByRank.containsKey(2),
+                   "boundary ghosts must be queued for every known remote rank, got "
+                   + channel.queuedByRank.keySet());
+        assertFalse(channel.queuedByRank.get(1).isEmpty(), "rank 1 must receive >=1 boundary ghost");
+        assertFalse(channel.queuedByRank.get(2).isEmpty(), "rank 2 must receive >=1 boundary ghost");
+        assertTrue(channel.flushedRanks.containsAll(java.util.Set.of(1, 2)),
+                   "the manager must flush to each target rank");
+
+        // The queued ghosts are exactly the detector's identified boundary elements (the elements this
+        // rank owns and advertises to peers) — and the set is non-empty (origin corner is a boundary).
+        var boundary = ghostDetector.getBoundaryElements();
+        assertFalse(boundary.isEmpty(), "precondition: origin corner yields boundary elements");
+        assertEquals(boundary, channel.queuedByRank.get(1),
+                     "queued ghosts to a rank must equal the local boundary element set");
+    }
+
+    @Test
+    void tetLeafBoundaryClassificationIsAConservativeSuperset() {
+        // SIG-2 (Phase C substantive-critic): the red-guard #2 safety argument is "tet-leaf
+        // getBoundaryDirections returns the ENCLOSING CUBE's classification = a conservative superset of
+        // the tet's true domain-boundary faces, hence ghost-safe (never under-classifies -> never drops a
+        // real boundary ghost)". Validate it concretely, not just no-throw: a shallow tet whose enclosing
+        // level-1 cube is anchored at (h,0,0) touches the y==0 and z==0 domain faces, so its boundary
+        // directions MUST include NEGATIVE_Y and NEGATIVE_Z (the superset), and must NOT claim NEGATIVE_X
+        // (anchor x == h != 0). encode(Tet) writes the genuine cube-id to the coord field (distinct from
+        // the type field), so anchorOf recovers the true surrounding cube.
+        int h = com.hellblazer.luciferase.lucien.Constants.lengthAtLevel((byte) 1);
+        var tet = new Tet(h, 0, 0, (byte) 1, (byte) 3, (byte) 1); // shallowest tet (minTetLevel == level)
+        var tetLeafKey = PyramidKeyCodec.encode(tet);
+        assertNotNull(tetLeafKey, "precondition: shallow tet encodes to a tet-leaf key");
+        assertTrue(PyramidIndex.elementFromKey(tetLeafKey) instanceof Tet, "precondition: tet-leaf key");
+
+        var detector = index.getNeighborDetector();
+        var dirs = detector.getBoundaryDirections(tetLeafKey);
+        assertTrue(dirs.contains(NeighborDetector.Direction.NEGATIVE_Y),
+                   "enclosing cube touches y==0 -> NEGATIVE_Y must be in the conservative superset");
+        assertTrue(dirs.contains(NeighborDetector.Direction.NEGATIVE_Z),
+                   "enclosing cube touches z==0 -> NEGATIVE_Z must be in the conservative superset");
+        assertFalse(dirs.contains(NeighborDetector.Direction.NEGATIVE_X),
+                    "enclosing cube anchored at x==h is not on the x==0 boundary");
+    }
+
+    @Test
+    void tetLeafKeyBoundaryClassificationIsGuardedAndGhostSafe() {
+        // Red-guard #2 (Phase B substantive-critic): isBoundaryElement / getBoundaryDirections are
+        // computed from the surrounding-cube anchor, which is the ENCLOSING PYRAMID's cube for a
+        // tet-leaf key. This must NOT throw, and the enclosing-cube classification is a conservative
+        // SUPERSET of the tet's true boundary faces — ghost-safe (it never misses a real boundary; an
+        // over-included element simply finds no remote owner and creates no ghost).
+        var tetLeafKey = firstShallowTetLeafKey();
+        assertNotNull(tetLeafKey, "expected a shallow tet-leaf key");
+
+        var detector = index.getNeighborDetector();
+        // No throw for any direction.
+        for (var dir : NeighborDetector.Direction.values()) {
+            assertDoesNotThrow(() -> detector.isBoundaryElement(tetLeafKey, dir),
+                               "isBoundaryElement must be guarded for a tet-leaf key (dir=" + dir + ")");
+        }
+        var dirs = assertDoesNotThrow(() -> detector.getBoundaryDirections(tetLeafKey),
+                                      "getBoundaryDirections must be guarded for a tet-leaf key");
+        assertNotNull(dirs);
+
+        // The GhostBoundaryDetector boundary scan must tolerate a tet-leaf key end-to-end (it calls
+        // getBoundaryDirections under the hood) without throwing.
+        var ghostDetector = new GhostBoundaryDetector<>(index, detector, GhostType.FACES,
+                                                        GhostAlgorithm.MINIMAL);
+        assertDoesNotThrow(ghostDetector::createGhostLayer,
+                           "ghost boundary scan must tolerate tet-leaf keys");
+    }
+
+    // ===== helpers =====
+
+    /** Insert entities across the domain-origin sub-cube so a boundary pyramid is occupied. */
+    private void occupyOriginCorner() {
+        int n = 0;
+        for (int i = 0; i < 8; i++) {
+            for (int j = 0; j < 8; j++) {
+                float x = 1 + i * 2;
+                float y = 1 + j * 2;
+                index.insert(new Point3f(x, y, 1), (byte) 5, "e" + (n++));
+                index.insert(new Point3f(x, y, 3), (byte) 5, "e" + (n++));
+            }
+        }
+    }
+
+    private record Qualifying(PyramidKey key, List<PyramidKey> tetNeighbors) {
+    }
+
+    /**
+     * Among occupied keys, find a boundary element whose cross-shape face neighbors include >=2 in-domain
+     * tet leaves that are NOT occupied (so they qualify as remote-owned ghosts).
+     */
+    private Qualifying findBoundaryKeyWithCrossShapeTetNeighbors(NeighborDetector<PyramidKey> detector) {
+        for (var key : index.getSpatialKeys()) {
+            if (detector.getBoundaryDirections(key).isEmpty()) {
+                continue;
+            }
+            var tets = new ArrayList<PyramidKey>();
+            for (var fk : detector.findFaceNeighbors(key)) {
+                if (PyramidIndex.elementFromKey(fk) instanceof Tet && !index.containsSpatialKey(fk)) {
+                    tets.add(fk);
+                }
+            }
+            if (tets.size() >= 2) {
+                return new Qualifying(key, tets);
+            }
+        }
+        return null;
+    }
+
+    /** A shallow (minTetLevel == level) tet-leaf key sourced from a pyramid's triangular face neighbor. */
+    private PyramidKey firstShallowTetLeafKey() {
+        var roots = new Pyramid[] { new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6),
+                                    new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_7) };
+        var stack = new java.util.ArrayDeque<Pyramid>();
+        for (var r : roots) {
+            stack.push(r);
+        }
+        while (!stack.isEmpty()) {
+            var p = stack.pop();
+            if (p.level() >= 2) {
+                for (int f = 0; f < 4; f++) {
+                    var fn = p.faceNeighbor(f);
+                    if (fn != null && fn.element() instanceof Tet t) {
+                        var tk = PyramidKeyCodec.encode(t);
+                        if (tk != null) {
+                            return tk;
+                        }
+                    }
+                }
+            }
+            if (p.level() < 5) {
+                for (int i = 0; i < com.hellblazer.luciferase.lucien.tetree.TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
+                    if (p.child(i) instanceof Pyramid pc) {
+                        stack.push(pc);
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeyCodecTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeyCodecTest.java
@@ -7,6 +7,7 @@ package com.hellblazer.luciferase.lucien.pyramid;
 
 import com.hellblazer.luciferase.lucien.Constants;
 import com.hellblazer.luciferase.lucien.HybridElement;
+import com.hellblazer.luciferase.lucien.tetree.Tet;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -20,14 +21,17 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Validates {@link PyramidKeyCodec#encode(Pyramid)} — the fail-safe, round-trip-verified inverse of
- * {@link PyramidIndex#pyramidFromKey(PyramidKey)} (RDR-010 pi1.4 Phase A, bead Luciferase-8zv).
+ * Validates the fail-safe, round-trip-verified {@link PyramidKeyCodec} encoders: {@code encode(Pyramid)}
+ * (RDR-010 pi1.4 Phase A, bead Luciferase-8zv) and {@code encode(Tet)} + {@code elementFromKey} for a
+ * shallowest tet leaf (RDR-010 pi1.5 Phase A, bead Luciferase-uqik).
  *
- * <p>Three contracts:
+ * <p>Contracts:
  * <ul>
  *   <li><b>decode∘encode == identity</b> for every valid SFC pyramid (types 6 and 7, multiple levels).</li>
  *   <li><b>encode∘decode == identity</b> (key-side bijection).</li>
  *   <li><b>non-SFC / unreachable candidate → null</b> with no exception on the hot path.</li>
+ *   <li><b>shallowest tet leaf round-trips</b> via {@code encode(Tet)} / {@code elementFromKey}; deeper
+ *       or pure-Tetree tets → null (deep-tet cross-shape deferred to q3p Phase E).</li>
  * </ul>
  *
  * @author hal.hildebrand
@@ -149,6 +153,108 @@ class PyramidKeyCodecTest {
         assertDoesNotThrow(() -> holder[0] = PyramidKeyCodec.encode(nonSfc),
                            "encode must be fail-safe on the hot path (no throw)");
         assertNull(holder[0], "non-SFC unreachable pyramid must encode to null");
+    }
+
+    // ===== pi1.5 Phase A (Luciferase-uqik): Tet->PyramidKey codec + leaf-aware decode =====
+
+    /**
+     * A shallowest tet leaf (minTetLevel == level) — the four triangular-face neighbors of a pyramid —
+     * round-trips: {@code encode(Tet)} yields a non-null key whose {@code elementFromKey} recovers the
+     * same Tet geometry (x,y,z,level,type). This is the bridge Phase B's detector needs to surface
+     * cross-shape neighbors as tet-leaf PyramidKeys.
+     */
+    @Test
+    void shallowTetLeafRoundTrips() {
+        // root6.child(1) = tet type 3 at cubeId 1 (anchor x-bit set), level 1, minTetLevel 1.
+        int h = Constants.lengthAtLevel((byte) 1);
+        var tet = new Tet(h, 0, 0, (byte) 1, (byte) 3, (byte) 1);
+        var key = PyramidKeyCodec.encode(tet);
+        assertNotNull(key, "a shallowest tet leaf must encode to a tet-leaf PyramidKey");
+        assertEquals((byte) 1, key.getLevel());
+        var decoded = PyramidIndex.elementFromKey(key);
+        assertTrue(decoded instanceof Tet, () -> "leaf must decode to a Tet, got " + decoded);
+        var dt = (Tet) decoded;
+        assertEquals(tet.x(), dt.x());
+        assertEquals(tet.y(), dt.y());
+        assertEquals(tet.z(), dt.z());
+        assertEquals(tet.level(), dt.level());
+        assertEquals(tet.type(), dt.type(), "leaf tet type must survive the round trip");
+    }
+
+    /**
+     * Level-2 round-trip — the path Phase B actually exercises (a pyramid at level &gt;= 1 whose
+     * triangular faces / children are shallowest tets at level &gt;= 2). This drives the {@code encode}
+     * pyramid-parent walk loop and the {@code elementFromKey} descent loop, both dead at level 1.
+     */
+    @Test
+    void shallowTetLeafRoundTripsAtLevel2() {
+        // root6.child(0) = type-6 pyramid at level 1; its child(1) = tet type 3 at level 2 (shallowest).
+        var p1 = new Pyramid(0, 0, 0, (byte) 1, Pyramid.TYPE_6);
+        var child = p1.child(1);
+        assertTrue(child instanceof Tet, () -> "precondition: level-1 pyramid child(1) is a tet, got " + child);
+        var tet2 = (Tet) child;
+        assertEquals((byte) 2, tet2.level());
+        assertEquals(tet2.level(), tet2.minTetLevel(), "precondition: shallowest tet (minTetLevel==level)");
+        var key = PyramidKeyCodec.encode(tet2);
+        assertNotNull(key, "a level-2 shallowest tet leaf must encode");
+        assertEquals((byte) 2, key.getLevel());
+        var decoded = PyramidIndex.elementFromKey(key);
+        assertTrue(decoded instanceof Tet, () -> "level-2 tet-leaf key must decode to a Tet, got " + decoded);
+        var dt = (Tet) decoded;
+        assertEquals(tet2.x(), dt.x());
+        assertEquals(tet2.y(), dt.y());
+        assertEquals(tet2.z(), dt.z());
+        assertEquals(tet2.level(), dt.level());
+        assertEquals(tet2.type(), dt.type());
+    }
+
+    /**
+     * Only the SHALLOWEST tet of a pyramidal branch (minTetLevel == level) is in pi1.5 scope. A deeper
+     * pyramid-rooted tet (minTetLevel &lt; level) and a pure-Tetree tet (minTetLevel == -1) both encode
+     * to null — fail-safe, never a throw, never a bogus key. Deep-tet cross-shape is deferred (q3p
+     * Phase E, fail-loud guarded).
+     */
+    @Test
+    void deepOrPureTetEncodesToNull() {
+        int h2 = Constants.lengthAtLevel((byte) 2);
+        // Deep pyramid-rooted tet: level 2 but the tet branch began at level 1.
+        var deep = new Tet(h2, 0, 0, (byte) 2, (byte) 3, (byte) 1);
+        assertNull(PyramidKeyCodec.encode(deep), "deeper-than-shallowest tet must encode to null");
+        // Pure-Tetree tet (no pyramid ancestor).
+        var pure = new Tet(h2, 0, 0, (byte) 2, (byte) 0, (byte) -1); // minTetLevel -1 = pure-Tetree
+        assertNull(PyramidKeyCodec.encode(pure), "pure-Tetree tet must encode to null");
+    }
+
+    /**
+     * Independent bit-value oracle for a tet-leaf key (defends against a co-consistent error in
+     * encode + elementFromKey). The level-1 tet root6.child(1) has cubeId 1, type 3, so its single
+     * 6-bit group = (coordBits &lt;&lt; 3) | typeBits = (1 &lt;&lt; 3) | 3 = 11.
+     */
+    @Test
+    void goldenTetLeafKeyIndependentOfFromLevels() {
+        int h = Constants.lengthAtLevel((byte) 1);
+        var tet = new Tet(h, 0, 0, (byte) 1, (byte) 3, (byte) 1);
+        var key = PyramidKeyCodec.encode(tet);
+        assertNotNull(key);
+        assertEquals((byte) 1, key.getLevel());
+        assertEquals(11L, key.getLowBits(), "golden tet-leaf lowBits = (1<<3)|3");
+        assertEquals(0L, key.getHighBits());
+    }
+
+    /**
+     * {@code elementFromKey} discriminates leaf shape by the leaf type bits: a tet-leaf key decodes to
+     * a {@link Tet}, a pyramid key to a {@link Pyramid}.
+     */
+    @Test
+    void elementFromKeyDiscriminatesLeafShape() {
+        int h = Constants.lengthAtLevel((byte) 1);
+        var tetKey = PyramidKeyCodec.encode(new Tet(h, 0, 0, (byte) 1, (byte) 3, (byte) 1));
+        assertNotNull(tetKey);
+        assertTrue(PyramidIndex.elementFromKey(tetKey) instanceof Tet, "tet-leaf key -> Tet");
+
+        var pyrKey = PyramidKeyCodec.encode(new Pyramid(0, 0, 0, (byte) 2, Pyramid.TYPE_6));
+        assertNotNull(pyrKey);
+        assertTrue(PyramidIndex.elementFromKey(pyrKey) instanceof Pyramid, "pyramid key -> Pyramid");
     }
 
     @Test

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborDetectorTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborDetectorTest.java
@@ -28,11 +28,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Same-shape (pyramid↔pyramid) topology for {@link PyramidNeighborDetector} (RDR-010 pi1.4 Phase B,
- * bead Luciferase-mu9). A pyramid's only same-shape face is the quadrilateral base (f4, type 6↔7);
- * the four triangular faces neighbor tetrahedra (cross-shape, deferred to pi1.5). Validation follows
- * the CLAUDE.md face-neighbor caveat: reciprocity/involution, plus the shared-vertex-count assertion
- * which is valid ONLY for the conforming pyramid quad base (invariant #5).
+ * Cross-shape (pyramid↔tet) topology for {@link PyramidNeighborDetector} (RDR-010 pi1.4 same-shape /
+ * pi1.5 cross-shape, beads Luciferase-mu9 / Luciferase-9e3a). A pyramid's only same-shape face is the
+ * quadrilateral base (f4, type 6↔7); the four triangular faces neighbor tetrahedra (cross-shape, now
+ * surfaced as tet-leaf keys). Validation follows the CLAUDE.md face-neighbor caveat: reciprocity/
+ * involution for cross-shape tet neighbors, and the shared-vertex-count assertion ONLY for the
+ * conforming pyramid quad base (invariant #5).
  *
  * @author hal.hildebrand
  */
@@ -70,6 +71,28 @@ class PyramidNeighborDetectorTest {
                 descend(pc, maxLevel, out);
             }
         }
+    }
+
+    /** The pyramid-typed (same-shape) subset of a neighbor-key list. */
+    private static List<PyramidKey> pyramidSubset(List<PyramidKey> keys) {
+        var out = new ArrayList<PyramidKey>();
+        for (var k : keys) {
+            if (PyramidIndex.elementFromKey(k) instanceof Pyramid) {
+                out.add(k);
+            }
+        }
+        return out;
+    }
+
+    /** The tet-typed (cross-shape) subset of a neighbor-key list. */
+    private static List<PyramidKey> tetSubset(List<PyramidKey> keys) {
+        var out = new ArrayList<PyramidKey>();
+        for (var k : keys) {
+            if (PyramidIndex.elementFromKey(k) instanceof Tet) {
+                out.add(k);
+            }
+        }
+        return out;
     }
 
     private static int sharedVertexCount(Pyramid a, Pyramid b) {
@@ -113,8 +136,11 @@ class PyramidNeighborDetectorTest {
         var neighborKey = PyramidKeyCodec.encode(neighbor);
 
         var faces = detector.findFaceNeighbors(selfKey);
-        assertEquals(1, faces.size(), "a pyramid has exactly one same-shape (quad-base) face neighbor");
-        assertEquals(neighborKey, faces.get(0));
+        // pi1.5: a pyramid has exactly ONE same-shape (quad-base) face neighbor; the rest of the face
+        // result is cross-shape tets. Filter to the pyramid subset to assert the same-shape contract.
+        var pyramidFaces = pyramidSubset(faces);
+        assertEquals(1, pyramidFaces.size(), "a pyramid has exactly one same-shape (quad-base) face neighbor");
+        assertEquals(neighborKey, pyramidFaces.get(0));
         // The quad base is a conforming face shared by exactly two pyramids → exactly 4 shared vertices
         // (invariant #5; this assertion is valid ONLY for the conforming pyramid quad base).
         assertEquals(4, sharedVertexCount(self, neighbor));
@@ -127,8 +153,9 @@ class PyramidNeighborDetectorTest {
         var self = pair[0];
         var selfKey = PyramidKeyCodec.encode(self);
         var expected = PyramidKeyCodec.encode((Pyramid) self.faceNeighbor(4).element());
-        assertEquals(List.of(expected), detector.findFaceNeighbors(selfKey),
-                     "unified-enum face result must agree with Pyramid.faceNeighbor(4)");
+        // The single pyramid-typed face neighbor must agree with Pyramid.faceNeighbor(4).
+        assertEquals(List.of(expected), pyramidSubset(detector.findFaceNeighbors(selfKey)),
+                     "the same-shape face result must agree with Pyramid.faceNeighbor(4)");
     }
 
     @Test
@@ -142,23 +169,87 @@ class PyramidNeighborDetectorTest {
                    "face-neighbor relation must be reciprocal (neighbor(neighbor)==self)");
     }
 
+    /**
+     * pi1.5 cross-shape (honesty-trap pin rewrite): the four triangular faces neighbor tetrahedra, and
+     * those in-domain, in-SFC tet neighbors are now PRESENT in the face result as tet-leaf keys (no
+     * longer absent). The same-shape f4 pyramid neighbor is also present. This is RED against the pi1.4
+     * same-shape-only detector (which returned only the f4 pyramid).
+     */
     @Test
-    void triangularFacesNeighborTetsAndAreAbsentFromSameShapeResult() {
-        var pair = selfAndQuadBaseNeighbor();
-        assertNotNull(pair);
-        var self = pair[0];
-        var selfKey = PyramidKeyCodec.encode(self);
-        // The four triangular faces neighbor tetrahedra (cross-shape, pi1.5) — documented here so the
-        // single-element same-shape face result is a deliberate deferral, not silent scope reduction.
-        for (int f = 0; f < 4; f++) {
-            var fn = self.faceNeighbor(f);
-            if (fn != null) {
-                assertInstanceOf(Tet.class, fn.element(),
-                                 "triangular face " + f + " must neighbor a tetrahedron");
+    void triangularFacesNeighborTetsAndArePresentInTheFaceResult() {
+        // A pyramid all four of whose triangular-face tet neighbors are in-domain SFC elements.
+        Pyramid self = null;
+        for (var p : validPyramids(5)) {
+            if (PyramidKeyCodec.encode(p) == null) {
+                continue;
+            }
+            int encodableTets = 0;
+            for (int f = 0; f < 4; f++) {
+                var fn = p.faceNeighbor(f);
+                if (fn != null && fn.element() instanceof Tet t && PyramidKeyCodec.encode(t) != null) {
+                    encodableTets++;
+                }
+            }
+            if (encodableTets >= 1) {
+                self = p;
+                break;
             }
         }
-        assertEquals(1, detector.findFaceNeighbors(selfKey).size(),
-                     "same-shape face result must exclude all four triangular (tet) faces");
+        assertNotNull(self, "expected an SFC pyramid with at least one in-SFC triangular tet neighbor");
+        var selfKey = PyramidKeyCodec.encode(self);
+        var faces = detector.findFaceNeighbors(selfKey);
+
+        // Every in-domain, in-SFC triangular-face tet neighbor must appear as a tet-leaf key.
+        int expectedTets = 0;
+        for (int f = 0; f < 4; f++) {
+            var fn = self.faceNeighbor(f);
+            if (fn != null && fn.element() instanceof Tet t) {
+                assertInstanceOf(Tet.class, fn.element(), "triangular face " + f + " neighbors a tet");
+                var tk = PyramidKeyCodec.encode(t);
+                if (tk != null) {
+                    expectedTets++;
+                    assertTrue(faces.contains(tk),
+                               "cross-shape tet face neighbor (face " + f + ") must be present: " + t);
+                    assertInstanceOf(Tet.class, PyramidIndex.elementFromKey(tk), "tet-leaf key decodes to a Tet");
+                }
+            }
+        }
+        assertTrue(expectedTets >= 1, "fixture must contribute >= 1 cross-shape tet face neighbor");
+        // Completeness (not just presence): the tet-typed subset of the face result equals exactly the
+        // count of encodable triangular-face tets — no legitimate neighbor dropped, no duplicate added.
+        assertEquals(expectedTets, tetSubset(faces).size(),
+                     "tet-leaf subset of face result must equal the count of encodable triangular-face tets");
+    }
+
+    /**
+     * Completeness count-oracle (substantive-critic Phase B finding): for a pyramid whose ALL FOUR
+     * triangular faces neighbor in-domain SFC tets, the detector must surface exactly four tet-leaf
+     * keys — the encode-filter must not silently drop a legitimate cross-shape neighbor (ghost hole).
+     * Reciprocity sweeps prove soundness of survivors; this proves coverage.
+     */
+    @Test
+    void allFourTriangularFaceTetsArePresentWhenInDomain() {
+        Pyramid self = null;
+        for (var p : validPyramids(5)) {
+            if (PyramidKeyCodec.encode(p) == null) {
+                continue;
+            }
+            int encodableTets = 0;
+            for (int f = 0; f < 4; f++) {
+                var fn = p.faceNeighbor(f);
+                if (fn != null && fn.element() instanceof Tet t && PyramidKeyCodec.encode(t) != null) {
+                    encodableTets++;
+                }
+            }
+            if (encodableTets == 4) {
+                self = p;
+                break;
+            }
+        }
+        assertNotNull(self, "expected an interior pyramid whose four triangular faces are all in-SFC tets");
+        var faces = detector.findFaceNeighbors(PyramidKeyCodec.encode(self));
+        assertEquals(4, tetSubset(faces).size(),
+                     "all four in-domain triangular-face tets must be surfaced (no encode-filter drop)");
     }
 
     @Test
@@ -184,16 +275,17 @@ class PyramidNeighborDetectorTest {
 
     @Test
     void everyEnumeratedNeighborSharesAtLeastTheBucketThreshold() {
-        // Non-vacuous: each returned vertex/edge/face neighbor genuinely shares ≥1/≥2/≥4 vertices
-        // with self, and is a pyramid (same-shape), and decodes back to the level-matched element.
+        // Non-vacuous: each returned SAME-SHAPE (pyramid) vertex/edge/face neighbor genuinely shares
+        // ≥1/≥2/≥4 vertices with self, and decodes back to the level-matched pyramid. (Cross-shape tet
+        // neighbors are validated by reciprocity, not shared-vertex — CLAUDE.md caveat.)
         var pair = selfAndQuadBaseNeighbor();
         assertNotNull(pair);
         var self = pair[0];
         var selfKey = PyramidKeyCodec.encode(self);
 
-        assertThresholds(self, detector.findVertexNeighbors(selfKey), 1);
-        assertThresholds(self, detector.findEdgeNeighbors(selfKey), 2);
-        assertThresholds(self, detector.findFaceNeighbors(selfKey), 4);
+        assertThresholds(self, pyramidSubset(detector.findVertexNeighbors(selfKey)), 1);
+        assertThresholds(self, pyramidSubset(detector.findEdgeNeighbors(selfKey)), 2);
+        assertThresholds(self, pyramidSubset(detector.findFaceNeighbors(selfKey)), 4);
     }
 
     private static void assertThresholds(Pyramid self, List<PyramidKey> neighbors, int min) {
@@ -219,9 +311,15 @@ class PyramidNeighborDetectorTest {
         var selfKey = PyramidKeyCodec.encode(self);
         var universe = validPyramids(5);
 
-        assertEquals(expectedNeighborKeys(self, universe, 4), setOf(detector.findFaceNeighbors(selfKey)));
-        assertEquals(expectedNeighborKeys(self, universe, 2), setOf(detector.findEdgeNeighbors(selfKey)));
-        assertEquals(expectedNeighborKeys(self, universe, 1), setOf(detector.findVertexNeighbors(selfKey)));
+        // The SAME-SHAPE (pyramid) subset of each bucket must match the brute-force same-shape oracle.
+        // Cross-shape tet neighbors are validated separately (navigation + reciprocity); they are not
+        // part of this shared-vertex pyramid oracle.
+        assertEquals(expectedNeighborKeys(self, universe, 4),
+                     setOf(pyramidSubset(detector.findFaceNeighbors(selfKey))));
+        assertEquals(expectedNeighborKeys(self, universe, 2),
+                     setOf(pyramidSubset(detector.findEdgeNeighbors(selfKey))));
+        assertEquals(expectedNeighborKeys(self, universe, 1),
+                     setOf(pyramidSubset(detector.findVertexNeighbors(selfKey))));
         // And the universe genuinely contains MORE than the single face neighbor at the edge/vertex
         // thresholds, so the oracle is not trivially equal to the 1-element face set.
         assertTrue(expectedNeighborKeys(self, universe, 2).size() > 1,
@@ -266,15 +364,41 @@ class PyramidNeighborDetectorTest {
     }
 
     @Test
-    void tetLeafKeyDefersToEmpty() {
-        // root6 child index 1 is a tetrahedron (cid 1, type 3). A tet-leaf PyramidKey is cross-shape
-        // territory (pi1.5): the same-shape detector returns empty, never throws.
+    void tetLeafKeyReportsCrossShapeNeighbors() {
+        // pi1.5 (was tetLeafKeyDefersToEmpty): root6.child(1) is a shallowest tet (cid 1, type 3). A
+        // tet-leaf PyramidKey now reports its cross-shape face neighbors (its bounding pyramid + tet
+        // neighbors at the shallow boundary) instead of deferring to empty.
         var tetLeafKey = PyramidKey.fromLevels((byte) 1, new int[] { 0, 1 }, new int[] { 0, 3 });
         assertEquals((byte) 3, tetLeafKey.getTypeAtLevel(1), "precondition: leaf type is a tet");
-        assertTrue(detector.findFaceNeighbors(tetLeafKey).isEmpty());
-        assertTrue(detector.findEdgeNeighbors(tetLeafKey).isEmpty());
-        assertTrue(detector.findVertexNeighbors(tetLeafKey).isEmpty());
-        assertTrue(detector.findNeighborsWithOwners(tetLeafKey, GhostType.FACES).isEmpty());
+        assertInstanceOf(Tet.class, PyramidIndex.elementFromKey(tetLeafKey), "precondition: decodes to a Tet");
+
+        var faces = detector.findFaceNeighbors(tetLeafKey);
+        assertFalse(faces.isEmpty(), "a shallow tet leaf must report cross-shape face neighbors");
+        // Reciprocity: the tet leaf appears in each of its neighbors' face results.
+        for (var nk : faces) {
+            assertTrue(detector.findFaceNeighbors(nk).contains(tetLeafKey),
+                       "cross-shape face-neighbor relation must be reciprocal: " + tetLeafKey + " <-> " + nk);
+        }
+        // Edge/vertex are bounded supersets of the face set (face ⊆ edge ⊆ vertex).
+        var edges = detector.findEdgeNeighbors(tetLeafKey);
+        var verts = detector.findVertexNeighbors(tetLeafKey);
+        assertTrue(edges.containsAll(faces), "edge set ⊇ face set");
+        assertTrue(verts.containsAll(edges), "vertex set ⊇ edge set");
+    }
+
+    @Test
+    void detectorNeverThrowsForAnyTetLeafKey() {
+        // The detector must never propagate an exception (a throw would break KnnSearcher/CollisionEngine
+        // BFS). A level-2 shallow tet leaf exercises the tet-leaf navigation path. Note: a DEEP tet
+        // (l > minTetLevel) is unreachable as a key by construction — encode(Tet) returns null for it
+        // and elementFromKey cannot reconstruct it — so Tet.faceNeighborElement's fail-loud guard is
+        // never actually reached through a key; the detector's catch is defensive against future change.
+        var p1 = new Pyramid(0, 0, 0, (byte) 1, Pyramid.TYPE_6);
+        var tet2 = (Tet) p1.child(1);               // shallow level-2 tet (minTetLevel == level == 2)
+        var tetKey = PyramidKeyCodec.encode(tet2);
+        assertNotNull(tetKey);
+        org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> detector.findFaceNeighbors(tetKey));
+        org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> detector.findVertexNeighbors(tetKey));
     }
 
     @Test
@@ -301,11 +425,15 @@ class PyramidNeighborDetectorTest {
         assertNotNull(pair);
         var selfKey = PyramidKeyCodec.encode(pair[0]);
         var neighborKey = PyramidKeyCodec.encode(pair[1]);
+        var faces = detector.findFaceNeighbors(selfKey);
         var owners = detector.findNeighborsWithOwners(selfKey, GhostType.FACES);
-        assertEquals(1, owners.size());
-        var info = owners.get(0);
-        assertEquals(neighborKey, info.neighborKey());
-        assertEquals(0, info.ownerRank());
-        assertTrue(info.isLocal());
+        // One NeighborInfo per face neighbor (the f4 pyramid + the cross-shape tets), all wrapped local.
+        assertEquals(faces.size(), owners.size());
+        var ownerKeys = owners.stream().map(NeighborDetector.NeighborInfo::neighborKey).toList();
+        assertTrue(ownerKeys.contains(neighborKey), "the f4 pyramid neighbor must be wrapped");
+        for (var info : owners) {
+            assertEquals(0, info.ownerRank(), "Phase B: ownership is local-only (distributed → Phase C)");
+            assertTrue(info.isLocal());
+        }
     }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborParityTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborParityTest.java
@@ -154,14 +154,51 @@ class PyramidNeighborParityTest {
         var selfKey = PyramidKeyCodec.encode(pair[0]);
         var neighborKey = PyramidKeyCodec.encode(pair[1]);
 
-        // Effective wiring: a call THROUGH the seam returns a real same-shape neighbor (the Phase-A
-        // stub would have thrown UnsupportedOperationException here).
+        // Effective wiring: a call THROUGH the seam returns the real cross-shape neighbor set.
         var faces = wired.findFaceNeighbors(selfKey);
-        assertEquals(List.of(neighborKey), faces, "seam must yield the real f4 neighbor, not a stub");
+        assertTrue(faces.contains(neighborKey), "seam must yield the real f4 pyramid neighbor");
 
-        // Pin the pi1.4 limitation: only the quad base is same-shape, so GhostType.FACES yields exactly
-        // ONE neighbor per interior pyramid. The four triangular (tet) faces produce no ghost entries
-        // until pi1.5 — this assertion makes that scope boundary visible in test output.
-        assertEquals(1, wired.findNeighbors(selfKey, GhostType.FACES).size());
+        // pi1.5 (honesty-trap pin rewrite): the four triangular faces now contribute cross-shape tet
+        // neighbors, so GhostType.FACES yields MORE than one neighbor for a pyramid whose triangular
+        // faces are in-domain SFC tets. This pins the cross-shape graduation in test output (was: == 1).
+        var ghostFaces = wired.findNeighbors(selfKey, GhostType.FACES);
+        assertTrue(ghostFaces.size() > 1,
+                   "cross-shape: a pyramid's triangular faces now add tet ghost entries (was 1 in pi1.4)");
+        // At least one ghost-face neighbor must be a tet (the cross-shape contribution).
+        assertTrue(ghostFaces.stream().anyMatch(k -> PyramidIndex.elementFromKey(k) instanceof com.hellblazer.luciferase.lucien.tetree.Tet),
+                   "GhostType.FACES must include at least one cross-shape tet neighbor");
+    }
+
+    @Test
+    void crossShapeFaceNeighborReciprocityAcrossTheRefinedTree() {
+        // BFS-symmetry guard (pi1.4 critic forward-flag): a pyramid's triangular-face tet neighbor must
+        // list the pyramid back, and vice versa — a one-sided union would silently miss ghost entities.
+        int checkedPyrToTet = 0;
+        int checkedTetToPyr = 0;
+        for (var p : validPyramids(5)) {
+            var pk = PyramidKeyCodec.encode(p);
+            if (pk == null) {
+                continue;
+            }
+            for (int f = 0; f < 4; f++) {
+                var fn = p.faceNeighbor(f);
+                if (fn == null || !(fn.element() instanceof com.hellblazer.luciferase.lucien.tetree.Tet t)) {
+                    continue;
+                }
+                var tk = PyramidKeyCodec.encode(t);
+                if (tk == null) {
+                    continue;
+                }
+                // pyramid -> tet present, and reciprocally tet -> pyramid present.
+                assertTrue(detector.findFaceNeighbors(pk).contains(tk),
+                           "pyramid " + p + " must report its triangular-face tet neighbor " + t);
+                assertTrue(detector.findFaceNeighbors(tk).contains(pk),
+                           "tet " + t + " must report its pyramid back (BFS symmetry) for " + p);
+                checkedPyrToTet++;
+                checkedTetToPyr++;
+            }
+        }
+        assertTrue(checkedPyrToTet >= 5, "expected a broad cross-shape sweep, only checked " + checkedPyrToTet);
+        assertTrue(checkedTetToPyr >= 5, "cross-shape reciprocity must be exercised both directions");
     }
 }


### PR DESCRIPTION
RDR-010 pi1.5 (Direction B, P4b) — surfaces cross-shape (pyramid↔tet) neighbor finding through `PyramidNeighborDetector` and wires the full distributed cross-rank ghost path via the inverted seam. Shallowest pyramid↔tet boundary only (`l == minTetLevel`); deep-tet stays fail-loud guarded (Finding #16). Three TDD phases, each dual-reviewed (code-review-expert + substantive-critic) before commit.

## Phase A — Tet→PyramidKey codec + leaf-aware decode (`Luciferase-uqik`, 78ae4b39)
`PyramidKeyCodec.encode(Tet)` (shallowest tet leaf → tet-leaf PyramidKey, fail-safe null otherwise) + `PyramidIndex.elementFromKey` (leaf-aware decoder returning the actual Tet or Pyramid leaf).

## Phase B — Detector cross-shape + pin rewrite (`Luciferase-9e3a`, 5736c052)
`findFaceNeighbors` now exact cross-shape via element navigation (`Pyramid.faceNeighbor` f0–f3 tets + f4 pyramid, `Tet.faceNeighborElement`), encoded as tet-leaf/pyramid keys. Edge/vertex are bounded supersets. Rewrote the pi1.4 same-shape-only pins (honesty trap). Reciprocity-validated, not shared-vertex.

## Phase C — addNeighboringNodes graduation + distributed ghost + gate (`Luciferase-azwr`, 1e16b07d)
`addNeighboringNodes` unions the now-cross-shape face set into the BFS frontier (auto-inherited via the detector; javadoc/comment rewrite documents it + the tet-sibling BFS bound; stays occupancy-blind). `GhostBoundaryDetector.createGhostElement` → `protected` (test-observability seam). `DistributedGhostManager.setElementOwner` gains an owner-map-split warning (the local ghost scan reads the detector's owner store, the inverted-seam one). New `PyramidCrossShapeGhostTest` proves cross-shape ghosts fire for ≥2 triangular tet faces with externally-assigned multi-rank owners (non-vacuous vs pi1.4's f4-only), plus DistributedGhostManager cross-rank fan-out and the tet-leaf conservative-superset boundary classification.

## Gate
- Full `lucien` suite green throughout (final **2696, 0 failures**); ghost-consumer suite green.
- Perf parity structural (no Octree/Tetree/Tet/Constants change — a visibility modifier + javadoc + tests).
- `phase-review-gate RDR-010 --phase 5` PASSED; §Approach cross-walk + explicit deferrals recorded in the RDR (2026-05-30 addendum).

## Registered deferrals (explicit, not silent)
- `Luciferase-pi1.6` — Forest `N_shape(ℓ)` weight + `TwoOneBalanceChecker` shape-router (§Approach Item4).
- `Luciferase-0utt` — exhaustive cross-shape edge/vertex topology (pi1.5 ships the bounded superset).
- Deep-tet (`l > minTetLevel`) cross-shape → q3p Phase E / future RDR-scoped tet-tree reconciliation (fail-loud guarded).

RDR-010 remains `accepted` (not closed) pending pi1.6 + pi1.7.