### PR TITLE
fix(Luciferase-v9vm): implement cross-parent edge/vertex neighbor walk

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/neighbor/TetreeNeighborDetector.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/neighbor/TetreeNeighborDetector.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.vecmath.Point3f;
+import javax.vecmath.Point3i;
 import java.util.*;
 
 /**
@@ -231,114 +232,131 @@ public class TetreeNeighborDetector implements NeighborDetector<TetreeKey<? exte
     }
     
     /**
-     * Find all neighbors sharing a specific edge with the given tetrahedron.
-     * This includes siblings and non-siblings at various levels.
+     * Find all same-level neighbors (siblings AND cross-parent non-siblings) sharing a specific edge with
+     * the given tetrahedron. The canonical-descent search in {@link #findNonSiblingNeighborsSharing} is
+     * authoritative over the whole edge fan, so no separate sibling pass is needed — siblings touching the
+     * edge are enumerated like any other fan member.
      */
-    private List<TetreeKey<?>> findNeighborsSharingEdge(Tet tet, int edge) {
+    List<TetreeKey<?>> findNeighborsSharingEdge(Tet tet, int edge) {
         var neighbors = new ArrayList<TetreeKey<?>>();
-        
         if (tet.l == 0) {
             return neighbors; // Root has no neighbors
         }
-        
-        // Get the two vertices that form this edge
-        int v0 = EDGE_VERTICES[edge][0];
-        int v1 = EDGE_VERTICES[edge][1];
-        
-        // Strategy: Find all tetrahedra that share these two vertices
-        // 1. Check siblings that share the edge
-        // 2. Check parent's neighbors that share the edge
-        // 3. Check children of neighbors at same level
-        
-        // First, find siblings sharing this edge
-        findSiblingsSharing(tet, neighbors, (sibling) -> sharesEdge(tet, sibling, v0, v1));
-        
-        // For non-sibling neighbors, we need to traverse up and across the tree
-        // This is more complex and depends on the specific edge and parent configuration
         findNonSiblingNeighborsSharing(tet, neighbors, edge, true);
-        
         return neighbors;
     }
-    
+
     /**
-     * Find all neighbors sharing a specific vertex with the given tetrahedron.
+     * Find all same-level neighbors (siblings AND cross-parent non-siblings) sharing a specific vertex with
+     * the given tetrahedron. See {@link #findNeighborsSharingEdge} — the descent covers the whole vertex star.
      */
-    private List<TetreeKey<?>> findNeighborsSharingVertex(Tet tet, int vertex) {
+    List<TetreeKey<?>> findNeighborsSharingVertex(Tet tet, int vertex) {
         var neighbors = new ArrayList<TetreeKey<?>>();
-        
         if (tet.l == 0) {
             return neighbors; // Root has no neighbors
         }
-        
-        // Strategy: Find all tetrahedra that share this vertex
-        // 1. Check siblings that share the vertex
-        // 2. Check parent's neighbors that share the vertex
-        // 3. Check descendants of parent's neighbors
-        
-        // First, find siblings sharing this vertex
-        findSiblingsSharing(tet, neighbors, (sibling) -> sharesVertex(tet, sibling, vertex));
-        
-        // For non-sibling neighbors, traverse up and across the tree
         findNonSiblingNeighborsSharing(tet, neighbors, vertex, false);
-        
         return neighbors;
     }
-    
+
     /**
-     * Find siblings that satisfy a given predicate.
-     */
-    private void findSiblingsSharing(Tet tet, List<TetreeKey<?>> neighbors, 
-                                     java.util.function.Predicate<Tet> predicate) {
-        var parentTet = tet.parent();
-        if (parentTet == null) {
-            return;
-        }
-        
-        for (int sibling = 0; sibling < 8; sibling++) {
-            var siblingTet = parentTet.child(sibling);
-            if (siblingTet.equals(tet)) {
-                continue; // Skip self
-            }
-            
-            if (predicate.test(siblingTet)) {
-                neighbors.add(tetToKey(siblingTet));
-            }
-        }
-    }
-    
-    /**
-     * Find non-sibling neighbors that share an edge or vertex.
-     * This requires traversing up the tree and across to other branches.
+     * Find neighbors (siblings AND cross-parent non-siblings) that share a given edge or vertex with
+     * {@code tet}, at the same refinement level.
      *
-     * TODO(Luciferase-v9vm): this is an UNIMPLEMENTED STUB — the loop walks up the parent chain but never
-     * collects any neighbors. Cross-parent EDGE/VERTEX ghost queries silently return only same-parent
-     * siblings. Owned by the cross-parent-walk bead Luciferase-v9vm (gated on this koaw fix).
+     * <p>Implementation (Luciferase-v9vm): a same-level tetrahedron is a neighbor across the element iff its
+     * vertex set contains all of the element's grid points (both endpoints for an edge, the single point for
+     * a vertex). We enumerate those tets by a pruned top-down descent over the canonical Bey tiling: from the
+     * root, recurse only into children whose cube encloses the target point, and at the target level keep the
+     * tets that actually carry the point as a vertex. For an edge we intersect the sharer sets of its two
+     * endpoints.
+     *
+     * <p>The descent uses {@code child()} exclusively, so it only ever yields canonical tiling tets — tets
+     * that the tree can actually store. This is deliberately NOT a {@link Tet#faceNeighbor(int)} flood: the
+     * Bey-SFC face neighbor is non-conforming (it returns geometrically-adjacent tets of types that are not
+     * the tiling's type at that cell), so a face flood wanders off the tiling and reports phantom neighbors.
+     * A tet's cube is exactly its axis-aligned bounding box (vertices span {@code v0..v7}), so cube-encloses
+     * is an exact, cheap prune that keeps the descent narrow (only the &le;8 cubes around the point at each
+     * level) and complete (every ancestor of a qualifying tet also encloses the point). The cost is therefore
+     * LINEAR in the level, not exponential: measured node visits are ~64 per level (1409 visits, &lt;1ms, at
+     * the max level 21), since the enclosing fan stays bounded at every level.
+     *
+     * <p>Scope: {@code TetreeNeighborDetector} is a pure-Tetree detector — the descent roots a fresh
+     * {@code Tet(0,0,0,0,0)} with {@code minTetLevel == NO_TET_ANCESTOR}. The self-exclusion
+     * {@code sharers.remove(tet)} relies on {@code Tet.equals} (which includes {@code minTetLevel}); it is
+     * correct here because the query {@code tet} also carries {@code NO_TET_ANCESTOR}. A hybrid/pyramid
+     * caller passing a tet with a real {@code minTetLevel} would not self-exclude — not a concern today, but
+     * a trap if this detector is ever reused outside pure-Tetree context.
+     *
+     * @param elementIndex edge index (0-5) when {@code isEdge}, else vertex index (0-3)
      */
     private void findNonSiblingNeighborsSharing(Tet tet, List<TetreeKey<?>> neighbors,
                                                int elementIndex, boolean isEdge) {
-        // To find non-sibling neighbors, we need to:
-        // 1. Go up to parent and find parent's neighbors
-        // 2. Check children of those neighbors
-        
-        var currentTet = tet;
-        var currentLevel = tet.l;
-        
-        // Traverse up the tree
-        while (currentLevel > 0 && neighbors.size() < 20) { // Limit to prevent excessive search
-            var parentTet = currentTet.parent();
-            if (parentTet == null) {
-                break;
-            }
-            
-            // Find parent's neighbors that might have children sharing our element
-            // This is simplified - a full implementation would use connectivity tables
-            // to determine which parent neighbors to check
-            
-            currentTet = parentTet;
-            currentLevel--;
+        if (tet.l == 0) {
+            return; // Root has no neighbors
+        }
+
+        // Grid points of the shared element: 2 endpoints for an edge, 1 for a vertex.
+        var coords = tet.coordinates();
+        int[] vertexIndices = isEdge ? EDGE_VERTICES[elementIndex] : new int[] { elementIndex };
+
+        // Sharers of the first point; for an edge, intersect with sharers of the second endpoint so only
+        // tets carrying the whole edge survive.
+        var sharers = sharersOfPoint(coords[vertexIndices[0]], tet.l);
+        for (int i = 1; i < vertexIndices.length; i++) {
+            sharers.retainAll(sharersOfPoint(coords[vertexIndices[i]], tet.l));
+        }
+        sharers.remove(tet); // exclude self
+
+        for (var sharer : sharers) {
+            neighbors.add(tetToKey(sharer));
         }
     }
-    
+
+    /**
+     * All in-domain canonical tiling tets at {@code level} that carry {@code p} as one of their four
+     * vertices. Found by a pruned descent from the root: a tet's cube is its exact AABB, so we recurse only
+     * into children whose cube encloses {@code p}, and at {@code level} keep those with {@code p} as an
+     * actual vertex.
+     */
+    private Set<Tet> sharersOfPoint(Point3i p, byte level) {
+        var result = new HashSet<Tet>();
+        var stack = new ArrayDeque<Tet>();
+        stack.push(new Tet(0, 0, 0, (byte) 0, (byte) 0));
+        while (!stack.isEmpty()) {
+            var t = stack.pop();
+            if (!cubeEncloses(t, p)) {
+                continue; // p outside this subtree's cube — prune
+            }
+            if (t.l == level) {
+                if (isWithinDomain(t) && hasVertex(t, p)) {
+                    result.add(t);
+                }
+            } else {
+                for (int c = 0; c < 8; c++) {
+                    stack.push(t.child(c));
+                }
+            }
+        }
+        return result;
+    }
+
+    /** True iff {@code p} lies within (inclusive) the closed cube spanned by {@code t}. */
+    private boolean cubeEncloses(Tet t, Point3i p) {
+        int h = Constants.lengthAtLevel(t.l);
+        return p.x >= t.x() && p.x <= t.x() + h && p.y >= t.y() && p.y <= t.y() + h && p.z >= t.z()
+        && p.z <= t.z() + h;
+    }
+
+    /** True iff {@code p} is one of {@code t}'s four vertices (exact integer match). */
+    private boolean hasVertex(Tet t, Point3i p) {
+        for (var c : t.coordinates()) {
+            if (c.x == p.x && c.y == p.y && c.z == p.z) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Convert a TetreeKey to a Tet object via the canonical TM-index decoder.
      * Delegates to {@link TetreeKey#toTet()} (which walks all path bits from
@@ -357,104 +375,4 @@ public class TetreeNeighborDetector implements NeighborDetector<TetreeKey<? exte
         return tet.tmIndex();
     }
     
-    /**
-     * Get the child index of a tet within its parent.
-     */
-    private int getChildIndex(Tet tet) {
-        if (tet.l == 0) {
-            return 0; // Root has no meaningful child index
-        }
-        
-        // The child index is determined by the coordinate bits at the current level
-        // In the Tet's morton encoding, this would be the last 3 bits
-        // For our purposes, we can derive it from the coordinate and type
-        
-        // Get the TetreeKey to access the coordinate bits
-        var key = tetToKey(tet);
-        byte coordBits = key.getCoordBitsAtLevel(tet.l);
-        
-        // The child index in Morton order is the coordinate bits
-        // This gives us values 0-7 corresponding to the 8 children
-        return coordBits & 0x7;
-    }
-    
-    /**
-     * Check if two tetrahedra share an edge defined by two vertices.
-     * This uses the vertex mapping tables from TetreeConnectivity.
-     */
-    private boolean sharesEdge(Tet tet1, Tet tet2, int v0, int v1) {
-        // For siblings in Bey refinement, we can use the connectivity tables
-        // to determine which children share edges
-        
-        // Get the child indices within their parent
-        int childIndex1 = getChildIndex(tet1);
-        int childIndex2 = getChildIndex(tet2);
-        
-        // Use the CHILD_VERTEX_PARENT_VERTEX table to check if they share
-        // the same parent edge
-        return checkSharedParentEdge(childIndex1, childIndex2, v0, v1);
-    }
-    
-    /**
-     * Check if two tetrahedra share a vertex.
-     * This uses the vertex mapping tables from TetreeConnectivity.
-     */
-    private boolean sharesVertex(Tet tet1, Tet tet2, int vertex) {
-        // For siblings in Bey refinement, we can use the connectivity tables
-        // to determine which children share vertices
-        
-        // Get the child indices within their parent
-        int childIndex1 = getChildIndex(tet1);
-        int childIndex2 = getChildIndex(tet2);
-        
-        // Use the CHILD_VERTEX_PARENT_VERTEX table to check if they share
-        // the same parent vertex
-        return checkSharedParentVertex(childIndex1, childIndex2, vertex);
-    }
-    
-    /**
-     * Check if two child indices share a parent edge.
-     */
-    private boolean checkSharedParentEdge(int child1, int child2, int v0, int v1) {
-        // Use CHILD_VERTEX_PARENT_VERTEX to map child vertices to parent references
-        byte[] child1Vertices = TetreeConnectivity.CHILD_VERTEX_PARENT_VERTEX[child1];
-        byte[] child2Vertices = TetreeConnectivity.CHILD_VERTEX_PARENT_VERTEX[child2];
-        
-        // An edge is shared if both children have vertices that map to the same 
-        // two parent reference points
-        int sharedCount = 0;
-        Set<Byte> sharedReferences = new HashSet<>();
-        
-        // Find parent references that both children share
-        for (int i = 0; i < 4; i++) {
-            for (int j = 0; j < 4; j++) {
-                if (child1Vertices[i] == child2Vertices[j]) {
-                    sharedReferences.add(child1Vertices[i]);
-                }
-            }
-        }
-        
-        // An edge is shared if they have at least 2 common parent references
-        return sharedReferences.size() >= 2;
-    }
-    
-    /**
-     * Check if two child indices share a parent vertex.
-     */
-    private boolean checkSharedParentVertex(int child1, int child2, int vertex) {
-        // Use CHILD_VERTEX_PARENT_VERTEX to map child vertices to parent references
-        byte[] child1Vertices = TetreeConnectivity.CHILD_VERTEX_PARENT_VERTEX[child1];
-        byte[] child2Vertices = TetreeConnectivity.CHILD_VERTEX_PARENT_VERTEX[child2];
-        
-        // Check if both children have a vertex that maps to the same parent reference
-        for (int i = 0; i < 4; i++) {
-            for (int j = 0; j < 4; j++) {
-                if (child1Vertices[i] == child2Vertices[j] && child1Vertices[i] < 4) {
-                    // Parent vertices are 0-3, edge midpoints are 4-9, center is 10
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/neighbor/TetreeCrossParentNeighborTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/neighbor/TetreeCrossParentNeighborTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.lucien.neighbor;
+
+import com.hellblazer.luciferase.lucien.Constants;
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.tetree.Tet;
+import com.hellblazer.luciferase.lucien.tetree.Tetree;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3i;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validation for Luciferase-v9vm: {@code TetreeNeighborDetector.findNonSiblingNeighborsSharing}, the
+ * cross-parent edge/vertex neighbor walk that used to be an unimplemented stub.
+ *
+ * <p>Three independent checks, none circular w.r.t. the SUT's own descent:
+ * <ul>
+ *   <li><b>Brute-force geometric ground truth</b> — over every level-{@code L} tet in the domain, the
+ *       detector's edge/vertex-neighbor set must EXACTLY equal the set of OTHER level-{@code L} tets whose
+ *       vertex set contains the element's endpoint(s). This is the definition of edge/vertex sharing
+ *       (legitimate for the sharing relation; distinct from the forbidden "&ge;N shared vertices" check on
+ *       non-conforming FACE neighbors). The oracle is independent of the SUT's <em>search strategy</em> (it
+ *       enumerates exhaustively rather than via the {@code cubeEncloses} prune), so it catches descent/prune
+ *       errors. It does share the {@code Tet.child()} / {@code Tet.coordinates()} primitives with the SUT —
+ *       a systematic fault there would be invisible to BOTH, so those primitives are validated separately by
+ *       {@code T8codeDtetOracleTest} / {@code T8codeDtetFaceNeighborOracleTest}.</li>
+ *   <li><b>Reciprocity / involution</b> — A is an edge(/vertex) neighbor of B iff B is one of A.</li>
+ *   <li><b>Non-vacuous growth</b> — for a tet whose edge/vertex lies on a parent boundary, the full
+ *       edge/vertex neighbor set is strictly larger than the same-parent sibling face neighbors, proving the
+ *       cross-parent walk actually contributes (the stub returned no cross-parent neighbors).</li>
+ * </ul>
+ */
+class TetreeCrossParentNeighborTest {
+
+    private static final byte LEVEL = 3;
+
+    private Tetree<LongEntityID, String> tetree;
+    private TetreeNeighborDetector detector;
+
+    @BeforeEach
+    void setUp() {
+        tetree = new Tetree<>(new SequentialLongIDGenerator());
+        detector = new TetreeNeighborDetector(tetree);
+    }
+
+    /** Every level-LEVEL tet reachable from root via Bey refinement, deduplicated. */
+    private List<Tet> allTetsAtLevel(byte level) {
+        var out = new ArrayList<Tet>();
+        var seen = new HashSet<Tet>();
+        var work = new ArrayDeque<Tet>();
+        work.push(new Tet(0, 0, 0, (byte) 0, (byte) 0));
+        while (!work.isEmpty()) {
+            var t = work.pop();
+            if (t.l() == level) {
+                if (seen.add(t)) {
+                    out.add(t);
+                }
+                continue;
+            }
+            for (int c = 0; c < 8; c++) {
+                work.push(t.child(c));
+            }
+        }
+        return out;
+    }
+
+    private static boolean inDomain(Tet t) {
+        int max = Constants.lengthAtLevel((byte) 0);
+        return t.x() >= 0 && t.x() < max && t.y() >= 0 && t.y() < max && t.z() >= 0 && t.z() < max;
+    }
+
+    private static boolean hasVertex(Tet t, Point3i p) {
+        for (var c : t.coordinates()) {
+            if (c.x == p.x && c.y == p.y && c.z == p.z) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Independent brute-force oracle: all OTHER level-L tets sharing every element endpoint with `tet`. */
+    private Set<TetreeKey<?>> bruteForceSharers(Tet tet, List<Tet> universe, Point3i[] target) {
+        var result = new HashSet<TetreeKey<?>>();
+        for (var other : universe) {
+            if (other.equals(tet)) {
+                continue;
+            }
+            boolean all = true;
+            for (var p : target) {
+                if (!hasVertex(other, p)) {
+                    all = false;
+                    break;
+                }
+            }
+            if (all) {
+                result.add(other.tmIndex());
+            }
+        }
+        return result;
+    }
+
+    @Test
+    void edgeNeighborsMatchBruteForceGeometricGroundTruth() {
+        var universe = allTetsAtLevel(LEVEL);
+        assertTrue(universe.size() >= 512, "expected full level-" + LEVEL + " coverage, got " + universe.size());
+        int checked = 0;
+        int withCrossParent = 0;
+        for (var tet : universe) {
+            for (int edge = 0; edge < 6; edge++) {
+                var coords = tet.coordinates();
+                int[] ev = edgeVertices(edge);
+                var target = new Point3i[] { coords[ev[0]], coords[ev[1]] };
+
+                var expected = bruteForceSharers(tet, universe, target);
+                var actual = new HashSet<>(detector.findNeighborsSharingEdge(tet, edge));
+
+                assertEquals(expected, actual,
+                             "edge-neighbor set must equal brute-force geometric sharers for " + tet + " edge " + edge);
+                checked++;
+                if (!expected.isEmpty()) {
+                    withCrossParent++;
+                }
+            }
+        }
+        assertTrue(checked > 3000, "expected broad edge coverage, got " + checked);
+        assertTrue(withCrossParent > 0, "expected some edges to have neighbors, got " + withCrossParent);
+    }
+
+    @Test
+    void vertexNeighborsMatchBruteForceGeometricGroundTruth() {
+        var universe = allTetsAtLevel(LEVEL);
+        int checked = 0;
+        for (var tet : universe) {
+            for (int vertex = 0; vertex < 4; vertex++) {
+                var coords = tet.coordinates();
+                var target = new Point3i[] { coords[vertex] };
+
+                var expected = bruteForceSharers(tet, universe, target);
+                var actual = new HashSet<>(detector.findNeighborsSharingVertex(tet, vertex));
+
+                assertEquals(expected, actual,
+                             "vertex-neighbor set must equal brute-force geometric sharers for " + tet + " vertex "
+                             + vertex);
+                checked++;
+            }
+        }
+        assertTrue(checked > 2000, "expected broad vertex coverage, got " + checked);
+    }
+
+    @Test
+    void edgeAndVertexNeighborsAreReciprocal() {
+        var universe = allTetsAtLevel(LEVEL);
+        // Build keyed edge-neighbor relation over the full uniform leaf set and assert symmetry.
+        var keyToTet = new java.util.HashMap<TetreeKey<?>, Tet>();
+        for (var t : universe) {
+            keyToTet.put(t.tmIndex(), t);
+        }
+        for (var tet : universe) {
+            var key = tet.tmIndex();
+            var edgeNbrs = new HashSet<>(detector.findEdgeNeighbors(key));
+            for (var n : edgeNbrs) {
+                // Only reciprocity-check neighbors that are themselves level-L domain leaves.
+                var nt = keyToTet.get(n);
+                if (nt == null) {
+                    continue;
+                }
+                var back = new HashSet<>(detector.findEdgeNeighbors(n));
+                assertTrue(back.contains(key),
+                           "edge-neighbor relation must be reciprocal: " + tet + " -> " + nt + " but not back");
+            }
+            var vertexNbrs = new HashSet<>(detector.findVertexNeighbors(key));
+            for (var n : vertexNbrs) {
+                var nt = keyToTet.get(n);
+                if (nt == null) {
+                    continue;
+                }
+                var back = new HashSet<>(detector.findVertexNeighbors(n));
+                assertTrue(back.contains(key),
+                           "vertex-neighbor relation must be reciprocal: " + tet + " -> " + nt + " but not back");
+            }
+        }
+    }
+
+    @Test
+    void crossParentWalkStrictlyGrowsBeyondSiblingFaceNeighbors() {
+        // Find a tet whose edge has neighbors that are NOT same-parent siblings, proving cross-parent
+        // discovery. The stub produced only same-parent siblings; this would have failed against it.
+        var universe = allTetsAtLevel(LEVEL);
+        boolean demonstrated = false;
+        for (var tet : universe) {
+            var parent = tet.parent();
+            var siblings = new HashSet<TetreeKey<?>>();
+            for (int c = 0; c < 8; c++) {
+                siblings.add(parent.child(c).tmIndex());
+            }
+            for (int edge = 0; edge < 6 && !demonstrated; edge++) {
+                var nbrs = detector.findNeighborsSharingEdge(tet, edge);
+                for (var n : nbrs) {
+                    if (!siblings.contains(n)) {
+                        demonstrated = true; // a genuine cross-parent edge neighbor
+                        break;
+                    }
+                }
+            }
+            if (demonstrated) {
+                break;
+            }
+        }
+        assertTrue(demonstrated,
+                   "expected at least one tet with a cross-parent (non-sibling) edge neighbor — the stub never produced any");
+    }
+
+    private static int[] edgeVertices(int edge) {
+        return switch (edge) {
+            case 0 -> new int[] { 0, 1 };
+            case 1 -> new int[] { 0, 2 };
+            case 2 -> new int[] { 0, 3 };
+            case 3 -> new int[] { 1, 2 };
+            case 4 -> new int[] { 1, 3 };
+            default -> new int[] { 2, 3 };
+        };
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/neighbor/TetreeGhostEdgeVertexIntegrationTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/neighbor/TetreeGhostEdgeVertexIntegrationTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.lucien.neighbor;
+
+import com.hellblazer.luciferase.lucien.SpatialIndex;
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostAlgorithm;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostBoundaryDetector;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostType;
+import com.hellblazer.luciferase.lucien.tetree.Tetree;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import javax.vecmath.Point3f;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end coverage of the live consumer ({@link GhostBoundaryDetector}) for {@code GhostType.EDGES} and
+ * {@code GhostType.VERTICES} through {@link TetreeNeighborDetector} (Luciferase-v9vm follow-up to a
+ * substantive-critic gap: before this bead the cross-parent edge/vertex walk was a stub, so this consumer path
+ * never produced cross-parent ghost requests and was never exercised end-to-end).
+ *
+ * <p>The base {@code createGhostElement} is a placeholder (real ghost data arrives via gRPC), so we record its
+ * invocations with a subclass — the same pattern as {@code PyramidCrossShapeGhostTest}. Asserts the
+ * now-populated, strictly larger edge/vertex neighbor sets flow through ghost-layer creation: the run completes
+ * in bounded time (no runaway descent — guarded by {@code @Timeout}), fires ghost requests for remote-owned
+ * absent neighbors, and never requests a ghost for a key that is present locally (no self/local ghost).
+ */
+class TetreeGhostEdgeVertexIntegrationTest {
+
+    /** Records the (key, rank) of every ghost request the detector fires (base impl is a gRPC placeholder). */
+    private static final class RecordingGhostBoundaryDetector<Key extends SpatialKey<Key>>
+        extends GhostBoundaryDetector<Key, LongEntityID, String> {
+
+        final Map<Key, Integer> requested = new LinkedHashMap<>();
+
+        RecordingGhostBoundaryDetector(SpatialIndex<Key, LongEntityID, String> index,
+                                       NeighborDetector<Key> detector, GhostType type, GhostAlgorithm algo) {
+            super(index, detector, type, algo);
+        }
+
+        @Override
+        protected void createGhostElement(Key neighborKey, int ownerRank) {
+            requested.put(neighborKey, ownerRank);
+        }
+    }
+
+    private Tetree<LongEntityID, String> populatedTreeNearOriginCorner() {
+        var tetree = new Tetree<LongEntityID, String>(new SequentialLongIDGenerator());
+        // Cluster near the NEGATIVE domain corner so boundary elements are guaranteed and their edge/vertex
+        // neighbors reach unoccupied (absent) in-domain cells we can mark remote.
+        for (int i = 1; i <= 12; i++) {
+            tetree.insert(new Point3f(i * 8, i * 8, i * 8), (byte) 10, "E" + i);
+        }
+        return tetree;
+    }
+
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @Test
+    void edgeGhostRequestsAreBoundedFiredAndSelfFree() {
+        runGhostScenario(GhostType.EDGES);
+    }
+
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @Test
+    void vertexGhostRequestsAreBoundedFiredAndSelfFree() {
+        runGhostScenario(GhostType.VERTICES);
+    }
+
+    private void runGhostScenario(GhostType ghostType) {
+        var tetree = populatedTreeNearOriginCorner();
+        var detector = new TetreeNeighborDetector(tetree);
+        var ghostDetector = new RecordingGhostBoundaryDetector<TetreeKey<? extends TetreeKey<?>>>(
+            tetree, detector, ghostType, GhostAlgorithm.CONSERVATIVE);
+
+        // Mark every absent neighbor (edge or vertex, per ghostType) of every local key as remotely owned, so
+        // ghost creation has remote targets to fire on.
+        int marked = 0;
+        for (var key : tetree.getSortedSpatialIndices()) {
+            var neighbors = ghostType == GhostType.EDGES ? detector.findEdgeNeighbors(key)
+                                                         : detector.findVertexNeighbors(key);
+            for (var n : neighbors) {
+                if (!tetree.containsSpatialKey(n)) {
+                    ghostDetector.setElementOwner(n, 1); // rank 1 = remote
+                    marked++;
+                }
+            }
+        }
+        assertTrue(marked > 0, "scenario must mark some absent remote " + ghostType + " neighbors to be meaningful");
+
+        ghostDetector.createGhostLayer(); // bounded by @Timeout; must not run away
+
+        assertFalse(ghostDetector.requested.isEmpty(),
+                    "remote-owned absent " + ghostType + " neighbors must fire ghost requests");
+        assertFalse(ghostDetector.getBoundaryElements().isEmpty(), "expected boundary elements near the corner");
+
+        // No ghost request may target a locally-present key (requests are only ever for absent/remote keys).
+        for (var requestedKey : ghostDetector.requested.keySet()) {
+            assertFalse(tetree.containsSpatialKey(requestedKey),
+                        "ghost request must not target a locally-present key: " + requestedKey);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`TetreeNeighborDetector.findNonSiblingNeighborsSharing` was a no-op stub — cross-parent EDGE/VERTEX ghost queries silently returned only same-parent siblings (T3 `critique-luciferase-t8code-tet-neighbor` finding C2, bead Luciferase-v9vm). The ghost layer's `GhostType.EDGES`/`VERTICES` path was structurally incomplete.

## Approach

Pruned top-down descent over the **canonical Bey tiling**: a same-level tet is a neighbor across the element iff its vertex set contains all the element's grid points. `sharersOfPoint(p, level)` descends from root, recursing only into children whose cube encloses `p` (a Kuhn tet's cube **is** its exact AABB — vertices span v0..v7), keeping target-level tets that carry `p` as a vertex. For an edge, intersect the two endpoints' sharer sets.

Key design point (verified empirically): this is **deliberately not** a `Tet.faceNeighbor` flood. The Bey-SFC face neighbor is non-conforming — it returns geometrically-adjacent tets of types *not in the tiling* at that cell, so a flood reports phantom neighbors that the tree never stores. The `child()`-only descent yields only canonical tets. The cube-prune keeps cost **linear** in level (~64 node visits/level; 1409 visits / <1ms at max level 21), not exponential.

Also deleted the old sibling-only predicate machinery (`getChildIndex`/`sharesEdge`/`sharesVertex`/`checkSharedParentEdge`/`checkSharedParentVertex`/`findSiblingsSharing`) — it over-reported and is subsumed by the geometrically-exact descent.

## Tests
- **TetreeCrossParentNeighborTest** — exact-equality vs an independent brute-force tiling oracle over all 512 level-3 tets, reciprocity/involution, non-vacuous cross-parent growth.
- **TetreeGhostEdgeVertexIntegrationTest** — end-to-end through `GhostBoundaryDetector` (live consumer) for EDGES/VERTICES: bounded time, ghost requests fire for remote absent neighbors, no self/local ghost.

177 ghost/neighbor tests pass.

## Review
Stacked review complete (code-review-expert + substantive-critic). The critic's headline O(8^L) performance concern was **empirically refuted** (measured linear, ~64/level). Addressed: oracle-independence javadoc precision, minTetLevel/pure-Tetree scoping note, and the untested-consumer gap (added the GhostBoundaryDetector integration test).

Note: the pre-existing redundant `findFaceNeighbors` call inside `findEdgeNeighbors` (face neighbors are now reachable via the edge descent) was left as-is — harmless (HashSet-deduped) and out of v9vm scope.

Stacks on #178 (Luciferase-4bmd oracle) and #179 (Luciferase-koaw detector fix), both merged.