### PR TITLE
RDR-010 0utt: exhaustive cross-shape EDGE/VERTEX neighbor topology

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborDetector.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborDetector.java
@@ -52,12 +52,13 @@ import java.util.Set;
  * the detector <em>catches and skips</em> that face rather than propagating — a thrown exception would
  * break the BFS in {@code KnnSearcher}/{@code CollisionEngine}.
  *
- * <p><b>Edge/vertex — bounded cumulative supersets (pi1.5).</b> Edge and vertex add the same-shape
- * (pyramid↔pyramid) geometric neighbors at shared-vertex thresholds 2 and 1 (the 27-cube enumeration
- * below) on top of the cross-shape face set, preserving face ⊆ edge ⊆ vertex. <em>Exhaustive
- * cross-shape edge/vertex adjacency</em> (tet-tet edge sharing, pyramid-tet vertex fans) is a
- * registered deferral — bead Luciferase-0utt — not silent scope reduction: ghost {@code FACES}
- * exchange needs only the face set, which is exact here.
+ * <p><b>Edge/vertex — exhaustive cross-shape cumulative supersets (RDR-010 Luciferase-0utt).</b> Edge
+ * and vertex enumerate ALL same-level SFC elements — pyramid (6/7) <em>and</em> shallowest tet (0-5) —
+ * in the 27-cube neighbourhood, classified by shared-vertex count (≥ 2 edge, ≥ 1 vertex) and unioned
+ * with the cross-shape face set, preserving face ⊆ edge ⊆ vertex. This surfaces tet↔tet edge sharing and
+ * pyramid↔tet vertex fans (the pi1.5 superset enumerated same-shape pyramids only). Deep pyramid-rooted
+ * tets (l &gt; minTetLevel) remain out of scope — {@link PyramidKeyCodec#encode} rejects them
+ * (Finding #16 / q3p Phase E). ghost {@code FACES} exchange still needs only the (exact) face set.
  *
  * <p><b>Same-shape enumeration (edge/vertex contribution).</b> For each of the 27 cube offsets
  * {@code (dx,dy,dz) ∈ {-1,0,+1}³} and each pyramid type {@code {6,7}}, a candidate same-level pyramid is
@@ -90,25 +91,25 @@ public final class PyramidNeighborDetector implements NeighborDetector<PyramidKe
 
     @Override
     public List<PyramidKey> findEdgeNeighbors(PyramidKey element) {
-        // Bounded superset: cross-shape faces ∪ same-shape edge neighbors (shared ≥ 2). Exhaustive
-        // cross-shape edge adjacency is deferred (bead Luciferase-0utt).
-        return unionFaceWithSameShape(element, EDGE_SHARED_VERTICES);
+        // Exhaustive cross-shape edge adjacency (RDR-010 Luciferase-0utt): cross-shape faces ∪ all-shape
+        // (pyramid+tet) elements sharing ≥ 2 vertices. Deep-tet (l > minTetLevel) stays out of scope.
+        return unionFaceWithAllShape(element, EDGE_SHARED_VERTICES);
     }
 
     @Override
     public List<PyramidKey> findVertexNeighbors(PyramidKey element) {
-        // Bounded superset: cross-shape faces ∪ same-shape vertex neighbors (shared ≥ 1). Exhaustive
-        // cross-shape vertex adjacency is deferred (bead Luciferase-0utt).
-        return unionFaceWithSameShape(element, VERTEX_SHARED_VERTICES);
+        // Exhaustive cross-shape vertex adjacency (RDR-010 Luciferase-0utt): cross-shape faces ∪ all-shape
+        // (pyramid+tet) elements sharing ≥ 1 vertex. Deep-tet (l > minTetLevel) stays out of scope.
+        return unionFaceWithAllShape(element, VERTEX_SHARED_VERTICES);
     }
 
     /**
-     * Cross-shape face set unioned with the same-shape neighbors at {@code minSharedVertices},
-     * insertion-ordered and de-duplicated, preserving face ⊆ edge ⊆ vertex.
+     * Cross-shape face set unioned with the all-shape (pyramid+tet) edge/vertex neighbors at
+     * {@code minSharedVertices}, insertion-ordered and de-duplicated, preserving face ⊆ edge ⊆ vertex.
      */
-    private List<PyramidKey> unionFaceWithSameShape(PyramidKey element, int minSharedVertices) {
+    private List<PyramidKey> unionFaceWithAllShape(PyramidKey element, int minSharedVertices) {
         var union = new LinkedHashSet<>(crossShapeFaceNeighbors(element));
-        union.addAll(sameShapeNeighbors(element, minSharedVertices));
+        union.addAll(allShapeNeighbors(element, minSharedVertices));
         return new ArrayList<>(union);
     }
 
@@ -209,27 +210,45 @@ public final class PyramidNeighborDetector implements NeighborDetector<PyramidKe
         var neighbors = findNeighbors(element, type);
         var result = new ArrayList<NeighborInfo<PyramidKey>>(neighbors.size());
         for (var neighbor : neighbors) {
-            // Same-shape, single-tree scope: all neighbors are local. Distributed ownership resolution
-            // (cross-rank, cross-tree) lands with the ghost wiring in pi1.5.
+            // Local-only for ALL ghost types (FACES, EDGES, VERTEXES) by design — the detector is purely
+            // geometric. Distributed cross-rank ownership is assigned externally via the inverted seam
+            // (GhostBoundaryDetector.setElementOwner), NOT resolved here (RDR-010 pi1.5, Luciferase-703).
+            // So edge/vertex ghost exchange (Luciferase-0utt) follows the same external-ownership model as
+            // faces: the geometric neighbour set is correct; rank resolution is the seam's job.
             result.add(new NeighborInfo<>(neighbor, 0, 0, true));
         }
         return result;
     }
 
     /**
-     * Same-shape (pyramid↔pyramid) geometric enumeration for the edge/vertex superset contribution.
-     * Returns the same-level pyramid keys that share at least {@code minSharedVertices} vertices with
-     * the query element. A tet-leaf or non-decodable key yields an empty list (so for a tet-leaf key the
-     * edge/vertex sets equal the cross-shape face set — exhaustive cross-shape edge/vertex topology is
-     * deferred to bead Luciferase-0utt); never throws.
+     * Exhaustive cross-shape (pyramid↔pyramid, pyramid↔tet, tet↔tet) edge/vertex enumeration (RDR-010,
+     * bead Luciferase-0utt). Returns every same-level SFC element — pyramid (type 6/7) <em>or</em>
+     * shallowest tet (type 0-5, {@code minTetLevel == level}) — in the 27-cube neighbourhood that shares
+     * at least {@code minSharedVertices} vertices with the query element's leaf.
+     *
+     * <p>Shared-vertex count is a <em>conservative superset</em> classifier for edge (≥ 2 shared
+     * vertices) and vertex (≥ 1) adjacency, honouring the {@link NeighborDetector} cumulative-superset
+     * contract. It is not exact for edges: a pyramid's two base-diagonal corners share no pyramid edge,
+     * so two elements sharing exactly that diagonal pair are counted as edge neighbours without a shared
+     * geometric edge. Over-inclusion is safe for the BFS/ghost consumers (they tolerate extra neighbours;
+     * never a false negative). Faces are NOT classified this way (Bey-SFC tet faces share 0-3 vertices) —
+     * they are handled separately by {@link #crossShapeFaceNeighbors} and unioned in. Candidates are filtered to genuine
+     * SFC elements via {@link PyramidKeyCodec#encode} (a non-SFC anchor/type, or a deep pyramid-rooted tet
+     * with {@code minTetLevel < level}, encodes to {@code null} — so deep-tet cross-shape adjacency below
+     * the shallow boundary remains out of scope, RDR-010 Finding #16 / q3p Phase E). Works for a pyramid
+     * <em>or</em> a tet-leaf query (vertices taken from the decoded leaf). Never throws.
      */
-    private List<PyramidKey> sameShapeNeighbors(PyramidKey element, int minSharedVertices) {
-        Pyramid self = resolvePyramid(element);
-        if (self == null) {
-            return List.of(); // tet-leaf key: same-shape edge/vertex N/A (exhaustive → bead Luciferase-0utt)
+    private List<PyramidKey> allShapeNeighbors(PyramidKey element, int minSharedVertices) {
+        HybridElement self = PyramidIndex.elementFromKey(element);
+        Point3i[] selfVerts;
+        if (self instanceof Pyramid p) {
+            selfVerts = p.coordinates();
+        } else if (self instanceof Tet t) {
+            selfVerts = t.coordinates();
+        } else {
+            return List.of(); // root / non-decodable — no same-level neighbours
         }
         int len = self.length();
-        Point3i[] selfVerts = self.coordinates();
         byte level = self.level();
         var neighbors = new ArrayList<PyramidKey>();
         for (int dx = -1; dx <= 1; dx++) {
@@ -242,18 +261,16 @@ public final class PyramidNeighborDetector implements NeighborDetector<PyramidKe
                         || nz > Constants.MAX_COORD) {
                         continue;
                     }
+                    // Pyramid candidates (type 6/7).
                     for (byte candType = Pyramid.TYPE_6; candType <= Pyramid.TYPE_7; candType++) {
-                        var cand = new Pyramid(nx, ny, nz, level, candType);
-                        if (cand.equals(self)) {
-                            continue; // self
-                        }
-                        if (sharedVertexCount(selfVerts, cand.coordinates()) < minSharedVertices) {
-                            continue;
-                        }
-                        var key = PyramidKeyCodec.encode(cand);
-                        if (key != null) { // null ⇒ not a genuine SFC element
-                            neighbors.add(key);
-                        }
+                        addCandidate(new Pyramid(nx, ny, nz, level, candType), selfVerts, minSharedVertices,
+                                     element, neighbors);
+                    }
+                    // Shallow-tet candidates (type 0-5, minTetLevel == level). encode() drops non-SFC and
+                    // deep tets, so only genuine shallow SFC tets at this cube survive.
+                    for (byte tetType = 0; tetType < 6; tetType++) {
+                        addCandidate(new Tet(nx, ny, nz, level, tetType, level), selfVerts, minSharedVertices,
+                                     element, neighbors);
                     }
                 }
             }
@@ -261,29 +278,20 @@ public final class PyramidNeighborDetector implements NeighborDetector<PyramidKe
         return neighbors;
     }
 
-    /**
-     * Decode {@code element} to its pyramid, or {@code null} if it is a tet leaf (cross-shape, pi1.5)
-     * or the root (no same-level neighbors). The key's leaf type bit is authoritative for shape —
-     * {@link PyramidIndex#pyramidFromKey} returns the enclosing parent pyramid for a deep tet-leaf
-     * key, so a {@code null} from it is not a reliable tet-leaf signal on its own.
-     */
-    private static Pyramid resolvePyramid(PyramidKey element) {
-        byte level = element.getLevel();
-        if (level == 0) {
-            return null; // root spans the domain; no same-level neighbors
+    /** Add {@code cand}'s key if it is a genuine SFC element, not the query, and shares ≥ min vertices. */
+    private static void addCandidate(HybridElement cand, Point3i[] selfVerts, int minSharedVertices,
+                                     PyramidKey selfKey, List<PyramidKey> out) {
+        Point3i[] candVerts = cand instanceof Pyramid p ? p.coordinates() : ((Tet) cand).coordinates();
+        if (sharedVertexCount(selfVerts, candVerts) < minSharedVertices) {
+            return;
         }
-        byte leafType = element.getTypeAtLevel(level);
-        if (leafType != Pyramid.TYPE_6 && leafType != Pyramid.TYPE_7) {
-            return null; // tet leaf: same-shape enumeration N/A (cross-shape faces handled separately)
+        PyramidKey key = encodeElement(cand);
+        if (key != null && !key.equals(selfKey)) {
+            out.add(key);
         }
-        Pyramid self = PyramidIndex.pyramidFromKey(element);
-        if (self == null || self.level() != level || self.type() != leafType) {
-            return null; // defensive: decode did not resolve to the leaf pyramid
-        }
-        return self;
     }
 
-    /** Count vertices shared (by exact integer coordinate) between two pyramid vertex sets. */
+    /** Count vertices shared (by exact integer coordinate) between two vertex sets. */
     private static int sharedVertexCount(Point3i[] a, Point3i[] b) {
         int shared = 0;
         for (Point3i pa : a) {

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidCrossShapeEdgeVertexTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidCrossShapeEdgeVertexTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.pyramid;
+
+import com.hellblazer.luciferase.lucien.Constants;
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.tetree.Tet;
+import com.hellblazer.luciferase.lucien.tetree.TetreeConnectivity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * RDR-010 (bead Luciferase-0utt): exhaustive cross-shape EDGE/VERTEX neighbor topology (pyramid↔tet).
+ *
+ * <p>pi1.5 made findEdge/VertexNeighbors a bounded superset (cross-shape faces ∪ same-shape pyramid
+ * neighbors), so a tet sharing only an edge or vertex (not a face) with a pyramid was missed, and a
+ * tet-leaf query got only its face set. 0utt enumerates ALL same-level SFC elements (pyramid 6/7 +
+ * shallowest tet 0-5) in the 27-cube neighbourhood and classifies by shared-vertex count (≥2 edge,
+ * ≥1 vertex) — the exact geometric definition for edge/vertex adjacency.
+ *
+ * <p>Validation is reciprocity/involution (CLAUDE.md): a cross-shape edge/vertex neighbor must list the
+ * query back. Deep-tet (l &gt; minTetLevel) stays out of scope (encode rejects it, Finding #16).
+ */
+class PyramidCrossShapeEdgeVertexTest {
+
+    private PyramidNeighborDetector detector;
+
+    @BeforeEach
+    void setUp() {
+        detector = (PyramidNeighborDetector) new PyramidIndex<LongEntityID, String>(
+            new SequentialLongIDGenerator()).getNeighborDetector();
+    }
+
+    /** SFC pyramids up to {@code maxLevel}, walked depth-first from the two roots. */
+    private List<Pyramid> validPyramids(int maxLevel) {
+        var out = new ArrayList<Pyramid>();
+        var stack = new ArrayDeque<Pyramid>();
+        stack.push(new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6));
+        stack.push(new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_7));
+        while (!stack.isEmpty()) {
+            var p = stack.pop();
+            if (p.level() >= 1) {
+                out.add(p);
+            }
+            if (p.level() < maxLevel) {
+                for (int i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
+                    if (p.child(i) instanceof Pyramid pc) {
+                        stack.push(pc);
+                    }
+                }
+            }
+        }
+        return out;
+    }
+
+    private static boolean isTetLeaf(PyramidKey k) {
+        byte t = k.getTypeAtLevel(k.getLevel());
+        return t != Pyramid.TYPE_6 && t != Pyramid.TYPE_7;
+    }
+
+    @Test
+    void crossShapeTetVertexAndEdgeNeighborsAreSurfacedAndReciprocal() {
+        int crossShapeVertexChecks = 0;
+        int crossShapeEdgeChecks = 0;
+        for (var p : validPyramids(5)) {
+            var pk = PyramidKeyCodec.encode(p);
+            if (pk == null) {
+                continue;
+            }
+            var faces = detector.findFaceNeighbors(pk);
+            for (var vk : detector.findVertexNeighbors(pk)) {
+                if (!isTetLeaf(vk) || faces.contains(vk)) {
+                    continue; // only the NEW contribution: cross-shape tets that are not face neighbors
+                }
+                // Reciprocity: the tet must list the pyramid back as a vertex neighbor.
+                assertTrue(detector.findVertexNeighbors(vk).contains(pk),
+                           "cross-shape vertex adjacency must be reciprocal: " + pk + " <-> " + vk);
+                crossShapeVertexChecks++;
+
+                // If it is an EDGE neighbor (≥2 shared verts) it must also be reciprocal in the edge set
+                // and present in the vertex set (face ⊆ edge ⊆ vertex).
+                if (detector.findEdgeNeighbors(pk).contains(vk)) {
+                    assertTrue(detector.findEdgeNeighbors(vk).contains(pk),
+                               "cross-shape edge adjacency must be reciprocal: " + pk + " <-> " + vk);
+                    crossShapeEdgeChecks++;
+                }
+            }
+        }
+        assertTrue(crossShapeVertexChecks >= 5,
+                   "exhaustive 0utt must surface cross-shape tet VERTEX neighbors beyond faces, got "
+                   + crossShapeVertexChecks);
+        assertTrue(crossShapeEdgeChecks >= 1,
+                   "exhaustive 0utt must surface at least one cross-shape tet EDGE neighbor, got "
+                   + crossShapeEdgeChecks);
+    }
+
+    @Test
+    void vertexNeighborsAreCompleteVsWholeDomainBruteForce() {
+        // Independent completeness oracle (closes the symmetric-miss blind spot reciprocity can't catch):
+        // enumerate EVERY valid level-2 SFC element across the WHOLE domain (not just the 27-cube), and
+        // for a query assert findVertexNeighbors contains every element sharing >=1 vertex. If the 27-cube
+        // grid were under-sized, this brute force would find a vertex-sharing element the detector missed.
+        int len = Constants.lengthAtLevel((byte) 2);
+        var universe = new ArrayList<javax.vecmath.Point3i[]>();
+        var universeKeys = new ArrayList<PyramidKey>();
+        for (int ax = 0; ax <= Constants.MAX_COORD; ax += len) {
+            for (int ay = 0; ay <= Constants.MAX_COORD; ay += len) {
+                for (int az = 0; az <= Constants.MAX_COORD; az += len) {
+                    for (byte t = Pyramid.TYPE_6; t <= Pyramid.TYPE_7; t++) {
+                        var p = new Pyramid(ax, ay, az, (byte) 2, t);
+                        var k = PyramidKeyCodec.encode(p);
+                        if (k != null) {
+                            universe.add(p.coordinates());
+                            universeKeys.add(k);
+                        }
+                    }
+                    for (byte t = 0; t < 6; t++) {
+                        var tet = new Tet(ax, ay, az, (byte) 2, t, (byte) 2);
+                        var k = PyramidKeyCodec.encode(tet);
+                        if (k != null) {
+                            universe.add(tet.coordinates());
+                            universeKeys.add(k);
+                        }
+                    }
+                }
+            }
+        }
+        assertTrue(universe.size() > 50, "expected a populated level-2 universe, got " + universe.size());
+
+        // Pick an interior query (a pyramid one cube off the origin corner — neighbours in all directions).
+        PyramidKey queryKey = null;
+        javax.vecmath.Point3i[] queryVerts = null;
+        for (int i = 0; i < universeKeys.size(); i++) {
+            var k = universeKeys.get(i);
+            if (!isTetLeaf(k) && k.getCoordBitsAtLevel(1) == 0 && k.getCoordBitsAtLevel(2) == 7) {
+                queryKey = k;
+                queryVerts = universe.get(i);
+                break;
+            }
+        }
+        assertNotNull(queryKey, "expected an interior level-2 pyramid query");
+
+        var found = new java.util.HashSet<>(detector.findVertexNeighbors(queryKey));
+        int checked = 0;
+        for (int i = 0; i < universeKeys.size(); i++) {
+            if (universeKeys.get(i).equals(queryKey)) {
+                continue;
+            }
+            if (sharedVertexCount(queryVerts, universe.get(i)) >= 1) {
+                assertTrue(found.contains(universeKeys.get(i)),
+                           "27-cube enumeration missed a whole-domain vertex-sharing neighbor: "
+                           + universeKeys.get(i));
+                checked++;
+            }
+        }
+        assertTrue(checked >= 5, "expected the query to have several vertex neighbors, got " + checked);
+    }
+
+    private static int sharedVertexCount(javax.vecmath.Point3i[] a, javax.vecmath.Point3i[] b) {
+        int shared = 0;
+        for (var pa : a) {
+            for (var pb : b) {
+                if (pa.equals(pb)) {
+                    shared++;
+                    break;
+                }
+            }
+        }
+        return shared;
+    }
+
+    @Test
+    void faceSubsetOfEdgeSubsetOfVertex() {
+        for (var p : validPyramids(4)) {
+            var pk = PyramidKeyCodec.encode(p);
+            if (pk == null) {
+                continue;
+            }
+            var faces = new java.util.HashSet<>(detector.findFaceNeighbors(pk));
+            var edges = new java.util.HashSet<>(detector.findEdgeNeighbors(pk));
+            var verts = new java.util.HashSet<>(detector.findVertexNeighbors(pk));
+            assertTrue(edges.containsAll(faces), "face ⊆ edge for " + pk);
+            assertTrue(verts.containsAll(edges), "edge ⊆ vertex for " + pk);
+        }
+    }
+
+    @Test
+    void tetLeafQueryHasExhaustiveEdgeVertexNeighbors() {
+        // A tet-leaf query previously got only its cross-shape face set from edge/vertex. Now it gets the
+        // full all-shape edge/vertex set — including same-shape pyramid neighbors sharing an edge/vertex.
+        PyramidKey tetKey = null;
+        for (var p : validPyramids(5)) {
+            if (p.level() < 2) {
+                continue;
+            }
+            for (int f = 0; f < 4; f++) {
+                var fn = p.faceNeighbor(f);
+                if (fn != null && fn.element() instanceof Tet t) {
+                    var tk = PyramidKeyCodec.encode(t);
+                    if (tk != null) {
+                        tetKey = tk;
+                        break;
+                    }
+                }
+            }
+            if (tetKey != null) {
+                break;
+            }
+        }
+        assertNotNull(tetKey, "expected an in-domain shallow tet-leaf key");
+
+        var verts = detector.findVertexNeighbors(tetKey);
+        var faces = new java.util.HashSet<>(detector.findFaceNeighbors(tetKey));
+        // The vertex set is a strict superset of the face set (the tet has neighbors sharing only a
+        // vertex/edge, not a face).
+        assertTrue(verts.size() > faces.size(),
+                   "tet-leaf vertex neighbors must exceed its face neighbors (exhaustive edge/vertex)");
+        // At least one vertex neighbor is a pyramid (cross-shape tet→pyramid vertex fan) and reciprocal.
+        final var tk = tetKey;
+        var pyrNeighbor = verts.stream().filter(k -> !isTetLeaf(k)).findFirst();
+        assertTrue(pyrNeighbor.isPresent(), "a tet-leaf must have a pyramid vertex neighbor");
+        assertTrue(detector.findVertexNeighbors(pyrNeighbor.get()).contains(tk),
+                   "tet→pyramid vertex adjacency must be reciprocal");
+    }
+}


### PR DESCRIPTION
## Summary
Closes **Luciferase-0utt**. Replaces the pi1.5 pyramid-only `sameShapeNeighbors` with `allShapeNeighbors`: enumerates the 27-cube neighbourhood over all same-level SFC elements (pyramid types 6/7 + shallowest tets 0–5) and classifies by shared-vertex count (≥2 edge, ≥1 vertex). `findEdge/VertexNeighbors` now = cross-shape faces ∪ all-shape neighbors — so a tet sharing only an edge or vertex with a pyramid is surfaced, and a tet-leaf query gets the full set (previously empty/face-only).

Conservative superset per the `NeighborDetector` cumulative contract (≥2-shared overcounts edges for pyramid base-diagonal corners); over-inclusion is safe for edge/vertex BFS consumers.

## Scope / deferral
Shallow-boundary exhaustive only. Deep pyramid-rooted tets (`l > minTetLevel`) stay excluded (`encode` rejects them, Finding #16 — Bey divergence below the boundary). Deep-tet face+edge/vertex registered as **Luciferase-cjwr** (blocked on the t8code deep-pyramid table port, q3p Phase E).

## Tests
`PyramidCrossShapeEdgeVertexTest` (4): cross-shape tet edge/vertex reciprocity + non-vacuity counts; face ⊆ edge ⊆ vertex; tet-leaf exhaustive; and an **independent whole-domain brute-force completeness oracle** proving the 27-cube enumeration misses no vertex-sharing element (closes the symmetric-miss blind spot reciprocity alone can't catch). Full lucien suite green **2739/0**.

## Review
code-review-expert APPROVED (0 crit/high; 27-cube completeness + reciprocity proven). substantive-critic partial/0-crit; all 3 significant findings addressed (scope-qualified deferral registered → cjwr; ghost-ownership doc clarified; completeness oracle added in-test).