### PR TITLE
RDR-010: close (implemented) + post-mortem

### DIFF
--- a/docs/rdr/RDR-010-pyramid-spatial-index.md
+++ b/docs/rdr/RDR-010-pyramid-spatial-index.md
@@ -2,16 +2,36 @@
 title: "Pyramid Spatial Index — Close the Hybrid Hex↔Tet Partition Gap"
 id: RDR-010
 type: Architecture
-status: accepted
+status: implemented
 priority: medium
 author: hal.hildebrand
 reviewed-by: self
 created: 2026-05-28
 accepted_date: 2026-05-28
+closed_date: 2026-05-31
 related_issues: [Luciferase-pi1, RDR-001, RDR-002, RDR-008, RDR-009]
 ---
 
 # RDR-010: Pyramid Spatial Index — Close the Hybrid Hex↔Tet Partition Gap
+
+## Close (implemented — 2026-05-31)
+
+**Status: implemented / closed.** The hybrid hex↔tet partition gap is closed by the pyramid construction (Knapp 2026). Shipped: `PyramidIndex` + `PyramidKey` (6D-Morton SFC, 128-bit), §3b decompose-and-reuse containment, all 17 `AbstractSpatialIndex` abstract methods, cross-shape pyramid↔tet neighbor finding, distributed ghost wiring, shape-aware Forest partition weights `N(ℓ)=2·8^ℓ−6^ℓ` + Alg-5.1 partitioner + `TwoOneBalanceChecker` shape-router, and forest lifecycle event coherence (`TreeAdded`/`TreesMerged`/`TreeRemoved`).
+
+**Divergence from Finding #16 — deep-tet cross-shape was NOT RDR-scoped after all.** Finding #16 (below) recorded the deep pyramid-rooted tet path (`l > minTetLevel`) as fail-loud-guarded and *blocked pending a separate tet-tree-reconciliation RDR*, on the premise that Luciferase's Bey subdivision is a geometrically different tree from t8code's dtet below the boundary. **That premise was superseded by Luciferase-4pd**, which aligned Luciferase tet type `k` to t8code dtet type `k` (subdivision now matches t8code exactly — `T8codeDtetOracleTest`). With the trees aligned, the t8code deep tables apply directly; the real blocker was only that the t8code dpyramid source had never been fetched. Deep cross-shape was then implemented within RDR-010 (no new RDR needed):
+- **cjwr Phase A** — deep `Tet.faceNeighborElement` via the ported `t8_dpyramid_tet_boundary` corner-walk (validated table-independently: conforming-face geometry + `Pyramid.faceNeighbor` involution).
+- **cjwr Phase B** — deep tet SFC keys (`encode(Tet)`/`elementFromKey` accept `minTetLevel < level`).
+- **2l04** — deep edge/vertex via full-depth `allShapeNeighbors` (whole-domain completeness oracle).
+
+**Honest scope caveat.** The deep-tet arc is complete and validated *as infrastructure* but is **not consumed in production**: `PyramidIndex`'s locate primitive stops at the shallowest tet leaf, so deep tet keys are never inserted. RDR-010's actual need is the shallow hex↔tet boundary, which is fully live. The deep path is reachable only via direct refinement / tests today.
+
+**Follow-ons at close:**
+- `Luciferase-401t` (open, backlog) — element-level/geometrically-filtered spanning (optional optimization; cube-granular spanning is shipped and correct).
+- Closed won't-do (speculative, no consumer): `Luciferase-9hse` (locate-deep-tet primitive), `Luciferase-kyz9` (deep-FACE completeness oracle), `Luciferase-tjdc` (production distributed pyramid bootstrap) — reopen only if a concrete workload needs deep-tet insertion or a distributed pyramid deployment.
+
+Implementation history (merged to main): pi1.1–pi1.7, 4pd, q3p, d3z3, uzyd, 7poh, 3y1, 7eb, l4p0, 0utt, juts, cjwr (A+B), 2l04. See `docs/rdr/post-mortem/010-pyramid-spatial-index.md`.
+
+---
 
 > Revise during planning; lock at implementation.
 > If wrong, abandon code and iterate RDR.

--- a/docs/rdr/post-mortem/010-pyramid-spatial-index.md
+++ b/docs/rdr/post-mortem/010-pyramid-spatial-index.md
@@ -1,0 +1,34 @@
+# Post-mortem: RDR-010 — Pyramid Spatial Index
+
+**Closed:** 2026-05-31 (implemented). **Accepted:** 2026-05-28. **Epic:** Luciferase-pi1.
+
+## Outcome
+
+The hybrid hex↔tet partition gap is closed via the Knapp 2026 pyramid construction. `PyramidIndex`/`PyramidKey` shipped with §3b containment, full `AbstractSpatialIndex` conformance, cross-shape neighbor finding (shallow **and** deep), distributed ghost wiring, shape-aware Forest weights + Alg-5.1 partitioner + balance-checker shape-router, and forest event coherence. Implemented across pi1.1–pi1.7 plus follow-ons (4pd, q3p, d3z3, uzyd, 7poh, 3y1, 7eb, l4p0, 0utt, juts, cjwr A+B, 2l04).
+
+## What diverged from the plan
+
+### 1. Finding #16 over-scoped deep-tet as a separate RDR (the headline divergence)
+
+Finding #16 (q3p Phase D, 2026-05-29) concluded that Luciferase's Bey subdivision is a *geometrically different tree* from t8code's dtet below the pyramid boundary (25/48, 36/64 child mismatches), so the borrowed t8code deep-boundary tables were "geometrically meaningless" and deep-tet cross-shape was **blocked pending its own tet-tree-reconciliation RDR**.
+
+This was wrong in its forward conclusion. **Luciferase-4pd** (which landed after the finding) re-aligned Luciferase tet type `k` to t8code dtet type `k`, making the subdivision match t8code exactly (`T8codeDtetOracleTest`). Once aligned, the deep tables applied directly. The *actual* blocker was mundane: the t8code dpyramid source (`t8_dpyramid_bits.c`) had never been fetched into `~/git/t8code` (it lives on `origin/main`, the local checkout lagged). Fetching it + porting `t8_dpyramid_tet_boundary` closed the deep path inside RDR-010 (cjwr) with no new RDR.
+
+**Lesson:** a "this needs its own RDR / fundamental divergence" finding should be re-validated after any subsequent alignment work (4pd) before it ossifies into a scope boundary. The fail-loud guard was the right *interim* call; the "separate RDR" framing outlived its premise. Cheap re-check (fetch the reference, run the oracle) beat the assumed blocker.
+
+### 2. Deep-tet arc is correct infrastructure with no production consumer
+
+cjwr A+B + 2l04 delivered deep cross-shape neighbors + deep SFC keys, all validated. But `PyramidIndex`'s locate primitive stops at the shallowest tet, so **nothing inserts deep tet keys** — the entire deep arc is dark machinery. The repeated reviewer signal ("surfaced-but-unused", "dark until Phase D") was correct and under-weighted at the time; I chained follow-on beads (9hse → kyz9) to *register the remainder* rather than recognizing that the remainder had no demand. At close those speculative beads (9hse, kyz9, tjdc) were honestly closed won't-do.
+
+**Lesson:** "register the deferred remainder" is the right reflex for *real* scope; it becomes backlog-inflation when the thing being deferred has no consumer. Distinguish "deferred because out of phase" from "speculative because nothing needs it." The shallow hex↔tet boundary — RDR-010's actual goal — was always the live target.
+
+## What worked
+
+- **Stacked dual review** (code-review-expert + substantive-critic) at every phase caught real issues the green suite hid: the missing `setNeighborDetector` seam (pi1.3), the `tmIndex`/`locatePointS0Tree` downward-trace bug (4pd), the silent-data-loss `MessageConverter` bug (RDR-004 D3), and repeated scope-honesty corrections. The critic's "dark machinery" persistence is what ultimately produced the honest close.
+- **Table-independent + cross-implementation validation**: conforming-face geometry + `Pyramid.faceNeighbor` involution, and whole-domain completeness oracles (refinement vs enumerate-and-filter) — these caught symmetric-miss gaps that reciprocity alone could not.
+- **Round-trip-self-check as the SFC validity oracle**: `encode → decode → equals` (hardened with `minTetLevel`) let the neighbor enumerator filter geometric candidates to genuine SFC elements without a separate validity table.
+
+## Open after close
+
+- `Luciferase-401t` (backlog) — element-level spanning; optional, cube-granular fallback shipped.
+- If a workload ever needs deep-tet insertion or a distributed pyramid deployment, reopen `9hse` / `tjdc` (and `kyz9` for face validation).


### PR DESCRIPTION
Closes RDR-010 by the book.

- Status: accepted → **implemented** (closed 2026-05-31). Epic `Luciferase-pi1` closed.
- Adds a **close addendum** (delivered scope) and a **post-mortem** (`docs/rdr/post-mortem/010-pyramid-spatial-index.md`).
- **Honest divergence recorded:** Finding #16 scoped deep-tet cross-shape as a *separate tet-tree-reconciliation RDR*; that premise was superseded by `Luciferase-4pd` (t8code dtet alignment), and deep cross-shape was implemented within RDR-010 (cjwr A+B + 2l04) — no new RDR.
- **Honest caveat:** the deep-tet arc is complete + validated infrastructure but **unconsumed** (PyramidIndex locate stops at the shallowest tet); RDR-010's live target — the shallow hex↔tet boundary — is fully delivered.
- Follow-ons: `401t` kept (optional spanning backlog); `9hse`/`kyz9`/`tjdc` closed won't-do (speculative, no consumer).

close_reason = **implemented** (all three Decision-locked Direction-B items shipped; no core §Approach item silently dropped).