### PR TITLE
fix(Luciferase-koaw): correct TetreeNeighborDetector face neighbors + per-type CHILDREN_AT_FACE

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/neighbor/TetreeNeighborDetector.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/neighbor/TetreeNeighborDetector.java
@@ -309,8 +309,12 @@ public class TetreeNeighborDetector implements NeighborDetector<TetreeKey<? exte
     /**
      * Find non-sibling neighbors that share an edge or vertex.
      * This requires traversing up the tree and across to other branches.
+     *
+     * TODO(Luciferase-v9vm): this is an UNIMPLEMENTED STUB — the loop walks up the parent chain but never
+     * collects any neighbors. Cross-parent EDGE/VERTEX ghost queries silently return only same-parent
+     * siblings. Owned by the cross-parent-walk bead Luciferase-v9vm (gated on this koaw fix).
      */
-    private void findNonSiblingNeighborsSharing(Tet tet, List<TetreeKey<?>> neighbors, 
+    private void findNonSiblingNeighborsSharing(Tet tet, List<TetreeKey<?>> neighbors,
                                                int elementIndex, boolean isEdge) {
         // To find non-sibling neighbors, we need to:
         // 1. Go up to parent and find parent's neighbors

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/neighbor/TetreeNeighborDetector.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/neighbor/TetreeNeighborDetector.java
@@ -203,23 +203,31 @@ public class TetreeNeighborDetector implements NeighborDetector<TetreeKey<? exte
         if (tet.l == 0) {
             return null; // Root has no neighbors
         }
-        
-        var parentTet = tet.parent();
-        if (parentTet == null) {
-            return null;
+
+        // Delegate to the verified t8code face-neighbor algorithm (Tet.faceNeighbor, oracle-gated by
+        // T8codeDtetFaceNeighborOracleTest / Luciferase-4bmd). The prior implementation passed a neighbor
+        // TYPE (0-5, from getFaceNeighborType) into parentTet.child() as a Morton index, which silently
+        // returned child[type] instead of the geometric face neighbor — corrupting every ghost face zone.
+        // This mirrors the correct sibling impl in TetreeNeighborFinder.findFaceNeighbor.
+        var neighbor = tet.faceNeighbor(face);
+        if (neighbor == null) {
+            return null; // Boundary of the positive octant
         }
-        
-        // Get sibling index within parent
-        var siblingIndex = TetreeConnectivity.getFaceNeighborType(tet.type, face);
-        if (siblingIndex >= 0 && siblingIndex < 8) {
-            // Neighbor is a sibling
-            var neighbor = parentTet.child(siblingIndex);
-            return tetToKey(neighbor);
+        var neighborTet = neighbor.tet();
+        if (!isWithinDomain(neighborTet)) {
+            return null; // Outside domain bounds
         }
-        
-        // Neighbor is in a different parent - need to go up and across
-        // This requires more complex logic using the connectivity tables
-        return null;
+        return tetToKey(neighborTet);
+    }
+
+    /**
+     * Domain-bounds check for a candidate neighbor: anchor in [0, rootLength). Mirrors
+     * TetreeNeighborFinder.isWithinDomain.
+     */
+    private boolean isWithinDomain(Tet tet) {
+        var maxCoord = Constants.lengthAtLevel((byte) 0);
+        return tet.x() >= 0 && tet.x() < maxCoord && tet.y() >= 0 && tet.y() < maxCoord && tet.z() >= 0
+        && tet.z() < maxCoord;
     }
     
     /**

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeConnectivity.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeConnectivity.java
@@ -208,96 +208,62 @@ public final class TetreeConnectivity {
      * Children at each face for Bey refinement. Given a parent type and face index, returns which children touch that
      * face (up to 4 children per face).
      *
-     * In Bey refinement, the children at each face are: - Face 0 (opposite vertex 0): children 4, 5, 6, 7 - Face 1
-     * (opposite vertex 1): children 2, 3, 6, 7 - Face 2 (opposite vertex 2): children 1, 3, 5, 7 - Face 3 (opposite
-     * vertex 3): children 1, 2, 4, 5
+     * The children touching a given parent face are TYPE-DEPENDENT in t8code's dtet refinement. This is a
+     * verbatim port of t8code {@code t8_dtet_face_child_id_by_type[6][4][4]}
+     * ({@code t8code/src/t8_schemes/t8_default/t8_default_tet/t8_dtet_connectivity.c}). The prior Luciferase
+     * table used a single type-invariant pattern ({4,5,6,7}/{2,3,6,7}/{1,3,5,7}/{1,2,4,5}) for all 6 types,
+     * which matched NONE of the t8code rows and propagated descendant neighbors through the wrong children
+     * (Luciferase-koaw; T3 critique-luciferase-t8code-tet-neighbor S1).
      *
-     * [parent_type][face_index][position] -> child_index
+     * [parent_type][face_index][position] -> child_index (Morton child index, 0-7)
      */
     public static final byte[][][] CHILDREN_AT_FACE = {
-    // Type 0 - same pattern for all types in standard Bey refinement
-    { { 4, 5, 6, 7 }, { 2, 3, 6, 7 }, { 1, 3, 5, 7 }, { 1, 2, 4, 5 } },
+    // Type 0
+    { { 1, 4, 5, 7 }, { 0, 4, 6, 7 }, { 0, 1, 2, 7 }, { 0, 1, 3, 4 } },
     // Type 1
-    { { 4, 5, 6, 7 }, { 2, 3, 6, 7 }, { 1, 3, 5, 7 }, { 1, 2, 4, 5 } },
+    { { 1, 4, 5, 7 }, { 0, 5, 6, 7 }, { 0, 1, 3, 7 }, { 0, 1, 2, 5 } },
     // Type 2
-    { { 4, 5, 6, 7 }, { 2, 3, 6, 7 }, { 1, 3, 5, 7 }, { 1, 2, 4, 5 } },
+    { { 3, 4, 5, 7 }, { 0, 4, 6, 7 }, { 0, 1, 3, 7 }, { 0, 2, 3, 4 } },
     // Type 3
-    { { 4, 5, 6, 7 }, { 2, 3, 6, 7 }, { 1, 3, 5, 7 }, { 1, 2, 4, 5 } },
+    { { 1, 5, 6, 7 }, { 0, 4, 6, 7 }, { 0, 1, 3, 7 }, { 0, 1, 2, 6 } },
     // Type 4
-    { { 4, 5, 6, 7 }, { 2, 3, 6, 7 }, { 1, 3, 5, 7 }, { 1, 2, 4, 5 } },
+    { { 3, 5, 6, 7 }, { 0, 4, 5, 7 }, { 0, 1, 3, 7 }, { 0, 2, 3, 5 } },
     // Type 5
-    { { 4, 5, 6, 7 }, { 2, 3, 6, 7 }, { 1, 3, 5, 7 }, { 1, 2, 4, 5 } } };
+    { { 3, 5, 6, 7 }, { 0, 4, 6, 7 }, { 0, 2, 3, 7 }, { 0, 1, 3, 6 } } };
 
     /**
      * Face-to-face mapping between parent and child. Given parent type, child index, and parent face, returns which
      * face of the child corresponds to that parent face.
      *
-     * A value of -1 indicates the child doesn't touch that parent face. Based on CHILDREN_AT_FACE: - Face 0: children
-     * 4,5,6,7 - Face 1: children 2,3,6,7 - Face 2: children 1,3,5,7 - Face 3: children 1,2,4,5
+     * A value of -1 indicates the child doesn't touch that parent face. This table is TYPE-DEPENDENT and
+     * is derived geometrically from the verified {@code Tet.coordinates()} so that it is consistent with the
+     * t8code per-type {@link #CHILDREN_AT_FACE}: for each (parentType, childIndex, parentFace), the value is
+     * the child-local face whose 3 vertices all lie on the parent face plane, or -1 if the child does not
+     * touch that face. (Derived offline and frozen here to avoid a static-init cycle Tet <-> TetreeConnectivity;
+     * the consistency invariant is enforced by TetreeConnectivityTest.testFaceChildFace.) The prior table was
+     * type-invariant and matched the made-up Bey CHILDREN_AT_FACE pattern (Luciferase-koaw).
      *
      * [parent_type][child_index][parent_face] -> child_face
      */
     public static final byte[][][] FACE_CHILD_FACE = {
     // Type 0
-    { { -1, -1, -1, -1 },  // Child 0 (interior)
-      { -1, -1, 2, 3 },    // Child 1 (at faces 2,3)
-      { -1, 1, -1, 3 },    // Child 2 (at faces 1,3)
-      { -1, 1, 2, -1 },    // Child 3 (at faces 1,2)
-      { 0, -1, -1, 3 },    // Child 4 (at faces 0,3)
-      { 0, -1, 2, 3 },     // Child 5 (at faces 0,2,3)
-      { 0, 1, -1, -1 },    // Child 6 (at faces 0,1)
-      { 0, 1, 2, -1 }      // Child 7 (at faces 0,1,2)
-    },
-    // Type 1 (same pattern for standard Bey refinement)
-    { { -1, -1, -1, -1 },  // Child 0 (interior)
-      { -1, -1, 2, 3 },    // Child 1 (at faces 2,3)
-      { -1, 1, -1, 3 },    // Child 2 (at faces 1,3)
-      { -1, 1, 2, -1 },    // Child 3 (at faces 1,2)
-      { 0, -1, -1, 3 },    // Child 4 (at faces 0,3)
-      { 0, -1, 2, 3 },     // Child 5 (at faces 0,2,3)
-      { 0, 1, -1, -1 },    // Child 6 (at faces 0,1)
-      { 0, 1, 2, -1 }      // Child 7 (at faces 0,1,2)
-    },
+    { { -1, 1, 2, 3 }, { 0, -1, 2, 3 }, { -1, -1, 1, -1 }, { -1, -1, -1, 3 }, { 0, 1, -1, 3 }, { 0, -1, -1, -1 },
+      { -1, 2, -1, -1 }, { 0, 1, 2, -1 } },
+    // Type 1
+    { { -1, 1, 2, 3 }, { 0, -1, 2, 3 }, { -1, -1, -1, 3 }, { -1, -1, 1, -1 }, { 0, -1, -1, -1 }, { 0, 1, -1, 3 },
+      { -1, 2, -1, -1 }, { 0, 1, 2, -1 } },
     // Type 2
-    { { -1, -1, -1, -1 },  // Child 0 (interior)
-      { -1, -1, 2, 3 },    // Child 1 (at faces 2,3)
-      { -1, 1, -1, 3 },    // Child 2 (at faces 1,3)
-      { -1, 1, 2, -1 },    // Child 3 (at faces 1,2)
-      { 0, -1, -1, 3 },    // Child 4 (at faces 0,3)
-      { 0, -1, 2, 3 },     // Child 5 (at faces 0,2,3)
-      { 0, 1, -1, -1 },    // Child 6 (at faces 0,1)
-      { 0, 1, 2, -1 }      // Child 7 (at faces 0,1,2)
-    },
+    { { -1, 1, 2, 3 }, { -1, -1, 1, -1 }, { -1, -1, -1, 3 }, { 0, -1, 2, 3 }, { 0, 1, -1, 3 }, { 0, -1, -1, -1 },
+      { -1, 2, -1, -1 }, { 0, 1, 2, -1 } },
     // Type 3
-    { { -1, -1, -1, -1 },  // Child 0 (interior)
-      { -1, -1, 2, 3 },    // Child 1 (at faces 2,3)
-      { -1, 1, -1, 3 },    // Child 2 (at faces 1,3)
-      { -1, 1, 2, -1 },    // Child 3 (at faces 1,2)
-      { 0, -1, -1, 3 },    // Child 4 (at faces 0,3)
-      { 0, -1, 2, 3 },     // Child 5 (at faces 0,2,3)
-      { 0, 1, -1, -1 },    // Child 6 (at faces 0,1)
-      { 0, 1, 2, -1 }      // Child 7 (at faces 0,1,2)
-    },
+    { { -1, 1, 2, 3 }, { 0, -1, 2, 3 }, { -1, -1, -1, 3 }, { -1, -1, 1, -1 }, { -1, 2, -1, -1 }, { 0, -1, -1, -1 },
+      { 0, 1, -1, 3 }, { 0, 1, 2, -1 } },
     // Type 4
-    { { -1, -1, -1, -1 },  // Child 0 (interior)
-      { -1, -1, 2, 3 },    // Child 1 (at faces 2,3)
-      { -1, 1, -1, 3 },    // Child 2 (at faces 1,3)
-      { -1, 1, 2, -1 },    // Child 3 (at faces 1,2)
-      { 0, -1, -1, 3 },    // Child 4 (at faces 0,3)
-      { 0, -1, 2, 3 },     // Child 5 (at faces 0,2,3)
-      { 0, 1, -1, -1 },    // Child 6 (at faces 0,1)
-      { 0, 1, 2, -1 }      // Child 7 (at faces 0,1,2)
-    },
+    { { -1, 1, 2, 3 }, { -1, -1, 1, -1 }, { -1, -1, -1, 3 }, { 0, -1, 2, 3 }, { -1, 2, -1, -1 }, { 0, 1, -1, 3 },
+      { 0, -1, -1, -1 }, { 0, 1, 2, -1 } },
     // Type 5
-    { { -1, -1, -1, -1 },  // Child 0 (interior)
-      { -1, -1, 2, 3 },    // Child 1 (at faces 2,3)
-      { -1, 1, -1, 3 },    // Child 2 (at faces 1,3)
-      { -1, 1, 2, -1 },    // Child 3 (at faces 1,2)
-      { 0, -1, -1, 3 },    // Child 4 (at faces 0,3)
-      { 0, -1, 2, 3 },     // Child 5 (at faces 0,2,3)
-      { 0, 1, -1, -1 },    // Child 6 (at faces 0,1)
-      { 0, 1, 2, -1 }      // Child 7 (at faces 0,1,2)
-    } };
+    { { -1, 1, 2, 3 }, { -1, -1, -1, 3 }, { -1, -1, 1, -1 }, { 0, -1, 2, 3 }, { -1, 2, -1, -1 }, { 0, -1, -1, -1 },
+      { 0, 1, -1, 3 }, { 0, 1, 2, -1 } } };
 
     /**
      * Sibling relationships in Bey refinement. Given two child indices, returns true if they are siblings (i.e., they

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeConnectivity.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeConnectivity.java
@@ -240,8 +240,15 @@ public final class TetreeConnectivity {
      * t8code per-type {@link #CHILDREN_AT_FACE}: for each (parentType, childIndex, parentFace), the value is
      * the child-local face whose 3 vertices all lie on the parent face plane, or -1 if the child does not
      * touch that face. (Derived offline and frozen here to avoid a static-init cycle Tet <-> TetreeConnectivity;
-     * the consistency invariant is enforced by TetreeConnectivityTest.testFaceChildFace.) The prior table was
+     * the exact values are re-derived geometrically and asserted by
+     * TetreeConnectivityTest.faceChildFaceMatchesGeometry, and the table is cross-checked against
+     * {@link #CHILDREN_AT_FACE} by TetreeConnectivityTest.testFaceChildFace.) The prior table was
      * type-invariant and matched the made-up Bey CHILDREN_AT_FACE pattern (Luciferase-koaw).
+     *
+     * <p>NOTE on index space: this is indexed by the MORTON child index (0-7), unlike t8code's
+     * {@code t8_dtet_face_child_face(elem, face, face_child)} which takes {@code face_child} as the ordinal
+     * among the 4 children on that face. t8code has no equivalent static lookup table (it computes the value
+     * algorithmically in {@code t8_dtri_bits.c}), so this table is validated by geometry, not by transcription.
      *
      * [parent_type][child_index][parent_face] -> child_face
      */

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/neighbor/TetreeNeighborDetectorTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/neighbor/TetreeNeighborDetectorTest.java
@@ -17,6 +17,8 @@
 
 package com.hellblazer.luciferase.lucien.neighbor;
 
+import com.hellblazer.luciferase.lucien.Constants;
+import com.hellblazer.luciferase.lucien.tetree.Tet;
 import com.hellblazer.luciferase.lucien.tetree.Tetree;
 import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
 import com.hellblazer.luciferase.lucien.forest.ghost.GhostType;
@@ -26,6 +28,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.vecmath.Point3f;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -53,6 +58,60 @@ class TetreeNeighborDetectorTest {
         }
     }
     
+    /**
+     * Regression for Luciferase-koaw: the detector's face-neighbor path must return the GEOMETRIC face
+     * neighbor (Tet.faceNeighbor, oracle-gated by Luciferase-4bmd), not child[neighborType]. The old impl
+     * passed a neighbor TYPE (0-5) into parentTet.child() as a Morton index, silently returning a wrong tet.
+     * This asserts EXACT set-equality between the detector output and the in-domain geometric neighbors —
+     * a non-vacuous check the prior size<=4 / no-duplicate tests could not catch.
+     */
+    @Test
+    void faceNeighborsMatchGeometricGroundTruth() {
+        int maxCoord = Constants.lengthAtLevel((byte) 0);
+        int checkedTets = 0;
+        int matchedNeighbors = 0;
+
+        // DFS a refined tree; every node is a genuinely valid Tet (no fabricated anchors/types).
+        Deque<Tet> work = new ArrayDeque<>();
+        work.push(new Tet(0, 0, 0, (byte) 0, (byte) 0));
+        while (!work.isEmpty()) {
+            var tet = work.pop();
+            if (tet.l() >= 1) {
+                var key = tet.tmIndex();
+                // Expected = in-domain geometric face neighbors, minus self (mirrors detector filtering).
+                var expected = new HashSet<TetreeKey<?>>();
+                for (int face = 0; face < 4; face++) {
+                    var fn = tet.faceNeighbor(face);
+                    if (fn == null) {
+                        continue;
+                    }
+                    var n = fn.tet();
+                    if (n.x() < 0 || n.y() < 0 || n.z() < 0 || n.x() >= maxCoord || n.y() >= maxCoord
+                    || n.z() >= maxCoord) {
+                        continue;
+                    }
+                    var nKey = n.tmIndex();
+                    if (!nKey.equals(key)) {
+                        expected.add(nKey);
+                    }
+                }
+
+                var actual = new HashSet<>(detector.findFaceNeighbors(key));
+                assertEquals(expected, actual,
+                             "detector face neighbors must equal geometric ground truth for " + tet);
+                checkedTets++;
+                matchedNeighbors += actual.size();
+            }
+            if (tet.l() < 4) {
+                for (int m = 0; m < 8; m++) {
+                    work.push(tet.child(m));
+                }
+            }
+        }
+        assertTrue(checkedTets > 1000, "expected broad tet coverage, got " + checkedTets);
+        assertTrue(matchedNeighbors > 0, "expected non-empty neighbor sets, got " + matchedNeighbors);
+    }
+
     @Test
     void testFaceNeighbors() {
         // Get a key from the tree

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/neighbor/TetreeNeighborDetectorTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/neighbor/TetreeNeighborDetectorTest.java
@@ -63,7 +63,13 @@ class TetreeNeighborDetectorTest {
      * neighbor (Tet.faceNeighbor, oracle-gated by Luciferase-4bmd), not child[neighborType]. The old impl
      * passed a neighbor TYPE (0-5) into parentTet.child() as a Morton index, silently returning a wrong tet.
      * This asserts EXACT set-equality between the detector output and the in-domain geometric neighbors —
-     * a non-vacuous check the prior size<=4 / no-duplicate tests could not catch.
+     * a non-vacuous check the prior size<=4 / no-duplicate tests could not catch. It WOULD have failed
+     * against the old child[neighborType] impl.
+     *
+     * <p>Scope: the detector now delegates to Tet.faceNeighbor, so this pins the detector plumbing (key
+     * round-trip, domain filter, self-exclusion) but is circular w.r.t. Tet.faceNeighbor's own correctness.
+     * The latter is independently validated against t8code by T8codeDtetFaceNeighborOracleTest
+     * (Luciferase-4bmd), on which this PR stacks.
      */
     @Test
     void faceNeighborsMatchGeometricGroundTruth() {

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeConnectivityTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeConnectivityTest.java
@@ -38,12 +38,15 @@ public class TetreeConnectivityTest {
         // 2. Each tetrahedron has exactly 4 faces
         assertEquals(4, TetreeConnectivity.FACES_PER_TET);
 
-        // 3. Interior child (0) touches no parent faces
+        // 3. Every child index in the t8code per-type CHILDREN_AT_FACE table is a valid Morton index (0-7).
+        //    NOTE: in the verbatim t8code t8_dtet_face_child_id_by_type table, child 0 (the corner child
+        //    sharing parent vertex 0) DOES lie on parent faces 1,2,3 — it is opposite face 0 only. The prior
+        //    "child 0 is interior, touches no face" assertion was a made-up Bey artifact, not t8code (koaw).
         for (byte parentType = 0; parentType < 6; parentType++) {
             for (int face = 0; face < 4; face++) {
                 byte[] childrenAtFace = TetreeConnectivity.getChildrenAtFace(parentType, face);
                 for (byte child : childrenAtFace) {
-                    assertNotEquals(0, child, "Interior child should not be at any face");
+                    assertTrue(child >= 0 && child < 8, "Child index must be a valid Morton index 0-7: " + child);
                 }
             }
         }
@@ -140,11 +143,9 @@ public class TetreeConnectivityTest {
                 }
             }
 
-            // Child 0 is interior, so it shouldn't be at any face
-            assertFalse(childAtSomeFace[0], "Child 0 should be interior");
-
-            // All other children should be at some face
-            for (int i = 1; i < 8; i++) {
+            // Every child (including child 0, the corner child opposite face 0) appears on some parent face
+            // in the t8code per-type table. No child is fully interior in t8_dtet_face_child_id_by_type.
+            for (int i = 0; i < 8; i++) {
                 assertTrue(childAtSomeFace[i], "Child " + i + " should be at some face");
             }
         }
@@ -178,11 +179,20 @@ public class TetreeConnectivityTest {
             }
         }
 
-        // Test interior child (index 0) has no face mappings
+        // Bidirectional consistency: a child appears in CHILDREN_AT_FACE[type][pf] IFF getChildFace != -1.
+        // (Reverse direction of the forward check above — closes the FACE_CHILD_FACE / CHILDREN_AT_FACE loop.)
         for (byte parentType = 0; parentType < 6; parentType++) {
             for (int parentFace = 0; parentFace < 4; parentFace++) {
-                assertEquals(-1, TetreeConnectivity.getChildFace(parentType, 0, parentFace),
-                             "Interior child should not touch any parent face");
+                var atFace = new boolean[8];
+                for (byte child : TetreeConnectivity.getChildrenAtFace(parentType, parentFace)) {
+                    atFace[child] = true;
+                }
+                for (int childIndex = 0; childIndex < 8; childIndex++) {
+                    byte childFace = TetreeConnectivity.getChildFace(parentType, childIndex, parentFace);
+                    assertEquals(atFace[childIndex], childFace != -1,
+                                 "FACE_CHILD_FACE/CHILDREN_AT_FACE disagree: type=" + parentType + " child="
+                                 + childIndex + " parentFace=" + parentFace);
+                }
             }
         }
     }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeConnectivityTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeConnectivityTest.java
@@ -18,6 +18,8 @@ package com.hellblazer.luciferase.lucien.tetree;
 
 import org.junit.jupiter.api.Test;
 
+import javax.vecmath.Point3i;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -195,6 +197,50 @@ public class TetreeConnectivityTest {
                 }
             }
         }
+    }
+
+    /**
+     * Independent geometric validation of FACE_CHILD_FACE (Luciferase-koaw). The table is a frozen,
+     * offline-derived lookup; this re-derives every (parentType, childMortonIndex, parentFace) entry live
+     * from the verified {@code Tet.coordinates()} — the child-local face whose 3 vertices all lie on the
+     * parent face plane, or -1 — and asserts equality. This removes the maintenance hazard of an
+     * unverifiable frozen table (t8code has no equivalent static table to transcribe against).
+     */
+    @Test
+    public void faceChildFaceMatchesGeometry() {
+        // child-local face f = the 3 vertices != f (t8code: face opposite vertex f)
+        final int[][] faceVerts = { { 1, 2, 3 }, { 0, 2, 3 }, { 0, 1, 3 }, { 0, 1, 2 } };
+        final byte level = 5;
+        for (byte ptype = 0; ptype < 6; ptype++) {
+            var parent = new Tet(0, 0, 0, level, ptype);
+            Point3i[] pv = parent.coordinates();
+            for (int child = 0; child < 8; child++) {
+                Point3i[] cv = parent.child(child).coordinates();
+                for (int pf = 0; pf < 4; pf++) {
+                    Point3i pa = pv[faceVerts[pf][0]], pb = pv[faceVerts[pf][1]], pc = pv[faceVerts[pf][2]];
+                    int expected = -1;
+                    for (int cf = 0; cf < 4; cf++) {
+                        boolean all = true;
+                        for (int k = 0; k < 3 && all; k++) {
+                            all = coplanar(pa, pb, pc, cv[faceVerts[cf][k]]);
+                        }
+                        if (all) {
+                            expected = cf;
+                            break;
+                        }
+                    }
+                    assertEquals(expected, TetreeConnectivity.getChildFace(ptype, child, pf),
+                                 "FACE_CHILD_FACE geometry mismatch type=" + ptype + " child=" + child + " face=" + pf);
+                }
+            }
+        }
+    }
+
+    private static boolean coplanar(Point3i a, Point3i b, Point3i c, Point3i p) {
+        long ux = b.x - a.x, uy = b.y - a.y, uz = b.z - a.z;
+        long vx = c.x - a.x, vy = c.y - a.y, vz = c.z - a.z;
+        long nx = uy * vz - uz * vy, ny = uz * vx - ux * vz, nz = ux * vy - uy * vx;
+        return nx * (p.x - a.x) + ny * (p.y - a.y) + nz * (p.z - a.z) == 0;
     }
 
     @Test


### PR DESCRIPTION
## Summary
WS-A **CRITICAL** silent ghost-zone corruption fix (bead Luciferase-koaw). Two coupled fixes.

**Stacks on #178 (Luciferase-4bmd)** — merge #178 first. The detector now delegates to `Tet.faceNeighbor`, whose t8code-correctness is independently pinned by the oracle in #178.

### 1. TetreeNeighborDetector.findFaceNeighbor — type-as-Morton-index bug
The method passed a neighbor **type** (0-5, from `getFaceNeighborType`) into `parentTet.child()` as a **Morton index**, returning `child[type]` instead of the geometric face neighbor. Every ghost-layer FACE query (live `GhostBoundaryDetector`) got a wrong tet. Now delegates to the verified `Tet.faceNeighbor(face)`, mirroring the correct `TetreeNeighborFinder`, with a domain-bounds check.

### 2. TetreeConnectivity.CHILDREN_AT_FACE — type-invariant → per-type
All 6 rows were identical (a made-up Bey pattern matching no t8code row). Ported t8code `t8_dtet_face_child_id_by_type[6][4][4]` **verbatim** (verified byte-for-byte by both reviewers). The coupled `FACE_CHILD_FACE` was likewise type-invariant; re-derived it geometrically from `Tet.coordinates()` so `getChildFace` (findDescendantsAtLevel recursion) stays consistent.

## Tests
- **New** `faceNeighborsMatchGeometricGroundTruth` — detector output == in-domain geometric neighbors over a depth-4 DFS (would have failed against the old impl).
- **New** `faceChildFaceMatchesGeometry` — live geometric re-derivation of FACE_CHILD_FACE (no frozen-table hazard).
- Corrected 3 `TetreeConnectivityTest` invariants encoding the false 'child 0 is interior' Bey artifact (t8code child 0 lies on faces 1,2,3) + bidirectional CHILDREN_AT_FACE↔FACE_CHILD_FACE consistency.
- Full neighbor + tetree + ghost suites green; render `ESVTTraversalTest` green.

## Reviewed
code-review-expert (0 Critical) + substantive-critic (0 Critical). All actionable findings applied: live FACE_CHILD_FACE test, circularity/index-semantics docs, stub TODO.

## Follow-ups filed
- **Luciferase-d5o9**: render keeps type-invariant CHILDREN_AT_FACE copies (ESVTTopology, raycast_esvt.comp) that now diverge.
- Luciferase-v9vm (cross-parent edge/vertex walk) now unblocked.