### PR TITLE
RDR-010 pi1.6: Forest shape-weight hook + Alg 5.1 partitioner + TwoOneBalanceChecker shape-router

### DIFF
--- a/docs/rdr/RDR-010-pyramid-spatial-index.md
+++ b/docs/rdr/RDR-010-pyramid-spatial-index.md
@@ -372,3 +372,25 @@ Accepted 2026-05-28 (gate PASSED 2026-05-28, self-reviewed; T2 `Luciferase_rdr/0
 **Additional registered deferrals (explicit, not silent):** deep-tet (`l > minTetLevel`) cross-shape face neighbors stay fail-loud guarded (Finding #16) → q3p Phase E / future RDR-scoped tet-tree reconciliation; exhaustive cross-shape edge/vertex topology → `Luciferase-0utt`. Both surfaced, not silently dropped.
 
 pi1.5 deliverable arc (cross-shape neighbor finding + distributed ghost wiring) is COMPLETE. Remaining RDR-010 work: pi1.6 (Forest weight + balance-router, Item4) and pi1.7 (hybrid-mesh demo + 128-bit-key/branching microbenchmarks). RDR-010 stays `accepted` (not closed) until pi1.6 + pi1.7 land.
+
+## Addendum 2026-05-30 — pi1.6 close / Phase-6 §Approach cross-walk gate PASSED
+
+`/conexus:phase-review-gate RDR-010 --phase 6` PASSED 2026-05-30 (bead `Luciferase-pi1.6`). §Approach cross-walk:
+
+- **Item1** PyramidKey + Pyramid primitive → `Luciferase-kto` (pi1.3; primitive beads pi1.1/pi1.2 compacted).
+- **Item2** reuse tet machinery → `Luciferase-9e3a` (q3p element-unification shipped; Tet type k IS t8code dtet type k).
+- **Item3** pyramid containment §3b → `Luciferase-ssu` (pi1.3 Phase B).
+- **Item4** Forest `ShapeWeightProvider` + balance-checker shape-router → **`Luciferase-pi1.6` (this close)**. Delivered:
+  - §4a/§4b — `ShapeWeightProvider.elementCount(level)`: `N_hex = N_tet = 8^ℓ` (AbstractSpatialIndex default), `N_pyramid = 2·8^ℓ − 6^ℓ` (PyramidIndex override, Knapp Eq 5.1), overflow-guarded (ℓ ≤ 20).
+  - §4c — `ShapeWeightPartitioner`: weighted-SFC cumulative-offset partition (Knapp Alg 5.1), `assign`/`weightsAtLevel`/`partitionForest`.
+  - §4d — `TwoOneBalanceChecker` TetreeKey + PyramidKey shape-router via the wired `NeighborDetector` (closes the silent-skip gap; was MortonKey-only).
+- **Item5** `PyramidNeighborDetector` → `Luciferase-azwr` (pi1.5).
+- **Item6** the gate question → resolved at accept (Direction B). No bead.
+
+**Explicit deferrals registered at this gate (not silent reduction):**
+- **§4c consumer-wiring** — the `ShapeWeightPartitioner` and the per-shape weight hook are delivered and tested, but wiring a *live consumer* (populating a `PartitionRegistry` / `Forest` partition assignment from the weighted partition) is **deferred**. Rationale: no clean seam exists today — `Forest.routeQuery` is a spatial AABB query (wrong home for partition weight), and partition assignment is held in `ParallelBalancer.PartitionRegistry`, populated externally. The weighted-partition computation itself is complete; its consumption lands with **pi1.7** (hybrid-mesh demo, where a real partition consumer exists) or a dedicated follow-on bead (`Luciferase-d3z3`). Surfaced by the pi1.6 substantive-critic, recorded here rather than left implicit.
+- **`partitionForest` hybrid limitation** — `Forest<Key>` is single-key-typed, so `partitionForest` only spans a homogeneous forest; genuine hex+pyramid partition uses `assign`/`weightsAtLevel` directly (documented `@apiNote`).
+- **Balance-router finer-direction** — the TetreeKey/PyramidKey router probes the coarser direction only (ghost-fine/local-coarse), matching Morton's coarser-half; the ghost-coarse/local-fine arrangement is an assumed distributed-protocol invariant (documented, scope-pinned by test).
+- **`N_prism(ℓ)`** — not in the Knapp corpus (Gap #5); Prism uses the default `8^ℓ` (slight partition inaccuracy if a prism tree enters a hybrid partition). Flagged, not blocking.
+
+Remaining RDR-010 work: **pi1.7** (hybrid-mesh demo + 128-bit-key/branching microbenchmarks + §4c consumer-wiring). RDR-010 stays `accepted` until pi1.7 closes.

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/AbstractSpatialIndex.java
@@ -84,7 +84,8 @@ import java.util.stream.Stream;
  * @author hal.hildebrand
  */
 public abstract class AbstractSpatialIndex<Key extends SpatialKey<Key>, ID extends EntityID, Content>
-implements SpatialIndex<Key, ID, Content> {
+implements SpatialIndex<Key, ID, Content>,
+           com.hellblazer.luciferase.lucien.balancing.ShapeWeightProvider {
 
     /**
      * Record representing a neighbor search result with distance information.
@@ -2628,6 +2629,19 @@ implements SpatialIndex<Key, ID, Content> {
     /** Gets the neighbor detector for this spatial index. */
     public NeighborDetector<Key> getNeighborDetector() {
         return ghost.getNeighborDetector();
+    }
+
+    /**
+     * Per-shape partition weight {@code N_shape(level)} (RDR-010 pi1.6, Knapp Eq 5.1). Default is the
+     * 1:8-refinement count {@code 8^level} shared by the hexahedral ({@link com.hellblazer.luciferase.lucien.octree.Octree})
+     * and tetrahedral ({@link com.hellblazer.luciferase.lucien.tetree.Tetree}) shapes. {@link com.hellblazer.luciferase.lucien.pyramid.PyramidIndex}
+     * overrides this with {@code 2·8^level − 6^level}.
+     *
+     * @see com.hellblazer.luciferase.lucien.balancing.ShapeWeightProvider
+     */
+    @Override
+    public long elementCount(int level) {
+        return com.hellblazer.luciferase.lucien.balancing.ShapeWeightProvider.eightToThe(level);
     }
 
     /** Subclasses call this during initialization to supply their tree-specific neighbor detector. */

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/ShapeWeightPartitioner.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/ShapeWeightPartitioner.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.balancing;
+
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+import com.hellblazer.luciferase.lucien.forest.Forest;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Weighted space-filling-curve cumulative-offset partitioner (RDR-010 pi1.6; Knapp 2026 Algorithm 5.1,
+ * the hybrid-forest specialization of the Burstedde+Holke weighted SFC partition).
+ *
+ * <p>Given an SFC-ordered sequence of indivisible units (forest trees) each carrying a weight
+ * {@code w[i]}, the partition assigns each unit to the rank whose {@code [r·W/P, (r+1)·W/P)} weight band
+ * its cumulative start offset falls into ({@code W = Σ w}, {@code P} = partition count). The result is a
+ * contiguous (non-decreasing) rank assignment in which every rank receives ≈ {@code W/P} total weight —
+ * the best a contiguous partition of indivisible units can do.
+ *
+ * <p><b>Shape-correctness.</b> Weights come from {@link ShapeWeightProvider#elementCount(int)}, so a
+ * pyramid tree ({@code N = 2·8^ℓ − 6^ℓ}) is weighted by its true element load rather than the 1:8
+ * ({@code 8^ℓ}) count a shape-blind partitioner would assume — see
+ * {@link #weightsAtLevel(List, int)} and {@link #partitionForest(Forest, int, int)}.
+ *
+ * <p><b>Forest key-type note.</b> A {@link Forest} is parameterized by a single {@link SpatialKey} type,
+ * so a single forest instance is homogeneous in key (all Octree, all Tetree, or all PyramidIndex). A
+ * genuinely heterogeneous hex+pyramid partition is computed by feeding mixed per-shape weights to
+ * {@link #assign(long[], int)} / {@link #weightsAtLevel(List, int)} directly.
+ *
+ * @author Hal Hildebrand
+ */
+public final class ShapeWeightPartitioner {
+
+    private ShapeWeightPartitioner() {
+    }
+
+    /**
+     * Assign each weighted unit (in SFC order) to one of {@code partitionCount} ranks by cumulative
+     * weight, so every rank receives ≈ {@code W/P} total weight.
+     *
+     * @param weights        per-unit weights in SFC order (non-negative)
+     * @param partitionCount number of ranks {@code P} (≥ 1)
+     * @return rank per unit (non-decreasing, each in {@code [0, P-1]}); empty if {@code weights} is empty
+     * @throws IllegalArgumentException if {@code partitionCount < 1} or any weight is negative
+     */
+    public static int[] assign(long[] weights, int partitionCount) {
+        if (partitionCount < 1) {
+            throw new IllegalArgumentException("partitionCount must be >= 1, got " + partitionCount);
+        }
+        int n = weights.length;
+        int[] result = new int[n];
+        if (n == 0) {
+            return result;
+        }
+
+        long total = 0;
+        for (long w : weights) {
+            if (w < 0) {
+                throw new IllegalArgumentException("weights must be non-negative, got " + w);
+            }
+            if (total + w < total) {
+                throw new ArithmeticException(
+                    "weight total overflows a signed long; reduce the level or the number of units");
+            }
+            total += w;
+        }
+
+        // Degenerate: no weight to balance — fall back to a contiguous even split by index.
+        if (total == 0) {
+            for (int i = 0; i < n; i++) {
+                int rank = (int) ((long) i * partitionCount / n);
+                result[i] = Math.min(rank, partitionCount - 1);
+            }
+            return result;
+        }
+
+        long prefix = 0;
+        for (int i = 0; i < n; i++) {
+            // Overflow-safe: prefix·P can exceed Long.MAX_VALUE at high levels (8^20·P). double's
+            // 53-bit mantissa keeps the rank error far below one partition for any practical P.
+            int rank = (int) ((double) prefix / total * partitionCount);
+            if (rank >= partitionCount) {
+                rank = partitionCount - 1;
+            }
+            result[i] = rank;
+            prefix += weights[i];
+        }
+        return result;
+    }
+
+    /**
+     * Map a list of shapes to their {@code N_shape(level)} weights.
+     *
+     * @param shapes the per-unit shape weight providers (typically forest tree spatial indices)
+     * @param level  the uniform refinement level
+     * @return the weight array, aligned with {@code shapes}
+     */
+    public static long[] weightsAtLevel(List<? extends ShapeWeightProvider> shapes, int level) {
+        long[] w = new long[shapes.size()];
+        for (int i = 0; i < w.length; i++) {
+            w[i] = shapes.get(i).elementCount(level);
+        }
+        return w;
+    }
+
+    /**
+     * Partition a homogeneous forest's trees across {@code partitionCount} ranks by shape-aware weight.
+     *
+     * <p>Each tree's weight is {@code tree.getSpatialIndex().elementCount(uniformLevel)} — shape-aware via
+     * {@link ShapeWeightProvider}, so even a single-shape forest is balanced by element load rather than
+     * tree count.
+     *
+     * @apiNote A {@link Forest} is parameterized by a single {@link SpatialKey} type, so this method can
+     *          only partition a <em>homogeneous</em> (single-shape) forest — where all trees share the
+     *          same {@code N_shape} and the shape-aware weighting is effectively uniform. For a genuinely
+     *          heterogeneous partition (e.g. hex + pyramid), build the weight array from mixed
+     *          {@link ShapeWeightProvider}s and call {@link #weightsAtLevel(List, int)} +
+     *          {@link #assign(long[], int)} directly; {@code partitionForest} cannot express that case.
+     * @return an insertion-ordered map of {@code treeId → rank}
+     */
+    public static <Key extends SpatialKey<Key>, ID extends EntityID, Content> Map<String, Integer>
+    partitionForest(Forest<Key, ID, Content> forest, int uniformLevel, int partitionCount) {
+        var trees = forest.getAllTrees();
+        long[] weights = new long[trees.size()];
+        for (int i = 0; i < trees.size(); i++) {
+            weights[i] = trees.get(i).getSpatialIndex().elementCount(uniformLevel);
+        }
+        int[] ranks = assign(weights, partitionCount);
+        var assignment = new LinkedHashMap<String, Integer>();
+        for (int i = 0; i < trees.size(); i++) {
+            assignment.put(trees.get(i).getTreeId(), ranks[i]);
+        }
+        return assignment;
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/ShapeWeightProvider.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/ShapeWeightProvider.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.balancing;
+
+/**
+ * Per-shape element-count weight {@code N_shape(level)} for hybrid-forest partitioning
+ * (RDR-010 pi1.6, Knapp 2026 §5 / Eq 5.1).
+ *
+ * <p>A uniformly refined root of a given element shape produces a shape-specific number of
+ * descendants after {@code level} refinement steps:
+ * <ul>
+ *   <li>hexahedron (Octree) / tetrahedron (Tetree): {@code N(ℓ) = 8^ℓ} (1:8 refinement)</li>
+ *   <li>pyramid (PyramidIndex): {@code N(ℓ) = 2·8^ℓ − 6^ℓ} — a pyramid refines into 6 pyramids
+ *       + 4 tets, and the {@code −6^ℓ} term corrects the non-uniform pyramid/tet mixing</li>
+ * </ul>
+ *
+ * <p><b>Why this matters.</b> A weighted space-filling-curve partition that assumes every tree
+ * refines 1:8 mis-balances a forest containing pyramid trees (a pyramid root holds
+ * {@code 2·8^ℓ − 6^ℓ} elements, not {@code 8^ℓ}). Consulting {@code elementCount(level)} per shape
+ * lets {@link ShapeWeightPartitioner} assign cumulative-weight-equal SFC ranges (Knapp Algorithm 5.1)
+ * across heterogeneous forests.
+ *
+ * @author Hal Hildebrand
+ */
+public interface ShapeWeightProvider {
+
+    /**
+     * The number of elements a single root of this shape contains after {@code level} uniform
+     * refinement steps — the partition weight {@code N_shape(level)}.
+     *
+     * @param level the uniform refinement level (≥ 0)
+     * @return the element count {@code N_shape(level)}
+     * @throws IllegalArgumentException if {@code level < 0}, or if the count would overflow a signed
+     *                                  {@code long} (i.e. {@code 8^level} exceeds {@link Long#MAX_VALUE};
+     *                                  {@code 8^21 = 2^63} overflows, so {@code level} must be ≤ 20)
+     */
+    long elementCount(int level);
+
+    /** Largest level whose {@code 8^level} (and {@code 2·8^level − 6^level}) fits a signed long. */
+    int MAX_WEIGHT_LEVEL = 20;
+
+    /**
+     * Validate that {@code level} is in the representable range {@code [0, }{@link #MAX_WEIGHT_LEVEL}{@code ]}.
+     *
+     * @throws IllegalArgumentException if {@code level < 0} or {@code level > }{@link #MAX_WEIGHT_LEVEL}
+     */
+    static void requireValidLevel(int level) {
+        if (level < 0) {
+            throw new IllegalArgumentException("level must be >= 0, got " + level);
+        }
+        if (level > MAX_WEIGHT_LEVEL) {
+            throw new IllegalArgumentException(
+                "level " + level + " overflows a signed long (8^" + level + " > Long.MAX_VALUE); max is "
+                + MAX_WEIGHT_LEVEL);
+        }
+    }
+
+    /** {@code 8^level = 2^(3·level)}, computed exactly by bit shift after range validation. */
+    static long eightToThe(int level) {
+        requireValidLevel(level);
+        return 1L << (3 * level);
+    }
+
+    /** {@code 6^level}, computed by iterated multiplication after range validation (no overflow for level ≤ 20). */
+    static long sixToThe(int level) {
+        requireValidLevel(level);
+        long r = 1L;
+        for (int i = 0; i < level; i++) {
+            r *= 6L;
+        }
+        return r;
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/TwoOneBalanceChecker.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/TwoOneBalanceChecker.java
@@ -21,11 +21,15 @@ import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.forest.Forest;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostElement;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostLayer;
+import com.hellblazer.luciferase.lucien.neighbor.NeighborDetector;
 import com.hellblazer.luciferase.lucien.octree.MortonKey;
+import com.hellblazer.luciferase.lucien.pyramid.PyramidKey;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -100,6 +104,15 @@ public class TwoOneBalanceChecker<Key extends SpatialKey<Key>, ID extends Entity
      * @param forest local forest containing local elements
      * @return list of violations found (empty if none)
      * @throws IllegalArgumentException if ghostLayer or forest is null
+     * @implNote MortonKey ghosts are probed in both directions (coarser ancestors AND finer
+     *           descendants) via the Morton level-scan. TetreeKey / PyramidKey ghosts (RDR-010 pi1.6)
+     *           are routed through the {@link NeighborDetector} and probe only the <em>coarser</em>
+     *           direction (ghost-fine / local-coarse). The ghost-coarse / local-fine arrangement is NOT
+     *           probed locally; detecting it relies on the partition that owns the finer element running
+     *           its own boundary-ghost balance check — an assumed distributed-protocol invariant, not a
+     *           guarantee enforced here (consistent with the chosen "Morton-behavior" scope; Morton does
+     *           not exhaustively probe finer either). Unhandled key types are logged, never silently
+     *           dropped.
      */
     public List<BalanceViolation<Key>> findViolations(
         GhostLayer<Key, ID, Content> ghostLayer,
@@ -127,8 +140,16 @@ public class TwoOneBalanceChecker<Key extends SpatialKey<Key>, ID extends Entity
             if (ghostKey instanceof MortonKey mortonGhost) {
                 checkMortonNeighborsForViolations(mortonGhost, ghostLevel, forest,
                                                  ghost.getOwnerRank(), violations);
+            } else if (ghostKey instanceof TetreeKey<?> || ghostKey instanceof PyramidKey) {
+                // RDR-010 pi1.6: tetrahedral / pyramid (cross-shape) neighbor topology via the wired
+                // NeighborDetector — closes the silent-skip gap for non-Morton keys (Approach §4d).
+                checkDetectorNeighborsForViolations(ghostKey, ghostLevel, forest,
+                                                    ghost.getOwnerRank(), violations);
+            } else {
+                log.warn("No balance-neighbor strategy for ghost key type {}; skipping (would silently "
+                         + "miss violations — file a follow-on if this key type needs balance checking)",
+                         ghostKey.getClass().getSimpleName());
             }
-            // Additional key types (TetreeKey, etc.) would be handled similarly
         }
 
         log.debug("Found {} violations in ghost layer with {} ghost elements",
@@ -196,6 +217,80 @@ public class TwoOneBalanceChecker<Key extends SpatialKey<Key>, ID extends Entity
         }
 
         log.debug("Checked {} neighbor positions, found {} neighbors", neighborsChecked, neighborsFound);
+    }
+
+    /**
+     * Check non-Morton (Tetree / Pyramid) ghost-element neighbors for 2:1 balance violations via the
+     * forest's wired {@link NeighborDetector} (RDR-010 pi1.6, Approach §4d — closes the silent-skip gap).
+     *
+     * <p>TetreeKey/PyramidKey have no {@code neighbor(Direction)} method (unlike MortonKey), so neighbor
+     * topology comes from the shape's {@link NeighborDetector#findFaceNeighbors}. For each same-level
+     * face neighbor we then walk its {@link SpatialKey#parent()} chain to the root, probing the forest at
+     * each level — this mirrors the <em>coarser</em> half of the Morton level-scan (where a fine ghost
+     * neighbors a coarser local element).
+     *
+     * <p><b>Scope (documented, not silent — matches the chosen "Morton-behavior" scope).</b> This detects
+     * the ghost-fine / local-coarse arrangement. The finer arrangement (a coarse ghost neighboring a
+     * finer local element) requires descending a canonical child chain, which has no key-level primitive
+     * on PyramidKey; it is deferred. In a distributed forest that arrangement is still detected from the
+     * partition that owns the finer element (whose own boundary ghost is checked from its side), so no
+     * violation goes globally undetected — only locally, on this side, for this arrangement.
+     */
+    private void checkDetectorNeighborsForViolations(
+        Key ghostKey,
+        int ghostLevel,
+        Forest<Key, ID, Content> forest,
+        int sourceRank,
+        List<BalanceViolation<Key>> violations
+    ) {
+        var detector = detectorFor(forest);
+        if (detector == null) {
+            // Every AbstractSpatialIndex subclass wires a detector in its constructor, so a null here is
+            // unexpected and would SILENTLY skip balance checking — warn rather than hide it.
+            log.warn("No neighbor detector available from forest trees; cannot balance-check ghost {} "
+                     + "(its violations are silently skipped)", ghostKey);
+            return;
+        }
+
+        var probed = new HashSet<Key>();
+        for (var neighbor : detector.findFaceNeighbors(ghostKey)) {
+            // Same-level neighbor plus its coarser ancestors (mirrors Morton's coarser level-scan).
+            Key probe = neighbor;
+            while (probe != null) {
+                if (probed.add(probe) && forestContains(forest, probe)) {
+                    int localLevel = probe.getLevel();
+                    int levelDiff = Math.abs(localLevel - ghostLevel);
+                    if (levelDiff > 1) {
+                        violations.add(new BalanceViolation<>(probe, ghostKey, localLevel, ghostLevel,
+                                                              levelDiff, sourceRank));
+                        log.debug("VIOLATION (detector): local level {} vs ghost level {} (diff={})",
+                                  localLevel, ghostLevel, levelDiff);
+                    }
+                }
+                probe = probe.parent();
+            }
+        }
+    }
+
+    /** First non-null neighbor detector among the forest's trees (geometry is index-independent). */
+    private NeighborDetector<Key> detectorFor(Forest<Key, ID, Content> forest) {
+        for (var tree : forest.getAllTrees()) {
+            var detector = tree.getSpatialIndex().getNeighborDetector();
+            if (detector != null) {
+                return detector;
+            }
+        }
+        return null;
+    }
+
+    /** True if any tree in the forest contains {@code key} as an occupied spatial key. */
+    private boolean forestContains(Forest<Key, ID, Content> forest, Key key) {
+        for (var tree : forest.getAllTrees()) {
+            if (tree.getSpatialIndex().containsSpatialKey(key)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
@@ -75,6 +75,21 @@ public class PyramidIndex<ID extends EntityID, Content> extends AbstractSpatialI
     // createTreeBalancer() is inherited from AbstractSpatialIndex; default returns DefaultTreeBalancer.
     // No pyramid-specific balancer in Phase A.
 
+    /**
+     * Per-shape partition weight {@code N_pyramid(level) = 2·8^level − 6^level} (RDR-010 pi1.6,
+     * Knapp 2026 Eq 5.1). A pyramid root refines into 6 pyramids + 4 tets; the {@code −6^level} term
+     * corrects the non-uniform pyramid/tet mixing across levels. Overrides the default {@code 8^level}
+     * so a hybrid-forest weighted partition ({@link com.hellblazer.luciferase.lucien.balancing.ShapeWeightPartitioner})
+     * counts pyramid trees by their true element load rather than as 1:8 trees.
+     *
+     * <p>{@code N_pyramid(0)=1}, {@code N_pyramid(1)=10} (= {@link TetreeConnectivity#CHILDREN_PER_PYRAMID}).
+     */
+    @Override
+    public long elementCount(int level) {
+        return 2L * com.hellblazer.luciferase.lucien.balancing.ShapeWeightProvider.eightToThe(level)
+               - com.hellblazer.luciferase.lucien.balancing.ShapeWeightProvider.sixToThe(level);
+    }
+
     // ===== SpatialIndex interface: enclosing methods (Phase C) =====
 
     @Override

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/ShapeWeightPartitionerTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/ShapeWeightPartitionerTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.balancing;
+
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.octree.Octree;
+import com.hellblazer.luciferase.lucien.pyramid.PyramidIndex;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * RDR-010 pi1.6 Phase B: weighted space-filling-curve cumulative-offset partition (Knapp Algorithm 5.1 /
+ * Burstedde+Holke weighted partition). Each contiguous unit (forest tree) is assigned to the rank its
+ * cumulative-weight start offset falls into, so every rank receives ≈ W/P total weight.
+ *
+ * <p>The shape-correctness point: weights come from {@link ShapeWeightProvider#elementCount(int)}, so a
+ * pyramid tree (N = 2·8^ℓ − 6^ℓ) carries more weight than a hex tree (N = 8^ℓ) and shifts the partition
+ * boundaries accordingly — a shape-blind 1:8 weighting would mis-balance.
+ */
+class ShapeWeightPartitionerTest {
+
+    private static long total(long[] w) {
+        long s = 0;
+        for (long x : w) {
+            s += x;
+        }
+        return s;
+    }
+
+    private static long[] rankWeights(long[] w, int[] assign, int p) {
+        long[] rw = new long[p];
+        for (int i = 0; i < w.length; i++) {
+            rw[assign[i]] += w[i];
+        }
+        return rw;
+    }
+
+    @Test
+    void ranksAreContiguousAndInRange() {
+        long[] w = { 5, 3, 8, 1, 4, 9, 2, 6 };
+        int p = 3;
+        int[] a = ShapeWeightPartitioner.assign(w, p);
+        assertEquals(w.length, a.length);
+        for (int i = 0; i < a.length; i++) {
+            assertTrue(a[i] >= 0 && a[i] < p, "rank in range at " + i);
+            if (i > 0) {
+                assertTrue(a[i] >= a[i - 1], "ranks must be non-decreasing (contiguous SFC order)");
+            }
+        }
+        assertEquals(0, a[0], "first unit goes to rank 0");
+    }
+
+    @Test
+    void equalWeightsSplitEvenlyWhenDivisible() {
+        long[] w = { 1, 1, 1, 1, 1, 1 };
+        int[] a = ShapeWeightPartitioner.assign(w, 3);
+        assertArrayEquals(new int[] { 0, 0, 1, 1, 2, 2 }, a, "6 equal units over 3 ranks → 2 each");
+    }
+
+    @Test
+    void weightedBalanceWithinLargestUnit() {
+        // SFC weighted-partition quality bound: each rank's total weight stays within one max-unit-weight
+        // of the ideal W/P. (Indivisible units cannot do better than this.)
+        long[] w = { 7, 2, 5, 9, 1, 4, 6, 3, 8 };
+        int p = 4;
+        int[] a = ShapeWeightPartitioner.assign(w, p);
+        long W = total(w);
+        long ideal = W / p;
+        long maxUnit = 9;
+        for (long rw : rankWeights(w, a, p)) {
+            // SFC partition of indivisible units: each rank stays within one max-unit of ideal on each
+            // side (theoretical bound 2·maxUnit on the spread).
+            assertTrue(rw <= ideal + 2 * maxUnit,
+                       "rank weight " + rw + " must be within 2 max-units of ideal " + ideal);
+        }
+        // Total weight conserved across ranks.
+        assertEquals(W, total(rankWeights(w, a, p)));
+    }
+
+    @Test
+    void singlePartitionPutsEverythingInRankZero() {
+        assertArrayEquals(new int[] { 0, 0, 0 }, ShapeWeightPartitioner.assign(new long[] { 5, 1, 9 }, 1));
+        assertArrayEquals(new int[] { 0, 0, 0 }, ShapeWeightPartitioner.assign(new long[] { 0, 0, 0 }, 1),
+                          "P=1 with zero weights must also land all in rank 0 (clamp)");
+    }
+
+    @Test
+    void singleUnitGoesToRankZero() {
+        assertArrayEquals(new int[] { 0 }, ShapeWeightPartitioner.assign(new long[] { 42 }, 4));
+    }
+
+    @Test
+    void negativeWeightThrows() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> ShapeWeightPartitioner.assign(new long[] { 1, -1, 1 }, 2));
+    }
+
+    @Test
+    void highLevelWeightsDoNotOverflowTheRankComputation() {
+        // Regression for the prefix·P long-overflow: 3 hex trees at level 20 (8^20 = 2^60 each), P=4.
+        // prefix at unit 2 = 2^61; prefix·4 = 2^63 overflows a signed long — the double reformulation
+        // must still yield a valid contiguous assignment (no negative ranks).
+        long n8_20 = ShapeWeightProvider.eightToThe(20); // 2^60
+        long[] w = { n8_20, n8_20, n8_20 };
+        int[] a = ShapeWeightPartitioner.assign(w, 4);
+        for (int i = 0; i < a.length; i++) {
+            assertTrue(a[i] >= 0 && a[i] < 4, "rank must be in [0,4) at " + i + ", got " + a[i]);
+            if (i > 0) {
+                assertTrue(a[i] >= a[i - 1], "ranks must stay non-decreasing under high weights");
+            }
+        }
+    }
+
+    @Test
+    void allZeroWeightsFallBackToEvenIndexSplit() {
+        long[] w = { 0, 0, 0, 0 };
+        int[] a = ShapeWeightPartitioner.assign(w, 2);
+        assertArrayEquals(new int[] { 0, 0, 1, 1 }, a, "zero weights → contiguous index split");
+    }
+
+    @Test
+    void invalidPartitionCountThrows() {
+        assertThrows(IllegalArgumentException.class, () -> ShapeWeightPartitioner.assign(new long[] { 1 }, 0));
+        assertThrows(IllegalArgumentException.class, () -> ShapeWeightPartitioner.assign(new long[] { 1 }, -1));
+    }
+
+    @Test
+    void emptyWeightsYieldEmptyAssignment() {
+        assertEquals(0, ShapeWeightPartitioner.assign(new long[0], 3).length);
+    }
+
+    @Test
+    void shapeAwareWeightsShiftBoundariesVsShapeBlind() {
+        // Hybrid weighting (the pi1.6 fix): a forest of [hex,hex,hex,pyramid,hex,hex] at level 1.
+        // Shape-aware: N_hex(1)=8, N_pyramid(1)=10 → [8,8,8,10,8,8], W=50, P=3.
+        //   boundaries at 50/3≈16.7 and 33.3 → assignment [0,0,0,1,2,2].
+        // Shape-blind (every tree 1:8 = 8): [8,8,8,8,8,8], W=48 → [0,0,1,1,2,2].
+        // The pyramid's extra weight pushes unit index 2 from rank 1 back into rank 0 — a real,
+        // boundary-shifting difference, proving the weight is consulted (non-vacuous).
+        var hex = new Octree<LongEntityID, String>(new SequentialLongIDGenerator());
+        var pyr = new PyramidIndex<LongEntityID, String>(new SequentialLongIDGenerator());
+        long[] shapeAware = ShapeWeightPartitioner.weightsAtLevel(List.of(hex, hex, hex, pyr, hex, hex), 1);
+        assertArrayEquals(new long[] { 8, 8, 8, 10, 8, 8 }, shapeAware, "shape-aware weights via provider");
+
+        long[] shapeBlind = { 8, 8, 8, 8, 8, 8 };
+        int[] aware = ShapeWeightPartitioner.assign(shapeAware, 3);
+        int[] blind = ShapeWeightPartitioner.assign(shapeBlind, 3);
+        assertArrayEquals(new int[] { 0, 0, 0, 1, 2, 2 }, aware, "shape-aware partition");
+        assertArrayEquals(new int[] { 0, 0, 1, 1, 2, 2 }, blind, "shape-blind partition");
+        assertFalse(java.util.Arrays.equals(aware, blind),
+                    "the pyramid tree's weight must shift a partition boundary vs shape-blind");
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/ShapeWeightProviderTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/ShapeWeightProviderTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.balancing;
+
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.octree.Octree;
+import com.hellblazer.luciferase.lucien.pyramid.PyramidIndex;
+import com.hellblazer.luciferase.lucien.tetree.Tetree;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * RDR-010 pi1.6 Phase A: the per-shape element-count weight {@code N_shape(level)} (Knapp Eq 5.1).
+ *
+ * <p>{@code N_hex = N_tet = 8^ℓ} (1:8 refinement); {@code N_pyramid = 2·8^ℓ − 6^ℓ}. Overflow-guarded
+ * (level ≤ 20, since {@code 8^21 = 2^63} overflows a signed long).
+ */
+class ShapeWeightProviderTest {
+
+    private static long pow(long base, int exp) {
+        long r = 1;
+        for (int i = 0; i < exp; i++) {
+            r *= base;
+        }
+        return r;
+    }
+
+    private Octree<LongEntityID, String> octree() {
+        return new Octree<>(new SequentialLongIDGenerator());
+    }
+
+    private Tetree<LongEntityID, String> tetree() {
+        return new Tetree<>(new SequentialLongIDGenerator());
+    }
+
+    private PyramidIndex<LongEntityID, String> pyramid() {
+        return new PyramidIndex<>(new SequentialLongIDGenerator());
+    }
+
+    @Test
+    void octreeAndTetreeUse8ToTheLevel() {
+        var hex = octree();
+        var tet = tetree();
+        for (int l = 0; l <= 15; l++) {
+            long expected = pow(8, l);
+            assertEquals(expected, hex.elementCount(l), "N_hex(" + l + ") = 8^" + l);
+            assertEquals(expected, tet.elementCount(l), "N_tet(" + l + ") = 8^" + l);
+        }
+        assertEquals(1L, hex.elementCount(0), "N_hex(0) = 1");
+        assertEquals(8L, hex.elementCount(1), "N_hex(1) = 8");
+    }
+
+    @Test
+    void pyramidUsesKnappEq51() {
+        var pyr = pyramid();
+        // N_pyramid(ℓ) = 2·8^ℓ − 6^ℓ. Golden values:
+        // ℓ=0: 2−1 = 1; ℓ=1: 16−6 = 10 (== 6 pyramids + 4 tets); ℓ=2: 128−36 = 92;
+        // ℓ=3: 1024−216 = 808; ℓ=4: 8192−1296 = 6896.
+        assertEquals(1L, pyr.elementCount(0), "N_pyramid(0) = 1");
+        assertEquals(10L, pyr.elementCount(1), "N_pyramid(1) = 10 (6 pyr + 4 tet)");
+        assertEquals(92L, pyr.elementCount(2), "N_pyramid(2) = 92");
+        assertEquals(808L, pyr.elementCount(3), "N_pyramid(3) = 808");
+        assertEquals(6896L, pyr.elementCount(4), "N_pyramid(4) = 6896");
+        for (int l = 0; l <= 15; l++) {
+            assertEquals(2 * pow(8, l) - pow(6, l), pyr.elementCount(l), "N_pyramid(" + l + ")");
+        }
+    }
+
+    @Test
+    void pyramidWeightExceedsHexAtEveryPositiveLevel() {
+        // The load-bearing property: a pyramid root holds MORE elements than a hex/tet root at every
+        // ℓ ≥ 1, so a shape-blind 8^ℓ weight under-counts pyramid trees (the partition bug pi1.6 fixes).
+        var pyr = pyramid();
+        var hex = octree();
+        for (int l = 1; l <= 15; l++) {
+            assertTrue(pyr.elementCount(l) > hex.elementCount(l),
+                       "N_pyramid(" + l + ") must exceed N_hex(" + l + ")");
+        }
+        assertEquals(hex.elementCount(0), pyr.elementCount(0), "both = 1 at level 0");
+    }
+
+    @Test
+    void negativeLevelThrows() {
+        assertThrows(IllegalArgumentException.class, () -> octree().elementCount(-1));
+        assertThrows(IllegalArgumentException.class, () -> pyramid().elementCount(-1));
+    }
+
+    @Test
+    void overflowingLevelThrows() {
+        // 8^21 = 2^63 overflows signed long; level must be <= 20.
+        assertThrows(IllegalArgumentException.class, () -> octree().elementCount(21));
+        assertThrows(IllegalArgumentException.class, () -> pyramid().elementCount(21));
+        // Level 20 is the largest that fits.
+        assertDoesNotThrow(() -> octree().elementCount(20));
+        assertDoesNotThrow(() -> pyramid().elementCount(20));
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/TwoOneBalanceCheckerShapeRouterTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/TwoOneBalanceCheckerShapeRouterTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.balancing;
+
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.forest.Forest;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostElement;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostLayer;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostType;
+import com.hellblazer.luciferase.lucien.pyramid.PyramidIndex;
+import com.hellblazer.luciferase.lucien.pyramid.PyramidKey;
+import com.hellblazer.luciferase.lucien.tetree.Tetree;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3f;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * RDR-010 pi1.6 Phase C (Approach §4d): {@link TwoOneBalanceChecker} must route non-Morton ghost keys
+ * (TetreeKey, PyramidKey) through the shape's
+ * {@link com.hellblazer.luciferase.lucien.neighbor.NeighborDetector} instead of silently skipping them.
+ *
+ * <p><b>Non-vacuous:</b> on the pre-pi1.6 checker (MortonKey-only {@code instanceof}), every positive
+ * assertion here returns zero violations — the silent-skip gap the RDR flags. Each test seeds a real
+ * ghost-fine / local-coarse arrangement (level difference 2) and asserts the violation is DETECTED.
+ *
+ * <p>Construction: insert one local coarse element at level 1 (its key {@code Kc}); insert several
+ * <em>remote</em> fine elements at level 3 in the same region; pick a remote fine key whose detector
+ * face-neighbor has {@code Kc} as its level-1 grandparent. The router walks that neighbor's parent chain
+ * to {@code Kc} (local), levels 3 vs 1 → diff 2 → violation.
+ */
+class TwoOneBalanceCheckerShapeRouterTest {
+
+    private static GhostLayer<TetreeKey<?>, LongEntityID, String> tetGhostLayer(TetreeKey<?> ghostKey, int rank) {
+        var layer = new GhostLayer<TetreeKey<?>, LongEntityID, String>(GhostType.FACES);
+        layer.addGhostElement(new GhostElement<>(ghostKey, new LongEntityID(1), "g",
+                                                 new Point3f(0, 0, 0), rank, 0L));
+        return layer;
+    }
+
+    private static GhostLayer<PyramidKey, LongEntityID, String> pyrGhostLayer(PyramidKey ghostKey, int rank) {
+        var layer = new GhostLayer<PyramidKey, LongEntityID, String>(GhostType.FACES);
+        layer.addGhostElement(new GhostElement<>(ghostKey, new LongEntityID(1), "g",
+                                                 new Point3f(0, 0, 0), rank, 0L));
+        return layer;
+    }
+
+    @Test
+    void detectsViolationOnTetreeKeyGhostNeighbor() {
+        var local = new Tetree<LongEntityID, String>(new SequentialLongIDGenerator());
+        var forest = new Forest<TetreeKey<?>, LongEntityID, String>();
+        forest.addTree(local);
+        var detector = local.getNeighborDetector();
+        assertNotNull(detector, "Tetree must wire a neighbor detector");
+
+        // Local coarse node at level 1.
+        var base = new Point3f(300.5f, 250.5f, 100.5f);
+        local.insert(base, (byte) 1, "local");
+        TetreeKey<?> kc = firstAtLevel(local.getSpatialKeys(), 1);
+        assertNotNull(kc, "expected a local level-1 coarse key");
+
+        // Remote fine cells (level 3) INSIDE Kc (grandparent == Kc), then take their face neighbors as
+        // ghost candidates: a Bey face neighbor of an inside-Kc cell sits in a different level-1 cell, but
+        // by reciprocity the inside-Kc cell is one of ITS face neighbors — so the router, probing the
+        // ghost's neighbors, walks the inside-Kc cell's parent chain to the local Kc.
+        var remote = new Tetree<LongEntityID, String>(new SequentialLongIDGenerator());
+        TetreeKey<?> ghostKey = pickGhostWithNeighborUnderCoarse(remote, detector, local, base, kc);
+        assertNotNull(ghostKey, "expected a fine ghost whose face-neighbor descends from the local coarse key");
+
+        var checker = new TwoOneBalanceChecker<TetreeKey<?>, LongEntityID, String>();
+        var violations = checker.findViolations(tetGhostLayer(ghostKey, 7), forest);
+
+        assertFalse(violations.isEmpty(), "TetreeKey ghost must produce a balance violation (no silent skip)");
+        final var gk = ghostKey;
+        assertTrue(violations.stream().anyMatch(v -> v.ghostKey().equals(gk) && v.localKey().equals(kc)
+                                                     && v.levelDifference() == 2 && v.sourceRank() == 7),
+                   "violation must name the coarse local + fine ghost with diff 2 and the ghost's rank");
+    }
+
+    @Test
+    void detectsViolationOnPyramidKeyGhostNeighbor() {
+        var local = new PyramidIndex<LongEntityID, String>(new SequentialLongIDGenerator());
+        var forest = new Forest<PyramidKey, LongEntityID, String>();
+        forest.addTree(local);
+        var detector = local.getNeighborDetector();
+        assertNotNull(detector, "PyramidIndex must wire a neighbor detector");
+
+        var base = new Point3f(300.5f, 250.5f, 100.5f);
+        local.insert(base, (byte) 1, "local");
+        PyramidKey kc = firstAtLevel(local.getSpatialKeys(), 1);
+        assertNotNull(kc, "expected a local level-1 coarse key");
+
+        var remote = new PyramidIndex<LongEntityID, String>(new SequentialLongIDGenerator());
+        PyramidKey ghostKey = pickGhostWithNeighborUnderCoarse(remote, detector, local, base, kc);
+        assertNotNull(ghostKey, "expected a fine pyramid ghost whose face-neighbor descends from the local coarse");
+
+        var checker = new TwoOneBalanceChecker<PyramidKey, LongEntityID, String>();
+        var violations = checker.findViolations(pyrGhostLayer(ghostKey, 5), forest);
+
+        assertFalse(violations.isEmpty(), "PyramidKey ghost must produce a balance violation (no silent skip)");
+        final var gk = ghostKey;
+        assertTrue(violations.stream().anyMatch(v -> v.ghostKey().equals(gk) && v.localKey().equals(kc)
+                                                     && v.levelDifference() == 2),
+                   "violation must name the coarse local pyramid + fine ghost with diff 2");
+    }
+
+    @Test
+    void noFalsePositiveOnEmptyLocalTetree() {
+        // Ghost with no local neighbors at all → no violations (guards against spurious detection).
+        var local = new Tetree<LongEntityID, String>(new SequentialLongIDGenerator());
+        var forest = new Forest<TetreeKey<?>, LongEntityID, String>();
+        forest.addTree(local); // empty: nothing local to violate against
+
+        var remote = new Tetree<LongEntityID, String>(new SequentialLongIDGenerator());
+        remote.insert(new Point3f(10.5f, 8.5f, 3.5f), (byte) 3, "f");
+        var ghostKey = remote.getSpatialKeys().iterator().next();
+
+        var checker = new TwoOneBalanceChecker<TetreeKey<?>, LongEntityID, String>();
+        var violations = checker.findViolations(tetGhostLayer(ghostKey, 1), forest);
+        assertTrue(violations.isEmpty(), "no local elements → no balance violations");
+    }
+
+    /**
+     * Find a level-3 ghost key whose detector face-neighbor set contains a cell descending (grandparent)
+     * from the local coarse key {@code kc}. Seeds {@code remote} with fine cells inside Kc's region, then
+     * uses their face neighbors (which sit outside Kc) as ghost candidates — the router, probing such a
+     * candidate's neighbors, walks the inside-Kc cell's parent chain back to the local {@code kc}.
+     */
+    private static <K extends com.hellblazer.luciferase.lucien.SpatialKey<K>>
+    K pickGhostWithNeighborUnderCoarse(
+        com.hellblazer.luciferase.lucien.SpatialIndex<K, LongEntityID, String> remote,
+        com.hellblazer.luciferase.lucien.neighbor.NeighborDetector<K> detector,
+        com.hellblazer.luciferase.lucien.SpatialIndex<K, LongEntityID, String> local,
+        Point3f base, K kc) {
+        for (int i = 0; i < 40; i++) {
+            remote.insert(new Point3f(base.x + i, base.y + (i % 7), base.z + (i % 5)), (byte) 3, "f" + i);
+        }
+        for (var inside : remote.getSpatialKeys()) {
+            if (inside.getLevel() != 3 || !isGrandchildOf(inside, kc)) {
+                continue;
+            }
+            for (var candidate : detector.findFaceNeighbors(inside)) {
+                if (candidate.getLevel() != 3 || local.containsSpatialKey(candidate)) {
+                    continue;
+                }
+                if (hasGrandparent(detector.findFaceNeighbors(candidate), kc)) {
+                    return candidate;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static <K extends com.hellblazer.luciferase.lucien.SpatialKey<K>> boolean isGrandchildOf(
+        K key, K coarse) {
+        var p = key.parent();
+        if (p == null) {
+            return false;
+        }
+        var gp = p.parent();
+        return gp != null && gp.equals(coarse);
+    }
+
+    @Test
+    void coarseGhostWithFinerLocalIsNotProbedLocally() {
+        // Documents the locked "Morton-behavior" scope (RDR-010 pi1.6): the detector router probes only
+        // the COARSER direction. A COARSE ghost (level 1) adjacent to FINER local elements (level 3) is
+        // NOT detected locally — by design it is caught from the partition owning the finer elements.
+        var local = new Tetree<LongEntityID, String>(new SequentialLongIDGenerator());
+        var forest = new Forest<TetreeKey<?>, LongEntityID, String>();
+        forest.addTree(local);
+
+        var base = new Point3f(300.5f, 250.5f, 100.5f);
+        for (int i = 0; i < 10; i++) {
+            local.insert(new Point3f(base.x + i, base.y + (i % 7), base.z + (i % 5)), (byte) 3, "fine" + i);
+        }
+        assertFalse(local.getSpatialKeys().isEmpty(), "precondition: local has fine elements");
+
+        var remote = new Tetree<LongEntityID, String>(new SequentialLongIDGenerator());
+        remote.insert(base, (byte) 1, "coarseGhost");
+        var coarseGhost = firstAtLevel(remote.getSpatialKeys(), 1);
+        assertNotNull(coarseGhost);
+
+        var checker = new TwoOneBalanceChecker<TetreeKey<?>, LongEntityID, String>();
+        var violations = checker.findViolations(tetGhostLayer(coarseGhost, 2), forest);
+        assertTrue(violations.isEmpty(),
+                   "coarse ghost / finer local is intentionally NOT probed locally (Morton-behavior scope)");
+    }
+
+    private static <K extends com.hellblazer.luciferase.lucien.SpatialKey<K>> K firstAtLevel(
+        java.util.Set<K> keys, int level) {
+        for (var k : keys) {
+            if (k.getLevel() == level) {
+                return k;
+            }
+        }
+        return null;
+    }
+
+    private static <K extends com.hellblazer.luciferase.lucien.SpatialKey<K>> boolean hasGrandparent(
+        java.util.List<K> neighbors, K target) {
+        for (var n : neighbors) {
+            var p = n.parent();
+            if (p == null) {
+                continue;
+            }
+            var gp = p.parent();
+            if (gp != null && gp.equals(target)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
RDR-010 Decision §4 (Forest + balancing integration), Approach §4a–4d. **Stacked on #163 (pi1.5)** — the pyramid balance-router needs pi1.5's cross-shape `PyramidNeighborDetector`. Review/merge after #163.

## §4a/§4b — `ShapeWeightProvider` (per-shape weight `N_shape(level)`)
`AbstractSpatialIndex` implements the 1:8 default `8^level`; `PyramidIndex` overrides to `2·8^level − 6^level` (Knapp Eq 5.1; golden 1, 10, 92, 808, 6896). Overflow-guarded (`level ≤ 20`; `8^21 = 2^63` overflows a signed long).

## §4c — `ShapeWeightPartitioner` (weighted-SFC cumulative-offset, Knapp Alg 5.1)
`assign(weights, P)` assigns each contiguous unit to the rank its cumulative-weight start offset falls into (≈`W/P` per rank); double reformulation avoids `prefix·P` long-overflow at high levels; total-overflow guarded; `total==0` → even index split. Plus `weightsAtLevel` and a homogeneous-forest `partitionForest` convenience.

> **Note:** the partitioner + weight hook are delivered and tested; wiring a *live consumer* (populating a `PartitionRegistry` / `Forest` partition assignment) is an **explicit deferral** → `Luciferase-d3z3` / pi1.7. No clean seam exists today (`routeQuery` is AABB-only; `PartitionRegistry` populated externally). Recorded at the phase-review-gate, not silently dropped.

## §4d — `TwoOneBalanceChecker` shape-router
The MortonKey path is unchanged; TetreeKey and PyramidKey ghosts now route through the wired `NeighborDetector` (`findFaceNeighbors` + `SpatialKey.parent()` coarser-ancestor probing) instead of being silently skipped. **Closes the silent-skip gap non-vacuously** — mixed-forest violations are now detected on both key types (was zero). Matches Morton's coarser-half behavior; the ghost-coarse/local-fine arrangement is an assumed distributed-protocol invariant (documented + scope-pinned by test).

## Gate
- Full `lucien` suite green (**2717, 0 failures**); 31 balancing tests deterministically green.
- Perf parity structural (pure math + detector routing; no Octree/Tetree/Tet/Constants hot-path change).
- `phase-review-gate RDR-010 --phase 6` PASSED; §Approach cross-walk + deferrals recorded in the RDR (2026-05-30 addendum).
- Dual review: code-review-expert (1 HIGH overflow fixed + 2 Medium); substantive-critic (3 significant — §4c-wiring deferred, `partitionForest` `@apiNote`, `@implNote` softened + scope test).

## Registered deferrals (explicit)
- `Luciferase-d3z3` — §4c consumer-wiring (partitioner → live partition assignment).
- Balance-router finer-direction (non-Morton) — Morton-behavior scope.
- `partitionForest` hybrid limitation (single-key `Forest`).
- `N_prism(ℓ)` not in corpus (Gap #5) → Prism uses default `8^ℓ` (flagged).

RDR-010 remains `accepted` pending pi1.7.