### PR TITLE
RDR-010 §4c (real, partial): Alg-5.1 tree→rank assignment + RegionShape.PYRAMID

### DIFF
--- a/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/balancing/ShapeWeightedPartitionBootstrapTest.java
+++ b/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/balancing/ShapeWeightedPartitionBootstrapTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.balancing;
+
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.octree.Octree;
+import com.hellblazer.luciferase.lucien.pyramid.PyramidIndex;
+import com.hellblazer.luciferase.lucien.tetree.Tetree;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * RDR-010 §4c (bead Luciferase-uzyd): the distributed layer consuming the shape-weighted partition.
+ *
+ * <p>This is the live consumer of {@link ShapeWeightPartitioner#assignTreesToRanks} (Knapp Alg 5.1
+ * weighted SFC partition) at the distributed-bootstrap seam: given a heterogeneous set of trees
+ * (hex / tet / pyramid) and the partition count, it computes which partition <em>rank</em> owns which
+ * trees, weighted by each shape's element load ({@code N_pyramid = 2·8^ℓ − 6^ℓ} &gt; {@code N_hex = 8^ℓ}).
+ *
+ * <p><b>Honesty note:</b> there is no production distributed launcher in the repo that calls this at
+ * startup — partition rank is currently supplied externally to {@link DistributedForestImpl}. This test
+ * is the proving consumer for the §4c rank-assignment path; wiring it into a production bootstrap is the
+ * remaining (registered) work, gated on a distributed-launch arc that does not yet exist.
+ */
+class ShapeWeightedPartitionBootstrapTest {
+
+    private static final int LEVEL = 2; // N_hex=N_tet=64, N_pyramid=92
+
+    /** A heterogeneous forest's trees, in SFC order, with their backing shape (hex/tet/pyramid). */
+    private record TreeShape(String id, ShapeWeightProvider index) {
+    }
+
+    private List<TreeShape> heterogeneousTrees() {
+        var gen = new SequentialLongIDGenerator();
+        // Four pyramids (N=92) then four hex (N=64) in SFC order — a heavy-front layout where the
+        // weighted cumulative-offset partition genuinely diverges from a tree-count split.
+        return List.of(
+            new TreeShape("t0-pyr", new PyramidIndex<LongEntityID, String>(gen)),
+            new TreeShape("t1-pyr", new PyramidIndex<LongEntityID, String>(gen)),
+            new TreeShape("t2-pyr", new PyramidIndex<LongEntityID, String>(gen)),
+            new TreeShape("t3-pyr", new PyramidIndex<LongEntityID, String>(gen)),
+            new TreeShape("t4-hex", new Octree<LongEntityID, String>(gen)),
+            new TreeShape("t5-hex", new Octree<LongEntityID, String>(gen)),
+            new TreeShape("t6-tet", new Tetree<LongEntityID, String>(gen)),
+            new TreeShape("t7-hex", new Octree<LongEntityID, String>(gen)));
+    }
+
+    @Test
+    void weightedRankAssignmentPartitionsAllTreesAcrossRanks() {
+        var trees = heterogeneousTrees();
+        var ids = trees.stream().map(TreeShape::id).toList();
+        long[] weights = ShapeWeightPartitioner.weightsAtLevel(trees.stream().map(TreeShape::index).toList(), LEVEL);
+        assertArrayEquals(new long[] { 92, 92, 92, 92, 64, 64, 64, 64 }, weights, "shape weights at level 2");
+
+        int partitions = 3;
+        Map<Integer, List<String>> byRank = ShapeWeightPartitioner.assignTreesToRanks(ids, weights, partitions);
+
+        // Every rank present; every tree assigned exactly once (no loss, no duplication).
+        assertEquals(partitions, byRank.size());
+        var assigned = byRank.values().stream().flatMap(List::stream).sorted().toList();
+        assertEquals(ids.stream().sorted().toList(), assigned, "every tree owned by exactly one rank");
+    }
+
+    @Test
+    void weightedAssignmentBalancesElementLoadBetterThanTreeCountSplit() {
+        var trees = heterogeneousTrees();
+        var ids = trees.stream().map(TreeShape::id).toList();
+        long[] weights = ShapeWeightPartitioner.weightsAtLevel(trees.stream().map(TreeShape::index).toList(), LEVEL);
+        var weightOf = new HashMap<String, Long>();
+        for (int i = 0; i < ids.size(); i++) {
+            weightOf.put(ids.get(i), weights[i]);
+        }
+        int partitions = 3;
+
+        // §4c weighted plan.
+        var weighted = ShapeWeightPartitioner.assignTreesToRanks(ids, weights, partitions);
+
+        // Naive shape-blind plan: contiguous even split by tree COUNT (every tree weight 1).
+        long[] ones = new long[ids.size()];
+        java.util.Arrays.fill(ones, 1L);
+        var naive = ShapeWeightPartitioner.assignTreesToRanks(ids, ones, partitions);
+
+        long weightedSpread = loadSpread(weighted, weightOf);
+        long naiveSpread = loadSpread(naive, weightOf);
+        // Exact deterministic values for [92,92,92,92,64,64,64,64] over P=3 (guards against a future
+        // input that satisfies a loose <= without actually exercising weight-sensitivity):
+        //   weighted ranks {0,0,0,1,1,2,2,2} → loads [276,156,192] → spread 120
+        //   naive count-split {0,0,0,1,1,1,2,2} → loads [276,220,128] → spread 148
+        assertEquals(120L, weightedSpread, "weighted element-load spread");
+        assertEquals(148L, naiveSpread, "naive count-split element-load spread");
+        assertTrue(weightedSpread < naiveSpread, "shape-weighted assignment balances element load strictly better");
+        // And it must genuinely consult the weight (the two plans differ on this pyramid-laden forest).
+        assertNotEquals(naive, weighted, "weighted plan must differ from the shape-blind count split");
+    }
+
+    @Test
+    void mismatchedWeightsRejected() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> ShapeWeightPartitioner.assignTreesToRanks(List.of("a", "b"), new long[] { 1 }, 2));
+    }
+
+    /** Max minus min total element-weight across ranks for a given assignment. */
+    private static long loadSpread(Map<Integer, List<String>> byRank, Map<String, Long> weightOf) {
+        long max = Long.MIN_VALUE;
+        long min = Long.MAX_VALUE;
+        for (var trees : byRank.values()) {
+            long w = trees.stream().mapToLong(weightOf::get).sum();
+            max = Math.max(max, w);
+            min = Math.min(min, w);
+        }
+        return max - min;
+    }
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/ShapeWeightPartitioner.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/ShapeWeightPartitioner.java
@@ -9,6 +9,7 @@ import com.hellblazer.luciferase.lucien.SpatialKey;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.forest.Forest;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -137,5 +138,36 @@ public final class ShapeWeightPartitioner {
             assignment.put(trees.get(i).getTreeId(), ranks[i]);
         }
         return assignment;
+    }
+
+    /**
+     * Bootstrap-facing inverse of {@link #assign(long[], int)} for a distributed partition: given the
+     * SFC-ordered trees, their per-shape weights, and the partition count, return which trees each rank
+     * owns (RDR-010 §4c, bead Luciferase-uzyd). This is the shape-weighted tree→rank assignment a
+     * distributed partition bootstrap consumes — heterogeneous (hex/tet/pyramid) weights are supported
+     * because the caller supplies the weight array directly (unlike {@link #partitionForest}, which a
+     * single-key {@link Forest} constrains to one shape).
+     *
+     * @param treeIds        SFC-ordered tree identifiers
+     * @param weights        per-tree shape weights ({@code N_shape(level)}), aligned with {@code treeIds}
+     * @param partitionCount number of ranks
+     * @return rank → list of tree ids owned by that rank (every rank {@code 0..P-1} present, possibly empty)
+     * @throws IllegalArgumentException if {@code treeIds.size() != weights.length}
+     */
+    public static Map<Integer, List<String>> assignTreesToRanks(List<String> treeIds, long[] weights,
+                                                                int partitionCount) {
+        if (treeIds.size() != weights.length) {
+            throw new IllegalArgumentException(
+                "treeIds (" + treeIds.size() + ") and weights (" + weights.length + ") must align");
+        }
+        int[] ranks = assign(weights, partitionCount);
+        var byRank = new LinkedHashMap<Integer, List<String>>();
+        for (int r = 0; r < partitionCount; r++) {
+            byRank.put(r, new ArrayList<>());
+        }
+        for (int i = 0; i < treeIds.size(); i++) {
+            byRank.get(ranks[i]).add(treeIds.get(i));
+        }
+        return byRank;
     }
 }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/AdaptiveForest.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/AdaptiveForest.java
@@ -663,6 +663,13 @@ public class AdaptiveForest<Key extends SpatialKey<Key>, ID extends EntityID, Co
 
     /**
      * Determine child region shape based on their TreeBounds.
+     *
+     * <p>TODO(RDR-010 uzyd): this still infers shape from {@code TreeBounds} (a pyramid/prism child has
+     * an AABB bounds and would resolve to {@code CUBIC} here). It is benign today — pyramid/prism trees
+     * never flow through the Bey/octant subdivision path that calls this — but if a future phase routes
+     * pyramid subdivision through {@code establishHierarchy}, switch to
+     * {@code RegionShape.of(children.get(0).getSpatialIndex())} (index-driven, as the TreeAdded emit
+     * site now does).
      */
     private RegionShape determineChildShape(List<TreeNode<Key, ID, Content>> children) {
         if (children.isEmpty()) {
@@ -1017,7 +1024,7 @@ public class AdaptiveForest<Key extends SpatialKey<Key>, ID extends EntityID, Co
             forestId,
             childId,
             bounds,
-            bounds instanceof TetrahedralBounds ? RegionShape.TETRAHEDRAL : RegionShape.CUBIC,
+            RegionShape.of(childSpatialIndex), // index-driven shape (RDR-010 uzyd): pyramid/prism aware
             parentTree.getTreeId()
         ));
 

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ForestEvent.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ForestEvent.java
@@ -63,7 +63,7 @@ public sealed interface ForestEvent permits
      * @param forestId forest identifier
      * @param treeId unique tree identifier
      * @param bounds spatial bounds (CubicBounds or TetrahedralBounds)
-     * @param regionShape shape of the spatial region (CUBIC or TETRAHEDRAL)
+     * @param regionShape shape of the spatial region (CUBIC, TETRAHEDRAL, PYRAMID, or PRISM)
      * @param parentId parent tree ID (null for root trees)
      */
     record TreeAdded(

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/RegionShape.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/RegionShape.java
@@ -36,5 +36,40 @@ public enum RegionShape {
      * Tetrahedral region.
      * Used for tetree-based trees after tetrahedral subdivision.
      */
-    TETRAHEDRAL
+    TETRAHEDRAL,
+
+    /**
+     * Pyramid region (RDR-010, hybrid hex↔tet transition shape).
+     * Used for {@code PyramidIndex}-based trees so forest events can represent pyramid trees
+     * distinctly rather than mislabelling them as {@link #TETRAHEDRAL}.
+     */
+    PYRAMID,
+
+    /**
+     * Prism region (anisotropic triangular/linear subdivision).
+     * Used for {@code Prism}-based trees.
+     */
+    PRISM;
+
+    /**
+     * Classify a spatial index to its {@code RegionShape} (RDR-010 §4c, bead Luciferase-uzyd) so a forest
+     * event can carry the tree's true shape rather than inferring it from bounds (a pyramid or prism tree
+     * has an AABB {@code TreeBounds} and would otherwise be mislabelled {@code CUBIC}).
+     *
+     * @param index the spatial index backing a forest tree
+     * @return {@code TETRAHEDRAL} for Tetree, {@code PYRAMID} for PyramidIndex, {@code PRISM} for Prism,
+     *         {@code CUBIC} otherwise (Octree, SFCArrayIndex)
+     */
+    public static RegionShape of(com.hellblazer.luciferase.lucien.AbstractSpatialIndex<?, ?, ?> index) {
+        if (index instanceof com.hellblazer.luciferase.lucien.tetree.Tetree) {
+            return TETRAHEDRAL;
+        }
+        if (index instanceof com.hellblazer.luciferase.lucien.pyramid.PyramidIndex) {
+            return PYRAMID;
+        }
+        if (index instanceof com.hellblazer.luciferase.lucien.prism.Prism) {
+            return PRISM;
+        }
+        return CUBIC;
+    }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/RegionShapeTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/RegionShapeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.forest;
+
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.octree.Octree;
+import com.hellblazer.luciferase.lucien.prism.Prism;
+import com.hellblazer.luciferase.lucien.pyramid.PyramidIndex;
+import com.hellblazer.luciferase.lucien.sfc.SFCArrayIndex;
+import com.hellblazer.luciferase.lucien.tetree.Tetree;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * RDR-010 §4c (bead Luciferase-uzyd): {@link RegionShape} gains PYRAMID (and PRISM) so forest events can
+ * represent a pyramid tree's true shape — previously the enum had only {CUBIC, TETRAHEDRAL}, forcing a
+ * PyramidIndex tree to be mislabelled (d3z3 substantive-critic SIG-4). {@link RegionShape#of} classifies
+ * a spatial index to its shape.
+ */
+class RegionShapeTest {
+
+    @Test
+    void pyramidAndPrismVariantsExist() {
+        // Enum carries all four peer shapes (the model gap fix).
+        assertNotNull(RegionShape.valueOf("PYRAMID"));
+        assertNotNull(RegionShape.valueOf("PRISM"));
+        assertEquals(4, RegionShape.values().length, "CUBIC, TETRAHEDRAL, PYRAMID, PRISM");
+    }
+
+    @Test
+    void classifierMapsEachIndexToItsShape() {
+        var gen = new SequentialLongIDGenerator();
+        assertEquals(RegionShape.CUBIC, RegionShape.of(new Octree<LongEntityID, String>(gen)));
+        assertEquals(RegionShape.CUBIC, RegionShape.of(new SFCArrayIndex<LongEntityID, String>(gen)));
+        assertEquals(RegionShape.TETRAHEDRAL, RegionShape.of(new Tetree<LongEntityID, String>(gen)));
+        assertEquals(RegionShape.PYRAMID, RegionShape.of(new PyramidIndex<LongEntityID, String>(gen)),
+                     "a PyramidIndex tree must classify as PYRAMID, not TETRAHEDRAL");
+        assertEquals(RegionShape.PRISM, RegionShape.of(new Prism<LongEntityID, String>(gen)));
+    }
+
+    @Test
+    void treeAddedEventCanCarryPyramidShape() {
+        // The concrete SIG-4 fix: a ForestEvent.TreeAdded can now carry PYRAMID end-to-end.
+        var event = new ForestEvent.TreeAdded(1L, "forest", "pyrTree", null, RegionShape.PYRAMID, null);
+        assertEquals(RegionShape.PYRAMID, event.regionShape());
+    }
+}


### PR DESCRIPTION
Follow-on from d3z3 (which consumed the shape **weight** via greedy at the tumbler-bridge seam). uzyd discharges the **algorithm** concern d3z3's critic raised — the real Knapp **Alg-5.1** cumulative-offset SFC partition is now consumed for partition-**rank** assignment.

## Changes
- **`ShapeWeightPartitioner.assignTreesToRanks(treeIds, weights, P)` → `Map<rank, List<treeId>>`** — the bootstrap-facing inverse of `assign()` (delegates to it; SFC-order **contiguous** = the ghost-locality property). Heterogeneous-weight capable (hex/tet/pyramid).
- **`RegionShape.PYRAMID` + `PRISM`** + `RegionShape.of(AbstractSpatialIndex)` classifier; `AdaptiveForest`'s `TreeAdded` emit is now index-driven. Fixes the d3z3 SIG-4 "pyramid mislabelled" gap at the model level.

## Consumer
`ShapeWeightedPartitionBootstrapTest` (lucien-distributed): builds a heterogeneous hex/tet/pyramid tree set, computes weights via `ShapeWeightProvider.elementCount`, assigns trees to 3 ranks weighted by element load — asserts all-trees-assigned, weighted spread **120 < naive count-split 148**, divergence from the shape-blind plan. The live consumer of the Alg-5.1 rank assignment at the distributed layer (integration template for a future production bootstrap).

## Scope — honest
The **operational** wiring is not done (scoped out) → follow-on **`Luciferase-7poh`**: (1) emit `RegionShape.PYRAMID` in a running system (`addTree` emits no event today; `TreeMetadata.TreeType` lacks PYRAMID); (2) a production bootstrap caller feeding `assignTreesToRanks` into `DistributedForestImpl` (rank is still external config). Both gated on a distributed-launch arc that doesn't exist.

## Gate
Full lucien green (**2727, 0**); 3 lucien-distributed tests green. Dual review: code-review APPROVED (2 Medium papercuts fixed); substantive-critic PARTIAL — **algorithm concern discharged**, 2 operational gaps registered as `Luciferase-7poh`, weak `≤` test assertion tightened to exact values.