### PR TITLE
RDR-010 follow-ons: extract PyramidKeyDecoder (3y1) + PyramidIndex spanning (7eb)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
@@ -620,61 +620,9 @@ public class PyramidIndex<ID extends EntityID, Content> extends AbstractSpatialI
      * @see #elementFromKey(PyramidKey)
      */
     static Pyramid pyramidFromKey(PyramidKey key) {
-        byte level = key.getLevel();
-        if (level == 0) {
-            // Virtual root — return the type-6 root cover pyramid
-            return new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6);
-        }
-        // Step 1: find the type-6 or type-7 root child at level 1
-        var type6Root = new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6);
-        var type7Root = new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_7);
-
-        // Identify the level-1 child by matching coordBits[1]/typeBits[1]
-        int coordBits1 = key.getCoordBitsAtLevel(1);
-        int typeBits1  = key.getTypeAtLevel(1);
-
-        Pyramid current = null;
-        outer:
-        for (var root : new Pyramid[] { type6Root, type7Root }) {
-            int row = root.type() - Pyramid.TYPE_6;
-            for (int i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
-                if (TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_CID[row][i]  == coordBits1
-                    && TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_TYPE[row][i] == typeBits1) {
-                    var child = root.child(i);
-                    if (child instanceof Pyramid pc) {
-                        current = pc;
-                    }
-                    // If it's a tet child at level 1 and level==1, fall through → return null below
-                    break outer;
-                }
-            }
-        }
-
-        if (current == null || level == 1) {
-            // level-1 element is a tet (or not found) — not a pyramid
-            return level == 1 && current != null ? current : null;
-        }
-
-        // Descend levels 2..level
-        for (int l = 2; l <= level; l++) {
-            int cb = key.getCoordBitsAtLevel(l);
-            int tb = key.getTypeAtLevel(l);
-            Pyramid next = null;
-            int row = current.type() - Pyramid.TYPE_6;
-            for (int i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
-                if (TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_CID[row][i]  == cb
-                    && TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_TYPE[row][i] == tb) {
-                    var child = current.child(i);
-                    if (child instanceof Pyramid pc) {
-                        next = pc;
-                    }
-                    break;
-                }
-            }
-            if (next == null) return current; // key ends in a tet at level l; return parent pyramid
-            current = next;
-        }
-        return current;
+        // Shared descent (RDR-010 Luciferase-3y1): delegate to PyramidKeyDecoder so this and
+        // PyramidSubdivisionStrategy.pyramidFromKey cannot silently diverge.
+        return PyramidKeyDecoder.pyramidFromKey(key);
     }
 
     /**

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
@@ -36,6 +36,8 @@ import java.util.stream.Stream;
  */
 public class PyramidIndex<ID extends EntityID, Content> extends AbstractSpatialIndex<PyramidKey, ID, Content> {
 
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(PyramidIndex.class);
+
     /** Default maximum entities per node, mirroring Octree. */
     private static final int DEFAULT_MAX_ENTITIES_PER_NODE = 10;
 
@@ -331,6 +333,91 @@ public class PyramidIndex<ID extends EntityID, Content> extends AbstractSpatialI
     @Override
     protected float getCellSizeAtLevel(byte level) {
         return Constants.lengthAtLevel(level);
+    }
+
+    /** Defensive cap on the spanning cube-grid enumeration to avoid pathological memory blow-up. */
+    private static final int MAX_SPANNING_CELLS = 1_000_000;
+
+    /**
+     * Distribute a bounded entity across the pyramid-SFC elements its bounds overlap (RDR-010, bead
+     * Luciferase-7eb), so {@code getEntitySpanCount > 1} for space-spanning bounds. Enumerates the cube
+     * grid at {@code level} clamped to {@code [0, MAX_COORD]}, and for each cube cell registers the entity
+     * in the one element returned by {@link #calculateSpatialIndex} for the cell <em>centre</em>.
+     *
+     * <p><b>Coverage is cube-granular and conservative — NOT element-granular (weaker than {@code Tetree},
+     * looser than {@code Octree}).</b> Two consequences callers (range query, kNN, ghost/forest spanning)
+     * must account for:
+     * <ul>
+     *   <li><b>Under-coverage within a cube:</b> a cube cell holds several pyramid/tet elements, but only
+     *       the element containing the cell centre is registered. An entity overlapping a <em>different</em>
+     *       element of that cube is not registered there — unlike {@code Tetree.findIntersectingTetrahedra}
+     *       (element-level) or {@code Octree} (one node per cube). Element-level coverage is a registered
+     *       follow-on (bead Luciferase-401t).</li>
+     *   <li><b>Over-inclusion across cubes:</b> no per-cell geometric intersection test is applied (unlike
+     *       Octree's {@code bounds.intersectsCube} filter); the entity is registered in every cube whose
+     *       origin falls in the clamped bounding box — a conservative superset (possible false-positive
+     *       range membership, never a false negative at cube granularity).</li>
+     *   <li><b>Mixed-level keys:</b> when a cell centre falls in a tet sub-region, {@link #calculateSpatialIndex}
+     *       returns a key at a <em>shallower</em> level than {@code level} (its documented caveat), so the
+     *       entity is registered at coarser granularity for that cell.</li>
+     * </ul>
+     *
+     * <p>Spanning does not trigger subdivision (avoids cascading subdivisions across many cells). Inverted
+     * or empty clamped ranges (bounds entirely outside the domain) and grids exceeding
+     * {@link #MAX_SPANNING_CELLS} fall back to single-node insertion at the entity position (with a warning
+     * for the cap case) — never leaving the entity registered in zero nodes.
+     */
+    @Override
+    protected void insertWithSpanning(ID entityId, EntityBounds bounds, byte level) {
+        if (bounds == null) {
+            super.insertWithSpanning(entityId, bounds, level);
+            return;
+        }
+        int cellSize = Constants.lengthAtLevel(level);
+        int max = Constants.MAX_COORD;
+        // Clamp the bounds to the domain and snap to the cube grid at this level.
+        int minX = Math.max(0, (int) Math.floor(bounds.getMinX() / cellSize) * cellSize);
+        int minY = Math.max(0, (int) Math.floor(bounds.getMinY() / cellSize) * cellSize);
+        int minZ = Math.max(0, (int) Math.floor(bounds.getMinZ() / cellSize) * cellSize);
+        int maxX = Math.min(max, (int) Math.floor(bounds.getMaxX() / cellSize) * cellSize);
+        int maxY = Math.min(max, (int) Math.floor(bounds.getMaxY() / cellSize) * cellSize);
+        int maxZ = Math.min(max, (int) Math.floor(bounds.getMaxZ() / cellSize) * cellSize);
+
+        // Inverted/empty range after clamping ⇒ the bounds lie entirely outside the domain in some axis.
+        // Fall back to single-node insertion so the entity is still registered (a negative cell count
+        // would otherwise slip past the cap guard and leave the entity in zero spatial nodes — invisible).
+        if (maxX < minX || maxY < minY || maxZ < minZ) {
+            super.insertWithSpanning(entityId, bounds, level);
+            return;
+        }
+
+        long cellsX = (long) (maxX - minX) / cellSize + 1;
+        long cellsY = (long) (maxY - minY) / cellSize + 1;
+        long cellsZ = (long) (maxZ - minZ) / cellSize + 1;
+        if (cellsX * cellsY * cellsZ > MAX_SPANNING_CELLS) {
+            log.warn("Spanning grid {}x{}x{} exceeds cap {} at level {} — falling back to single-node insert",
+                     cellsX, cellsY, cellsZ, MAX_SPANNING_CELLS, level);
+            super.insertWithSpanning(entityId, bounds, level);
+            return;
+        }
+
+        var keys = new HashSet<PyramidKey>();
+        float half = cellSize / 2f;
+        for (int x = minX; x <= maxX; x += cellSize) {
+            for (int y = minY; y <= maxY; y += cellSize) {
+                for (int z = minZ; z <= maxZ; z += cellSize) {
+                    // Resolve the pyramid/tet element containing this cube cell's centre.
+                    var key = calculateSpatialIndex(new Point3f(x + half, y + half, z + half), level);
+                    keys.add(key);
+                }
+            }
+        }
+
+        for (var key : keys) {
+            var node = spatialIndex.computeIfAbsent(key, k -> createNode());
+            node.addEntity(entityId);
+            entityManager.addEntityLocation(entityId, key);
+        }
     }
 
     /**

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeyDecoder.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeyDecoder.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.pyramid;
+
+import com.hellblazer.luciferase.lucien.tetree.TetreeConnectivity;
+
+/**
+ * Shared pyramid-SFC key → {@link Pyramid} decoder (RDR-010, bead Luciferase-3y1).
+ *
+ * <p>The root-to-key descent was previously duplicated verbatim (~50 lines) in
+ * {@link PyramidIndex#pyramidFromKey(PyramidKey)} (private) and
+ * {@code PyramidSubdivisionStrategy.pyramidFromKey} (the strategy has no back-reference to the index).
+ * Both now delegate here so the descent logic cannot silently diverge if the SFC encoding changes.
+ *
+ * @author Hal Hildebrand
+ */
+final class PyramidKeyDecoder {
+
+    private PyramidKeyDecoder() {
+    }
+
+    /**
+     * Reconstruct the {@link Pyramid} element for {@code key} by descending the pyramid tree from the
+     * root, following the coordinate/type bits encoded at each level.
+     *
+     * <p><b>Tet-child keys:</b> for a <em>level-1</em> tet-child key this returns {@code null} (no pyramid
+     * at that key). For a <em>deeper</em> ({@code level > 1}) tet-child key it returns the nearest
+     * enclosing parent pyramid (a strictly larger bounding volume) rather than {@code null} — a
+     * conservative over-approximation (the pyramid bound encloses the tet; never a false negative). When
+     * the <em>actual</em> leaf element is needed for a tet leaf, use
+     * {@link PyramidIndex#elementFromKey(PyramidKey)} instead.
+     */
+    static Pyramid pyramidFromKey(PyramidKey key) {
+        byte level = key.getLevel();
+        if (level == 0) {
+            // Virtual root — return the type-6 root cover pyramid
+            return new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6);
+        }
+        // Step 1: find the type-6 or type-7 root child at level 1
+        var type6Root = new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6);
+        var type7Root = new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_7);
+
+        int coordBits1 = key.getCoordBitsAtLevel(1);
+        int typeBits1 = key.getTypeAtLevel(1);
+
+        Pyramid current = null;
+        outer:
+        for (var root : new Pyramid[] { type6Root, type7Root }) {
+            int row = root.type() - Pyramid.TYPE_6;
+            for (int i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
+                if (TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_CID[row][i] == coordBits1
+                    && TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_TYPE[row][i] == typeBits1) {
+                    var child = root.child(i);
+                    if (child instanceof Pyramid pc) {
+                        current = pc;
+                    }
+                    // If it's a tet child at level 1 and level==1, fall through → return null below
+                    break outer;
+                }
+            }
+        }
+
+        if (current == null || level == 1) {
+            // level-1 element is a tet (or not found) — not a pyramid
+            return level == 1 && current != null ? current : null;
+        }
+
+        // Descend levels 2..level
+        for (int l = 2; l <= level; l++) {
+            int cb = key.getCoordBitsAtLevel(l);
+            int tb = key.getTypeAtLevel(l);
+            Pyramid next = null;
+            int row = current.type() - Pyramid.TYPE_6;
+            for (int i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
+                if (TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_CID[row][i] == cb
+                    && TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_TYPE[row][i] == tb) {
+                    var child = current.child(i);
+                    if (child instanceof Pyramid pc) {
+                        next = pc;
+                    }
+                    break;
+                }
+            }
+            if (next == null) {
+                return current; // key ends in a tet at level l; return parent pyramid
+            }
+            current = next;
+        }
+        return current;
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidSubdivisionStrategy.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidSubdivisionStrategy.java
@@ -205,57 +205,12 @@ extends SubdivisionStrategy<PyramidKey, ID, Content> {
     }
 
     /**
-     * Reconstruct the Pyramid element for a key by descending from root. Package-private mirror of
-     * PyramidIndex.pyramidFromKey — needed here since SubdivisionStrategy has no back-reference
-     * to the index.
-     *
-     * <p>TODO(Luciferase-3y1): this descent is duplicated verbatim with
-     * {@code PyramidIndex.pyramidFromKey} (~50 lines). Extract to a shared package-private
-     * {@code PyramidKeyDecoder} so the two cannot silently diverge. Deferred out of pi1.3 Phase F
-     * (close-out, no new production code beyond the max-level fix-back); pure refactor, tracked.
+     * Reconstruct the Pyramid element for a key by descending from root. Delegates to the shared
+     * {@link PyramidKeyDecoder} (RDR-010 Luciferase-3y1) — the strategy has no back-reference to the
+     * index, and sharing the descent keeps it from diverging from {@code PyramidIndex.pyramidFromKey}.
      */
     static Pyramid pyramidFromKey(PyramidKey key) {
-        byte level = key.getLevel();
-        if (level == 0) {
-            return new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6);
-        }
-        var type6Root = new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6);
-        var type7Root = new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_7);
-        int cb1 = key.getCoordBitsAtLevel(1);
-        int tb1 = key.getTypeAtLevel(1);
-        Pyramid current = null;
-        outer:
-        for (var root : new Pyramid[]{ type6Root, type7Root }) {
-            int row = root.type() - Pyramid.TYPE_6;
-            for (int i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
-                if (TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_CID[row][i] == cb1
-                    && TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_TYPE[row][i] == tb1) {
-                    var child = root.child(i);
-                    if (child instanceof Pyramid pc) current = pc;
-                    break outer;
-                }
-            }
-        }
-        if (current == null || level == 1) {
-            return (level == 1 && current != null) ? current : null;
-        }
-        for (int l = 2; l <= level; l++) {
-            int cb = key.getCoordBitsAtLevel(l);
-            int tb = key.getTypeAtLevel(l);
-            int row = current.type() - Pyramid.TYPE_6;
-            Pyramid next = null;
-            for (int i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
-                if (TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_CID[row][i] == cb
-                    && TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_TYPE[row][i] == tb) {
-                    var child = current.child(i);
-                    if (child instanceof Pyramid pc) next = pc;
-                    break;
-                }
-            }
-            if (next == null) return current;
-            current = next;
-        }
-        return current;
+        return PyramidKeyDecoder.pyramidFromKey(key);
     }
 
     /**

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndexParityTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndexParityTest.java
@@ -8,6 +8,8 @@ package com.hellblazer.luciferase.lucien.pyramid;
 import com.hellblazer.luciferase.lucien.Constants;
 import com.hellblazer.luciferase.lucien.Ray3D;
 import com.hellblazer.luciferase.lucien.Spatial;
+import com.hellblazer.luciferase.lucien.entity.EntityBounds;
+import com.hellblazer.luciferase.lucien.entity.EntitySpanningPolicy;
 import com.hellblazer.luciferase.lucien.entity.LongEntityID;
 import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
 import com.hellblazer.luciferase.lucien.octree.Octree;
@@ -34,9 +36,9 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * <p><b>Explicitly deferred (NOT pi1.3 scope, surfaced as follow-on beads — not silent reduction):</b>
  * <ul>
- *   <li>Multi-node entity spanning ({@code insertWithSpanning} override): pi1.3 inherits the
- *       single-node default. Octree/Tetree override it; Prism (the most recent peer) does NOT —
- *       so this is an optional cross-index feature. Tracked by bead <b>Luciferase-7eb</b>.</li>
+ *   <li>Multi-node entity spanning ({@code insertWithSpanning} override): <b>SHIPPED</b> (bead
+ *       Luciferase-7eb) — see {@link #spanningEntityCoversMultipleNodes()}. PyramidIndex now overrides
+ *       {@code insertWithSpanning} (one pyramid/tet element per intersected cube cell at the level).</li>
  *   <li>Full same/cross-shape neighbor topology ({@code addNeighboringNodes} beyond the minimum
  *       SFC-adjacent contract): deferred to pi1.4 (PyramidNeighborDetector). Cross-node kNN that
  *       must hop through non-adjacent subtrees is therefore out of scope here.</li>
@@ -51,6 +53,62 @@ class PyramidIndexParityTest {
     @BeforeEach
     void setUp() {
         pyramid = new PyramidIndex<>(new SequentialLongIDGenerator());
+    }
+
+    @Test
+    void spanningEntityCoversMultipleNodes() {
+        // RDR-010 Luciferase-7eb: a bounded entity spanning the domain must be distributed across
+        // multiple pyramid nodes (getEntitySpanCount > 1), mirroring the shared Octree/Tetree spanning
+        // contract (SpatialIndexEdgeCaseTest.testLargeSpanningEntity). PyramidIndex is a dedicated peer
+        // suite (project convention) rather than a member of the shared parameterized provider.
+        var spanning = new PyramidIndex<LongEntityID, String>(new SequentialLongIDGenerator(), 1000,
+                                                              (byte) 20, EntitySpanningPolicy.withSpanning());
+        int maxCoord = Constants.MAX_COORD;
+        var bounds = new EntityBounds(new Point3f(0, 0, 0), new Point3f(maxCoord, maxCoord, maxCoord));
+        var position = new Point3f(maxCoord / 2f, maxCoord / 2f, maxCoord / 2f);
+        var id = new LongEntityID(1);
+
+        spanning.insert(id, position, (byte) 5, "huge", bounds);
+
+        assertTrue(spanning.getEntitySpanCount(id) > 1,
+                   "a domain-spanning entity must span > 1 pyramid node, got " + spanning.getEntitySpanCount(id));
+        // Findable in range queries at opposite ends of its bounds.
+        assertTrue(spanning.entitiesInRegion(new Spatial.Cube(0, 0, 0, 100)).contains(id),
+                   "spanning entity must be found near the origin corner");
+        assertTrue(spanning.entitiesInRegion(
+                       new Spatial.Cube(maxCoord - 100f, maxCoord - 100f, maxCoord - 100f, 100)).contains(id),
+                   "spanning entity must be found near the opposite corner");
+    }
+
+    @Test
+    void outOfDomainBoundsFallBackToSingleNodeNotSilentLoss() {
+        // RDR-010 Luciferase-7eb edge guard: bounds entirely outside [0, MAX_COORD] clamp to an inverted
+        // range. The spanning override must fall back to single-node insertion (at the in-domain
+        // position) rather than leave the entity registered in zero nodes (silently unfindable).
+        var spanning = new PyramidIndex<LongEntityID, String>(new SequentialLongIDGenerator(), 1000,
+                                                              (byte) 20, EntitySpanningPolicy.withSpanning());
+        int maxCoord = Constants.MAX_COORD;
+        var inDomainPos = new Point3f(1000, 1000, 1000);
+        var outOfDomainBounds = new EntityBounds(new Point3f(maxCoord * 2f, maxCoord * 2f, maxCoord * 2f),
+                                                 new Point3f(maxCoord * 3f, maxCoord * 3f, maxCoord * 3f));
+        var id = new LongEntityID(7);
+
+        spanning.insert(id, inDomainPos, (byte) 5, "oob", outOfDomainBounds);
+
+        assertTrue(spanning.containsEntity(id), "entity must remain registered (no silent loss)");
+        // The discriminating assertion: without the inverted-range guard the spanning loop registers the
+        // entity in ZERO nodes (span 0, unfindable); the guard's single-node fallback yields span >= 1.
+        assertTrue(spanning.getEntitySpanCount(id) >= 1, "entity must occupy at least one node");
+        assertEquals(inDomainPos, spanning.getEntityPosition(id), "position preserved at the in-domain point");
+    }
+
+    @Test
+    void singleEntityDoesNotSpan() {
+        // A point entity (no bounds) stays single-node even with spanning enabled.
+        var spanning = new PyramidIndex<LongEntityID, String>(new SequentialLongIDGenerator(), 1000,
+                                                              (byte) 20, EntitySpanningPolicy.withSpanning());
+        var id = spanning.insert(new Point3f(100, 100, 100), (byte) 10, "point");
+        assertEquals(1, spanning.getEntitySpanCount(id), "a point entity must occupy exactly one node");
     }
 
     @Test


### PR DESCRIPTION
Two RDR-010 pyramid follow-ons.

## 3y1 — extract `PyramidKeyDecoder` (pure refactor)
The root-to-key `pyramidFromKey` descent was duplicated verbatim (~50 lines) in `PyramidIndex` and `PyramidSubdivisionStrategy`. Extracted to a shared package-private `PyramidKeyDecoder.pyramidFromKey`; both delegate, so the SFC descent can't silently diverge. No behavior change — verified by the green pyramid suite (190/0).

## 7eb — `PyramidIndex.insertWithSpanning` (feature)
PyramidIndex previously inherited the single-node default (`getEntitySpanCount==1` for bounded entities). New override distributes a bounded entity across the cube grid at `level` (clamped to the domain): one element per cube cell (the element containing the cell centre), materialised + entity added. Guards: null bounds → super; **inverted/out-of-domain clamped range → super (single-node, never silent zero-node loss)**; `MAX_SPANNING_CELLS` cap → super + warn.

**Coverage is cube-granular and conservative — documented honestly** (not the element-level coverage of Tetree, nor Octree's geometrically-filtered one-node-per-cube). Element-level + filtered coverage is a registered follow-on (`Luciferase-401t`).

Tests (`PyramidIndexParityTest`, dedicated peer suite per project convention): `spanningEntityCoversMultipleNodes` (span>1, findable at both corners), `singleEntityDoesNotSpan`, `outOfDomainBoundsFallBackToSingleNodeNotSilentLoss` (the M1 guard).

## Gate
Full lucien green (pyramid 190/0; one pre-existing `P443` fault-recovery flake passes in isolation, orthogonal). Dual review: code-review-expert APPROVED (1 Medium out-of-domain silent-loss + 1 Low fixed); substantive-critic PARTIAL→addressed (3 characterization findings → honest javadoc + follow-on `Luciferase-401t`).