### PR TITLE
test(Luciferase-o988): RED-first TetreeKey key-invariant spec

### DIFF
--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeKeyInvariantTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeKeyInvariantTest.java
@@ -1,0 +1,270 @@
+package com.hellblazer.luciferase.lucien.tetree;
+
+import com.hellblazer.luciferase.geometry.MortonCurve;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Key-invariant contract tests for {@link TetreeKey} and its implementations
+ * ({@link CompactTetreeKey}, {@link ExtendedTetreeKey}, {@link LazyTetreeKey}).
+ *
+ * <p>These are the RED-first specification (bead Luciferase-o988) that gates the encoding flip
+ * keystone (bead Luciferase-tkvb). The tetrahedral TM-index currently packs the <em>coarsest</em>
+ * level at the LSB tuple and the finest (leaf) level at the most-significant tuple
+ * (see {@link Tet#tmIndex()}: level index {@code i=0} is written at bit {@code 6*i}). Under that
+ * layout two key-level invariants are violated:
+ * <ul>
+ *   <li><b>parent()</b>: {@link CompactTetreeKey#parent()} shifts right by 6 bits, which strips the
+ *       LSB tuple (the <em>coarsest</em> level) rather than the finest. So
+ *       {@code tet.tmIndex().parent()} disagrees with the ground-truth {@code tet.parent().tmIndex()}
+ *       at every level &ge; 2. Fixed by Luciferase-tkvb (coarsest-at-MSB consecutive encoding).</li>
+ *   <li><b>level-21 round-trip</b>: the level-21 split-bit packing does not round-trip
+ *       {@code Tet -> tmIndex -> Tet}. Also in Luciferase-tkvb's scope.</li>
+ * </ul>
+ * The tests asserting those two are {@link Disabled @Disabled} with a pointer to the owning bead;
+ * <b>Luciferase-tkvb's acceptance criterion is to remove those {@code @Disabled} markers and have the
+ * tests pass.</b> The remaining tests lock in behaviour that is correct today (decode round-trip
+ * L1-20, equals/compareTo consistency for concrete keys) as regression guards.
+ *
+ * <p>Ground truth for the parent/round-trip invariants is the geometric/topological {@link Tet}
+ * (its {@link Tet#parent()} and {@link Tet#tmIndex()} are independently validated against the t8code
+ * dtet oracle by {@link T8codeDtetOracleTest}); these tests only assert that the pure bit-level
+ * {@code TetreeKey} operations agree with that ground truth.
+ */
+class TetreeKeyInvariantTest {
+
+    private static final byte MAX_LEVEL = MortonCurve.MAX_REFINEMENT_LEVEL; // 21
+
+    /** Deterministically descend a child chain from root to {@code targetLevel}. */
+    private static Tet descend(Random rnd, byte targetLevel) {
+        var tet = new Tet(0, 0, 0, (byte) 0, (byte) 0);
+        for (int lvl = 0; lvl < targetLevel; lvl++) {
+            tet = tet.child(rnd.nextInt(8));
+        }
+        return tet;
+    }
+
+    // ===================================================================================
+    // Invariant 1 — parent round-trip: tet.parent().tmIndex() == tet.tmIndex().parent()
+    // ===================================================================================
+
+    /**
+     * RED until Luciferase-tkvb. The key-level {@code parent()} must equal the ground-truth parent
+     * key (encode the parent Tet) at every level 1..21. Currently violated at level &ge; 2 because
+     * {@code parent()} strips the coarsest tuple instead of the finest.
+     */
+    @Test
+    @Disabled("RED until Luciferase-tkvb: TetreeKey.parent() strips coarsest-at-LSB tuple instead of "
+              + "the finest level; tet.tmIndex().parent() != tet.parent().tmIndex() for level >= 2")
+    void parentRoundTrip_allLevels() {
+        var rnd = new Random(0xB0BACAFEL);
+        // Note: level 1 passes today (parent is root, all-zero bits); the breakage starts at level 2.
+        // After Luciferase-tkvb ALL levels 1..21 must pass.
+        for (byte target = 1; target <= MAX_LEVEL; target++) {
+            for (int sample = 0; sample < 64; sample++) {
+                assertParentRoundTrip(descend(rnd, target), target);
+            }
+        }
+        // Structural boundary pinning: the random walk above may not deterministically hit the
+        // compact<->extended boundary (L10->L11) or the last standard-extended level (L20). Pin all
+        // 6 tet types at a fixed anchor for those levels so the encoding flip cannot pass these tests
+        // while silently regressing a boundary case.
+        for (byte target : new byte[] { 10, 11, 20 }) {
+            for (byte type = 0; type < 6; type++) {
+                assertParentRoundTrip(new Tet(0, 0, 0, target, type), target);
+            }
+        }
+    }
+
+    private static void assertParentRoundTrip(Tet tet, byte target) {
+        var groundTruth = tet.parent().tmIndex();       // build parent Tet, then encode
+        var viaKey = tet.tmIndex().parent();             // encode, then key.parent()
+        assertEquals(groundTruth, viaKey,
+                     "parent key mismatch at level " + target + " for " + tet
+                     + ": ground-truth=" + groundTruth + " key.parent()=" + viaKey);
+        assertEquals((byte) (target - 1), viaKey.getLevel(),
+                     "parent level must be one coarser at level " + target);
+    }
+
+    // ===================================================================================
+    // Invariant 2 — decode round-trip: Tet.tetrahedron(tet.tmIndex()) == tet
+    //   (extends the oracle sweep past level 5 into the L11-21 ExtendedTetreeKey split)
+    // ===================================================================================
+
+    /**
+     * GREEN regression guard. {@code Tet -> tmIndex -> Tet} must round-trip for levels 1..20,
+     * exercising both the single-long {@link CompactTetreeKey} range (L1-10) and the dual-long
+     * {@link ExtendedTetreeKey} split (L11-20). The existing oracle sweep
+     * ({@link T8codeDtetOracleTest}) only reaches level 5; this carries it to L20.
+     */
+    @Test
+    void decodeRoundTrip_L1toL20() {
+        var rnd = new Random(0x5EED1234L);
+        for (byte target = 1; target <= 20; target++) {
+            for (int sample = 0; sample < 200; sample++) {
+                var tet = descend(rnd, target);
+                var decoded = Tet.tetrahedron(tet.tmIndex());
+                assertEquals(tet, decoded,
+                             "tmIndex decode round-trip failed at level " + target + " for " + tet);
+            }
+        }
+    }
+
+    /**
+     * RED until Luciferase-tkvb. Level 21 (maximum refinement) uses split-bit packing that does not
+     * currently round-trip {@code Tet -> tmIndex -> Tet}. Same encoding flip that fixes parent()
+     * fixes the level-21 split.
+     */
+    @Test
+    @Disabled("RED until Luciferase-tkvb: level-21 split-bit encoding does not round-trip "
+              + "Tet -> tmIndex -> Tet")
+    void decodeRoundTrip_L21() {
+        var rnd = new Random(0x21212121L);
+        for (int sample = 0; sample < 256; sample++) {
+            var tet = descend(rnd, MAX_LEVEL);
+            var decoded = Tet.tetrahedron(tet.tmIndex());
+            assertEquals(tet, decoded, "level-21 tmIndex decode round-trip failed for " + tet);
+        }
+    }
+
+    // ===================================================================================
+    // Invariant 3 — equals <-> compareTo consistency
+    // ===================================================================================
+
+    /**
+     * GREEN regression guard. For concrete keys ({@link CompactTetreeKey} at L1-10 and
+     * {@link ExtendedTetreeKey} at L11-20), {@code a.equals(b)} must agree with
+     * {@code a.compareTo(b) == 0}, equals must be symmetric, and equal keys must share a hashCode.
+     */
+    @Test
+    void equalsCompareToConsistency_concreteKeys() {
+        var rnd = new Random(0xC0FFEEL);
+        var keys = new java.util.ArrayList<TetreeKey<?>>();
+        for (byte target = 1; target <= 20; target++) {
+            for (int sample = 0; sample < 40; sample++) {
+                keys.add(descend(rnd, target).tmIndex());
+            }
+        }
+        for (var a : keys) {
+            // re-derive an independent but equal instance to exercise the equal branch
+            var aCopy = TetreeKey.create(a.getLevel(), a.getLowBits(), a.getHighBits());
+            assertTrue(a.equals(aCopy), "equal-bits keys must be equal: " + a);
+            assertTrue(aCopy.equals(a), "equals must be symmetric for equal-bits keys: " + a);
+            assertEquals(0, a.compareTo(aCopy), "compareTo must be 0 for equal keys: " + a);
+            assertEquals(a.hashCode(), aCopy.hashCode(), "equal keys must share hashCode: " + a);
+
+            for (var b : keys) {
+                boolean eq = a.equals(b);
+                boolean cmpZero = a.compareTo(b) == 0;
+                assertEquals(cmpZero, eq,
+                             "equals/compareTo disagreement: a=" + a + " b=" + b
+                             + " equals=" + eq + " compareTo==0=" + cmpZero);
+                // symmetry of equals across the whole sample
+                assertEquals(eq, b.equals(a), "equals must be symmetric: a=" + a + " b=" + b);
+                // antisymmetry of compareTo
+                assertEquals(Integer.signum(a.compareTo(b)), -Integer.signum(b.compareTo(a)),
+                             "compareTo must be antisymmetric: a=" + a + " b=" + b);
+            }
+        }
+    }
+
+    /**
+     * RED until Luciferase-567m. Two concrete keys with identical (level, bits) but different runtime
+     * classes must be mutually equal and share a hashCode. {@link ExtendedTetreeKey} extends
+     * {@link CompactTetreeKey}, and each {@code equals} uses an {@code instanceof} keyed to its own
+     * class: {@code compact.equals(extended)} is true but {@code extended.equals(compact)} is false,
+     * an {@link Object#equals} symmetry violation that also diverges from {@code compareTo == 0}.
+     * The fix (567m) is to compare on (level, lowBits, highBits) uniformly across all implementations.
+     */
+    @Test
+    @Disabled("RED until Luciferase-567m: Compact/Extended equals is asymmetric (instanceof keyed to "
+              + "own class); equal-bits keys of different impls are not mutually equal")
+    void equalsSymmetry_crossImpl() {
+        // Same level (10), same bits, different runtime classes: Compact vs Extended-with-zero-high.
+        long bits = 0x1234567L;
+        var compact = new CompactTetreeKey((byte) 10, bits);
+        var extended = new ExtendedTetreeKey((byte) 10, bits, 0L);
+        assertEquals(0, compact.compareTo(extended), "compareTo must agree (0) for equal-bits keys");
+        assertEquals(0, extended.compareTo(compact), "compareTo must agree (0) for equal-bits keys");
+        assertTrue(compact.equals(extended), "compact.equals(extended) for equal-bits keys");
+        assertTrue(extended.equals(compact), "extended.equals(compact) for equal-bits keys");
+        assertEquals(compact.hashCode(), extended.hashCode(), "equal-bits keys must share hashCode");
+    }
+
+    /**
+     * RED until Luciferase-567m. {@link LazyTetreeKey} and the concrete key it resolves to must be
+     * mutually equal for the same {@link Tet}. Today {@code lazy.equals(concrete)} is true but
+     * {@code concrete.equals(lazy)} is false (same {@code instanceof}-keyed equals root cause as
+     * {@link #equalsSymmetry_crossImpl()}). Additionally {@code LazyTetreeKey.hashCode()} returns a
+     * Tet-coordinate polynomial rather than the tmIndex-based hash the concrete keys use, so equal
+     * lazy/concrete keys have different hash codes — 567m must align hashCode, not just equals.
+     */
+    @Test
+    @Disabled("RED until Luciferase-567m: LazyTetreeKey.equals is asymmetric vs Compact/Extended keys, "
+              + "and LazyTetreeKey.hashCode() uses a Tet-coordinate polynomial rather than the tmIndex "
+              + "hash, so equal lazy/concrete keys have different hash codes")
+    void equalsSymmetry_lazyVsConcrete() {
+        var rnd = new Random(0x1A2B3CL);
+        for (byte target = 1; target <= 20; target++) {
+            for (int sample = 0; sample < 40; sample++) {
+                var tet = descend(rnd, target);
+                var lazy = new LazyTetreeKey(tet);
+                var concrete = tet.tmIndex();
+                assertTrue(lazy.equals(concrete), "lazy.equals(concrete) at level " + target + " for " + tet);
+                assertTrue(concrete.equals(lazy), "concrete.equals(lazy) at level " + target + " for " + tet);
+                assertEquals(0, lazy.compareTo(concrete), "lazy.compareTo(concrete)==0 for " + tet);
+                assertEquals(0, concrete.compareTo(lazy), "concrete.compareTo(lazy)==0 for " + tet);
+                assertEquals(lazy.hashCode(), concrete.hashCode(),
+                             "equal lazy/concrete keys must share hashCode for " + tet);
+            }
+        }
+    }
+
+    /**
+     * GREEN regression guard. Distinct sibling tets must produce keys that are unequal and order
+     * strictly (no two distinct cells collide), and ordering must be a strict total order on the
+     * sample (irreflexive distinctness).
+     */
+    @Test
+    void distinctTetsProduceDistinctOrderedKeys() {
+        // Sibling-set check at the root: all 8 children must map to distinct, strictly-ordered keys.
+        var root = new Tet(0, 0, 0, (byte) 0, (byte) 0);
+        var siblingKeys = new java.util.ArrayList<TetreeKey<?>>();
+        for (int i = 0; i < 8; i++) {
+            siblingKeys.add(root.child(i).tmIndex());
+        }
+        for (int i = 0; i < 8; i++) {
+            for (int j = 0; j < 8; j++) {
+                var keyI = siblingKeys.get(i);
+                var keyJ = siblingKeys.get(j);
+                if (i == j) {
+                    assertEquals(0, keyI.compareTo(keyJ), "same child must compare equal");
+                } else {
+                    assertFalse(keyI.equals(keyJ), "distinct children must not be equal");
+                    assertFalse(keyI.compareTo(keyJ) == 0, "distinct children must not compare equal");
+                }
+            }
+        }
+
+        // No-collision check across a deeper sample spanning the compact (<=10) and extended (>10)
+        // ranges: distinct Tets at distinct levels must never collide on a single key.
+        var rnd = new Random(0xD15C0L);
+        var seen = new java.util.HashMap<TetreeKey<?>, Tet>();
+        for (byte target : new byte[] { 5, 10, 11, 15, 20 }) {
+            for (int sample = 0; sample < 100; sample++) {
+                var tet = descend(rnd, target);
+                var key = tet.tmIndex();
+                var prior = seen.putIfAbsent(key, tet);
+                // A collision is only a defect when the colliding Tets differ.
+                assertTrue(prior == null || prior.equals(tet),
+                           "distinct Tets collided on key " + key + ": " + prior + " vs " + tet);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `TetreeKeyInvariantTest` — the RED-first key-invariant specification (bead **Luciferase-o988**) that gates the `TetreeKey` encoding-flip keystone (**Luciferase-tkvb**). Test-only; no production changes.

The tetrahedral TM-index currently packs the **coarsest** level at the LSB tuple and the finest at the MSB. This exposes two key-level bugs (owned by tkvb) and an equals/hashCode contract bug (owned by **Luciferase-567m**, filed and broadened during this work).

## GREEN regression guards (pass today)
- `decodeRoundTrip_L1toL20` — `Tet → tmIndex → Tet` across the compact (L1-10) and extended (L11-20) ranges; carries the oracle sweep past its previous L5 ceiling.
- `equalsCompareToConsistency_concreteKeys` — `equals ⇔ compareTo==0`, symmetry, antisymmetry, hashCode consistency for concrete keys.
- `distinctTetsProduceDistinctOrderedKeys` — no key collisions across an L5–L20 sample + strict sibling ordering.

## RED (`@Disabled`, verified non-vacuous, pointers to owning beads)
- `parentRoundTrip_allLevels` (+ structural pins at L10/L11/L20, all 6 types) and `decodeRoundTrip_L21` → **Luciferase-tkvb**: `TetreeKey.parent()` strips the coarsest-at-LSB tuple instead of the finest (~85% fail L2+); the level-21 split does not round-trip (702/914 fail).
- `equalsSymmetry_crossImpl`, `equalsSymmetry_lazyVsConcrete` → **Luciferase-567m**: `equals` is asymmetric across Compact/Extended/Lazy (each `equals` uses an `instanceof` keyed to its own class; `ExtendedTetreeKey extends CompactTetreeKey`), and `LazyTetreeKey.hashCode()` uses a Tet-coordinate polynomial rather than the tmIndex hash.

`tkvb` and `567m` acceptance criteria are pinned to remove the `@Disabled` markers and turn the tests green.

## Review
Stacked review run (code-review-expert + substantive-critic). Addressed: added the cross-impl equals RED case (the "across Compact/Extended" coverage gap), structural boundary pinning at L10/L11/L20, broadened 567m scope to cover hashCode + cross-impl, and pinned both downstream beads' ACs to re-enable the disabled tests.

Bead: Luciferase-o988