### PR TITLE
RDR-010: AdaptiveForest.mergeTrees emits TreesMerged (fix dead-letter handler + assignment leak)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/AdaptiveForest.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/AdaptiveForest.java
@@ -1527,10 +1527,18 @@ public class AdaptiveForest<Key extends SpatialKey<Key>, ID extends EntityID, Co
         transferEntities(tree1, mergedTree);
         transferEntities(tree2, mergedTree);
         
+        // Announce the merge (RDR-010 Luciferase-l4p0): the merged tree was created via addTreeInternal
+        // (no root TreeAdded), so TreesMerged is the only event that announces it. Listeners
+        // (ForestToTumblerBridge) clear the source assignments and assign the merged tree on this event —
+        // without it, handleTreesMerged is dead code and source server assignments leak. Emitted BEFORE
+        // removeTree so the source trees are still reachable (getTree) for any listener that inspects them.
+        emitEvent(new ForestEvent.TreesMerged(System.currentTimeMillis(), forestId,
+                                              Arrays.asList(tree1.getTreeId(), tree2.getTreeId()), mergedId));
+
         // Remove original trees
         removeTree(tree1.getTreeId());
         removeTree(tree2.getTreeId());
-        
+
         // Trigger ghost updates after forest repartitioning
         triggerGhostUpdatesAfterRepartitioning(mergedTree.getSpatialIndex());
     }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ForestEvent.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/ForestEvent.java
@@ -108,7 +108,10 @@ public sealed interface ForestEvent permits
     ) implements ForestEvent {}
 
     /**
-     * Event emitted when multiple trees are merged into one.
+     * Event emitted when multiple trees are merged into one. The merged tree is created without its own
+     * {@code TreeAdded} event, so this is the <em>only</em> announcement of its existence — a listener
+     * that tracks trees must handle {@code TreesMerged} (not just {@code TreeAdded}) to learn of it
+     * (RDR-010 Luciferase-l4p0).
      *
      * @param timestamp event timestamp
      * @param forestId forest identifier

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/MergeTreesEmissionTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/MergeTreesEmissionTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.forest;
+
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.octree.MortonKey;
+import com.hellblazer.luciferase.lucien.octree.Octree;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * RDR-010 (bead Luciferase-l4p0): {@link AdaptiveForest#mergeTrees} must emit
+ * {@link ForestEvent.TreesMerged}. Before this fix the merged tree was created via {@code addTreeInternal}
+ * (no {@code TreeAdded}) and no {@code TreesMerged} was emitted, so {@link ForestToTumblerBridge#getServerAssignment}
+ * leaked the source trees' server assignments and the merged tree was never assigned —
+ * {@code handleTreesMerged} was dead code.
+ */
+class MergeTreesEmissionTest {
+
+    @Test
+    void mergeEmitsTreesMergedAndBridgeReconcilesAssignments() throws Exception {
+        var gen = new SequentialLongIDGenerator();
+        var forest = new AdaptiveForest<MortonKey, LongEntityID, String>(gen);
+
+        var bridge = new ForestToTumblerBridge();
+        forest.addEventListener(bridge);
+        var merges = new ArrayList<ForestEvent.TreesMerged>();
+        forest.addEventListener(e -> {
+            if (e instanceof ForestEvent.TreesMerged tm) {
+                merges.add(tm);
+            }
+        });
+
+        // Two root trees — each assigned a server on add (RDR-010 7poh root TreeAdded emission).
+        var id1 = forest.addTree(new Octree<>(gen), null);
+        var id2 = forest.addTree(new Octree<>(gen), null);
+        assertNotNull(bridge.getServerAssignment(id1), "source tree 1 assigned on add");
+        assertNotNull(bridge.getServerAssignment(id2), "source tree 2 assigned on add");
+
+        // Drive the (private) merge directly — the merge-consideration loop only fires for low-density
+        // adjacent trees; reflection gives a deterministic exercise of the event path.
+        var m = AdaptiveForest.class.getDeclaredMethod("mergeTrees", TreeNode.class, TreeNode.class);
+        m.setAccessible(true);
+        m.invoke(forest, forest.getTree(id1), forest.getTree(id2));
+
+        // Exactly one TreesMerged naming both sources and the merged tree.
+        assertEquals(1, merges.size(), "merge must emit exactly one TreesMerged");
+        var event = merges.get(0);
+        assertEquals(List.of(id1, id2), event.sourceIds(), "TreesMerged must name both source trees");
+        assertNotNull(event.mergedId());
+        assertNotEquals(id1, event.mergedId());
+        assertNotEquals(id2, event.mergedId());
+
+        // The bridge reconciled: source assignments cleared, merged tree assigned (no leak, no dead code).
+        assertNull(bridge.getServerAssignment(id1), "source 1 server assignment cleared on merge");
+        assertNull(bridge.getServerAssignment(id2), "source 2 server assignment cleared on merge");
+        assertNotNull(bridge.getServerAssignment(event.mergedId()), "merged tree assigned a server");
+    }
+}


### PR DESCRIPTION
`mergeTrees` created the merged tree via `addTreeInternal` (no `TreeAdded`) and removed the source trees, but **never emitted `ForestEvent.TreesMerged`** — so `ForestToTumblerBridge.handleTreesMerged` was dead code and the source trees' server assignments leaked on every merge.

## Fix
- `mergeTrees` now emits `TreesMerged([src1,src2], mergedId)` **before** `removeTree` (sources remain reachable for listeners at event time). The merged tree (no `TreeAdded`) is announced solely by this event.
- `ForestEvent.TreesMerged` javadoc documents that tree-tracking listeners must handle `TreesMerged` (no `TreeAdded` for the merged tree).
- `MergeTreesEmissionTest`: reflectively drives the private merge; asserts exactly one `TreesMerged` with both source ids + a distinct merged id, and that the bridge cleared both source assignments and assigned the merged tree.

## Gate
Full lucien green (**2735, 0**); merge-exercising forest tests pass. Dual review: code-review APPROVED (verified `removeTree` doesn't double-emit); substantive-critic PARTIAL → resolved (fixed a duplicate javadoc block I'd introduced + reordered the emit before `removeTree`).

## Follow-on
The **symmetric** gap — `removeTree` never emits `TreeRemoved` (`handleTreeRemoved` is also dead-letter; standalone removal leaks assignment) — is registered as a separate bead (with the merge double-announce design nuance noted).