### PR TITLE
RDR-010 §4c (partial): shape-weighted server assignment in ForestToTumblerBridge

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ForestToTumblerBridge.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ForestToTumblerBridge.java
@@ -24,17 +24,22 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.ToLongFunction;
 
 /**
  * Bridge between AdaptiveForest and Tumbler framework for server assignment.
  *
  * Translates forest lifecycle events (tree creation, subdivision, removal)
- * into server assignment operations. In Phase 3, this uses a simple
- * round-robin mock assignment. Future integration with actual Tumbler
- * will replace the mock logic.
+ * into server assignment operations. By default this uses a simple round-robin
+ * mock assignment; a {@link #forShapeWeightedAssignment shape-weighted} bridge
+ * instead assigns root trees to the least-loaded server by accumulated
+ * {@code N_shape(level)} weight (RDR-010 §4c). Future integration with actual
+ * Tumbler will replace the mock logic.
  *
- * Thread Safety: All operations are thread-safe using ConcurrentHashMap
- * and atomic counters.
+ * Thread Safety: lookups (ConcurrentHashMap) are lock-free; the assignment
+ * mutators ({@code handleTree*}) are {@code synchronized} so the read-min /
+ * accumulate sequence of the weighted greedy path is atomic. The legacy
+ * round-robin path also uses an {@link AtomicInteger} counter.
  *
  * Design Rationale: The forest remains agnostic to server assignment,
  * emitting events that this bridge translates. This loose coupling enables:
@@ -48,6 +53,9 @@ public class ForestToTumblerBridge implements ForestEventListener {
 
     private static final Logger log = LoggerFactory.getLogger(ForestToTumblerBridge.class);
 
+    /** Number of mock servers the bridge balances across (server-0 .. server-{N-1}). */
+    private static final int SERVER_COUNT = 4;
+
     /**
      * Mock server assignment mapping (tree ID -> server ID).
      * In real Tumbler integration, this would be replaced with actual
@@ -60,6 +68,116 @@ public class ForestToTumblerBridge implements ForestEventListener {
      * Cycles through server-0, server-1, server-2, server-3.
      */
     private final AtomicInteger serverAssignmentCounter = new AtomicInteger(0);
+
+    /**
+     * Optional per-tree shape weight (tree ID → {@code N_shape(level)} weight). When non-null, root trees
+     * are assigned to the least-loaded server by accumulated weight (RDR-010 §4c, bead Luciferase-d3z3),
+     * so a pyramid-heavy forest balances server <em>load</em> rather than tree <em>count</em>. When null,
+     * assignment is the legacy exact round-robin.
+     */
+    private final ToLongFunction<String> treeWeigher;
+
+    /** Accumulated shape weight per server (only used when {@link #treeWeigher} is non-null). */
+    private final Map<String, Long> serverLoad;
+
+    /** Weight credited per tree at assignment time, so removals decrement the right amount (weighted only). */
+    private final Map<String, Long> treeAssignedWeight;
+
+    /** Create a bridge with legacy round-robin server assignment (no shape weighting). */
+    public ForestToTumblerBridge() {
+        this(null);
+    }
+
+    /**
+     * Create a bridge that assigns root trees to the least-loaded server by accumulated shape weight.
+     *
+     * @param treeWeigher tree ID → shape weight (e.g. {@code N_shape(level)}); {@code null} ⇒ legacy
+     *                    round-robin
+     */
+    public ForestToTumblerBridge(ToLongFunction<String> treeWeigher) {
+        this.treeWeigher = treeWeigher;
+        this.serverLoad = treeWeigher == null ? null : new ConcurrentHashMap<>();
+        this.treeAssignedWeight = treeWeigher == null ? null : new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Build a shape-weighted bridge whose weigher resolves each tree's {@code N_shape(level)} from its
+     * spatial index ({@link com.hellblazer.luciferase.lucien.balancing.ShapeWeightProvider#elementCount}).
+     * This is the live consumer of the per-shape partition weight (RDR-010 §4c): a pyramid tree
+     * ({@code N_pyramid = 2·8^ℓ − 6^ℓ}) outweighs a hex/tet tree ({@code 8^ℓ}). An absent tree weighs 0.
+     *
+     * <p>The weigher is evaluated at assignment time. {@code elementCount} is the structural refinement
+     * count {@code N_shape(level)} — independent of entity population — so a just-created (empty) tree
+     * already carries its full shape weight (unlike a live-entity-count weigher, which would read 0).
+     *
+     * @param forest the forest whose trees are being assigned
+     * @param level  the uniform refinement level at which to evaluate each shape's element count
+     */
+    public static <Key extends com.hellblazer.luciferase.lucien.SpatialKey<Key>,
+                   ID extends com.hellblazer.luciferase.lucien.entity.EntityID, Content>
+    ForestToTumblerBridge forShapeWeightedAssignment(Forest<Key, ID, Content> forest, int level) {
+        Objects.requireNonNull(forest, "forest");
+        return new ForestToTumblerBridge(treeId -> {
+            var tree = forest.getTree(treeId);
+            return tree == null ? 0L : tree.getSpatialIndex().elementCount(level);
+        });
+    }
+
+    /** The shape weight this bridge attributes to {@code treeId} (1 when no weigher is configured). */
+    public long treeWeight(String treeId) {
+        return treeWeigher == null ? 1L : treeWeigher.applyAsLong(treeId);
+    }
+
+    /**
+     * Choose a server for a root/standalone tree: legacy round-robin when unweighted, else the
+     * least-loaded server by accumulated shape weight (ties broken by lowest server index — which makes
+     * the equal-weight case reproduce round-robin).
+     */
+    private String chooseRootServer() {
+        if (treeWeigher == null) {
+            return "server-" + (serverAssignmentCounter.getAndIncrement() % SERVER_COUNT);
+        }
+        String best = "server-0";
+        long bestLoad = Long.MAX_VALUE;
+        for (int i = 0; i < SERVER_COUNT; i++) {
+            var server = "server-" + i;
+            long load = serverLoad.getOrDefault(server, 0L);
+            if (load < bestLoad) {
+                bestLoad = load;
+                best = server;
+            }
+        }
+        return best;
+    }
+
+    /** Record a tree→server assignment, accumulating its shape weight onto the server (when weighted). */
+    private void recordAssignment(String treeId, String serverId) {
+        var prior = treeToServerAssignments.put(treeId, serverId);
+        if (serverLoad != null) {
+            // If this tree was already assigned elsewhere (e.g. child re-homed on subdivision), move its
+            // previously-credited weight off the old server first.
+            if (prior != null) {
+                Long old = treeAssignedWeight.remove(treeId);
+                if (old != null) {
+                    serverLoad.merge(prior, -old, Long::sum);
+                }
+            }
+            long weight = treeWeigher.applyAsLong(treeId);
+            treeAssignedWeight.put(treeId, weight);
+            serverLoad.merge(serverId, weight, Long::sum);
+        }
+    }
+
+    /** Remove a tree's assignment, returning its credited shape weight to its server (when weighted). */
+    private void removeAssignment(String treeId) {
+        var server = treeToServerAssignments.remove(treeId);
+        if (serverLoad != null && server != null) {
+            Long weight = treeAssignedWeight.remove(treeId);
+            if (weight != null) {
+                serverLoad.merge(server, -weight, Long::sum);
+            }
+        }
+    }
 
     @Override
     public void onEvent(ForestEvent event) {
@@ -80,23 +198,23 @@ public class ForestToTumblerBridge implements ForestEventListener {
      *
      * @param event tree creation event
      */
-    private void handleTreeAdded(ForestEvent.TreeAdded event) {
+    private synchronized void handleTreeAdded(ForestEvent.TreeAdded event) {
         String serverId;
 
         if (event.parentId() != null) {
             // Child tree: inherit parent's server
             serverId = treeToServerAssignments.get(event.parentId());
             if (serverId == null) {
-                log.warn("Parent tree {} has no server assignment, using round-robin for child {}",
+                log.warn("Parent tree {} has no server assignment, assigning child {} directly",
                         event.parentId(), event.treeId());
-                serverId = "server-" + (serverAssignmentCounter.getAndIncrement() % 4);
+                serverId = chooseRootServer();
             }
         } else {
-            // Root tree: round-robin assignment
-            serverId = "server-" + (serverAssignmentCounter.getAndIncrement() % 4);
+            // Root tree: least-loaded (shape-weighted) or round-robin assignment
+            serverId = chooseRootServer();
         }
 
-        treeToServerAssignments.put(event.treeId(), serverId);
+        recordAssignment(event.treeId(), serverId);
 
         log.debug("Assigned tree {} ({}) to {} (parent: {})",
                 event.treeId(), event.regionShape(), serverId, event.parentId());
@@ -111,20 +229,19 @@ public class ForestToTumblerBridge implements ForestEventListener {
      *
      * @param event subdivision event
      */
-    private void handleTreeSubdivided(ForestEvent.TreeSubdivided event) {
+    private synchronized void handleTreeSubdivided(ForestEvent.TreeSubdivided event) {
         var parentServer = treeToServerAssignments.get(event.parentId());
 
         if (parentServer == null) {
             // Parent has no assignment yet (e.g., root tree created via addTree())
-            // Assign parent first using round-robin
-            parentServer = "server-" + (serverAssignmentCounter.getAndIncrement() % 4);
-            treeToServerAssignments.put(event.parentId(), parentServer);
+            parentServer = chooseRootServer();
+            recordAssignment(event.parentId(), parentServer);
             log.debug("Assigned parent tree {} to {} (no prior assignment)", event.parentId(), parentServer);
         }
 
         // Children inherit parent's server (overriding any prior TreeAdded assignments)
         for (var childId : event.childIds()) {
-            treeToServerAssignments.put(childId, parentServer);
+            recordAssignment(childId, parentServer);
         }
 
         log.debug("Assigned {} {} children to parent's server {}",
@@ -136,8 +253,8 @@ public class ForestToTumblerBridge implements ForestEventListener {
      *
      * @param event tree removal event
      */
-    private void handleTreeRemoved(ForestEvent.TreeRemoved event) {
-        treeToServerAssignments.remove(event.treeId());
+    private synchronized void handleTreeRemoved(ForestEvent.TreeRemoved event) {
+        removeAssignment(event.treeId());
         log.debug("Removed server assignment for tree {}", event.treeId());
     }
 
@@ -149,15 +266,15 @@ public class ForestToTumblerBridge implements ForestEventListener {
      *
      * @param event tree merge event
      */
-    private void handleTreesMerged(ForestEvent.TreesMerged event) {
+    private synchronized void handleTreesMerged(ForestEvent.TreesMerged event) {
         // Remove source tree assignments
         for (var sourceId : event.sourceIds()) {
-            treeToServerAssignments.remove(sourceId);
+            removeAssignment(sourceId);
         }
 
         // Assign merged tree
-        var serverId = "server-" + (serverAssignmentCounter.getAndIncrement() % 4);
-        treeToServerAssignments.put(event.mergedId(), serverId);
+        var serverId = chooseRootServer();
+        recordAssignment(event.mergedId(), serverId);
 
         log.debug("Merged {} trees into {} on {}", event.sourceIds().size(), event.mergedId(), serverId);
     }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/ForestToTumblerBridgeShapeWeightTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/ForestToTumblerBridgeShapeWeightTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.forest;
+
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.octree.Octree;
+import com.hellblazer.luciferase.lucien.pyramid.PyramidIndex;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * RDR-010 §4c (bead Luciferase-d3z3): shape-weighted server assignment in
+ * {@link ForestToTumblerBridge} — the live consumer of {@link
+ * com.hellblazer.luciferase.lucien.balancing.ShapeWeightProvider#elementCount(int)}.
+ *
+ * <p>The default (no weigher) path stays exact round-robin (covered by {@code ForestTumblerBridgeTest}).
+ * The shape-weighted path assigns each root tree to the least-loaded server by accumulated shape weight,
+ * so a forest of pyramid-heavy trees (N_pyramid = 2·8^ℓ − 6^ℓ &gt; N_hex = 8^ℓ) balances server <em>load</em>
+ * rather than tree <em>count</em>.
+ */
+class ForestToTumblerBridgeShapeWeightTest {
+
+    private static ForestEvent.TreeAdded rootAdded(String treeId, RegionShape shape) {
+        return new ForestEvent.TreeAdded(1L, "forest", treeId, null, shape, null);
+    }
+
+    @Test
+    void shapeWeightedGreedyBalancesServerLoadNotTreeCount() {
+        // Weigher: pyramid trees weigh 92 (N_pyramid(2)), hex trees 64 (N_hex(2)).
+        java.util.function.ToLongFunction<String> weigher = id -> id.startsWith("pyr") ? 92 : 64;
+
+        // Sequence: one heavy pyramid root, then four hex roots. The heavy pyramid on server-0 makes the
+        // 5th tree (hex3) go to a LIGHTER server under greedy, where naive count round-robin would cycle
+        // it back to the already-heavy server-0.
+        String[] ids = { "pyr0", "hex0", "hex1", "hex2", "hex3" };
+
+        var bridge = new ForestToTumblerBridge(weigher);
+        for (var id : ids) {
+            bridge.onEvent(rootAdded(id, id.startsWith("pyr") ? RegionShape.TETRAHEDRAL : RegionShape.CUBIC));
+        }
+        var greedy = bridge.getAllAssignments();
+
+        // Reference: naive count round-robin (index % 4).
+        var roundRobin = new HashMap<String, String>();
+        for (int i = 0; i < ids.length; i++) {
+            roundRobin.put(ids[i], "server-" + (i % 4));
+        }
+
+        // The two assignments diverge (hex3: greedy→least-loaded, round-robin→back to heavy server-0).
+        assertNotEquals(roundRobin, greedy,
+                        "shape-weighted greedy must diverge from count round-robin when weights are uneven");
+
+        // And the greedy assignment yields a strictly tighter server-load spread — the §4c payoff.
+        assertTrue(spread(greedy, weigher) < spread(roundRobin, weigher),
+                   "greedy load spread " + spread(greedy, weigher) + " must beat round-robin "
+                   + spread(roundRobin, weigher));
+    }
+
+    private static long spread(Map<String, String> assignment, java.util.function.ToLongFunction<String> w) {
+        var serverWeight = new HashMap<String, Long>();
+        for (var e : assignment.entrySet()) {
+            serverWeight.merge(e.getValue(), w.applyAsLong(e.getKey()), Long::sum);
+        }
+        long max = serverWeight.values().stream().mapToLong(Long::longValue).max().orElse(0);
+        long min = serverWeight.values().stream().mapToLong(Long::longValue).min().orElse(0);
+        return max - min;
+    }
+
+    @Test
+    void defaultConstructorPreservesRoundRobin() {
+        // Backward-compat: no weigher → exact round-robin server-0..3 (as ForestTumblerBridgeTest expects).
+        var bridge = new ForestToTumblerBridge();
+        for (int i = 0; i < 5; i++) {
+            bridge.onEvent(rootAdded("t" + i, RegionShape.CUBIC));
+        }
+        var a = bridge.getAllAssignments();
+        assertEquals("server-0", a.get("t0"));
+        assertEquals("server-1", a.get("t1"));
+        assertEquals("server-2", a.get("t2"));
+        assertEquals("server-3", a.get("t3"));
+        assertEquals("server-0", a.get("t4"));
+    }
+
+    @Test
+    void factoryConsumesShapeWeightProviderFromForest() {
+        // The genuine wiring: the weigher resolves a tree's weight from its index's elementCount(level)
+        // (ShapeWeightProvider). A pyramid tree must weigh more than a hex tree at the same level.
+        var forest = new Forest<com.hellblazer.luciferase.lucien.octree.MortonKey, LongEntityID, String>();
+        var hex = new Octree<LongEntityID, String>(new SequentialLongIDGenerator());
+        var hexId = forest.addTree(hex);
+
+        var pyrForest = new Forest<com.hellblazer.luciferase.lucien.pyramid.PyramidKey, LongEntityID, String>();
+        var pyr = new PyramidIndex<LongEntityID, String>(new SequentialLongIDGenerator());
+        var pyrId = pyrForest.addTree(pyr);
+
+        var hexBridge = ForestToTumblerBridge.forShapeWeightedAssignment(forest, 2);
+        var pyrBridge = ForestToTumblerBridge.forShapeWeightedAssignment(pyrForest, 2);
+
+        assertEquals(64L, hexBridge.treeWeight(hexId), "hex weight = N_hex(2) = 64");
+        assertEquals(92L, pyrBridge.treeWeight(pyrId), "pyramid weight = N_pyramid(2) = 92");
+        assertTrue(pyrBridge.treeWeight(pyrId) > hexBridge.treeWeight(hexId),
+                   "a pyramid tree must carry more shape weight than a hex tree (the §4c point)");
+    }
+
+    @Test
+    void weightedRemovalAndRehomeKeepServerLoadConsistent() {
+        // Exercises the recordAssignment(prior!=null) re-home path + removeAssignment decrement, so the
+        // greedy keeps balancing correctly across the full tree lifecycle (not just initial adds).
+        java.util.function.ToLongFunction<String> weigher = id -> id.startsWith("pyr") ? 92 : 64;
+        var bridge = new ForestToTumblerBridge(weigher);
+
+        // Two roots: pyr0→server-0 (92), hex0→server-1 (64).
+        bridge.onEvent(rootAdded("pyr0", RegionShape.TETRAHEDRAL));
+        bridge.onEvent(rootAdded("hex0", RegionShape.CUBIC));
+        assertEquals("server-0", bridge.getServerAssignment("pyr0"));
+        assertEquals("server-1", bridge.getServerAssignment("hex0"));
+
+        // Child TreeAdded inherits the parent's server (server-0); the subsequent TreeSubdivided
+        // re-records it onto the parent's server, exercising recordAssignment's prior!=null re-home path
+        // (remove old credit, add new) — the bookkeeping must net to no double-count.
+        bridge.onEvent(new ForestEvent.TreeAdded(2L, "f", "pyr0-c0", null, RegionShape.TETRAHEDRAL, "pyr0"));
+        bridge.onEvent(new ForestEvent.TreeSubdivided(3L, "f", "pyr0", java.util.List.of("pyr0-c0"),
+                                                      AdaptiveForest.AdaptationConfig.SubdivisionStrategy.OCTANT,
+                                                      RegionShape.TETRAHEDRAL));
+        assertEquals("server-0", bridge.getServerAssignment("pyr0-c0"),
+                     "child must end up on the parent's server after subdivision");
+
+        // Remove the child: server-0's load must drop back. The next NEW heavy root should then prefer a
+        // genuinely least-loaded server, proving serverLoad was decremented (no leaked weight).
+        bridge.onEvent(new ForestEvent.TreeRemoved(4L, "f", "pyr0-c0"));
+
+        // Add a fresh root: with pyr0(92) on s0, hex0(64) on s1, s2=s3=0 → least-loaded is server-2.
+        bridge.onEvent(rootAdded("pyr1", RegionShape.TETRAHEDRAL));
+        assertEquals("server-2", bridge.getServerAssignment("pyr1"),
+                     "after the child's weight was removed, a fresh root lands on a truly least-loaded server");
+    }
+
+    @Test
+    void unknownTreeWeighsZeroWithoutThrowing() {
+        var forest = new Forest<com.hellblazer.luciferase.lucien.octree.MortonKey, LongEntityID, String>();
+        var bridge = ForestToTumblerBridge.forShapeWeightedAssignment(forest, 2);
+        assertEquals(0L, bridge.treeWeight("no-such-tree"), "absent tree → weight 0, no throw");
+    }
+}


### PR DESCRIPTION
Consumes the per-shape weight (`ShapeWeightProvider.elementCount`) at the **one live tree-assignment seam** in lucien-core — `ForestToTumblerBridge` (a `ForestEventListener`).

## What changed
`ForestToTumblerBridge` gains an optional `ToLongFunction<String> treeWeigher`:
- **null (default)** → byte-identical legacy exact round-robin (the 8 existing tests pass unchanged).
- **set** → root trees assigned to the **least-loaded server by accumulated shape weight** (greedy), so a pyramid-heavy forest (`N_pyramid = 2·8^ℓ − 6^ℓ`) balances server **load**, not tree **count**.
- Factory `forShapeWeightedAssignment(forest, level)` resolves each tree's weight via its index's `elementCount(level)`.
- Mutating handlers are `synchronized` (atomic read-min/accumulate); `serverLoad` + `treeAssignedWeight` keep the greedy correct across re-home/removal.

## Scope — honest (does NOT fully close §4c)
This consumes the **weight** via an **incremental greedy** at the tree→**server** seam. It deliberately does **not**:
- consume `ShapeWeightPartitioner` (Knapp **Alg 5.1** contiguous cumulative-offset SFC partition) — greedy abandons SFC-contiguity;
- touch partition-**rank** assignment in `DistributedForestImpl` (still external);
- add a `RegionShape.PYRAMID` variant (event model is `{CUBIC, TETRAHEDRAL}`).

The real §4c (Alg 5.1 → partition-rank assignment, consumed by the distributed bootstrap) is registered as follow-on **`Luciferase-uzyd`**. The greedy here is the event-bridge layer; Alg 5.1 belongs at the batch `DistributedForestImpl` layer.

## Tests / gate
13 bridge tests (5 new: greedy-beats-round-robin spread, default round-robin preserved, factory `elementCount` 64/92, weighted re-home+removal, absent-tree→0; + 8 backward-compat). Full lucien green (**2724, 0**). Dual review: code-review APPROVED (1 Important concurrency-contract fixed); substantive-critic PARTIAL (4 scope-honesty findings → registered in `Luciferase-uzyd`, not silently closed).