### PR TITLE
RDR-010 §4c (emission half): AdaptiveForest.addTree emits root TreeAdded with shape

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/AdaptiveForest.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/AdaptiveForest.java
@@ -317,6 +317,29 @@ public class AdaptiveForest<Key extends SpatialKey<Key>, ID extends EntityID, Co
     
     @Override
     public String addTree(AbstractSpatialIndex<Key, ID, Content> spatialIndex, TreeMetadata metadata) {
+        var treeId = addTreeInternal(spatialIndex, metadata);
+
+        // Emit a root TreeAdded so listeners (e.g. ForestToTumblerBridge, shape-aware partitioners) see
+        // externally-added trees — RDR-010 §4c (Luciferase-7poh): the event carries the tree's true shape
+        // (RegionShape.of) so a PyramidIndex root reports PYRAMID rather than being invisible. (Internal
+        // subdivision/merge paths use addTreeInternal and emit their own parented events, avoiding a
+        // double emit.)
+        var node = getTree(treeId);
+        TreeBounds eventBounds = node != null ? node.getTreeBounds() : null;
+        if (eventBounds == null && node != null && node.getGlobalBounds() != null) {
+            eventBounds = new CubicBounds(node.getGlobalBounds());
+        }
+        emitEvent(new ForestEvent.TreeAdded(System.currentTimeMillis(), forestId, treeId, eventBounds,
+                                            RegionShape.of(spatialIndex), null));
+        return treeId;
+    }
+
+    /**
+     * Add a tree without emitting a {@link ForestEvent.TreeAdded} event. Used by the internal
+     * subdivision/merge paths, which emit their own parented events (so a child/merged tree is not
+     * double-announced). The public {@link #addTree} wraps this and emits the root-level event.
+     */
+    private String addTreeInternal(AbstractSpatialIndex<Key, ID, Content> spatialIndex, TreeMetadata metadata) {
         var treeId = super.addTree(spatialIndex, metadata);
 
         // Initialize density tracking for the new tree
@@ -1005,7 +1028,7 @@ public class AdaptiveForest<Key extends SpatialKey<Key>, ID extends EntityID, Co
             .build();
 
         // Add to forest
-        var childId = addTree(childSpatialIndex, childMetadata);
+        var childId = addTreeInternal(childSpatialIndex, childMetadata);
         var childTree = getTree(childId);
 
         // Expand bounds
@@ -1329,7 +1352,7 @@ public class AdaptiveForest<Key extends SpatialKey<Key>, ID extends EntityID, Co
             .build();
         
         // Add to forest
-        var childId = addTree(childSpatialIndex, childMetadata);
+        var childId = addTreeInternal(childSpatialIndex, childMetadata);
         var childTree = getTree(childId);
         childTree.expandGlobalBounds(bounds);
 
@@ -1345,7 +1368,8 @@ public class AdaptiveForest<Key extends SpatialKey<Key>, ID extends EntityID, Co
             forestId,
             childId,
             cubicBounds,
-            RegionShape.CUBIC,
+            RegionShape.of(childSpatialIndex), // index-driven (RDR-010 uzyd/7poh): was hardcoded CUBIC,
+                                               // mislabelling a Tetree child created via this split path
             parentTree.getTreeId()
         ));
 
@@ -1495,7 +1519,7 @@ public class AdaptiveForest<Key extends SpatialKey<Key>, ID extends EntityID, Co
             .property("mergeTime", System.currentTimeMillis())
             .build();
         
-        var mergedId = addTree(mergedIndex, mergedMetadata);
+        var mergedId = addTreeInternal(mergedIndex, mergedMetadata);
         var mergedTree = getTree(mergedId);
         mergedTree.expandGlobalBounds(mergedBounds);
         

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/DynamicForestManager.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/DynamicForestManager.java
@@ -21,6 +21,7 @@ import com.hellblazer.luciferase.lucien.SpatialKey;
 import com.hellblazer.luciferase.lucien.entity.EntityBounds;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.octree.Octree;
+import com.hellblazer.luciferase.lucien.pyramid.PyramidIndex;
 import com.hellblazer.luciferase.lucien.tetree.Tetree;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -384,6 +385,13 @@ public class DynamicForestManager<Key extends SpatialKey<Key>, ID extends Entity
     /**
      * Add a new tree to the forest at runtime.
      *
+     * <p><b>Factory caveat (RDR-010 §4c / Luciferase-7poh):</b> the concrete index is produced by the
+     * injected {@code treeFactory}, which is homogeneous — {@code treeType} is recorded as metadata and
+     * checked against the produced type (a mismatch logs a warning), but it does NOT itself construct a
+     * {@code PyramidIndex}. To create a pyramid tree (so it emits {@link RegionShape#PYRAMID}), inject a
+     * factory that produces {@code PyramidIndex}, or add it directly via
+     * {@code forest.addTree(new PyramidIndex<>(...), metadata)}.
+     *
      * @param treeType the type of tree to add
      * @param name     optional name for the tree
      * @param bounds   optional initial bounds
@@ -707,6 +715,9 @@ public class DynamicForestManager<Key extends SpatialKey<Key>, ID extends Entity
             log.warn("Tree factory produced non-Octree for OCTREE type");
         } else if (type == TreeMetadata.TreeType.TETREE && !(tree instanceof Tetree)) {
             log.warn("Tree factory produced non-Tetree for TETREE type");
+        } else if (type == TreeMetadata.TreeType.PYRAMID
+                   && !(tree instanceof PyramidIndex)) {
+            log.warn("Tree factory produced non-PyramidIndex for PYRAMID type");
         }
         return tree;
     }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ForestToTumblerBridge.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ForestToTumblerBridge.java
@@ -233,7 +233,11 @@ public class ForestToTumblerBridge implements ForestEventListener {
         var parentServer = treeToServerAssignments.get(event.parentId());
 
         if (parentServer == null) {
-            // Parent has no assignment yet (e.g., root tree created via addTree())
+            // Parent has no assignment yet. Since RDR-010 §4c (Luciferase-7poh) made addTree emit a root
+            // TreeAdded, a root added through the public API is already assigned, so this guard now fires
+            // only for trees added before a listener was registered or via non-public paths. (The child
+            // TreeAdded emitted during subdivision also assigns each child to the parent's server; the
+            // re-assignment here is net-neutral — recordAssignment removes then re-adds the same weight.)
             parentServer = chooseRootServer();
             recordAssignment(event.parentId(), parentServer);
             log.debug("Assigned parent tree {} to {} (no prior assignment)", event.parentId(), parentServer);

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/TreeMetadata.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/TreeMetadata.java
@@ -21,7 +21,8 @@ public class TreeMetadata {
     public enum TreeType {
         OCTREE,
         TETREE,
-        PRISM
+        PRISM,
+        PYRAMID
     }
     
     private final String name;

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/ForestMultiIndexTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/ForestMultiIndexTest.java
@@ -725,10 +725,11 @@ public class ForestMultiIndexTest {
         
         // 1. TreeMetadata system supports all types
         var allTypes = TreeMetadata.TreeType.values();
-        assertEquals(3, allTypes.length);
+        assertEquals(4, allTypes.length);
         assertTrue(List.of(allTypes).contains(TreeMetadata.TreeType.OCTREE));
         assertTrue(List.of(allTypes).contains(TreeMetadata.TreeType.TETREE));
         assertTrue(List.of(allTypes).contains(TreeMetadata.TreeType.PRISM));
+        assertTrue(List.of(allTypes).contains(TreeMetadata.TreeType.PYRAMID));
         
         // 2. All spatial index implementations exist and can be instantiated
         var octree = new Octree<LongEntityID, String>(idGenerator);

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/ForestTumblerBridgeTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/ForestTumblerBridgeTest.java
@@ -192,9 +192,8 @@ public class ForestTumblerBridgeTest {
             .build();
         var treeId = forest.addTree(tree, metadata);
 
-        // Manually trigger TreeAdded event via createChildTreeWithBounds
-        // (since addTree() doesn't emit TreeAdded in current impl)
-        // We'll test via subdivision which does emit TreeAdded
+        // addTree now emits a root TreeAdded (RDR-010 §4c / Luciferase-7poh), so the root tree is itself
+        // assigned a server; subdivision below then emits parented TreeAdded events for the children.
         for (int i = 0; i < 150; i++) {
             var pos = new Point3f(i * 2.0f, i * 2.0f, i * 2.0f);
             var entityId = idGenerator.generateID();

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/PyramidTreeEmissionTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/PyramidTreeEmissionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.forest;
+
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.octree.Octree;
+import com.hellblazer.luciferase.lucien.octree.MortonKey;
+import com.hellblazer.luciferase.lucien.pyramid.PyramidIndex;
+import com.hellblazer.luciferase.lucien.pyramid.PyramidKey;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * RDR-010 §4c operational wiring (bead Luciferase-7poh): {@link AdaptiveForest#addTree} now emits a root
+ * {@link ForestEvent.TreeAdded} carrying the tree's true {@link RegionShape} (via {@link RegionShape#of}),
+ * so a {@code PyramidIndex} tree is announced as {@link RegionShape#PYRAMID} in a running forest — closing
+ * the d3z3/uzyd SIG "pyramid is representable but never emitted" gap operationally, not just at the enum.
+ */
+class PyramidTreeEmissionTest {
+
+    @Test
+    void addingPyramidTreeEmitsTreeAddedWithPyramidShape() {
+        var forest = new AdaptiveForest<PyramidKey, LongEntityID, String>(new SequentialLongIDGenerator());
+        var events = new ArrayList<ForestEvent.TreeAdded>();
+        forest.addEventListener(e -> {
+            if (e instanceof ForestEvent.TreeAdded added) {
+                events.add(added);
+            }
+        });
+
+        var treeId = forest.addTree(new PyramidIndex<>(new SequentialLongIDGenerator()), null);
+
+        assertEquals(1, events.size(), "addTree must emit exactly one root TreeAdded (no double emit)");
+        var event = events.get(0);
+        assertEquals(treeId, event.treeId());
+        assertNull(event.parentId(), "a root tree's TreeAdded has no parent");
+        assertEquals(RegionShape.PYRAMID, event.regionShape(),
+                     "a PyramidIndex tree must be announced as PYRAMID, not mislabelled");
+    }
+
+    @Test
+    void addingOctreeTreeEmitsCubicShape() {
+        var forest = new AdaptiveForest<MortonKey, LongEntityID, String>(new SequentialLongIDGenerator());
+        var shapes = new ArrayList<RegionShape>();
+        forest.addEventListener(e -> {
+            if (e instanceof ForestEvent.TreeAdded added) {
+                shapes.add(added.regionShape());
+            }
+        });
+
+        forest.addTree(new Octree<>(new SequentialLongIDGenerator()), null);
+
+        assertEquals(List.of(RegionShape.CUBIC), shapes, "an Octree root tree is announced as CUBIC");
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/TetrahedralForestE2ETest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/TetrahedralForestE2ETest.java
@@ -806,8 +806,8 @@ class TetrahedralForestE2ETest {
         var rootId = forest.addTree((com.hellblazer.luciferase.lucien.AbstractSpatialIndex) spatialIndex, metadata);
         var root = forest.getTree(rootId);
 
-        // Server assignment occurs during subdivision (not during addTree):
-        // ForestToTumblerBridge.handleTreeSubdivided assigns parent if null, then children inherit
+        // The root is assigned a server on addTree (RDR-010 §4c / Luciferase-7poh: addTree emits a root
+        // TreeAdded); subdivision then assigns the children (inheriting the parent's server).
 
         // 2. Add entities to trigger subdivision (need >7.5, use 10)
         for (int i = 0; i < 10; i++) {
@@ -829,9 +829,9 @@ class TetrahedralForestE2ETest {
         assertTrue(root.isSubdivided(), "Root should be subdivided");
         assertEquals(6, root.getChildTreeIds().size(), "Should have 6 tetrahedral children");
 
-        // Get root server assignment (assigned during subdivision)
+        // Get root server assignment (assigned on addTree; subdivision assigns the children)
         var rootServer = bridge.getServerAssignment(rootId);
-        assertNotNull(rootServer, "Root should have server assignment after subdivision");
+        assertNotNull(rootServer, "Root should have a server assignment");
         assertTrue(rootServer.startsWith("server-"), "Root server should follow 'server-N' pattern");
 
         // 5. Verify all children have server assignments
@@ -971,9 +971,13 @@ class TetrahedralForestE2ETest {
         // 6. Verify all entities remain in parent
         assertEquals(10, spatialIndex.entityCount(), "All 10 entities should remain in parent tree");
 
-        // 7. Verify no server assignment (only occurs during subdivision)
-        assertNull(bridge.getServerAssignment(rootId),
-                  "Root should have no server assignment without subdivision");
+        // 7. The root tree is assigned a server on add (RDR-010 §4c / Luciferase-7poh: addTree now emits
+        // a root TreeAdded), but NO child trees were created (the no-subdivision intent above). The bridge
+        // therefore holds exactly the one root assignment and no child assignments.
+        assertEquals("server-0", bridge.getServerAssignment(rootId),
+                     "root is assigned a server on add (no longer gated on subdivision)");
+        assertEquals(1, bridge.getAllAssignments().size(),
+                     "only the root is assigned — no subdivision children");
 
         // Cleanup
         forest.shutdown();


### PR DESCRIPTION
Operational follow-on to uzyd. Makes a `PyramidIndex` tree emit `RegionShape.PYRAMID` in a running forest (direct-API path) — closing the d3z3/uzyd "pyramid representable but never emitted" gap operationally.

## Changes
- `TreeMetadata.TreeType` += `PYRAMID`.
- **`AdaptiveForest.addTree` now emits a root `ForestEvent.TreeAdded(RegionShape.of(index), parentId=null)`** — reversing the prior "addTree does not emit" contract so listeners see externally-added trees with their true shape. Split into a non-emitting `addTreeInternal` used by the 3 internal subdivision/merge callers (**no double-emit**).
- `createChildTree`'s emit: hardcoded `CUBIC` → `RegionShape.of(childSpatialIndex)` (fixes a latent mislabel of Tetree children via the binary-split path).
- `DynamicForestManager.createTree` PYRAMID warn-branch + javadoc caveat (homogeneous factory, not the TreeType label, picks the concrete index).

## Contract-reversal safety
`ForestToTumblerBridge` is the only production listener — gates on `parentId==null`, never reads event bounds → root emission + null-bounds fallback safe; it now assigns a server to root trees on add. Verified: full lucien green (**2732, 0**), lucien-distributed green.

## Tests
New `PyramidTreeEmissionTest` (pyramid root→PYRAMID, octree→CUBIC, exactly-one-event); updated `TetrahedralForestE2ETest` (root assigned on add) + `ForestMultiIndexTest` (TreeType 3→4).

## Scope — honest
This is the **emission half**. Remainders registered (gated on a distributed launcher that doesn't exist):
- `Luciferase-tjdc` — production distributed bootstrap: pyramid-typed factory + `assignTreesToRanks`→`DistributedForestImpl` rank consumption.
- `Luciferase-l4p0` — `mergeTrees` must emit `TreesMerged` (`handleTreesMerged` is dead-letter).

Dual review: code-review APPROVED (double-emit clean, ripple benign); substantive-critic PARTIAL (contract reversal sound; remainders registered, not silently dropped).