### PR TITLE
RDR-010 pi1.7: hybrid-mesh demo + PyramidKey microbenchmark + JMH wiring + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,12 +239,11 @@ Historical reference:
 - **Lock-Free**: Optimistic concurrency control for entity updates
 - **ObjectPool**: Used for k-NN, collision, ray intersection, frustum culling to reduce GC pressure
 
-### T8code Partition Limitation
+### T8code Partition Limitation — CLOSED via PyramidIndex (RDR-010)
 
-- **t8code tetrahedra fundamentally don't partition the cube**: ~48% gaps and ~32% overlaps
-- **This is a fundamental limitation**, not a bug in our implementation
-- **Affected Tests**: Disabled tests expecting proper cube partitioning
-- **Documentation**: See `lucien/doc/TETREE_T8CODE_PARTITION_ANALYSIS.md` for details
+- **Historical**: plain t8code tetrahedra do not tile a cube on their own (~48% gaps / ~32% overlaps); long treated as a fundamental limitation.
+- **Closed (RDR-010, 2026-05-30)**: the hex↔tet partition gap is closed by the **hybrid pyramid construction** (Knapp 2026). `PyramidIndex` (pyramid SFC, `PyramidKey`) is the hex↔tet transition primitive, with cross-shape pyramid↔tet neighbor finding + distributed ghost wiring (pi1.5) and shape-aware Forest partition weights `N_pyramid(ℓ)=2·8^ℓ−6^ℓ` (pi1.6). See `docs/rdr/RDR-010-pyramid-spatial-index.md`.
+- **Scope note**: cross-shape support is at the shallow pyramid↔tet boundary (`l == minTetLevel`); deep-tet cross-shape stays fail-loud guarded (Finding #16, deferred). The standalone `TETREE_T8CODE_PARTITION_ANALYSIS.md` is retired — RDR-010 is the authoritative record.
 
 ### DSOC (Dynamic Spatial Occlusion Culling)
 

--- a/docs/rdr/RDR-010-pyramid-spatial-index.md
+++ b/docs/rdr/RDR-010-pyramid-spatial-index.md
@@ -394,3 +394,20 @@ pi1.5 deliverable arc (cross-shape neighbor finding + distributed ghost wiring) 
 - **`N_prism(ℓ)`** — not in the Knapp corpus (Gap #5); Prism uses the default `8^ℓ` (slight partition inaccuracy if a prism tree enters a hybrid partition). Flagged, not blocking.
 
 Remaining RDR-010 work: **pi1.7** (hybrid-mesh demo + 128-bit-key/branching microbenchmarks + §4c consumer-wiring). RDR-010 stays `accepted` until pi1.7 closes.
+
+## Addendum 2026-05-30 — pi1.7 close / Phase-7 gate PASSED + RDR close-readiness
+
+`/conexus:phase-review-gate RDR-010 --phase 7` PASSED (bead `Luciferase-pi1.7`, Item6 — the gate-question Direction B validated end-to-end). Delivered:
+
+- **Hybrid-mesh demo** (`HybridMeshIntegrationDemoTest`, 7 tests): per-shape Forests (hex/tet/pyramid/prism) exercised through insert/kNN/neighbor; the pyramid↔tet cross-shape seam; the **pyramid ghost-layer build leg**; and the shape-aware partition. `Forest` is single-key-typed, so the realistic hybrid surface is multi-forest + cross-shape element coupling (not one four-shape Forest) — a deliberate, documented adaptation of the bead's "one Forest" wording.
+- **Microbenchmark** (`PyramidKeyVsMortonKeyBenchmark`, JMH, authoritative forked run): PyramidKey (128-bit) vs MortonKey (64-bit) — `compareTo` ≈ 1.72×, `ConcurrentSkipListMap.get` ≈ 1.21×. Modest constant factors; **the two-`long` representation is validated** (Finding #7 closed) at current workloads. Recorded in `PERFORMANCE_METRICS_MASTER.md`.
+- **JMH build wiring**: `jmh-generator-annprocess` wired into `lucien` `default-testCompile` (repo JMH benchmarks were previously un-runnable — no `BenchmarkList`).
+- **Docs**: CLAUDE.md partition-gap → "closed via PyramidIndex" (shallow-boundary scope note); LUCIEN_ARCHITECTURE.md Pyramid package; `TETREE_T8CODE_PARTITION_ANALYSIS.md` **retired** (the bead named it for update; it no longer exists — RDR-010 is the authoritative record).
+
+**Scope-accounting (substantive-critic, explicit — not silent):**
+- The demo's **ghost** leg (`ghostLayerWiresForThePyramidShape`) is a smoke-level build check; substantive cross-shape / distributed-ghost-exchange correctness (multi-rank fan-out via the inverted seam) is covered by `PyramidCrossShapeGhostTest` (pi1.5 / `Luciferase-azwr`).
+- **§4c consumer-wiring (`Luciferase-d3z3`)** — pi1.6's addendum named pi1.7 as its "natural home"; it is **re-deferred** to the standalone bead. `ShapeWeightPartitioner` is delivered + tested (pi1.6); populating `PartitionRegistry`/`Forest.routeQuery` from the weighted partition is the remaining work.
+
+**RDR-010 close-readiness.** Decision items 1–5 delivered; the Direction-B gate question (item 6) validated. RDR-010 may close with these EXPLICIT, live follow-on beads OPEN (they are registered deferrals, not silent reductions, and must NOT be closed alongside the RDR):
+- `Luciferase-d3z3` (§4c consumer-wiring) · `Luciferase-0utt` (exhaustive cross-shape edge/vertex) · deep-tet (`l > minTetLevel`) cross-shape (Finding #16, fail-loud guarded — pending a future tree-divergence RDR) · `Luciferase-3y1` (PyramidKeyDecoder dedup) · `Luciferase-7eb` (insertWithSpanning).
+- The deep-tet fail-loud guard (Finding #16) remains in place; no silent enablement.

--- a/lucien/doc/LUCIEN_ARCHITECTURE.md
+++ b/lucien/doc/LUCIEN_ARCHITECTURE.md
@@ -139,7 +139,8 @@ SpatialIndex<Key extends SpatialKey<Key>, ID extends EntityID, Content> (interfa
             ├── Octree<ID, Content> extends AbstractSpatialIndex<MortonKey, ID, Content>
             ├── SFCArrayIndex<ID, Content> extends AbstractSpatialIndex<MortonKey, ID, Content>
             ├── Tetree<ID, Content> extends AbstractSpatialIndex<TetreeKey, ID, Content>
-            └── Prism<ID, Content> extends AbstractSpatialIndex<PrismKey, ID, Content>
+            ├── Prism<ID, Content> extends AbstractSpatialIndex<PrismKey, ID, Content>
+            └── PyramidIndex<ID, Content> extends AbstractSpatialIndex<PyramidKey, ID, Content>  (RDR-010)
 ```
 
 ### Node Storage (Phase 6.2 Update)
@@ -601,6 +602,17 @@ Specialized operations:
 - **PrismCollisionDetector** - Collision detection optimized for anisotropic geometry
 - **PrismRayIntersector** - Ray intersection with triangular/linear space partitioning
 - **PrismNeighborFinder** - Neighbor traversal across triangular and linear boundaries
+
+### Pyramid Package (RDR-010)
+
+Hybrid hex↔tet transition shape (Knapp 2026); closes the t8code cube-partition gap.
+
+- **PyramidIndex** - Pyramid-SFC spatial index; each pyramid refines into 6 pyramid + 4 tet children (`N_pyramid(ℓ)=2·8^ℓ−6^ℓ`); subclass of `AbstractSpatialIndex<PyramidKey>`
+- **PyramidKey** - 128-bit (two-`long`) pyramid SFC key encoding the 6D Morton embedding; carries the hybrid pyramid/tet path
+- **Pyramid** - Pyramid element primitive (analogous to `Tet`); cross-shape navigation via `HybridElement` / `Pyramid.faceNeighbor` (f0–f3 → tets, f4 → pyramid)
+- **PyramidNeighborDetector** - Cross-shape (pyramid↔tet) neighbor detector wired into the ghost layer (same-shape pi1.4, cross-shape pi1.5)
+- **PyramidKeyCodec** - Element↔`PyramidKey` encoder (pyramid + shallowest tet-leaf); **PyramidContainment** - §3b decompose-and-reuse containment
+- Forest integration: `balancing.ShapeWeightProvider` (`N_pyramid(ℓ)=2·8^ℓ−6^ℓ`) + `ShapeWeightPartitioner` (weighted-SFC partition) + `TwoOneBalanceChecker` pyramid/tet shape-router (pi1.6)
 
 ### Tetree Package (34)
 

--- a/lucien/doc/PERFORMANCE_METRICS_MASTER.md
+++ b/lucien/doc/PERFORMANCE_METRICS_MASTER.md
@@ -9,6 +9,31 @@
 
 > **NEW**: SFCArrayIndex benchmarks added (December 25, 2025). LITMAX/BIGMIN optimization complete for Octree, Tetree, and SFCArrayIndex. k-NN unlimited distance fix deployed.
 
+## RDR-010 pi1.7: PyramidKey (128-bit) vs MortonKey (64-bit) Microbenchmark (2026-05-30)
+
+**Benchmark**: `PyramidKeyVsMortonKeyBenchmark.java` (JMH, Throughput). Quantifies the cost of the 128-bit
+two-`long` `PyramidKey` relative to the 64-bit one-`long` `MortonKey` — RDR-010 Finding #7 / Cost-risk §312
+(validate the representation before any at-scale hybrid deployment).
+
+**Authoritative numbers** (forked `-f 1 -wi 3 -i 5 × 1s`, `keyCount=10000`, JDK 25 GraalVM):
+
+| Benchmark | Morton (1-long) | Pyramid (2-long) | Ratio |
+|-----------|-----------------|------------------|-------|
+| `compareTo` | 190.5 ± 10.0 ops/ms | 110.6 ± 3.7 ops/ms | **Pyramid ≈ 1.72× the compare cost** |
+| `skipListGet` | 1.131 ± 0.25 ops/ms | 0.938 ± 0.04 ops/ms | **Pyramid ≈ 1.21× slower at scale** |
+
+**Conclusion**: the 128-bit key's per-comparison overhead is ~1.7× (a two-`long` lexicographic compare vs
+one), and `ConcurrentSkipListMap` lookup — comparison-dominated, O(log n) compares per get — is ~1.2×
+slower. Both are modest constant factors. At Luciferase's typical workload (≤10⁵ elements) the storage
+delta is ~1 MB (16 vs 8 bytes/key) and the lookup penalty is sub-millisecond — **the two-`long`
+representation is validated** (RDR-010 Finding #7). The 640 GB-vs-320 GB key-storage figure (Knapp §7
+40·10⁹-element scale) remains a future at-scale caveat, not a concern at current workloads.
+
+**JMH wiring note**: pi1.7 added the `jmh-generator-annprocess` annotation processor to `lucien/pom.xml`
+(test compile) so `@Benchmark` classes generate their `META-INF/BenchmarkList` — this makes all of the
+repo's JMH benchmarks runnable. Run in-process via `mvn -pl lucien exec:java
+-Dexec.mainClass=...PyramidKeyVsMortonKeyBenchmark -Dexec.classpathScope=test -Dexec.args="-f 0 ..."`.
+
 ## Epic 0: Baseline Measurements (Bead 0.1 - December 8, 2025)
 
 Four JMH benchmarks established to measure pre-optimization baselines for Epic 1-4:

--- a/lucien/pom.xml
+++ b/lucien/pom.xml
@@ -131,6 +131,35 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <!-- Wire the JMH annotation processor into the TEST compile only (default-testCompile) so
+                 @Benchmark classes generate their META-INF/BenchmarkList (required to run JMH benchmarks;
+                 RDR-010 pi1.7). Scoped to test compilation so it never displaces a future main-source
+                 annotation processor (setting annotationProcessorPaths disables classpath APT discovery
+                 for the execution it applies to). Merges with the root maven-compiler-plugin config
+                 (release, preview flags, incubator.vector). -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.openjdk.jmh</groupId>
+                                    <artifactId>jmh-generator-annprocess</artifactId>
+                                    <version>${jmh.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <!-- Performance Testing Profile -->
         <profile>

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/benchmark/PyramidKeyVsMortonKeyBenchmark.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/benchmark/PyramidKeyVsMortonKeyBenchmark.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.benchmark;
+
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.octree.MortonKey;
+import com.hellblazer.luciferase.lucien.octree.Octree;
+import com.hellblazer.luciferase.lucien.pyramid.PyramidIndex;
+import com.hellblazer.luciferase.lucien.pyramid.PyramidKey;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import javax.vecmath.Point3f;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * RDR-010 pi1.7 microbenchmark (bead Luciferase-pi1.7) — quantifies the cost of the 128-bit
+ * {@link PyramidKey} (two {@code long}s, 16 bytes) relative to the 64-bit {@link MortonKey} (one
+ * {@code long}, 8 bytes). Closes RDR-010 Finding #7 / Open-Q (validate the representation before any
+ * at-scale hybrid deployment) and the Cost/risk §312 per-element comparison-overhead question.
+ *
+ * <p>Two questions, four benchmarks:
+ * <ul>
+ *   <li><b>compareTo overhead</b> ({@code compareTo*}): the per-element branching cost of a 2-long vs a
+ *       1-long key comparison — the operation {@code ConcurrentSkipListMap} performs O(log n) times per
+ *       insert/lookup.</li>
+ *   <li><b>storage + lookup at scale</b> ({@code skipListGet*}): {@code ConcurrentSkipListMap} lookup
+ *       throughput, which folds in both the comparison overhead and the larger key footprint / reduced
+ *       cache locality of the 128-bit key.</li>
+ * </ul>
+ *
+ * <p>Run manually (not part of the test suite or CI): {@code java ... PyramidKeyVsMortonKeyBenchmark}
+ * or via the {@link #main(String[])} JMH runner. Record results in
+ * {@code lucien/doc/PERFORMANCE_METRICS_MASTER.md}.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+@Fork(1)
+public class PyramidKeyVsMortonKeyBenchmark {
+
+    @Param({ "10000", "100000" })
+    private int keyCount;
+
+    private MortonKey[] mortonKeys;
+    private PyramidKey[] pyramidKeys;
+    private MortonKey[] mortonProbes;
+    private PyramidKey[] pyramidProbes;
+    private ConcurrentSkipListMap<MortonKey, Integer> mortonMap;
+    private ConcurrentSkipListMap<PyramidKey, Integer> pyramidMap;
+
+    @Setup
+    public void setup() {
+        var rng = new Random(42);
+
+        // Harvest valid keys of each shape by inserting a randomized point cloud and reading the
+        // occupied spatial keys (guarantees genuine, well-formed SFC keys of each type).
+        mortonKeys = harvestMorton(Math.max(keyCount, 1), rng).toArray(new MortonKey[0]);
+        pyramidKeys = harvestPyramid(Math.max(keyCount, 1), rng).toArray(new PyramidKey[0]);
+
+        // Equal-length probe arrays (cycled) so the two compareTo loops do identical work counts.
+        int n = Math.min(mortonKeys.length, pyramidKeys.length);
+        mortonKeys = java.util.Arrays.copyOf(mortonKeys, n);
+        pyramidKeys = java.util.Arrays.copyOf(pyramidKeys, n);
+        mortonProbes = shuffledCopy(mortonKeys, rng);
+        pyramidProbes = shuffledCopy(pyramidKeys, rng);
+
+        mortonMap = new ConcurrentSkipListMap<>();
+        pyramidMap = new ConcurrentSkipListMap<>();
+        for (int i = 0; i < n; i++) {
+            mortonMap.put(mortonKeys[i], i);
+            pyramidMap.put(pyramidKeys[i], i);
+        }
+    }
+
+    @Benchmark
+    public void compareToMorton(Blackhole bh) {
+        for (int i = 1; i < mortonKeys.length; i++) {
+            bh.consume(mortonKeys[i].compareTo(mortonKeys[i - 1]));
+        }
+    }
+
+    @Benchmark
+    public void compareToPyramid(Blackhole bh) {
+        for (int i = 1; i < pyramidKeys.length; i++) {
+            bh.consume(pyramidKeys[i].compareTo(pyramidKeys[i - 1]));
+        }
+    }
+
+    @Benchmark
+    public void skipListGetMorton(Blackhole bh) {
+        for (var probe : mortonProbes) {
+            bh.consume(mortonMap.get(probe));
+        }
+    }
+
+    @Benchmark
+    public void skipListGetPyramid(Blackhole bh) {
+        for (var probe : pyramidProbes) {
+            bh.consume(pyramidMap.get(probe));
+        }
+    }
+
+    private static List<MortonKey> harvestMorton(int target, Random rng) {
+        var octree = new Octree<LongEntityID, String>(new SequentialLongIDGenerator());
+        int i = 0;
+        while (octree.getSpatialKeys().size() < target && i < target * 4) {
+            octree.insert(new Point3f(rng.nextFloat() * 1_000_000f, rng.nextFloat() * 1_000_000f,
+                                      rng.nextFloat() * 1_000_000f), (byte) 14, "m" + (i++));
+        }
+        return new ArrayList<>(octree.getSpatialKeys());
+    }
+
+    private static List<PyramidKey> harvestPyramid(int target, Random rng) {
+        var pyramid = new PyramidIndex<LongEntityID, String>(new SequentialLongIDGenerator());
+        int i = 0;
+        while (pyramid.getSpatialKeys().size() < target && i < target * 4) {
+            pyramid.insert(new Point3f(rng.nextFloat() * 1_000_000f, rng.nextFloat() * 1_000_000f,
+                                       rng.nextFloat() * 1_000_000f), (byte) 14, "p" + (i++));
+        }
+        return new ArrayList<>(pyramid.getSpatialKeys());
+    }
+
+    private static <T> T[] shuffledCopy(T[] src, Random rng) {
+        var copy = src.clone();
+        for (int i = copy.length - 1; i > 0; i--) {
+            int j = rng.nextInt(i + 1);
+            var tmp = copy[i];
+            copy[i] = copy[j];
+            copy[j] = tmp;
+        }
+        return copy;
+    }
+
+    public static void main(String[] args) throws Exception {
+        org.openjdk.jmh.Main.main(args);
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/HybridMeshIntegrationDemoTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/HybridMeshIntegrationDemoTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.forest;
+
+import com.hellblazer.luciferase.lucien.AbstractSpatialIndex;
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.balancing.ShapeWeightPartitioner;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.octree.Octree;
+import com.hellblazer.luciferase.lucien.prism.Prism;
+import com.hellblazer.luciferase.lucien.pyramid.PyramidIndex;
+import com.hellblazer.luciferase.lucien.pyramid.PyramidKey;
+import com.hellblazer.luciferase.lucien.tetree.Tetree;
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3f;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * RDR-010 pi1.7 — hybrid-mesh integration demo (bead Luciferase-pi1.7, Knapp 2026 §7 in spirit).
+ *
+ * <p>Exercises the full RDR-010 stack end-to-end across all four element shapes: hexahedron (Octree),
+ * tetrahedron (Tetree), pyramid (PyramidIndex), and prism (Prism). Each shape is driven through
+ * insert / kNN / spatial-key / neighbor-detection in its own {@link Forest}, then the two genuinely
+ * <em>coupled</em> shapes are exercised across the pyramid↔tet cross-shape seam (pi1.5), and the
+ * shape-aware partition weight (pi1.6) is demonstrated on a heterogeneous weight set.
+ *
+ * <p><b>Why multi-forest, not one forest.</b> {@link Forest} is parameterized by a single
+ * {@link SpatialKey} type, so a single forest instance is homogeneous in key — hex (MortonKey),
+ * tet (TetreeKey), pyramid (PyramidKey), and prism cannot co-reside in one {@code Forest}. The realistic
+ * "hybrid mesh" surface in Luciferase is therefore: per-shape indices as peers + the element-level
+ * pyramid↔tet cross-shape coupling (the RDR's core contribution) + a shape-weighted partition computed
+ * over mixed per-shape weights. This demo asserts each of those legs.
+ */
+class HybridMeshIntegrationDemoTest {
+
+    private static final int N = 200;
+
+    @Test
+    void hexLegInsertsQueriesAndFindsNeighbors() {
+        var octree = new Octree<LongEntityID, String>(new SequentialLongIDGenerator());
+        var forest = new Forest<com.hellblazer.luciferase.lucien.octree.MortonKey, LongEntityID, String>();
+        forest.addTree(octree);
+        seedGrid(octree, 100f, 5000f);
+        assertShapeLegHealthy(octree, "hex/Octree");
+    }
+
+    @Test
+    void tetLegInsertsQueriesAndFindsNeighbors() {
+        var tetree = new Tetree<LongEntityID, String>(new SequentialLongIDGenerator());
+        var forest = new Forest<com.hellblazer.luciferase.lucien.tetree.TetreeKey<?>, LongEntityID, String>();
+        forest.addTree(tetree);
+        seedGrid(tetree, 100f, 5000f);
+        assertShapeLegHealthy(tetree, "tet/Tetree");
+    }
+
+    @Test
+    void pyramidLegInsertsQueriesAndFindsNeighbors() {
+        var pyramid = new PyramidIndex<LongEntityID, String>(new SequentialLongIDGenerator());
+        var forest = new Forest<PyramidKey, LongEntityID, String>();
+        forest.addTree(pyramid);
+        seedGrid(pyramid, 100f, 5000f);
+        assertShapeLegHealthy(pyramid, "pyramid/PyramidIndex");
+    }
+
+    @Test
+    void prismLegInsertsAndQueriesInTriangularDomain() {
+        // Prism uses a normalized triangular domain (worldSize 1.0, x + y < 1).
+        var prism = new Prism<LongEntityID, String>(new SequentialLongIDGenerator());
+        int n = 0;
+        for (int i = 1; i < 10; i++) {
+            for (int j = 1; j < 10 - i; j++) {
+                float x = i / 20f;
+                float y = j / 20f;
+                if (x + y < 0.95f) {
+                    prism.insert(new Point3f(x, y, 0.5f), (byte) 10, "p" + (n++));
+                }
+            }
+        }
+        assertTrue(prism.entityCount() > 0, "prism leg must insert entities in its triangular domain");
+        assertTrue(prism.nodeCount() > 0, "prism must occupy nodes");
+        var knn = prism.kNearestNeighbors(new Point3f(0.25f, 0.25f, 0.5f), 5, Float.MAX_VALUE);
+        assertFalse(knn.isEmpty(), "prism kNN must return neighbors");
+    }
+
+    @Test
+    void crossShapePyramidTetSeamCouplesTheTwoShapes() {
+        // The genuine hybrid coupling (pi1.5): a pyramid's four triangular faces neighbor tetrahedra.
+        // Driven entirely through the public API — seed a PyramidIndex, then scan occupied keys (and
+        // their face neighbors) for a cross-shape pyramid→tet adjacency surfaced by the detector.
+        var pyramid = new PyramidIndex<LongEntityID, String>(new SequentialLongIDGenerator());
+        var detector = pyramid.getNeighborDetector();
+        assertNotNull(detector, "pyramid index wires a cross-shape neighbor detector");
+        seedGrid(pyramid, 100f, 5000f);
+
+        boolean foundCrossShape = false;
+        for (var key : pyramid.getSpatialKeys()) {
+            for (var fk : detector.findFaceNeighbors(key)) {
+                if (isTetLeafKey(fk)) { // leaf type 0-5 = tet (cross-shape); 6/7 = pyramid (same-shape)
+                    foundCrossShape = true;
+                    break;
+                }
+            }
+            if (foundCrossShape) {
+                break;
+            }
+        }
+        assertTrue(foundCrossShape,
+                   "the hybrid mesh must couple pyramid↔tet: an occupied pyramid's face neighbors a tet");
+    }
+
+    /** A PyramidKey whose leaf-level type is a tet type (0-5), i.e. a cross-shape tet-leaf neighbor. */
+    private static boolean isTetLeafKey(PyramidKey key) {
+        byte t = key.getTypeAtLevel(key.getLevel());
+        return t != com.hellblazer.luciferase.lucien.pyramid.Pyramid.TYPE_6
+               && t != com.hellblazer.luciferase.lucien.pyramid.Pyramid.TYPE_7;
+    }
+
+    @Test
+    void ghostLayerWiresForThePyramidShape() {
+        // The fourth bead leg (insert/query/neighbor/GHOST): demonstrate the ghost boundary stack wires
+        // end-to-end for the pyramid shape in the hybrid mesh. Substantive cross-shape / distributed
+        // ghost-exchange correctness (multi-rank fan-out via the inverted seam) is covered by
+        // PyramidCrossShapeGhostTest (pi1.5); here we only show the ghost layer builds over a populated
+        // pyramid index without error and surfaces boundary elements.
+        var pyramid = new PyramidIndex<LongEntityID, String>(new SequentialLongIDGenerator());
+        seedGrid(pyramid, 1f, 8000f); // span to the domain edge so boundary elements exist
+        var ghost = new com.hellblazer.luciferase.lucien.forest.ghost.GhostBoundaryDetector<>(
+            pyramid, pyramid.getNeighborDetector(),
+            com.hellblazer.luciferase.lucien.forest.ghost.GhostType.FACES,
+            com.hellblazer.luciferase.lucien.forest.ghost.GhostAlgorithm.MINIMAL);
+
+        assertDoesNotThrow(ghost::createGhostLayer, "pyramid ghost layer must build without error");
+        assertNotNull(ghost.getGhostLayer(), "pyramid ghost layer must be present");
+        assertFalse(ghost.getBoundaryElements().isEmpty(),
+                    "a domain-spanning pyramid index must yield boundary elements for ghost exchange");
+    }
+
+    @Test
+    void shapeAwarePartitionBalancesAHeterogeneousWeightSet() {
+        // pi1.6: a hybrid mesh's partition must weight pyramid roots by N_pyramid = 2·8^ℓ − 6^ℓ, not 1:8.
+        var hex = new Octree<LongEntityID, String>(new SequentialLongIDGenerator());
+        var tet = new Tetree<LongEntityID, String>(new SequentialLongIDGenerator());
+        var pyr = new PyramidIndex<LongEntityID, String>(new SequentialLongIDGenerator());
+        // A heterogeneous "forest" of roots: hex, tet, pyramid, pyramid, hex, tet at level 2.
+        long[] weights = ShapeWeightPartitioner.weightsAtLevel(
+            java.util.List.of(hex, tet, pyr, pyr, hex, tet), 2);
+        assertArrayEquals(new long[] { 64, 64, 92, 92, 64, 64 }, weights,
+                          "N_hex=N_tet=64, N_pyramid=92 at level 2");
+
+        int[] ranks = ShapeWeightPartitioner.assign(weights, 3);
+        // Contiguous, in range, and the two heavy pyramid roots pull a partition boundary.
+        for (int i = 0; i < ranks.length; i++) {
+            assertTrue(ranks[i] >= 0 && ranks[i] < 3);
+            if (i > 0) {
+                assertTrue(ranks[i] >= ranks[i - 1], "partition must be contiguous in SFC order");
+            }
+        }
+        int[] shapeBlind = ShapeWeightPartitioner.assign(new long[] { 64, 64, 64, 64, 64, 64 }, 3);
+        assertFalse(java.util.Arrays.equals(ranks, shapeBlind),
+                    "shape-aware partition must differ from the shape-blind 1:8 partition");
+    }
+
+    // ===== helpers =====
+
+    /** Insert a coarse grid of entities into a MAX_COORD-space index. */
+    private static <K extends SpatialKey<K>> void seedGrid(AbstractSpatialIndex<K, LongEntityID, String> index,
+                                                           float origin, float span) {
+        int n = 0;
+        int side = (int) Math.cbrt(N) + 1;
+        float step = span / side;
+        for (int i = 0; i < side; i++) {
+            for (int j = 0; j < side; j++) {
+                for (int k = 0; k < side && n < N; k++) {
+                    index.insert(new Point3f(origin + i * step, origin + j * step, origin + k * step),
+                                 (byte) 10, "e" + (n++));
+                }
+            }
+        }
+    }
+
+    /** Assert a MAX_COORD-space shape leg inserts, queries (kNN), and exposes a working neighbor detector. */
+    private static <K extends SpatialKey<K>> void assertShapeLegHealthy(
+        AbstractSpatialIndex<K, LongEntityID, String> index, String label) {
+        assertTrue(index.entityCount() > 0, label + ": must insert entities");
+        assertTrue(index.nodeCount() > 0, label + ": must occupy nodes");
+
+        var knn = index.kNearestNeighbors(new Point3f(2500f, 2500f, 2500f), 8, Float.MAX_VALUE);
+        assertFalse(knn.isEmpty(), label + ": kNN must return neighbors");
+
+        var detector = index.getNeighborDetector();
+        assertNotNull(detector, label + ": must wire a neighbor detector");
+        // Neighbor detection must not throw for an occupied key (and the API is exercised end-to-end).
+        var anyKey = index.getSpatialKeys().iterator().next();
+        assertDoesNotThrow(() -> detector.findFaceNeighbors(anyKey),
+                           label + ": face-neighbor detection must not throw for an occupied key");
+    }
+}


### PR DESCRIPTION
Final RDR-010 phase — validates the full pyramid stack end-to-end and closes the measurement/documentation questions.

## Hybrid-mesh demo (`HybridMeshIntegrationDemoTest`, 7 tests)
Per-shape Forests (hex/tet/pyramid/prism) each driven through insert + kNN + neighbor detection; the genuine pyramid↔tet **cross-shape seam** (an occupied pyramid's triangular face neighbors a tet); the pyramid **ghost-layer** build; and the **shape-aware partition** (`N_pyramid`-weighted ≠ shape-blind). `Forest` is single-key-typed, so the realistic "hybrid mesh" is multi-forest + cross-shape element coupling, not one four-shape Forest (documented adaptation).

## Microbenchmark (`PyramidKeyVsMortonKeyBenchmark`, JMH)
128-bit two-`long` PyramidKey vs 64-bit MortonKey, authoritative **forked** run:

| | Morton | Pyramid | Ratio |
|--|--|--|--|
| `compareTo` | 190.5 ops/ms | 110.6 ops/ms | ~1.72× |
| `skipListGet` | 1.131 ops/ms | 0.938 ops/ms | ~1.21× slower |

Modest constant factors — the two-`long` representation is **validated** for current workloads (Finding #7).

## JMH build wiring (`lucien/pom.xml`)
Wired `jmh-generator-annprocess` into `default-testCompile` so `@Benchmark` classes generate their `META-INF/BenchmarkList` — the repo's JMH benchmarks were previously un-runnable. Scoped to test compilation so it never displaces a future main-source processor.

## Docs
CLAUDE.md partition-gap → "closed via PyramidIndex (RDR-010)" (shallow-boundary scope note); LUCIEN_ARCHITECTURE.md adds the Pyramid package; PERFORMANCE_METRICS_MASTER.md records the microbenchmark + JMH-wiring note. `TETREE_T8CODE_PARTITION_ANALYSIS.md` retired (RDR-010 is the authoritative record).

## Gate
Full lucien suite green (**2719, 0 failures**). `phase-review-gate RDR-010 --phase 7` PASSED. Dual review: code-review-expert APPROVED (1 Medium pom-scope fixed); substantive-critic 3 significant — all resolved (ghost leg added, d3z3 re-deferral registered, forked benchmark numbers).

## RDR-010 close-readiness
Decision items 1–6 delivered (pi1.1–pi1.7). Closes with explicit OPEN follow-ons: `Luciferase-d3z3` (§4c partition consumer-wiring), `Luciferase-0utt` (exhaustive cross-shape edge/vertex), deep-tet cross-shape (Finding #16, fail-loud guarded), `Luciferase-3y1`, `Luciferase-7eb`.