### PR TITLE
RDR-010 cjwr A+B: deep pyramid-rooted tet face neighbors + deep SFC keys

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidIndex.java
@@ -719,12 +719,11 @@ public class PyramidIndex<ID extends EntityID, Content> extends AbstractSpatialI
      * key to its enclosing parent pyramid), this returns the tet itself, so it is the validating
      * inverse of {@link PyramidKeyCodec#encode(Tet)}.
      *
-     * <p><b>Shallow boundary only.</b> The descent follows {@link Pyramid#child(int)} edges, so it can
-     * reconstruct a tet only at the leaf level (a tet born directly from a pyramid, {@code minTetLevel
-     * == level}). A key whose bits select a tet at a non-leaf level — a <em>deep</em> pyramid-rooted
-     * tet ({@code l > minTetLevel}) — is not reconstructible here (the tet-of-tet refinement is the
-     * q3p Phase E deferral, fail-loud elsewhere) and returns {@code null}. A key with no matching
-     * child at some level also returns {@code null}.
+     * <p><b>Full depth.</b> The descent follows {@link Pyramid#child(int)} edges while the path is
+     * pyramidal and {@link Tet#child(int)} edges once it enters the tetrahedral branch, so it
+     * reconstructs both a shallowest tet leaf ({@code minTetLevel == level}) and a <em>deep</em>
+     * pyramid-rooted tet ({@code l > minTetLevel}) — the tet-of-tet refinement below the boundary
+     * (RDR-010 Luciferase-cjwr Phase B). A key with no matching child at some level returns {@code null}.
      *
      * @param key the SFC key
      * @return the leaf element (Pyramid or Tet), or {@code null} for a non-reconstructible key
@@ -753,21 +752,36 @@ public class PyramidIndex<ID extends EntityID, Content> extends AbstractSpatialI
         if (currentEl == null || level == 1) {
             return currentEl; // level-1 leaf (Tet or Pyramid), or no match
         }
-        // Descend levels 2..level via pyramid children. A tet at a non-leaf level cannot parent the
-        // next level here (deep-tet, out of pi1.5 scope) → null.
+        // Descend levels 2..level. While the path is pyramidal, follow Pyramid.child edges (matching the
+        // child's coord+type bits). Once it enters the tetrahedral branch, follow Tet.child edges (the
+        // deep tet-of-tet refinement, RDR-010 Luciferase-cjwr Phase B) — Tet.child inherits minTetLevel,
+        // so the reconstructed deep tet carries the boundary level set at the shallowest tet.
         for (int l = 2; l <= level; l++) {
-            if (!(currentEl instanceof Pyramid cp)) {
-                return null; // deep tet-of-tet path: not reconstructible at the shallow boundary
-            }
             int cb = key.getCoordBitsAtLevel(l);
             int tb = key.getTypeAtLevel(l);
             HybridElement next = null;
-            int row = cp.type() - Pyramid.TYPE_6;
-            for (int i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
-                if (TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_CID[row][i] == cb
-                    && TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_TYPE[row][i] == tb) {
-                    next = cp.child(i);
-                    break;
+            if (currentEl instanceof Pyramid cp) {
+                int row = cp.type() - Pyramid.TYPE_6;
+                for (int i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
+                    if (TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_CID[row][i] == cb
+                        && TetreeConnectivity.PYRAMID_PARENT_TO_CHILD_TYPE[row][i] == tb) {
+                        next = cp.child(i);
+                        break;
+                    }
+                }
+            } else {
+                // Deep tet-of-tet: (parent type, child cube-id) uniquely identifies the Bey child
+                // (TYPE_CID_TO_BEYID rows are permutations), so match on cube-id; type bits cross-check.
+                var ct = (Tet) currentEl;
+                int h = Constants.lengthAtLevel((byte) l);
+                for (int i = 0; i < TetreeConnectivity.CHILDREN_PER_TET; i++) {
+                    var c = ct.child(i);
+                    int childCb = ((c.x() & h) != 0 ? 1 : 0) | ((c.y() & h) != 0 ? 2 : 0)
+                                  | ((c.z() & h) != 0 ? 4 : 0);
+                    if (childCb == cb && c.type() == tb) {
+                        next = c;
+                        break;
+                    }
                 }
             }
             if (next == null) {

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeyCodec.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeyCodec.java
@@ -11,8 +11,9 @@ import com.hellblazer.luciferase.lucien.tetree.Tet;
 
 /**
  * Encoder from a hybrid SFC element to its {@link PyramidKey}: {@link #encode(Pyramid)} (RDR-010 pi1.4
- * Phase A, bead Luciferase-8zv) and {@link #encode(Tet)} for a shallowest tet leaf (RDR-010 pi1.5
- * Phase A, bead Luciferase-uqik). Both are the inverse of the canonical decoders on {@link PyramidIndex}
+ * Phase A, bead Luciferase-8zv) and {@link #encode(Tet)} for a pyramid-rooted tet leaf — shallowest
+ * (RDR-010 pi1.5 Phase A, bead Luciferase-uqik) or deep (RDR-010 cjwr Phase B). Both are the inverse of
+ * the canonical decoders on {@link PyramidIndex}
  * ({@link PyramidIndex#pyramidFromKey(PyramidKey)} / {@link PyramidIndex#elementFromKey(PyramidKey)}).
  *
  * <p>The encoder walks the pyramid's {@link Pyramid#parent()} chain to the root, collecting at each
@@ -98,35 +99,32 @@ final class PyramidKeyCodec {
     }
 
     /**
-     * Encode a <em>shallowest</em> tet leaf to its tet-leaf {@link PyramidKey}, or {@code null} if the
-     * tet is not a shallowest, reachable element of the pyramid SFC (RDR-010 pi1.5 Phase A, bead
-     * Luciferase-uqik). This is the bridge that lets {@code PyramidNeighborDetector} (Phase B) surface
-     * a pyramid's four triangular-face tet neighbors (and a tet leaf's own neighbors) as keys.
+     * Encode a pyramid-rooted tet leaf to its tet-leaf {@link PyramidKey}, or {@code null} if the tet is
+     * not a reachable element of the pyramid SFC (RDR-010 pi1.5 Phase A, bead Luciferase-uqik; deep tets
+     * RDR-010 cjwr Phase B). This is the bridge that lets {@code PyramidNeighborDetector} surface a
+     * pyramid's tet neighbors (and a tet leaf's own neighbors) as keys.
      *
-     * <p><b>Shallow boundary only.</b> A tet whose tetrahedral branch begins at its own level
-     * ({@code minTetLevel == level}) sits directly on a pyramid face — its parent is a pyramid
-     * (recoverable via {@link Tet#parentElement()}). A deeper pyramid-rooted tet
-     * ({@code minTetLevel < level}) or a pure-Tetree tet ({@code minTetLevel == -1}) is out of pi1.5
-     * scope and returns {@code null} (deep-tet cross-shape is the q3p Phase E deferral). The level-0
-     * root is a pyramid, never a tet → {@code null}.
+     * <p><b>Full depth.</b> Both a shallowest tet ({@code minTetLevel == level}, parent is a pyramid) and
+     * a deep pyramid-rooted tet ({@code minTetLevel < level}, a tet-of-tet refinement below the boundary)
+     * are encodable: the parent walk follows {@link Tet#parentElement()} through the tetrahedral branch
+     * and then the pyramid chain to the root. A pure-Tetree tet ({@code minTetLevel == -1}) has no
+     * pyramidal ancestor and returns {@code null}; so does the level-0 root (a pyramid, never a tet).
      *
-     * <p><b>Fail-safe contract.</b> Mirrors {@link #encode(Pyramid)}: the {@link Tet#parentElement()}
-     * walk may throw on a non-SFC candidate; that is caught and funneled to {@code null}. The internal
-     * round-trip self-check ({@code elementFromKey(key)} must recover the same tet geometry) is the
-     * single source of truth for validity, so a co-consistent bit error never emits a bogus key.
+     * <p><b>Fail-safe contract.</b> Mirrors {@link #encode(Pyramid)}: the parent walk may throw on a
+     * non-SFC candidate; that is caught and funneled to {@code null}. The internal round-trip self-check
+     * ({@code elementFromKey(key)} must recover the same tet geometry) is the single source of truth for
+     * validity, so a co-consistent bit error never emits a bogus key.
      *
      * @param t the tetrahedron element
-     * @return the round-trip-verified tet-leaf key, or {@code null} for a non-shallowest / non-SFC tet
+     * @return the round-trip-verified tet-leaf key, or {@code null} for a pure-Tetree / non-SFC tet
      */
     static PyramidKey encode(Tet t) {
         byte level = t.level();
         if (level < 1) {
             return null; // the level-0 root is the pyramid cover, not a tet
         }
-        if (t.minTetLevel() != level) {
-            // Only the shallowest tet of a pyramidal branch (parent is a pyramid) is in pi1.5 scope.
-            // Deeper pyramid-rooted tets and pure-Tetree tets (minTetLevel == -1) are not SFC pyramid
-            // leaves the codec can bridge — reject up front (fail-safe, no throw).
+        if (t.minTetLevel() == Tet.NO_TET_ANCESTOR) {
+            // A pure-Tetree tet has no pyramidal ancestor — it is not an element of the pyramid SFC.
             return null;
         }
         // coordBits/typeBits indexed by refinement step 1..level (index 0 unused; root has no bits).
@@ -138,13 +136,10 @@ final class PyramidKeyCodec {
                          | ((t.z() & hLeaf) != 0 ? 4 : 0);
         typeBits[level] = t.type();
         try {
-            // The shallowest tet's parent is the pyramid that birthed it (Tet.parentElement, the
-            // minTetLevel == level branch). Walk that pyramid chain to the root for the coarser bits.
-            HybridElement parent = t.parentElement();
-            if (!(parent instanceof Pyramid pyramidParent)) {
-                return null; // defensive: a shallowest tet must have a pyramid parent
-            }
-            Pyramid cur = pyramidParent;
+            // Walk the ancestor chain to the root collecting coarser bits. Through the tetrahedral branch
+            // (levels > minTetLevel) the parent is a Tet; at the boundary Tet.parentElement returns the
+            // birthing Pyramid, and above that the pure pyramid chain continues to the root.
+            HybridElement cur = t.parentElement();
             for (int l = level - 1; l >= 1; l--) {
                 int h = Constants.lengthAtLevel((byte) l);
                 coordBits[l] = ((cur.x() & h) != 0 ? 1 : 0)
@@ -152,7 +147,7 @@ final class PyramidKeyCodec {
                              | ((cur.z() & h) != 0 ? 4 : 0);
                 typeBits[l] = cur.type();
                 if (l > 1) {
-                    cur = cur.parent();
+                    cur = (cur instanceof Tet ct) ? ct.parentElement() : ((Pyramid) cur).parent();
                 }
             }
             PyramidKey key = PyramidKey.fromLevels(level, coordBits, typeBits);

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborDetector.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborDetector.java
@@ -46,11 +46,12 @@ import java.util.Set;
  * reciprocity-validatable face topology (the {@link HybridFaceNeighbor#face()} reciprocal index), not a
  * shared-vertex heuristic.
  *
- * <p><b>Shallow boundary only.</b> Cross-shape descends to the shallowest pyramid↔tet boundary
- * ({@code l == minTetLevel}). A deep pyramid-rooted tet ({@code l > minTetLevel}) trips
- * {@link Tet#faceNeighborElement}'s fail-loud guard (RDR-010 Finding #16, deferred to q3p Phase E);
- * the detector <em>catches and skips</em> that face rather than propagating — a thrown exception would
- * break the BFS in {@code KnnSearcher}/{@code CollisionEngine}.
+ * <p><b>Face neighbors: full depth.</b> {@link Tet#faceNeighborElement} resolves both the shallowest
+ * pyramid↔tet boundary ({@code l == minTetLevel}) and deep pyramid-rooted tets ({@code l > minTetLevel})
+ * via the t8code {@code t8_dpyramid_tet_boundary} corner-walk (RDR-010 Luciferase-cjwr). Until
+ * {@link PyramidKeyCodec#encode(Tet)} accepts deep tets (cjwr Phase B) the detector only ever holds
+ * shallow tet keys, so deep tets are not yet reachable as a query here — but the face topology itself
+ * is no longer depth-limited.
  *
  * <p><b>Edge/vertex — bounded cumulative supersets (pi1.5).</b> Edge and vertex add the same-shape
  * (pyramid↔pyramid) geometric neighbors at shared-vertex thresholds 2 and 1 (the 27-cube enumeration
@@ -115,9 +116,9 @@ public final class PyramidNeighborDetector implements NeighborDetector<PyramidKe
     /**
      * The exact conforming face neighbors of {@code element}'s leaf, as keys. Resolves the leaf via
      * {@link PyramidIndex#elementFromKey} (a {@link Pyramid} or a shallowest {@link Tet}) and walks
-     * {@link Pyramid#faceNeighbor(int)} / {@link Tet#faceNeighborElement(int)}. A deep pyramid-rooted
-     * tet's fail-loud guard is caught and that face skipped (BFS-safe; deep cross-shape deferred to q3p
-     * Phase E). Out-of-domain / non-SFC neighbors encode to {@code null} and are dropped.
+     * {@link Pyramid#faceNeighbor(int)} / {@link Tet#faceNeighborElement(int)} (deep pyramid-rooted tets
+     * resolved via the cjwr corner-walk). Out-of-domain / non-SFC neighbors encode to {@code null} and
+     * are dropped.
      */
     private Set<PyramidKey> crossShapeFaceNeighbors(PyramidKey element) {
         HybridElement self = PyramidIndex.elementFromKey(element);
@@ -133,18 +134,10 @@ public final class PyramidNeighborDetector implements NeighborDetector<PyramidKe
             }
         } else if (self instanceof Tet t) {
             for (int f = 0; f < 4; f++) {
-                HybridFaceNeighbor fn;
-                try {
-                    fn = t.faceNeighborElement(f);
-                } catch (IllegalStateException deepTet) {
-                    // Defensive: a deep pyramid-rooted tet (l > minTetLevel) trips Tet.faceNeighborElement's
-                    // fail-loud guard (RDR-010 Finding #16, q3p Phase E). In practice this is unreachable
-                    // via a key — encode(Tet) rejects deep tets and elementFromKey cannot reconstruct one,
-                    // so `self` here is always a SHALLOW tet (l == minTetLevel). The catch guards against
-                    // future change: propagating would break the BFS in KnnSearcher/CollisionEngine.
-                    continue;
-                }
-                addFaceNeighbor(fn, element, out);
+                // faceNeighborElement now resolves deep pyramid-rooted tets too (RDR-010 Luciferase-cjwr,
+                // t8code t8_dpyramid_tet_boundary corner-walk); no fail-loud guard to catch. In practice
+                // `self` is still a shallow tet here until encode(Tet) accepts deep tets (cjwr Phase B).
+                addFaceNeighbor(t.faceNeighborElement(f), element, out);
             }
         }
         return out;

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborDetector.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborDetector.java
@@ -48,10 +48,10 @@ import java.util.Set;
  *
  * <p><b>Face neighbors: full depth.</b> {@link Tet#faceNeighborElement} resolves both the shallowest
  * pyramid↔tet boundary ({@code l == minTetLevel}) and deep pyramid-rooted tets ({@code l > minTetLevel})
- * via the t8code {@code t8_dpyramid_tet_boundary} corner-walk (RDR-010 Luciferase-cjwr). Until
- * {@link PyramidKeyCodec#encode(Tet)} accepts deep tets (cjwr Phase B) the detector only ever holds
- * shallow tet keys, so deep tets are not yet reachable as a query here — but the face topology itself
- * is no longer depth-limited.
+ * via the t8code {@code t8_dpyramid_tet_boundary} corner-walk (RDR-010 Luciferase-cjwr). The codec
+ * round-trips deep tet keys too (cjwr Phase B); in practice the detector still only holds shallow tet
+ * keys because the index locate primitive stops at the shallowest tet leaf (deep tet keys are not
+ * inserted until that primitive is extended) — but the face topology itself is no longer depth-limited.
  *
  * <p><b>Edge/vertex — bounded cumulative supersets (pi1.5).</b> Edge and vertex add the same-shape
  * (pyramid↔pyramid) geometric neighbors at shared-vertex thresholds 2 and 1 (the 27-cube enumeration
@@ -136,7 +136,8 @@ public final class PyramidNeighborDetector implements NeighborDetector<PyramidKe
             for (int f = 0; f < 4; f++) {
                 // faceNeighborElement now resolves deep pyramid-rooted tets too (RDR-010 Luciferase-cjwr,
                 // t8code t8_dpyramid_tet_boundary corner-walk); no fail-loud guard to catch. In practice
-                // `self` is still a shallow tet here until encode(Tet) accepts deep tets (cjwr Phase B).
+                // `self` is still a shallow tet here because the index locate primitive stops at the
+                // shallowest tet leaf, so deep tet keys are not inserted into the index.
                 addFaceNeighbor(t.faceNeighborElement(f), element, out);
             }
         }

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/Tet.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/Tet.java
@@ -1800,6 +1800,13 @@ public class Tet implements Spatial.aabt, HybridElement {
      * {@link Pyramid} neighbor; all other faces (and all faces of types 1,2,4,5) yield a tetrahedral
      * neighbor with {@code minTetLevel} propagated.
      *
+     * <p><b>Depth.</b> Both the shallowest pyramid-rooted tet ({@code l == minTetLevel}) and deep ones
+     * ({@code l > minTetLevel}) are resolved via {@link #tetBoundary(int)} (RDR-010 Luciferase-cjwr). The
+     * deep path is reached <em>in production</em> only once {@link
+     * com.hellblazer.luciferase.lucien.pyramid.PyramidKeyCodec#encode(Tet)} accepts deep tets (cjwr
+     * Phase B); until then a deep tet is not constructible from a key, so this path is exercised by tests
+     * (and by direct {@link #child(int)} refinement) only.
+     *
      * @param face face index, 0..3
      * @return the face neighbor (tetrahedron or pyramid) with its reciprocal face, or {@code null} if
      *         the neighbor lies outside the domain
@@ -1810,18 +1817,10 @@ public class Tet implements Spatial.aabt, HybridElement {
         // logic applies directly with no type translation. Only types 0 and 3 ever touch a pyramid.
         byte t8 = type;
         boolean pyramidCapable = minTetLevel != NO_TET_ANCESTOR && (t8 == 0 || t8 == 3);
-        if (pyramidCapable && l > minTetLevel) {
-            // Deep pyramid-rooted tet: the deep pyramid-boundary connectivity (t8code's multi-level
-            // corner-walk tables) is not yet ported, so deep-tet pyramid face neighbors are not yet
-            // computed. Fail loud rather than return a wrong neighbor. The shallowest tet
-            // (l == minTetLevel) is fully supported. Deep enablement: RDR-010 q3p Phase E / pi1.5.
-            throw new IllegalStateException(
-            "Deep pyramid-rooted tetrahedron (level " + l + " > minTetLevel " + minTetLevel
-            + ") face neighbors are not yet supported: deep pyramid-boundary connectivity not yet "
-            + "ported (RDR-010 q3p Phase E).");
-        }
         // Pure-Tetree or a type that never touches a pyramid, or a face that does not: tet neighbor.
-        if (!pyramidCapable || !tetTouchesPyramid(face)) {
+        // tetBoundary handles both the shallowest tet (l == minTetLevel) and deep pyramid-rooted tets
+        // (l > minTetLevel) via the t8code corner-walk (RDR-010 Luciferase-cjwr).
+        if (!pyramidCapable || !tetBoundary(face)) {
             var fn = faceNeighbor(face);
             if (fn == null) {
                 return null;
@@ -1885,16 +1884,45 @@ public class Tet implements Spatial.aabt, HybridElement {
     }
 
     /**
-     * Whether this shallowest pyramid-rooted tet's {@code face} touches the bounding pyramid envelope
-     * (t8code {@code t8_dpyramid_tet_pyra_face_connection}). Only valid for {@code l == minTetLevel}
-     * (the pyramid's direct tet child); {@link #faceNeighborElement(int)} guards deeper tets, whose
-     * boundary detection is deferred (RDR-010 q3p Phase E). The receiver's {@code type} is already a
-     * t8code dtet type (Luciferase-4pd alignment), so no translation is needed.
+     * Whether this pyramid-rooted tet's {@code face} touches the bounding pyramid envelope — the deep
+     * boundary test, a direct port of t8code {@code t8_dpyramid_tet_boundary} (RDR-010 Luciferase-cjwr).
+     * Handles both the shallowest tet ({@code l == minTetLevel}, where it reduces to
+     * {@code t8_dpyramid_tet_pyra_face_connection}) and deep pyramid-rooted tets ({@code l > minTetLevel}).
+     *
+     * <p>For a deep tet the connection is valid only when (a) the shallowest tet ancestor's same face
+     * connects to a pyramid AND (b) the tet hugs that face's corner at every refinement level down to
+     * the ancestor — otherwise the neighbor across the face is another tet. The receiver's {@code type}
+     * is already a t8code dtet type (Luciferase-4pd alignment), so no translation is needed.
+     *
+     * @param face triangular face index 0..3 (type-0/3 tets only; the caller guards type)
      */
-    private boolean tetTouchesPyramid(int face) {
-        assert l == minTetLevel : "tetTouchesPyramid is only valid for the shallowest tet; deeper "
-                                  + "tets are guarded in faceNeighborElement (RDR-010 q3p Phase E)";
-        return tetPyraFaceConnection(type, cubeIdAt(l), face);
+    private boolean tetBoundary(int face) {
+        // Shallowest tet: its parent is the pyramid, so the connection is the direct face test.
+        if (l == minTetLevel) {
+            return tetPyraFaceConnection(type, cubeIdAt(l), face);
+        }
+        // Deep tet: walk the type up to the shallowest ancestor (at minTetLevel), then test that
+        // ancestor's face against the pyramid (t8_dpyramid_tet_boundary: anc = ancestor at switch level).
+        byte ancType = type;
+        for (int i = l; i > minTetLevel; i--) {
+            ancType = TetreeConnectivity.CID_TYPE_TO_PARENTTYPE[cubeIdAt((byte) i)][ancType];
+        }
+        boolean validTouch = tetPyraFaceConnection(ancType, cubeIdAt((byte) minTetLevel), face);
+        if (!validTouch) {
+            return false;
+        }
+        // Corner-walk: the tet must lie in the pyramid-face corner at every level i in (minTetLevel, l].
+        // If at any level the Bey child is not "inside" that face, the neighbor is a tet, not the pyramid.
+        byte typeTemp = type;
+        for (int i = l; i > minTetLevel; i--) {
+            int cubeId = cubeIdAt((byte) i);
+            int beyId = TetreeConnectivity.TYPE_CID_TO_BEYID[typeTemp][cubeId];
+            if (TetreeConnectivity.FACE_CHILDID_TO_IS_INSIDE[face][beyId] == -1) {
+                return false;
+            }
+            typeTemp = TetreeConnectivity.CID_TYPE_TO_PARENTTYPE[cubeId][typeTemp];
+        }
+        return true;
     }
 
     /**

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeConnectivity.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeConnectivity.java
@@ -127,12 +127,24 @@ public final class TetreeConnectivity {
      * used to walk a tet's type up the refinement tree (RDR-010 q3p face-neighbor ancestor walk).
      * {@code [cubeId][type]}. Verified against t8code {@code t8_dtet_cid_type_to_parenttype}.
      */
-    // The deep-tet face-boundary walk tables (t8code t8_dtet_cid_type_to_parenttype and
-    // t8_dpyramid_face_childid_to_is_inside) were removed in RDR-010 q3p Phase D: Luciferase's S0-S5
-    // Bey subdivision diverges from t8code's dtet tree below the pyramid boundary (Finding #16), so
-    // those t8code-tree tables do not apply to Luciferase's deep tets; faceNeighborElement guards the
-    // deep case fail-loud. They must be re-derived (or t8code dtet subdivision adopted under pyramids)
-    // by the tet-tree reconciliation RDR before deep-tet pyramid face neighbors can be supported.
+    /**
+     * Whether a deep pyramid-rooted tet hugs the pyramid-face corner at refinement level i, indexed
+     * {@code [face][beyId]} — t8code {@code t8_dpyramid_face_childid_to_is_inside}, verbatim. A value of
+     * {@code -1} means the child does NOT lie in the corner at this face (so the deep tet's face neighbor
+     * is a tet, not the bounding pyramid); {@code 0} means it stays in the corner and the corner-walk
+     * continues. Used by {@link Tet#faceNeighborElement(int)}'s deep boundary test (port of t8code
+     * {@code t8_dpyramid_tet_boundary}). RDR-010 Luciferase-cjwr — restored after q3p Phase D removed it
+     * on the (now-stale, pre-4pd) premise that the t8code deep tables did not apply to Luciferase tets.
+     * <p>Scope of validation: the dtet table <em>values</em> this walk consumes ({@link #TYPE_CID_TO_BEYID},
+     * {@link #CID_TYPE_TO_PARENTTYPE}) are oracle-verified by {@code T8codeDtetOracleTest} (Luciferase tet
+     * type k IS t8code dtet type k). The {@code tetBoundary} corner-walk <em>algorithm</em> that uses this
+     * table is first validated by {@code HybridFaceNeighborTest} (Phase A), not by that oracle.
+     */
+    public static final int[][] FACE_CHILDID_TO_IS_INSIDE = {
+    { -1, 0, 0, 0, -1, -1, -1, -1 },
+    { 0, -1, 0, 0, -1, -1, -1, -1 },
+    { 0, 0, -1, 0, -1, -1, -1, -1 },
+    { 0, 0, 0, -1, -1, -1, -1, -1 } };
 
     /**
      * Parent type by (child cube-id, child type) — t8code's {@code t8_dtet_cid_type_to_parenttype}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/HybridFaceNeighborTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/HybridFaceNeighborTest.java
@@ -168,34 +168,74 @@ class HybridFaceNeighborTest {
     }
 
     @Test
-    void deepPyramidRootedTetFaceNeighborFailsLoud() {
-        // A deep pyramid-rooted tet (level > minTetLevel) of pyramid-capable type cannot have its
-        // pyramid-boundary faces resolved: Luciferase's Bey subdivision diverges from t8code's dtet
-        // tree below the pyramid boundary (RDR-010 Finding #16), so faceNeighborElement fails loud
-        // rather than returning a silently-wrong neighbor. (The prior geometric ">=3 shared vertices"
-        // test was invalid: Luciferase's non-conforming SFC face neighbors share 0-3 vertices.)
-        var l = Constants.lengthAtLevel(LEVEL);
-        var checked = 0;
+    void deepPyramidRootedTetFaceNeighborsAreConformingAndReciprocal() {
+        // RDR-010 Luciferase-cjwr: deep pyramid-rooted tets (level > minTetLevel) now resolve their
+        // pyramid-boundary faces via the ported t8code t8_dpyramid_tet_boundary corner-walk. Validation
+        // is table-INDEPENDENT: when faceNeighborElement returns a Pyramid, the abutting face is a
+        // conforming triangle, so the deep tet and the pyramid share exactly the 3 face vertices; and the
+        // pyramid's reciprocal-face neighbor (computed by the separate Pyramid.faceNeighbor pi1.5 code
+        // path) must geometrically be this same deep tet (cross-implementation involution).
+        var counts = new int[2]; // [0] = pyramid returns, [1] = tet returns
+        var depths = new HashSet<Integer>();
         for (var type : new byte[] { Pyramid.TYPE_6, Pyramid.TYPE_7 }) {
-            var p = new Pyramid(4 * l, 4 * l, 4 * l, LEVEL, type);
+            // Anchor deep enough that 3 extra refinement levels stay in-domain.
+            var l3 = Constants.lengthAtLevel((byte) (LEVEL + 3));
+            var p = new Pyramid(4 * l3, 4 * l3, 4 * l3, LEVEL, type);
             for (var i = 0; i < 10; i++) {
-                if (!(p.child(i) instanceof Tet shallow)) {
-                    continue;
-                }
-                for (var k = 0; k < 8; k++) {
-                    var deep = shallow.child(k); // minTetLevel == shallow.level < deep.level
-                    assertTrue(deep.minTetLevel() < deep.l, "deep tet: minTetLevel < level");
-                    if (deep.type != 0 && deep.type != 3) {
-                        continue; // only pyramid-capable types (t8code 0/3 == Luciferase 0/3) hit the guard
-                    }
-                    var d = deep;
-                    assertThrows(IllegalStateException.class, () -> d.faceNeighborElement(0),
-                                 "deep pyramid-capable tet must fail loud (type " + type + ")");
-                    checked++;
+                if (p.child(i) instanceof Tet shallow) {
+                    // Recurse up to 3 levels below the shallow tet → corner-walk of 1..3 iterations.
+                    checkDeepTet(shallow, shallow, 3, counts, depths);
                 }
             }
         }
-        assertTrue(checked > 0, "must exercise at least one deep pyramid-capable tet");
+        // Non-vacuity AND discrimination: the corner-walk must classify some deep faces as pyramid-bound
+        // and some as tet-bound — proving it is not trivially returning one branch.
+        // NOTE (cjwr Phase A scope): the pyramid-return branch is double-validated (conforming 3-vertex +
+        // cross-path involution), so a false-POSITIVE cannot survive. The tet-return branch is only
+        // counted, so a partial false-NEGATIVE (a face wrongly classified tet-bound) is not fully excluded
+        // here — that gap is closed in Phase C by a face-by-face comparison against the independent t8code
+        // port of t8_dpyramid_tet_boundary in the extended whole-domain oracle (substantive-critic SIG-2).
+        assertTrue(counts[0] > 0, "deep tets must surface pyramid face neighbors (got 0)");
+        assertTrue(counts[1] > 0, "deep tets must also have tet face neighbors (corner-walk discriminates)");
+        // Exercised more than a single refinement level (multi-iteration corner-walk + type propagation).
+        assertTrue(depths.size() >= 2, "must exercise deep tets at multiple levels, got depths " + depths);
+    }
+
+    /**
+     * Recurse {@code remainingDepth} levels below a shallow tet, validating every pyramid-capable (type
+     * 0/3) deep tet. The DFS over both pyramid types' 10 children, refined 3 levels, reliably yields deep
+     * tets whose corner-walk classifies some faces pyramid-bound and others tet-bound — so the caller's
+     * {@code counts[1] > 0} (tet-return) discrimination assertion is satisfied across the swept anchors.
+     */
+    private void checkDeepTet(Tet shallow, Tet current, int remainingDepth, int[] counts, HashSet<Integer> depths) {
+        if (current.l > shallow.l && (current.type == 0 || current.type == 3)) {
+            depths.add(current.l - shallow.l);
+            for (var face = 0; face < 4; face++) {
+                var hfn = current.faceNeighborElement(face);
+                if (hfn == null) {
+                    continue;
+                }
+                if (hfn.element() instanceof Pyramid pyr) {
+                    counts[0]++;
+                    // Geometric ground truth: conforming triangular face → exactly 3 shared vertices.
+                    assertEquals(3, sharedVertices(current, pyr),
+                                 "deep tet↔pyramid face " + face + " must share the 3 face vertices");
+                    // Cross-implementation involution: the pyramid's reciprocal-face neighbor (the separate
+                    // Pyramid.faceNeighbor pi1.5 path) is this deep tet (vertex set — minTetLevel is metadata).
+                    var back = pyr.faceNeighbor(hfn.face());
+                    assertNotNull(back, "pyramid reciprocal neighbor exists");
+                    assertEquals(vertexSet(current), vertexSet(back.element()),
+                                 "involution: pyramid.faceNeighbor(reciprocal) is the deep tet");
+                } else {
+                    counts[1]++;
+                }
+            }
+        }
+        if (remainingDepth > 0) {
+            for (var k = 0; k < 8; k++) {
+                checkDeepTet(shallow, current.child(k), remainingDepth - 1, counts, depths);
+            }
+        }
     }
 
     @Test

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeyCodecTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidKeyCodecTest.java
@@ -8,6 +8,7 @@ package com.hellblazer.luciferase.lucien.pyramid;
 import com.hellblazer.luciferase.lucien.Constants;
 import com.hellblazer.luciferase.lucien.HybridElement;
 import com.hellblazer.luciferase.lucien.tetree.Tet;
+import com.hellblazer.luciferase.lucien.tetree.TetreeConnectivity;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -15,6 +16,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -30,8 +32,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *   <li><b>decode∘encode == identity</b> for every valid SFC pyramid (types 6 and 7, multiple levels).</li>
  *   <li><b>encode∘decode == identity</b> (key-side bijection).</li>
  *   <li><b>non-SFC / unreachable candidate → null</b> with no exception on the hot path.</li>
- *   <li><b>shallowest tet leaf round-trips</b> via {@code encode(Tet)} / {@code elementFromKey}; deeper
- *       or pure-Tetree tets → null (deep-tet cross-shape deferred to q3p Phase E).</li>
+ *   <li><b>pyramid-rooted tet leaves round-trip</b> via {@code encode(Tet)} / {@code elementFromKey} —
+ *       both shallowest ({@code minTetLevel == level}) and deep ({@code minTetLevel < level}) tets
+ *       (RDR-010 cjwr Phase B); a pure-Tetree tet ({@code minTetLevel == -1}) → null.</li>
  * </ul>
  *
  * @author hal.hildebrand
@@ -209,20 +212,116 @@ class PyramidKeyCodecTest {
     }
 
     /**
-     * Only the SHALLOWEST tet of a pyramidal branch (minTetLevel == level) is in pi1.5 scope. A deeper
-     * pyramid-rooted tet (minTetLevel &lt; level) and a pure-Tetree tet (minTetLevel == -1) both encode
-     * to null — fail-safe, never a throw, never a bogus key. Deep-tet cross-shape is deferred (q3p
-     * Phase E, fail-loud guarded).
+     * A pure-Tetree tet (minTetLevel == -1) has no pyramidal ancestor, so it is not an element of the
+     * pyramid SFC and encodes to {@code null} — fail-safe, never a throw.
      */
     @Test
-    void deepOrPureTetEncodesToNull() {
+    void pureTetEncodesToNull() {
         int h2 = Constants.lengthAtLevel((byte) 2);
-        // Deep pyramid-rooted tet: level 2 but the tet branch began at level 1.
-        var deep = new Tet(h2, 0, 0, (byte) 2, (byte) 3, (byte) 1);
-        assertNull(PyramidKeyCodec.encode(deep), "deeper-than-shallowest tet must encode to null");
-        // Pure-Tetree tet (no pyramid ancestor).
         var pure = new Tet(h2, 0, 0, (byte) 2, (byte) 0, (byte) -1); // minTetLevel -1 = pure-Tetree
         assertNull(PyramidKeyCodec.encode(pure), "pure-Tetree tet must encode to null");
+    }
+
+    /**
+     * Deep pyramid-rooted tets (minTetLevel &lt; level, a tet-of-tet refinement below the boundary) now
+     * round-trip through {@code encode(Tet)} / {@code elementFromKey} (RDR-010 cjwr Phase B). Generated
+     * via the real child chain (pyramid → shallowest tet → deeper tets) so every tet is a genuine SFC
+     * element. Distinct deep tets must yield distinct keys.
+     */
+    @Test
+    void deepTetRoundTrips() {
+        var seen = new java.util.HashMap<PyramidKey, Tet>();
+        var checked = 0;
+        // Arm 1: shallowest tets at level 2 (minTetLevel == 2), refined 2 more levels.
+        for (var rootType : new byte[] { Pyramid.TYPE_6, Pyramid.TYPE_7 }) {
+            var root = new Pyramid(0, 0, 0, (byte) 1, rootType);
+            for (var i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
+                if (!(root.child(i) instanceof Tet shallow)) {
+                    continue; // shallowest tet (minTetLevel == its level == 2)
+                }
+                checked += roundTripDeep(shallow, shallow, 2, seen);
+            }
+        }
+        // Arm 2: shallowest tets at level 1 (minTetLevel == 1) — the distinct l=1 boundary code path
+        // (encode/decode handle the level-1 group as a TET type, not a pyramid type). Refine 1 level.
+        for (var rootType : new byte[] { Pyramid.TYPE_6, Pyramid.TYPE_7 }) {
+            var root0 = new Pyramid(0, 0, 0, (byte) 0, rootType);
+            for (var i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
+                if (!(root0.child(i) instanceof Tet shallow1)) {
+                    continue; // shallowest tet at level 1 (minTetLevel == 1)
+                }
+                checked += roundTripDeep(shallow1, shallow1, 1, seen);
+            }
+        }
+        assertTrue(checked > 0, "must exercise deep pyramid-rooted tets");
+    }
+
+    /** Recurse {@code remainingDepth} below a shallowest tet, asserting each deep tet round-trips. */
+    private int roundTripDeep(Tet shallow, Tet current, int remainingDepth, java.util.Map<PyramidKey, Tet> seen) {
+        var count = 0;
+        if (current.l > shallow.l) {
+            var key = PyramidKeyCodec.encode(current);
+            assertNotNull(key, "deep tet must encode (level " + current.l + ", minTetLevel "
+                               + current.minTetLevel() + ", type " + current.type() + ")");
+            var prior = seen.put(key, current);
+            assertNull(prior, "distinct deep tets must yield distinct keys: " + current + " vs " + prior);
+            var decoded = PyramidIndex.elementFromKey(key);
+            assertInstanceOf(Tet.class, decoded, "deep tet key decodes to a Tet");
+            var dt = (Tet) decoded;
+            assertEquals(current.x(), dt.x(), "deep round-trip x");
+            assertEquals(current.y(), dt.y(), "deep round-trip y");
+            assertEquals(current.z(), dt.z(), "deep round-trip z");
+            assertEquals(current.level(), dt.level(), "deep round-trip level");
+            assertEquals(current.type(), dt.type(), "deep round-trip type");
+            assertEquals(current.minTetLevel(), dt.minTetLevel(), "deep round-trip minTetLevel");
+            count++;
+        }
+        if (remainingDepth > 0) {
+            for (var k = 0; k < TetreeConnectivity.CHILDREN_PER_TET; k++) {
+                count += roundTripDeep(shallow, current.child(k), remainingDepth - 1, seen);
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Independent bit-value oracle for a DEEP tet-leaf key (RDR-010 cjwr Phase B; parallels the 0utt
+     * SIG-3 golden-key discipline). Defends against a co-evolved error in {@code encode(Tet)} +
+     * {@code elementFromKey} (e.g. a wrong {@code lengthAtLevel}) that would still round-trip
+     * self-consistently. The per-level coord/type bits are derived from the leaf and its shallowest-tet
+     * ancestor using <em>literal</em> level lengths ({@code 1 << (21 - l)}) — independent of
+     * {@code Constants.lengthAtLevel} — and compared against the key's long-unpacking accessors.
+     */
+    @Test
+    void goldenDeepTetKeyBitsIndependentOfLengthAtLevel() {
+        // A deep tet: a level-1 shallowest tet (minTetLevel 1) refined once via Bey child 0.
+        var root6 = new Pyramid(0, 0, 0, (byte) 0, Pyramid.TYPE_6);
+        Tet shallow1 = null;
+        for (var i = 0; i < TetreeConnectivity.CHILDREN_PER_PYRAMID; i++) {
+            if (root6.child(i) instanceof Tet t) {
+                shallow1 = t;
+                break;
+            }
+        }
+        assertNotNull(shallow1, "root6 has a tet child");
+        assertEquals(1, shallow1.minTetLevel(), "shallowest tet at level 1");
+        var deep2 = (Tet) shallow1.child(0); // level 2, minTetLevel 1 (deep)
+        assertEquals(2, deep2.level());
+        assertEquals(1, deep2.minTetLevel(), "deep tet keeps the level-1 boundary");
+
+        var key = PyramidKeyCodec.encode(deep2);
+        assertNotNull(key, "deep tet encodes");
+
+        final int h1 = 1 << (21 - 1); // == lengthAtLevel(1), literal — independent of Constants
+        final int h2 = 1 << (21 - 2); // == lengthAtLevel(2)
+        int expectCb1 = ((shallow1.x() & h1) != 0 ? 1 : 0) | ((shallow1.y() & h1) != 0 ? 2 : 0)
+                        | ((shallow1.z() & h1) != 0 ? 4 : 0);
+        int expectCb2 = ((deep2.x() & h2) != 0 ? 1 : 0) | ((deep2.y() & h2) != 0 ? 2 : 0)
+                        | ((deep2.z() & h2) != 0 ? 4 : 0);
+        assertEquals(expectCb1, key.getCoordBitsAtLevel(1), "level-1 coord bits");
+        assertEquals(shallow1.type(), key.getTypeAtLevel(1), "level-1 type bits (shallowest tet type)");
+        assertEquals(expectCb2, key.getCoordBitsAtLevel(2), "level-2 coord bits");
+        assertEquals(deep2.type(), key.getTypeAtLevel(2), "level-2 type bits (deep tet type)");
     }
 
     /**

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborDetectorTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/pyramid/PyramidNeighborDetectorTest.java
@@ -391,8 +391,8 @@ class PyramidNeighborDetectorTest {
         // The detector must never propagate an exception (a throw would break KnnSearcher/CollisionEngine
         // BFS). A level-2 shallow tet leaf exercises the tet-leaf navigation path. Note: a DEEP tet
         // (l > minTetLevel) is unreachable as a key by construction — encode(Tet) returns null for it
-        // and elementFromKey cannot reconstruct it — so Tet.faceNeighborElement's fail-loud guard is
-        // never actually reached through a key; the detector's catch is defensive against future change.
+        // and elementFromKey cannot reconstruct it (until cjwr Phase B). Tet.faceNeighborElement no
+        // longer fails loud for deep tets either (RDR-010 Luciferase-cjwr), so there is no throw to catch.
         var p1 = new Pyramid(0, 0, 0, (byte) 1, Pyramid.TYPE_6);
         var tet2 = (Tet) p1.child(1);               // shallow level-2 tet (minTetLevel == level == 2)
         var tetKey = PyramidKeyCodec.encode(tet2);


### PR DESCRIPTION
## Summary
Closes **Luciferase-cjwr** (Phases A+B). Resolves the deep pyramid-rooted tet (`l > minTetLevel`) cross-shape **face** topology and makes deep tets reachable as SFC keys — the deferred remainder of q3p Phase E / Finding #16.

**The actual blocker was never a geometric divergence** — it was that the t8code dpyramid source had never been fetched. 4pd already made Luciferase tet type k == t8code dtet type k (oracle-verified), so the t8code deep tables apply directly. Fetched `~/git/t8code origin/main` and ported.

### Phase A — deep `faceNeighborElement`
- `TetreeConnectivity`: restored `FACE_CHILDID_TO_IS_INSIDE[4][8]` (t8code verbatim); rewrote the stale table-removal comment.
- `Tet`: replaced the `l > minTetLevel` fail-loud throw with a unified `tetBoundary(face)` — a direct port of `t8_dpyramid_tet_boundary` (shallow → `tet_pyra_face_connection`; deep → ancestor valid-touch + corner-walk). Pyramid-neighbor construction unchanged.
- `PyramidNeighborDetector`: removed the now-dead try/catch.
- Validation (table-independent): conforming-face geometry (shared==3) + cross-implementation involution via the separate `Pyramid.faceNeighbor` path, multi-level DFS.

### Phase B — deep encode/decode
- `encode(Tet)` accepts deep tets (rejects only pure-Tetree); generalized ancestor-bit walk through the tet branch then pyramid chain.
- `elementFromKey` descends `Tet.child` edges in the tetrahedral branch (Bey child matched by cube-id, `minTetLevel` inherited).
- Validation: deep round-trip (minTetLevel 1 & 2 arms, distinct keys, full geometry) + a golden bit oracle independent of `encode` and `Constants.lengthAtLevel`.

## Scope / follow-ons
A+B deliver deep face + deep keys. **Deep edge/vertex** (via `allShapeNeighbors`) is split to **Luciferase-2l04**, blocked on the 0utt merge (`allShapeNeighbors` is not on main yet). A+B are machinery until a locate-deep-tet primitive (Phase D) inserts deep keys — registered.

## Review
code-review-expert APPROVED both phases (0 crit/high; t8code port fidelity verified loop/table/cubeId; Bey (cubeId,type) uniqueness; minTetLevel-by-construction; capacity; blast radius). substantive-critic 0-crit across both; findings addressed (Phase A: oracle-scope comment narrowed, Phase B dependency registered, SIG-2 false-negative gap registered to 2l04; Phase B: golden bit oracle added, minTetLevel=1 arm added, scope retitle). Full lucien green **2745/0**.