### PR TITLE
feat(Luciferase-tkvb): flip TetreeKey to coarsest-at-MSB consecutive encoding

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/CompactTetreeKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/CompactTetreeKey.java
@@ -86,15 +86,16 @@ public class CompactTetreeKey extends TetreeKey<CompactTetreeKey> {
             return levelComparison;
         }
         
-        // Levels are equal, now compare TM-index bits
-        // First compare low bits
-        int lowComparison = Long.compareUnsigned(tmIndex, other.getLowBits());
-        if (lowComparison != 0) {
-            return lowComparison;
+        // Levels are equal, now compare TM-index bits. Coarsest-at-MSB layout (Luciferase-tkvb):
+        // the shallowest step occupies the most significant bits, so compare (highBits, lowBits) as
+        // a 128-bit unsigned value - high bits first - to reproduce the coarse-dominant SFC order.
+        // A CompactTetreeKey has no high bits (always 0).
+        int highComparison = Long.compareUnsigned(0L, other.getHighBits());
+        if (highComparison != 0) {
+            return highComparison;
         }
 
-        // If low bits are equal, compare high bits (this key has no high bits)
-        return Long.compareUnsigned(0L, other.getHighBits());
+        return Long.compareUnsigned(tmIndex, other.getLowBits());
     }
 
     @Override

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/ExtendedTetreeKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/ExtendedTetreeKey.java
@@ -22,22 +22,16 @@ import java.util.Objects;
 
 /**
  * Extended spatial key implementation for Tetree structures using 128-bit representation supporting all levels 0-21.
- * This provides full Octree-equivalent refinement capacity with innovative level 21 bit packing.
+ * This provides full Octree-equivalent refinement capacity.
  *
- * <h3>Memory Layout</h3>
+ * <h3>Bit layout (coarsest-at-MSB, Luciferase-tkvb)</h3>
  * <ul>
- * <li><b>Total Storage</b>: 128 bits (two longs: lowBits + highBits)</li>
- * <li><b>Standard Encoding</b>: Levels 0-20 use standard 6-bits-per-level encoding</li>
- * <li><b>Level 21 Bit Packing</b>: Uses leftover bits in both longs for full 21-level support</li>
- * </ul>
- *
- * <h3>Level 21 Innovation</h3>
- * Level 21 uses split encoding across both longs:
- * <ul>
- * <li><b>Low Long</b>: 4 bits stored in positions 60-63</li>
- * <li><b>High Long</b>: 2 bits stored in positions 60-61</li>
- * <li><b>Total</b>: 6 bits (3 coordinate + 3 type) maintaining SFC semantics</li>
- * <li><b>Ordering</b>: Preserves space-filling curve ordering properties</li>
+ * <li><b>Total Storage</b>: 128 bits (two longs: lowBits = bits 0-63, highBits = bits 64-125)</li>
+ * <li><b>Uniform Encoding</b>: 6 bits per level (3 coordinate + 3 type), all levels 1-21 alike</li>
+ * <li><b>No Split</b>: 21 * 6 = 126 bits fit two longs with no special level-21 packing</li>
+ * <li><b>Ordering</b>: the shallowest step occupies the most significant bits; the leaf is at bits
+ *     0-5. {@link #compareTo} compares {@code (highBits, lowBits)} unsigned, giving the
+ *     coarse-dominant SFC order (matches {@code PyramidKey})</li>
  * </ul>
  *
  * <h3>Key Features</h3>
@@ -52,15 +46,15 @@ import java.util.Objects;
  */
 public class ExtendedTetreeKey extends CompactTetreeKey {
 
-    private final long highBits; // Upper 64 bits (levels 10-20, 6 bits per level)
+    private final long highBits; // Index bits 64-125 (coarsest-at-MSB uniform layout)
 
     /**
-     * Create a new ExtendedTetreeKey using 128-bit representation.
-     * For level 21, uses special bit packing with level 21 data split across both longs.
+     * Create a new ExtendedTetreeKey using 128-bit representation. Coarsest-at-MSB uniform layout
+     * (Luciferase-tkvb): 6 bits per level, leaf at the LSB, no level-21 split.
      *
      * @param level    the hierarchical level (0-based, 0-21)
-     * @param lowBits  the lower 64 bits of the TM-index (levels 0-9, plus level 21 bits 0-3)
-     * @param highBits the upper 64 bits of the TM-index (levels 10-20, plus level 21 bits 4-5)
+     * @param lowBits  index bits 0-63 (the deeper refinement steps; leaf at bits 0-5)
+     * @param highBits index bits 64-125 (the shallower refinement steps)
      */
     public ExtendedTetreeKey(byte level, long lowBits, long highBits) {
         super(level, lowBits, true); // Use protected constructor to skip level validation

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/ExtendedTetreeKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/ExtendedTetreeKey.java
@@ -78,22 +78,18 @@ public class ExtendedTetreeKey extends CompactTetreeKey {
     }
 
     /**
-     * Create a level 21 ExtendedTetreeKey with proper bit packing.
-     * This method handles the special encoding required for level 21.
+     * Create a level-21 ExtendedTetreeKey in the coarsest-at-MSB uniform layout (Luciferase-tkvb).
+     * {@code (baseHighBits, baseLowBits)} are the 120-bit packed index of the level-20 parent
+     * (deepest group at the LSB); the level-21 leaf group is appended at the least-significant end.
      *
-     * @param baseLowBits  the TM-index data for levels 0-9 (60 bits)
-     * @param baseHighBits the TM-index data for levels 10-20 (60 bits)
-     * @param level21Bits  the 6-bit value for level 21 (will be split across both longs)
-     * @return ExtendedTetreeKey with level 21 encoding
+     * @param baseLowBits  the level-20 parent's low 64 bits
+     * @param baseHighBits the level-20 parent's high bits
+     * @param level21Bits  the 6-bit leaf group {@code (coord << 3) | type}
+     * @return the level-21 key
      */
     public static ExtendedTetreeKey createLevel21Key(long baseLowBits, long baseHighBits, byte level21Bits) {
-        // Pack the level 21 bits using the split encoding
-        long[] packedBits = packLevel21Bits(level21Bits);
-        
-        // Combine base bits with packed level 21 bits
-        long finalLowBits = baseLowBits | packedBits[0];
-        long finalHighBits = baseHighBits | packedBits[1];
-        
+        long finalHighBits = (baseHighBits << BITS_PER_LEVEL) | (baseLowBits >>> (64 - BITS_PER_LEVEL));
+        long finalLowBits = (baseLowBits << BITS_PER_LEVEL) | (level21Bits & 0x3FL);
         return new ExtendedTetreeKey((byte) 21, finalLowBits, finalHighBits);
     }
 
@@ -139,46 +135,19 @@ public class ExtendedTetreeKey extends CompactTetreeKey {
 
     @Override
     public boolean isValid() {
-        // Check basic level validity
         if (level < 0 || level > MortonCurve.MAX_REFINEMENT_LEVEL) {
             return false;
         }
-
-        // For level 0 (root), should have no bits set
-        if (level == 0) {
-            return getLowBits() == 0 && highBits == 0;
+        // Coarsest-at-MSB uniform layout (Luciferase-tkvb): a level-L key occupies the low
+        // 6*L bits of the 128-bit (highBits, lowBits) value; all higher bits must be zero.
+        int usedBits = level * BITS_PER_LEVEL;
+        if (usedBits <= 64) {
+            long lowMask = (usedBits == 64) ? -1L : (1L << usedBits) - 1;
+            return (getLowBits() & ~lowMask) == 0L && highBits == 0L;
         }
-
-        // For levels 1-10, only low bits should be used (high bits should be 0)
-        if (level <= 10) {
-            if (highBits != 0) {
-                return false;
-            }
-            // Check that we don't have bits set beyond what's needed
-            long maxBitsForLevel = (1L << (level * BITS_PER_LEVEL)) - 1;
-            return (getLowBits() & ~maxBitsForLevel) == 0;
-        }
-
-        // Special validation for level 21 with split bit encoding
-        if (level == 21) {
-            return isLevel21Valid();
-        }
-
-        // For levels 11-20, both low and high bits may be used
-        // Low bits can use up to 60 bits (10 levels * 6 bits per level)
-        // High bits usage depends on the level
-        int highLevels = level - 10;
-        int bitsNeeded = highLevels * BITS_PER_LEVEL;
-
-        // Handle case where we need all 64 bits or more
-        if (bitsNeeded >= 64) {
-            // For level 20: highLevels=10, bitsNeeded=60
-            // We can use up to 60 bits in highBits
-            return true;
-        }
-
-        long maxHighBitsForLevel = (1L << bitsNeeded) - 1;
-        return (highBits & ~maxHighBitsForLevel) == 0;
+        int usedHigh = usedBits - 64;
+        long highMask = (usedHigh >= 64) ? -1L : (1L << usedHigh) - 1;
+        return (highBits & ~highMask) == 0L;
     }
 
     @Override
@@ -187,70 +156,13 @@ public class ExtendedTetreeKey extends CompactTetreeKey {
             return null; // Root has no parent
         }
 
-        // Calculate parent by removing the last 6-bit tuple
+        // Coarsest-at-MSB layout (Luciferase-tkvb): the leaf (deepest) group is at the LSB. The
+        // parent drops that group by shifting the whole 128-bit (highBits, lowBits) value right by
+        // one 6-bit group. Uniform across all levels - no level-21 split.
         byte parentLevel = (byte) (level - 1);
-
-        // Special handling for level 21 with split encoding
-        if (level == 21) {
-            // For level 21, we need to remove the split-encoded level 21 bits
-            // and return a level 20 key with standard encoding
-            long parentLowBits = getLowBits() & ((1L << LEVEL_21_LOW_BITS_SHIFT) - 1); // Clear bits 60-63
-            long parentHighBits = highBits & ((1L << LEVEL_21_HIGH_BITS_SHIFT) - 1);   // Clear bits 60-61
-            return new ExtendedTetreeKey(parentLevel, parentLowBits, parentHighBits);
-        }
-
-        // The tm-index structure stores levels 0-9 in lowBits (60 bits used)
-        // and levels 10-20 in highBits (66 bits used)
-        long parentLowBits;
-        long parentHighBits;
-
-        if (level <= 10) {
-            // Current key uses only lowBits, parent also uses only lowBits
-            parentLowBits = getLowBits() >>> BITS_PER_LEVEL;
-            parentHighBits = 0L;
-        } else {
-            // Current key uses both lowBits and highBits
-            // When level > 10, the encoding changes:
-            // - lowBits contains levels 0-9 (unchanged)
-            // - highBits contains levels 10 and up
-
-            // For parent, we need to remove 6 bits from the highBits
-            parentHighBits = highBits >>> BITS_PER_LEVEL;
-            // lowBits remains the same for levels 0-9
-            parentLowBits = getLowBits();
-        }
-
+        long parentLowBits = (getLowBits() >>> BITS_PER_LEVEL) | (highBits << (64 - BITS_PER_LEVEL));
+        long parentHighBits = highBits >>> BITS_PER_LEVEL;
         return new ExtendedTetreeKey(parentLevel, parentLowBits, parentHighBits);
-    }
-
-    /**
-     * Validates level 21 bit encoding. For level 21, validates that:
-     * 1. Low bits 0-59 contain valid levels 0-9 data
-     * 2. Low bits 60-63 contain valid level 21 data (4 bits)
-     * 3. High bits 0-59 contain valid levels 10-20 data
-     * 4. High bits 60-61 contain valid level 21 data (2 bits)
-     * 5. High bits 62-63 are unused (must be 0)
-     *
-     * @return true if level 21 encoding is valid
-     */
-    private boolean isLevel21Valid() {
-        // Check that unused high bits (62-63) are zero
-        long unusedHighBits = highBits & ~((1L << 62) - 1); // Mask off bits 0-61
-        if (unusedHighBits != 0) {
-            return false;
-        }
-        
-        // Level 21 needs 21 * 6 = 126 bits total
-        // We have 60 (low 0-59) + 60 (high 0-59) + 4 (low 60-63) + 2 (high 60-61) = 126 bits exactly
-        // So the encoding can use all available bits except high bits 62-63
-        
-        // Validate that level 21 split bits are within valid range (0-63 for 6-bit value)
-        long lowLevel21Bits = (getLowBits() >> LEVEL_21_LOW_BITS_SHIFT) & LEVEL_21_LOW_MASK;
-        long highLevel21Bits = (highBits >> LEVEL_21_HIGH_BITS_SHIFT) & LEVEL_21_HIGH_MASK;
-        long combinedLevel21Bits = lowLevel21Bits | (highLevel21Bits << 4);
-        
-        // The 6-bit value should be valid (0-63)
-        return combinedLevel21Bits <= 0x3F;
     }
 
     // toString() inherited from TetreeKey base class provides appropriate format

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/Tet.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/Tet.java
@@ -567,13 +567,21 @@ public class Tet implements Spatial.aabt, HybridElement {
             throw new IllegalArgumentException("Level " + level + " exceeds maximum supported level 21");
         }
 
-        // Extract 6-bit chunks from least significant to most significant
+        // Extract 6-bit chunks. Coarsest-at-MSB layout (Luciferase-tkvb): step i (i=0 shallowest)
+        // sits at bit offset 6*(level-1-i) from the LSB across the 128-bit (highBits, lowBits) value,
+        // and may straddle the 64-bit boundary.
         for (int i = 0; i < maxBits; i++) {
+            int bit = (maxBits - 1 - i) * 6; // offset from LSB
             int sixBits;
-            if (i < 10) {
-                sixBits = (int) ((lowBits >> (6 * i)) & 0x3F);
+            if (bit >= 64) {
+                sixBits = (int) ((highBits >>> (bit - 64)) & 0x3F);
+            } else if (bit + 6 <= 64) {
+                sixBits = (int) ((lowBits >>> bit) & 0x3F);
             } else {
-                sixBits = (int) ((highBits >> (6 * (i - 10))) & 0x3F);
+                // Straddles the low/high boundary.
+                long lowPart = lowBits >>> bit;
+                long highPart = highBits << (64 - bit);
+                sixBits = (int) ((lowPart | highPart) & 0x3F);
             }
 
             // Lower 3 bits are type
@@ -2025,11 +2033,14 @@ public class Tet implements Spatial.aabt, HybridElement {
             throw new IllegalStateException("Level " + l + " exceeds maximum supported level 21 for 128-bit TM-index");
         }
 
-        // Use 128-bit representation
+        // Use 128-bit representation, coarsest-at-MSB consecutive layout (matches PyramidKey,
+        // Luciferase-tkvb). Each refinement step's 6-bit group is appended at the least-significant
+        // end: the shallowest step (i=0) migrates to the most significant bits, the leaf (i=l-1)
+        // lands at bits 0-5. compareTo on (highBits, lowBits) unsigned then reproduces the
+        // coarse-dominant SFC order. No level-21 split: 21 * 6 = 126 bits fit two longs.
         long lowBits = 0L;
         long highBits = 0L;
 
-        // Process each level in order with cached types
         for (int i = 0; i < l; i++) {
             int bitPos = Constants.getMaxRefinementLevel() - 1 - i;
             int xBit = (shiftedX >> bitPos) & 1;
@@ -2039,11 +2050,9 @@ public class Tet implements Spatial.aabt, HybridElement {
             int coordBits = (zBit << 2) | (yBit << 1) | xBit;
             int sixBits = (coordBits << 3) | types[i];
 
-            if (i < 10) {
-                lowBits |= ((long) sixBits) << (6 * i);
-            } else {
-                highBits |= ((long) sixBits) << (6 * (i - 10));
-            }
+            // Shift the running 128-bit value left by one group and OR the new group into the LSB.
+            highBits = (highBits << 6) | (lowBits >>> 58);
+            lowBits = (lowBits << 6) | sixBits;
         }
 
         // Use compact key for levels <= 10 for better performance

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeKey.java
@@ -36,13 +36,13 @@ import java.util.Objects;
  * <li><b>ExtendedTetreeKey</b>: Dual 64-bit longs for levels 0-21 (full Octree-equivalent capacity)</li>
  * </ul>
  *
- * <h3>Level 21 Bit Packing</h3>
- * Level 21 uses innovative split encoding to achieve full 21-level support:
+ * <h3>Bit Layout (coarsest-at-MSB, Luciferase-tkvb)</h3>
+ * Uniform 6 bits per level across two longs, no special level-21 split:
  * <ul>
- * <li>4 bits stored in low long positions 60-63</li>
- * <li>2 bits stored in high long positions 60-61</li>
- * <li>Preserves space-filling curve ordering properties</li>
- * <li>Enables efficient parent/child computation</li>
+ * <li>21 * 6 = 126 bits fit two longs (lowBits = 0-63, highBits = 64-125)</li>
+ * <li>Shallowest refinement step occupies the most significant bits; the leaf is at bits 0-5</li>
+ * <li>compareTo compares (highBits, lowBits) unsigned, giving coarse-dominant SFC order</li>
+ * <li>parent() drops the leaf group via a 128-bit right shift of 6 (matches PyramidKey)</li>
  * </ul>
  *
  * <h3>Tetrahedral Space-Filling Curve</h3>
@@ -177,8 +177,9 @@ public abstract class TetreeKey<K extends TetreeKey<K>> implements SpatialKey<Te
     }
 
     /**
-     * Get the low bits of the TM-index. For levels <= 10, this contains the entire TM-index. For levels > 10, this
-     * contains levels 0-9.
+     * Get the low bits of the TM-index (index bits 0-63). Coarsest-at-MSB layout (Luciferase-tkvb):
+     * these are the deeper refinement steps, with the leaf group at bits 0-5. For levels <= 10 the
+     * whole index fits here and the high bits are 0.
      *
      * @return the low bits of the TM-index
      */
@@ -471,7 +472,10 @@ public abstract class TetreeKey<K extends TetreeKey<K>> implements SpatialKey<Te
      * @param key the current key
      * @return the next key in SFC order, or a sentinel maximum key if at the end
      */
-    private static TetreeKey<?> getNextKey(TetreeKey<?> key) {
+    // Package-private (not private) so the unsigned-increment boundary can be regression-tested
+    // directly (Luciferase-tkvb): the lowBits == -1L all-ones carry path is not reachable through
+    // estimateSFCRange with ordinary inputs.
+    static TetreeKey<?> getNextKey(TetreeKey<?> key) {
         // Strategy: Try to increment the tm-index by 1
         // If we overflow at this level, return a key at level-1 (coarser level)
         // This ensures we don't miss any keys in the range

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeKey.java
@@ -58,16 +58,10 @@ import java.util.Objects;
  */
 public abstract class TetreeKey<K extends TetreeKey<K>> implements SpatialKey<TetreeKey<? extends TetreeKey<?>>> {
 
-    // Bit layout constants
+    // Bit layout constants. Coarsest-at-MSB uniform layout (Luciferase-tkvb): 6 bits per level,
+    // 21 * 6 = 126 bits across two longs, no special level-21 split.
     protected static final int  BITS_PER_LEVEL       = 6;
     protected static final int  MAX_COMPACT_LEVEL    = 10;
-
-
-    // Level 21 special bit packing constants
-    protected static final int  LEVEL_21_LOW_BITS_SHIFT = 60;  // Position in low long for level 21 bits
-    protected static final int  LEVEL_21_HIGH_BITS_SHIFT = 60; // Position in high long for level 21 bits
-    protected static final long LEVEL_21_LOW_MASK = 0xFL;      // 4 bits: 0b1111
-    protected static final long LEVEL_21_HIGH_MASK = 0x3L;     // 2 bits: 0b11
 
     // Cached root instance - root is always compact
     private static final CompactTetreeKey ROOT = new CompactTetreeKey((byte) 0, 0L);
@@ -136,22 +130,38 @@ public abstract class TetreeKey<K extends TetreeKey<K>> implements SpatialKey<Te
         if (targetLevel < 0 || targetLevel > level) {
             throw new IllegalArgumentException("Target level must be between 0 and " + level);
         }
+        // Coordinate bits are the upper 3 bits of the 6-bit group.
+        return (byte) ((rawGroupAt(targetLevel) >> 3) & 0x7);
+    }
 
-        // Special handling for level 21 with split bit encoding
-        if (targetLevel == 21) {
-            return getLevel21CoordBits();
+    /**
+     * Extract the raw 6-bit group for refinement step {@code targetLevel}. Coarsest-at-MSB layout
+     * (Luciferase-tkvb): {@code targetLevel == 0} is the shallowest step and sits in the most
+     * significant occupied bits; {@code targetLevel == level - 1} is the leaf and sits at bits 0-5.
+     * The group lives at bit offset {@code (level - 1 - targetLevel) * 6} from the LSB across the
+     * 128-bit {@code (highBits, lowBits)} value and may straddle the 64-bit boundary.
+     *
+     * @param targetLevel the 0-indexed refinement step (0 = shallowest, level-1 = leaf)
+     * @return the 6-bit group value (0..63)
+     */
+    private long rawGroupAt(int targetLevel) {
+        if (level == 0) {
+            return 0L;
         }
-
-        // Determine which long contains this level's data
-        if (targetLevel < 10) {
-            // In low bits: level 0 at bits 0-5, level 1 at bits 6-11, ..., level 9 at bits 54-59
-            int shift = targetLevel * BITS_PER_LEVEL + 3;
-            return (byte) ((getLowBits() >> shift) & 0x7);
-        } else {
-            // In high bits: level 10 at bits 0-5, level 11 at bits 6-11, etc.
-            int shift = (targetLevel - 10) * BITS_PER_LEVEL + 3;
-            return (byte) ((getHighBits() >> shift) & 0x7);
+        int bit = (level - 1 - targetLevel) * BITS_PER_LEVEL; // offset from LSB
+        if (bit < 0) {
+            return 0L; // targetLevel == level (one past the leaf): no group
         }
+        if (bit >= 64) {
+            return (getHighBits() >>> (bit - 64)) & 0x3FL;
+        }
+        if (bit + BITS_PER_LEVEL <= 64) {
+            return (getLowBits() >>> bit) & 0x3FL;
+        }
+        // Straddles the low/high boundary.
+        long lowPart = getLowBits() >>> bit;
+        long highPart = getHighBits() << (64 - bit);
+        return (lowPart | highPart) & 0x3FL;
     }
 
     /**
@@ -184,22 +194,8 @@ public abstract class TetreeKey<K extends TetreeKey<K>> implements SpatialKey<Te
         if (targetLevel < 0 || targetLevel > level) {
             throw new IllegalArgumentException("Target level must be between 0 and " + level);
         }
-
-        // Special handling for level 21 with split bit encoding
-        if (targetLevel == 21) {
-            return getLevel21TypeBits();
-        }
-
-        // Determine which long contains this level's data
-        if (targetLevel < 10) {
-            // In low bits: level 0 at bits 0-5, level 1 at bits 6-11, ..., level 9 at bits 54-59
-            int shift = targetLevel * BITS_PER_LEVEL;
-            return (byte) ((getLowBits() >> shift) & 0x7);
-        } else {
-            // In high bits: level 10 at bits 0-5, level 11 at bits 6-11, etc.
-            int shift = (targetLevel - 10) * BITS_PER_LEVEL;
-            return (byte) ((getHighBits() >> shift) & 0x7);
-        }
+        // Type bits are the lower 3 bits of the 6-bit group.
+        return (byte) (rawGroupAt(targetLevel) & 0x7);
     }
 
     @Override
@@ -342,77 +338,6 @@ public abstract class TetreeKey<K extends TetreeKey<K>> implements SpatialKey<Te
         return base64.substring(firstNonA);
     }
 
-    // ===== Level 21 Special Bit Packing Support =====
-
-    /**
-     * Extract coordinate bits for level 21 from split encoding.
-     * Level 21 coordinate bits are split: 4 bits in low long (60-63), 2 bits in high long (60-61).
-     * The coordinate bits are the high 3 bits of the 6-bit level encoding.
-     *
-     * @return 3-bit coordinate value for level 21
-     */
-    protected byte getLevel21CoordBits() {
-        if (level != 21) {
-            throw new IllegalStateException("getLevel21CoordBits() can only be called for level 21");
-        }
-
-        // Extract 4 bits from low long (bits 60-63)
-        long lowPart = (getLowBits() >> LEVEL_21_LOW_BITS_SHIFT) & LEVEL_21_LOW_MASK;
-        // Extract 2 bits from high long (bits 60-61)
-        long highPart = (getHighBits() >> LEVEL_21_HIGH_BITS_SHIFT) & LEVEL_21_HIGH_MASK;
-
-        // Combine: low 4 bits + high 2 bits = 6 bits total
-        // Coordinate bits are the upper 3 bits of this 6-bit value
-        long combined = lowPart | (highPart << 4);
-        return (byte) ((combined >> 3) & 0x7);
-    }
-
-    /**
-     * Extract type bits for level 21 from split encoding.
-     * Level 21 type bits are split: 4 bits in low long (60-63), 2 bits in high long (60-61).
-     * The type bits are the low 3 bits of the 6-bit level encoding.
-     *
-     * @return 3-bit type value for level 21
-     */
-    protected byte getLevel21TypeBits() {
-        if (level != 21) {
-            throw new IllegalStateException("getLevel21TypeBits() can only be called for level 21");
-        }
-
-        // Extract 4 bits from low long (bits 60-63)
-        long lowPart = (getLowBits() >> LEVEL_21_LOW_BITS_SHIFT) & LEVEL_21_LOW_MASK;
-        // Extract 2 bits from high long (bits 60-61)
-        long highPart = (getHighBits() >> LEVEL_21_HIGH_BITS_SHIFT) & LEVEL_21_HIGH_MASK;
-
-        // Combine: low 4 bits + high 2 bits = 6 bits total
-        // Type bits are the lower 3 bits of this 6-bit value
-        long combined = lowPart | (highPart << 4);
-        return (byte) (combined & 0x7);
-    }
-
-    /**
-     * Pack level 21 data (6 bits) into the split encoding.
-     * Splits 6 bits across low long (4 bits at position 60-63) and high long (2 bits at position 60-61).
-     *
-     * @param level21Bits the 6-bit value to pack (typically type + (coord << 3))
-     * @return array with [lowBits, highBits] containing the packed data
-     */
-    protected static long[] packLevel21Bits(byte level21Bits) {
-        // Ensure we only have 6 bits
-        long bits = level21Bits & 0x3F;
-
-        // Split into 4-bit low part and 2-bit high part
-        long lowPart = bits & LEVEL_21_LOW_MASK;           // Lower 4 bits
-        long highPart = (bits >> 4) & LEVEL_21_HIGH_MASK; // Upper 2 bits
-
-        // Position them correctly in their respective longs
-        long lowBits = lowPart << LEVEL_21_LOW_BITS_SHIFT;   // Bits 60-63
-        long highBits = highPart << LEVEL_21_HIGH_BITS_SHIFT; // Bits 60-61
-
-        return new long[]{lowBits, highBits};
-    }
-
-
     // ===== SFC Range Estimation for k-NN Optimization =====
     
     /**
@@ -554,27 +479,29 @@ public abstract class TetreeKey<K extends TetreeKey<K>> implements SpatialKey<Te
         long lowBits = key.getLowBits();
         long highBits = key.getHighBits();
         byte level = key.getLevel();
-        
-        // Try to increment low bits
-        if (lowBits < Long.MAX_VALUE) {
+
+        // Coarsest-at-MSB layout (Luciferase-tkvb): lowBits is the least-significant half of the
+        // 128-bit index. Increment it as an unsigned 128-bit value. -1L is the all-ones (unsigned
+        // max) word, so a non-all-ones word increments without carry.
+        if (lowBits != -1L) {
             return create(level, lowBits + 1, highBits);
         }
-        
-        // Low bits overflow, try to increment high bits
-        if (highBits < Long.MAX_VALUE) {
-            return create(level, 0, highBits + 1);
+
+        // Low bits are all-ones: they wrap to 0, carry into high bits.
+        if (highBits != -1L) {
+            return create(level, 0L, highBits + 1);
         }
-        
-        // Both overflow - use a sentinel at parent level if possible
+
+        // Both halves are all-ones (the maximum key at this level) - use a sentinel at parent level.
         if (level > 0) {
             var parent = key.parent();
             if (parent != null) {
                 return getNextKey((TetreeKey<?>) parent);
             }
         }
-        
-        // At root and overflowed - return maximum possible key
-        return create(level, Long.MAX_VALUE, Long.MAX_VALUE);
+
+        // At root and overflowed - return maximum possible key.
+        return create(level, -1L, -1L);
     }
 
     /**

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/SpatialKeyParentTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/SpatialKeyParentTest.java
@@ -101,16 +101,15 @@ public class SpatialKeyParentTest {
         assertEquals(0xFFFFFFFFFFFFFFFFL >>> 6, parent10to9.getLowBits());
         assertEquals(0L, parent10to9.getHighBits());
 
-        // Level 11 -> 10 (transition from using highBits to not using them)
-        // lowBits contains levels 0-9, highBits contains level 10 and up
+        // Level 11 -> 10. Coarsest-at-MSB layout (Luciferase-tkvb): parent() drops the leaf group
+        // (LSB) by shifting the whole 128-bit (highBits, lowBits) value right by 6 bits, so the low
+        // bits also receive the bottom 6 bits of the high word.
         TetreeKey<? extends TetreeKey<?>> level11 = new ExtendedTetreeKey((byte) 11, 0xAAAAAAAAAAAAAAAAL,
-                                                                       0xBBL); // highBits has 6 bits for level 10
+                                                                       0xBBL);
         TetreeKey<? extends TetreeKey<?>> parent11to10 = level11.parent();
         assertNotNull(parent11to10);
         assertEquals(10, parent11to10.getLevel());
-        // Low bits stay the same (contains levels 0-9)
-        assertEquals(0xAAAAAAAAAAAAAAAAL, parent11to10.getLowBits());
-        // High bits are shifted right by 6 to remove level 10
+        assertEquals((0xAAAAAAAAAAAAAAAAL >>> 6) | (0xBBL << 58), parent11to10.getLowBits());
         assertEquals(0xBBL >>> 6, parent11to10.getHighBits());
     }
 

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/CompactTetreeKeyTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/CompactTetreeKeyTest.java
@@ -141,22 +141,22 @@ public class CompactTetreeKeyTest {
 
     @Test
     void testTypeAndCoordExtraction() {
-        // Create a key with known bit pattern
+        // Create a key with known bit pattern. Coarsest-at-MSB layout (Luciferase-tkvb): step 0 is
+        // the shallowest and lives in the more-significant group; the leaf (step level-1) lives at
+        // bits 0-5.
         // Level 2: two 6-bit groups
-        // Group 0: coords=101 (5), type=011 (3) -> 101011 = 43
-        // Group 1: coords=110 (6), type=010 (2) -> 110010 = 50
+        //   bits 0-5  (leaf, step 1):      coords=101 (5), type=011 (3) -> 101011 = 43
+        //   bits 6-11 (shallowest, step 0): coords=110 (6), type=010 (2) -> 110010 = 50
         long tmIndex = (50L << 6) | 43L;
         CompactTetreeKey key = new CompactTetreeKey((byte) 2, tmIndex);
 
-        // Extract type at level 0
-        assertEquals(3, key.getTypeAtLevel(0));
-        // Extract coords at level 0
-        assertEquals(5, key.getCoordBitsAtLevel(0));
+        // Step 0 (shallowest) reads the more-significant group (50).
+        assertEquals(2, key.getTypeAtLevel(0));
+        assertEquals(6, key.getCoordBitsAtLevel(0));
 
-        // Extract type at level 1
-        assertEquals(2, key.getTypeAtLevel(1));
-        // Extract coords at level 1
-        assertEquals(6, key.getCoordBitsAtLevel(1));
+        // Step 1 (leaf) reads the least-significant group (43).
+        assertEquals(3, key.getTypeAtLevel(1));
+        assertEquals(5, key.getCoordBitsAtLevel(1));
     }
 
     @Test

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/CrossLevelSFCOrderingTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/CrossLevelSFCOrderingTest.java
@@ -425,9 +425,10 @@ class CrossLevelSFCOrderingTest {
         assertTrue(level20Key.compareTo(level21Key) < 0,
             "Level 20 should < Level 21 for non-zero coordinates - bit packing test!");
         
-        // Verify we can extract the coordinates correctly from level 21
-        assertEquals(1, level21Key.getCoordBitsAtLevel(21));
-        assertEquals(1, level21Key.getTypeAtLevel(21));
+        // Verify we can extract the coordinates correctly from the level-21 leaf. Coarsest-at-MSB
+        // layout (Luciferase-tkvb): the leaf is step level-1 == 20, at bits 0-5.
+        assertEquals(1, level21Key.getCoordBitsAtLevel(20));
+        assertEquals(1, level21Key.getTypeAtLevel(20));
     }
     
     /**

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/Level21SFCOrderingTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/Level21SFCOrderingTest.java
@@ -19,22 +19,23 @@ package com.hellblazer.luciferase.lucien.tetree;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Tests to verify whether the level 21 bit packing approach preserves Space-Filling Curve (SFC) ordering.
- * This is critical for spatial indexing performance as SFC ordering ensures spatial locality.
- * 
+ * Level-21 (maximum refinement) key tests for the coarsest-at-MSB uniform encoding (Luciferase-tkvb).
+ * Level 21 uses the same 6-bits-per-level layout as every other level (21 * 6 = 126 bits across two
+ * longs); there is no special split-bit packing. These tests verify that real level-21 keys round-trip,
+ * compute parents correctly, and preserve the coarse-dominant space-filling-curve order.
+ *
  * @author hal.hildebrand
  */
 class Level21SFCOrderingTest {
 
     /**
      * Descend from the root to a real level-21 tetrahedron via a deterministic child chain. The
-     * resulting key is valid by construction in the coarsest-at-MSB uniform layout (Luciferase-tkvb).
+     * resulting key is valid by construction in the coarsest-at-MSB uniform layout.
      */
     private static Tet descendToLevel21(int seed) {
         var tet = new Tet(0, 0, 0, (byte) 0, (byte) 0);
@@ -42,6 +43,12 @@ class Level21SFCOrderingTest {
             tet = tet.child((seed + lvl * 3) % 8);
         }
         return tet;
+    }
+
+    /** Independent 128-bit unsigned comparison of (highBits, lowBits) — the coarse-dominant order. */
+    private static int compare128(TetreeKey<?> a, TetreeKey<?> b) {
+        int hi = Long.compareUnsigned(a.getHighBits(), b.getHighBits());
+        return hi != 0 ? hi : Long.compareUnsigned(a.getLowBits(), b.getLowBits());
     }
 
     /**
@@ -71,7 +78,6 @@ class Level21SFCOrderingTest {
         var level21Key = tet.tmIndex();
         var parent = level21Key.parent();
 
-        assertNotNull(parent);
         assertEquals(20, parent.getLevel());
         assertTrue(parent instanceof ExtendedTetreeKey);
 
@@ -80,100 +86,38 @@ class Level21SFCOrderingTest {
     }
 
     /**
-     * Critical test: Does level 21 bit packing preserve SFC ordering?
-     * 
-     * This test creates consecutive level 21 indices and verifies that their
-     * comparison order matches their numerical order. If bit packing breaks
-     * this property, spatial locality is lost.
+     * SFC ordering preservation across MANY distinct subtrees. The keys descend from 200 distinct
+     * child chains, so their coarse (upper) bits genuinely vary — a vacuous version that shares all
+     * but the leaf 6 bits cannot detect an upper-bit scramble, but this one can. {@code compareTo}
+     * must reproduce the independent 128-bit unsigned (highBits, lowBits) order exactly.
      */
     @Test
     void testLevel21SFCOrdering() {
-        System.out.println("Testing Level 21 SFC Ordering Preservation...");
-        
-        // Test data: consecutive level 21 indices that should maintain order
-        List<TestCase> testCases = new ArrayList<>();
-        
-        // Base data for levels 0-20 (same for all test cases)
-        long baseLow = 0x0123456789ABCDEFL;  // Some arbitrary level 0-9 data
-        long baseHigh = 0x0FEDCBA987654321L; // Some arbitrary level 10-20 data
-        
-        // Create keys with consecutive level 21 indices
-        for (int i = 0; i < 64; i++) { // Test all 6-bit values (0-63)
-            var key = ExtendedTetreeKey.createLevel21Key(baseLow, baseHigh, (byte) i);
-            testCases.add(new TestCase(i, key));
+        var keys = new ArrayList<TetreeKey<?>>();
+        for (int seed = 0; seed < 200; seed++) {
+            keys.add(descendToLevel21(seed).tmIndex());
         }
-        
-        // Test 1: Natural order should match comparison order
-        System.out.println("Testing natural order preservation...");
-        boolean orderingPreserved = true;
-        List<String> violations = new ArrayList<>();
-        
-        for (int i = 0; i < testCases.size() - 1; i++) {
-            var current = testCases.get(i);
-            var next = testCases.get(i + 1);
-            
-            // Keys with smaller indices should compare as less than keys with larger indices
-            int comparison = current.key.compareTo(next.key);
-            if (comparison >= 0) { // Should be < 0 for proper ordering
-                orderingPreserved = false;
-                violations.add(String.format(
-                    "Order violation: index %d should < index %d, but compareTo() = %d\n" +
-                    "  Key[%d]: low=0x%016X, high=0x%016X\n" +
-                    "  Key[%d]: low=0x%016X, high=0x%016X",
-                    current.index, next.index, comparison,
-                    current.index, current.key.getLowBits(), current.key.getHighBits(),
-                    next.index, next.key.getLowBits(), next.key.getHighBits()
-                ));
+
+        // compareTo must agree with the independent 128-bit oracle for every ordered pair.
+        for (var a : keys) {
+            for (var b : keys) {
+                assertEquals(Integer.signum(compare128(a, b)), Integer.signum(a.compareTo(b)),
+                             "compareTo must match the 128-bit (high,low) unsigned order for "
+                             + a + " vs " + b);
             }
         }
-        
-        // Test 2: Sorted order should match natural order
-        System.out.println("Testing sort consistency...");
-        List<TestCase> sorted = new ArrayList<>(testCases);
-        Collections.shuffle(sorted); // Randomize order
-        sorted.sort((a, b) -> a.key.compareTo(b.key)); // Sort by key comparison
-        
-        boolean sortConsistent = true;
-        for (int i = 0; i < sorted.size(); i++) {
-            if (sorted.get(i).index != i) {
-                sortConsistent = false;
-                violations.add(String.format(
-                    "Sort inconsistency: expected index %d at position %d, got index %d",
-                    i, i, sorted.get(i).index
-                ));
-                break;
-            }
-        }
-        
-        // Test 3: Analyze bit patterns causing violations
-        if (!orderingPreserved || !sortConsistent) {
-            System.out.println("\nBit pattern analysis for violations:");
-            analyzeViolations(testCases);
-        }
-        
-        // Report results
-        System.out.printf("SFC Ordering Test Results:\n");
-        System.out.printf("  Natural order preserved: %s\n", orderingPreserved);
-        System.out.printf("  Sort consistency: %s\n", sortConsistent);
-        System.out.printf("  Total violations: %d\n", violations.size());
-        
-        if (!violations.isEmpty()) {
-            System.out.println("\nFirst few violations:");
-            for (int i = 0; i < Math.min(5, violations.size()); i++) {
-                System.out.println(violations.get(i));
-            }
-        }
-        
-        // The test fails if ordering is not preserved
-        if (!orderingPreserved || !sortConsistent) {
-            fail("Level 21 bit packing BREAKS SFC ordering! This is a critical issue for spatial indexing.");
-        }
+
+        // Sorting by compareTo must equal sorting by the independent oracle.
+        var byCompareTo = new ArrayList<>(keys);
+        byCompareTo.sort((x, y) -> x.compareTo(y));
+        var byOracle = new ArrayList<>(keys);
+        byOracle.sort(Level21SFCOrderingTest::compare128);
+        assertEquals(byOracle, byCompareTo, "compareTo sort order must match the 128-bit oracle order");
     }
 
     /**
      * Real level-21 sibling keys (the 8 children of a common level-20 parent) are all valid, share
-     * the common parent, and are pairwise distinct with a consistent strict total order under
-     * {@code compareTo} (coarsest-at-MSB layout).
+     * the common parent, and form a strict total order under {@code compareTo}.
      */
     @Test
     void testLevel21BitBoundaries() {
@@ -188,7 +132,7 @@ class Level21SFCOrderingTest {
             assertEquals(parentKey, key.parent(), "child's parent key must equal the parent");
             keys.add(key);
         }
-        // Pairwise distinct and antisymmetric ordering (a strict total order).
+        // Pairwise distinct with antisymmetric ordering (a strict total order).
         for (int a = 0; a < keys.size(); a++) {
             for (int b = a + 1; b < keys.size(); b++) {
                 int cmp = keys.get(a).compareTo(keys.get(b));
@@ -198,60 +142,4 @@ class Level21SFCOrderingTest {
             }
         }
     }
-
-    /**
-     * Analyze why bit packing breaks ordering
-     */
-    private void analyzeViolations(List<TestCase> testCases) {
-        System.out.println("Analysis of comparison logic with split encoding:");
-        
-        // Show how the first few consecutive pairs compare
-        for (int i = 0; i < Math.min(8, testCases.size() - 1); i++) {
-            var curr = testCases.get(i);
-            var next = testCases.get(i + 1);
-            
-            // Show the bit layouts
-            long currLow = curr.key.getLowBits();
-            long currHigh = curr.key.getHighBits();
-            long nextLow = next.key.getLowBits();
-            long nextHigh = next.key.getHighBits();
-            
-            // Extract level 21 bits
-            long currLevel21Low = (currLow >> 60) & 0xF;
-            long currLevel21High = (currHigh >> 60) & 0x3;
-            long nextLevel21Low = (nextLow >> 60) & 0xF;
-            long nextLevel21High = (nextHigh >> 60) & 0x3;
-            
-            int comparison = curr.key.compareTo(next.key);
-            
-            System.out.printf("Index %d→%d (should be <0, actual: %d):\n", i, i+1, comparison);
-            System.out.printf("  Curr[%d]: level21=0x%02X, low=0x%X, high=0x%X\n", 
-                             i, i, currLevel21Low, currLevel21High);
-            System.out.printf("  Next[%d]: level21=0x%02X, low=0x%X, high=0x%X\n", 
-                             i+1, i+1, nextLevel21Low, nextLevel21High);
-            
-            // Show why comparison fails
-            if (currHigh != nextHigh) {
-                System.out.printf("  → High bits differ: 0x%X vs 0x%X\n", currLevel21High, nextLevel21High);
-            }
-            if (currLow != nextLow) {
-                System.out.printf("  → Low bits differ: 0x%X vs 0x%X\n", currLevel21Low, nextLevel21Low);
-            }
-            System.out.println();
-        }
-    }
-
-    /**
-     * Helper class for test data
-     */
-    private static class TestCase {
-        final int index;
-        final ExtendedTetreeKey key;
-        
-        TestCase(int index, ExtendedTetreeKey key) {
-            this.index = index;
-            this.key = key;
-        }
-    }
-
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/Level21SFCOrderingTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/Level21SFCOrderingTest.java
@@ -33,55 +33,50 @@ import static org.junit.jupiter.api.Assertions.*;
 class Level21SFCOrderingTest {
 
     /**
-     * Test basic level 21 bit packing functionality
+     * Descend from the root to a real level-21 tetrahedron via a deterministic child chain. The
+     * resulting key is valid by construction in the coarsest-at-MSB uniform layout (Luciferase-tkvb).
      */
-    @Test
-    void testLevel21BitPacking() {
-        // Create level 21 key with some test data
-        long baseLow = 0x0FFFFFFFFFFFFFFFL;  // Levels 0-9 data (60 bits)
-        long baseHigh = 0x0FFFFFFFFFFFFFFFL; // Levels 10-20 data (60 bits)
-        byte level21Data = 0x2A; // 101010 in binary (6 bits)
-        
-        var key = ExtendedTetreeKey.createLevel21Key(baseLow, baseHigh, level21Data);
-        
-        assertEquals(21, key.getLevel());
-        assertTrue(key.isValid());
-        
-        // Verify bit extraction works
-        byte extractedCoord = key.getCoordBitsAtLevel(21);
-        byte extractedType = key.getTypeAtLevel(21);
-        
-        // level21Data = 101010, so coord = 101 (5), type = 010 (2)
-        assertEquals(5, extractedCoord);
-        assertEquals(2, extractedType);
+    private static Tet descendToLevel21(int seed) {
+        var tet = new Tet(0, 0, 0, (byte) 0, (byte) 0);
+        for (int lvl = 0; lvl < 21; lvl++) {
+            tet = tet.child((seed + lvl * 3) % 8);
+        }
+        return tet;
     }
 
     /**
-     * Test that level 21 parent computation works correctly
+     * A real level-21 key round-trips Tet -> tmIndex -> Tet and is valid (uniform layout, no split).
+     */
+    @Test
+    void testLevel21BitPacking() {
+        var tet = descendToLevel21(1);
+        var key = tet.tmIndex();
+
+        assertEquals(21, key.getLevel());
+        assertTrue(key.isValid(), "real level-21 key must be valid");
+
+        // The leaf (deepest) group is step level-1 == 20, at bits 0-5; its type is the tet's type.
+        assertEquals(tet.type(), key.getTypeAtLevel(20), "leaf type at step 20");
+
+        // Decode round-trips back to the same tetrahedron.
+        assertEquals(tet, Tet.tetrahedron(key), "level-21 tmIndex must round-trip");
+    }
+
+    /**
+     * Parent of a real level-21 key is the level-20 key of the parent tetrahedron.
      */
     @Test
     void testLevel21ParentChild() {
-        // Create level 21 key with base data that doesn't use level 21 bit positions
-        long baseLow = 0x0123456789ABCDEFL;  // Clear bits 60-63 (level 21 positions)
-        long baseHigh = 0x0EDCBA9876543210L; // Clear bits 60-63 (level 21 positions)
-        byte level21Data = 0x15; // 010101
-        
-        var level21Key = ExtendedTetreeKey.createLevel21Key(baseLow, baseHigh, level21Data);
+        var tet = descendToLevel21(2);
+        var level21Key = tet.tmIndex();
         var parent = level21Key.parent();
-        
+
         assertNotNull(parent);
         assertEquals(20, parent.getLevel());
         assertTrue(parent instanceof ExtendedTetreeKey);
-        
-        // Verify parent has the original base bits (level 21 bits removed)
-        var parentExtended = (ExtendedTetreeKey) parent;
-        assertEquals(baseLow, parentExtended.getLowBits());
-        assertEquals(baseHigh, parentExtended.getHighBits());
-        
-        // Verify the level 21 key actually has the level 21 data
-        // 0x15 = 010101 -> coord=010 (2), type=101 (5)
-        assertEquals(2, level21Key.getCoordBitsAtLevel(21)); // coord = 010 = 2
-        assertEquals(5, level21Key.getTypeAtLevel(21));      // type = 101 = 5
+
+        // The key-level parent must equal the ground-truth parent (encode the parent Tet).
+        assertEquals(tet.parent().tmIndex(), parent, "level-21 parent key must match parent tet key");
     }
 
     /**
@@ -176,33 +171,31 @@ class Level21SFCOrderingTest {
     }
 
     /**
-     * Test edge cases around bit boundaries
+     * Real level-21 sibling keys (the 8 children of a common level-20 parent) are all valid, share
+     * the common parent, and are pairwise distinct with a consistent strict total order under
+     * {@code compareTo} (coarsest-at-MSB layout).
      */
-    @Test 
+    @Test
     void testLevel21BitBoundaries() {
-        System.out.println("Testing Level 21 bit boundary cases...");
-        
-        long baseLow = 0x0FFFFFFFFFFFFFFFL;  // Max valid bits for levels 0-9
-        long baseHigh = 0x0FFFFFFFFFFFFFFFL; // Max valid bits for levels 10-20
-        
-        // Test boundary values for level 21 data
-        byte[] boundaryValues = {0x00, 0x0F, 0x10, 0x1F, 0x20, 0x2F, 0x30, 0x3F};
-        
-        ExtendedTetreeKey prevKey = null;
-        byte prevValue = 0;
-        for (byte value : boundaryValues) {
-            var key = ExtendedTetreeKey.createLevel21Key(baseLow, baseHigh, value);
-            assertTrue(key.isValid(), "Key should be valid for value " + value);
-            
-            if (prevKey != null) {
-                int comparison = prevKey.compareTo(key);
-                if (comparison >= 0) {
-                    System.out.printf("Boundary violation: 0x%02X should < 0x%02X but compareTo() = %d\n",
-                                    prevValue, value, comparison);
-                }
+        var parent = descendToLevel21(3).parent(); // a level-20 tetrahedron
+        var parentKey = parent.tmIndex();
+
+        var keys = new ArrayList<TetreeKey<?>>();
+        for (int child = 0; child < 8; child++) {
+            var key = parent.child(child).tmIndex();
+            assertEquals(21, key.getLevel());
+            assertTrue(key.isValid(), "level-21 child key must be valid for child " + child);
+            assertEquals(parentKey, key.parent(), "child's parent key must equal the parent");
+            keys.add(key);
+        }
+        // Pairwise distinct and antisymmetric ordering (a strict total order).
+        for (int a = 0; a < keys.size(); a++) {
+            for (int b = a + 1; b < keys.size(); b++) {
+                int cmp = keys.get(a).compareTo(keys.get(b));
+                assertTrue(cmp != 0, "distinct level-21 siblings must not compare equal");
+                assertEquals(Integer.signum(cmp), -Integer.signum(keys.get(b).compareTo(keys.get(a))),
+                             "compareTo must be antisymmetric");
             }
-            prevKey = key;
-            prevValue = value;
         }
     }
 
@@ -261,15 +254,4 @@ class Level21SFCOrderingTest {
         }
     }
 
-    /**
-     * Helper method to extract the raw level 21 6-bit value for testing purposes
-     */
-    private byte getLevel21Data(ExtendedTetreeKey key) {
-        if (key.getLevel() != 21) return 0;
-        
-        long lowPart = (key.getLowBits() >> TetreeKey.LEVEL_21_LOW_BITS_SHIFT) & TetreeKey.LEVEL_21_LOW_MASK;
-        long highPart = (key.getHighBits() >> TetreeKey.LEVEL_21_HIGH_BITS_SHIFT) & TetreeKey.LEVEL_21_HIGH_MASK;
-        
-        return (byte) (lowPart | (highPart << 4));
-    }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeKeyInvariantTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeKeyInvariantTest.java
@@ -14,23 +14,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Key-invariant contract tests for {@link TetreeKey} and its implementations
  * ({@link CompactTetreeKey}, {@link ExtendedTetreeKey}, {@link LazyTetreeKey}).
  *
- * <p>These are the RED-first specification (bead Luciferase-o988) that gates the encoding flip
- * keystone (bead Luciferase-tkvb). The tetrahedral TM-index currently packs the <em>coarsest</em>
- * level at the LSB tuple and the finest (leaf) level at the most-significant tuple
- * (see {@link Tet#tmIndex()}: level index {@code i=0} is written at bit {@code 6*i}). Under that
- * layout two key-level invariants are violated:
- * <ul>
- *   <li><b>parent()</b>: {@link CompactTetreeKey#parent()} shifts right by 6 bits, which strips the
- *       LSB tuple (the <em>coarsest</em> level) rather than the finest. So
- *       {@code tet.tmIndex().parent()} disagrees with the ground-truth {@code tet.parent().tmIndex()}
- *       at every level &ge; 2. Fixed by Luciferase-tkvb (coarsest-at-MSB consecutive encoding).</li>
- *   <li><b>level-21 round-trip</b>: the level-21 split-bit packing does not round-trip
- *       {@code Tet -> tmIndex -> Tet}. Also in Luciferase-tkvb's scope.</li>
- * </ul>
- * The tests asserting those two are {@link Disabled @Disabled} with a pointer to the owning bead;
- * <b>Luciferase-tkvb's acceptance criterion is to remove those {@code @Disabled} markers and have the
- * tests pass.</b> The remaining tests lock in behaviour that is correct today (decode round-trip
- * L1-20, equals/compareTo consistency for concrete keys) as regression guards.
+ * <p>Originally the RED-first specification (bead Luciferase-o988) that gated the encoding-flip
+ * keystone (bead Luciferase-tkvb). The TM-index now packs the <em>coarsest</em> level at the
+ * most-significant tuple and the finest (leaf) level at the LSB tuple (coarsest-at-MSB consecutive
+ * layout, matching {@code PyramidKey}; see {@link Tet#tmIndex()}). tkvb landed the flip, so the
+ * {@code parent()} round-trip ({@link #parentRoundTrip_allLevels()}) and level-21 decode round-trip
+ * ({@link #decodeRoundTrip_L21()}) invariants now hold and their tests are enabled.
+ *
+ * <p>Two tests remain {@link Disabled @Disabled} pending bead Luciferase-567m (equals/hashCode are
+ * not uniform across {@link CompactTetreeKey}/{@link ExtendedTetreeKey}/{@link LazyTetreeKey}): its
+ * acceptance criterion is to remove those markers and have the tests pass. The other tests lock in
+ * the encoding contract (decode round-trip L1-20, parent round-trip, equals/compareTo consistency
+ * for concrete keys, distinct-key ordering) as regression guards.
  *
  * <p>Ground truth for the parent/round-trip invariants is the geometric/topological {@link Tet}
  * (its {@link Tet#parent()} and {@link Tet#tmIndex()} are independently validated against the t8code
@@ -60,8 +55,6 @@ class TetreeKeyInvariantTest {
      * {@code parent()} strips the coarsest tuple instead of the finest.
      */
     @Test
-    @Disabled("RED until Luciferase-tkvb: TetreeKey.parent() strips coarsest-at-LSB tuple instead of "
-              + "the finest level; tet.tmIndex().parent() != tet.parent().tmIndex() for level >= 2")
     void parentRoundTrip_allLevels() {
         var rnd = new Random(0xB0BACAFEL);
         // Note: level 1 passes today (parent is root, all-zero bits); the breakage starts at level 2.
@@ -122,8 +115,6 @@ class TetreeKeyInvariantTest {
      * fixes the level-21 split.
      */
     @Test
-    @Disabled("RED until Luciferase-tkvb: level-21 split-bit encoding does not round-trip "
-              + "Tet -> tmIndex -> Tet")
     void decodeRoundTrip_L21() {
         var rnd = new Random(0x21212121L);
         for (int sample = 0; sample < 256; sample++) {

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeKeyInvariantTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeKeyInvariantTest.java
@@ -258,4 +258,34 @@ class TetreeKeyInvariantTest {
             }
         }
     }
+
+    /**
+     * Regression guard for the {@code getNextKey} signed-compare bug (Luciferase-tkvb). The SFC
+     * "next key" (exclusive {@code subMap} upper bound) must increment the 128-bit
+     * {@code (highBits, lowBits)} value as <em>unsigned</em>. The original code used
+     * {@code lowBits < Long.MAX_VALUE}, which at {@code lowBits == -1L} (all ones) wrongly returned
+     * {@code (0, highBits)} — dropping the carry into the high word and silently truncating
+     * k-NN/range scans over the upper half of the curve.
+     */
+    @Test
+    void getNextKey_unsignedCarryAtAllOnesLowBits() {
+        // lowBits all-ones must carry into highBits (the case the signed compare got wrong).
+        var atLowMax = TetreeKey.create((byte) 21, -1L, 5L);
+        var next = TetreeKey.getNextKey(atLowMax);
+        assertEquals(TetreeKey.create((byte) 21, 0L, 6L), next,
+                     "all-ones lowBits must carry into highBits");
+        assertTrue(next.compareTo(atLowMax) > 0, "next key must be strictly greater");
+
+        // A lowBits value that is negative-as-signed but NOT all-ones must increment in place.
+        var midHigh = TetreeKey.create((byte) 21, 0x8000_0000_0000_0000L, 5L);
+        var nextMid = TetreeKey.getNextKey(midHigh);
+        assertEquals(TetreeKey.create((byte) 21, 0x8000_0000_0000_0001L, 5L), nextMid,
+                     "negative-as-signed lowBits must still increment in place");
+        assertTrue(nextMid.compareTo(midHigh) > 0, "next key must be strictly greater");
+
+        // Ordinary case: plain low-bit increment.
+        var ordinary = TetreeKey.create((byte) 11, 0x123L, 0L);
+        assertEquals(TetreeKey.create((byte) 11, 0x124L, 0L), TetreeKey.getNextKey(ordinary),
+                     "ordinary increment must add 1 to lowBits");
+    }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeKeyLevelEncodingTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeKeyLevelEncodingTest.java
@@ -28,89 +28,35 @@ public class TetreeKeyLevelEncodingTest {
     
     @Test
     void testTetreeKeyCanEncodeAllLevels() {
-        // Test that we can create TetreeKeys for all levels 0-21
+        // Coarsest-at-MSB uniform layout (Luciferase-tkvb): each step's 6-bit group is appended at
+        // the LSB, so step 0 (shallowest) ends in the most significant bits and the leaf
+        // (step level-1) is at bits 0-5. All 21 levels fit two longs with no split and no
+        // truncation. Plant a known (coord, type) per step, then read it back exactly.
         for (byte level = 0; level <= 21; level++) {
-            // Create a key with some pattern of bits
             long lowBits = 0L;
             long highBits = 0L;
-            
-            // For each level, encode some type and coordinate bits
-            if (level <= 10) {
-                // Compact form - all data in low bits
-                for (int i = 0; i < level; i++) {
-                    // Each level uses 6 bits: 3 for type, 3 for coordinates
-                    int shift = i * 6;
-                    byte type = (byte) (i % 6); // Valid types are 0-5
-                    byte coords = (byte) (i % 8); // 3 bits for coordinates
-                    lowBits |= ((long) type) << shift;
-                    lowBits |= ((long) coords) << (shift + 3);
-                }
-            } else {
-                // Extended form - levels 0-9 in low bits, 10+ in high bits
-                // Fill low bits with levels 0-9
-                for (int i = 0; i < 10; i++) {
-                    int shift = i * 6;
-                    byte type = (byte) (i % 6);
-                    byte coords = (byte) (i % 8);
-                    lowBits |= ((long) type) << shift;
-                    lowBits |= ((long) coords) << (shift + 3);
-                }
-                
-                // Fill high bits with levels 10+
-                for (int i = 10; i < level; i++) {
-                    int shift = (i - 10) * 6;
-                    byte type = (byte) (i % 6);
-                    byte coords = (byte) (i % 8);
-                    // Ensure we don't overflow when shifting
-                    if (shift < 64) {
-                        highBits |= ((long) type) << shift;
-                    }
-                    if (shift + 3 < 64) {
-                        highBits |= ((long) coords) << (shift + 3);
-                    }
-                }
+            for (int i = 0; i < level; i++) {
+                byte type = (byte) (i % 6);   // valid types 0-5
+                byte coords = (byte) (i % 8); // 3 coordinate bits
+                int sixBits = (coords << 3) | type;
+                // Append at the LSB (shift the running 128-bit value left by one group).
+                highBits = (highBits << 6) | (lowBits >>> 58);
+                lowBits = (lowBits << 6) | sixBits;
             }
-            
-            // Create the key
+
             TetreeKey<?> key = TetreeKey.create(level, lowBits, highBits);
-            
-            // Verify the key was created successfully
+
             assertNotNull(key, "Key should not be null for level " + level);
             assertEquals(level, key.getLevel(), "Key level should match");
-            
-            // Verify we can extract data from each level
+
+            // Every step round-trips exactly - no truncation in the uniform layout.
             for (int i = 0; i < level; i++) {
                 byte expectedType = (byte) (i % 6);
                 byte expectedCoords = (byte) (i % 8);
-                
-                // For levels beyond bit capacity, expect 0
-                if (i >= 10) {
-                    int shift = (i - 10) * 6;
-                    if (shift >= 64) {
-                        expectedType = 0;
-                        expectedCoords = 0;
-                    } else if (shift + 3 >= 64) {
-                        expectedCoords = 0;
-                    } else if (shift + 6 > 64) {
-                        // Partial bits - type might fit but coords might be truncated
-                        int bitsAvailable = 64 - shift;
-                        if (bitsAvailable < 3) {
-                            expectedType = 0;
-                            expectedCoords = 0;
-                        } else if (bitsAvailable < 6) {
-                            // Type fits, but coords might be truncated
-                            expectedCoords &= (1 << (bitsAvailable - 3)) - 1;
-                        }
-                    }
-                }
-                
-                byte actualType = key.getTypeAtLevel(i);
-                byte actualCoords = key.getCoordBitsAtLevel(i);
-                
-                assertEquals(expectedType, actualType, 
-                    "Type at level " + i + " should match for key at level " + level);
-                assertEquals(expectedCoords, actualCoords, 
-                    "Coords at level " + i + " should match for key at level " + level);
+                assertEquals(expectedType, key.getTypeAtLevel(i),
+                    "Type at step " + i + " should match for key at level " + level);
+                assertEquals(expectedCoords, key.getCoordBitsAtLevel(i),
+                    "Coords at step " + i + " should match for key at level " + level);
             }
             
             // Test that the key is valid


### PR DESCRIPTION
## Summary

Flips the tetrahedral TM-index from **coarsest-at-LSB/finest-at-MSB** to **coarsest-at-MSB/finest-at-LSB** (6 bits/level, 21·6 = 126 bits across two longs, **no level-21 split**), matching the existing `PyramidKey` layout. Closes bead **Luciferase-tkvb** (the WS-B keystone gated by the o988 RED tests).

Fixes three coupled bugs in one move:
1. **parent()** was stripping the wrong tuple — `tet.tmIndex().parent() != tet.parent().tmIndex()` at every level ≥ 2.
2. **level-21 bit-split** broke unsigned SFC order and didn't round-trip `Tet → tmIndex → Tet`.
3. **getNextKey** used signed compares (`lowBits < Long.MAX_VALUE`) → silent k-NN/range truncation over the upper half of the curve.

## Production changes
- `Tet.tmIndex()` encoder: shift-append (`high = (high<<6)|(low>>>58)`); leaf lands at bits 0–5.
- `Tet.tetrahedron(long,long,byte)` decoder: straddle-safe group extraction at offset `6·(level-1-i)`.
- `TetreeKey`: `getCoordBitsAtLevel`/`getTypeAtLevel` delegate to a straddle-safe `rawGroupAt()`; `getNextKey()` uses unsigned 128-bit increment (`-1L` all-ones carry); removed all `LEVEL_21_*` constants + `getLevel21CoordBits/TypeBits` + `packLevel21Bits`.
- `CompactTetreeKey.compareTo`: `(highBits, lowBits)` unsigned order. `parent()` unchanged (`>>>6`, now correct under the flip).
- `ExtendedTetreeKey`: `parent()` 128-bit right-shift by 6; `isValid()` uniform mask; removed L21 special-case + `isLevel21Valid`; `createLevel21Key` reshimmed to uniform append.

## Tests
- The o988 RED tests `parentRoundTrip_allLevels` and `decodeRoundTrip_L21` are **enabled and now pass** (tkvb's acceptance criterion).
- Updated 6 white-box test files to the new layout.
- Stacked-review follow-ups (second commit): rewrote the vacuous `testLevel21SFCOrdering` to descend 200 distinct subtrees and check `compareTo` against an independent 128-bit unsigned oracle; added `getNextKey_unsignedCarryAtAllOnesLowBits` regression guard for bug #3; refreshed stale javadoc.
- **Full lucien suite: 2780 tests, 0 failures, 0 errors.** `PyramidKeyTest` parity guard unaffected.

## Review
Stacked review run (code-review-expert + substantive-critic): **0 Critical, 0 High**. All Medium/Significant findings addressed in the follow-up commit.

The Compact/Extended/Lazy equals-asymmetry is **out of scope** (bead Luciferase-567m); its two o988 tests remain `@Disabled` pointing there.

Beads: Luciferase-tkvb