### PR TITLE
docs(Luciferase-i3e4): reconcile SpatialKey ordering contract

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialKey.java
@@ -26,8 +26,18 @@ import java.util.NavigableSet;
  * This interface defines the contract for keys used in spatial index structures. Each spatial structure (Octree,
  * Tetree, etc.) implements its own key type that encodes the necessary information for unique spatial identification.
  *
- * Keys must be immutable and implement proper equals/hashCode semantics. The Comparable ordering must preserve spatial
- * locality where possible.
+ * Keys must be immutable and implement proper equals/hashCode semantics.
+ *
+ * <h2>Ordering contract</h2>
+ * <p>All current {@code SpatialKey} implementations order <em>level first</em>: {@link #compareTo} compares
+ * {@link #getLevel()} before any space-filling-curve bits. Consequently every key at level {@code L} sorts before
+ * every key at level {@code L+1}, regardless of SFC position. Within a single level, ordering follows the
+ * implementation's space-filling curve and preserves spatial locality where possible. This holds for both
+ * {@code MortonKey} (level, then Morton code) and {@code TetreeKey} (level, then 128-bit TM-index, unsigned).
+ *
+ * <p><strong>Implication for range queries:</strong> a {@code subMap(lower, upper)} whose bounds are both at level
+ * {@code L} returns only level-{@code L} keys. Callers that must cover entities stored across multiple levels (e.g.
+ * k-NN SFC pruning) must issue one range per occupied level — see {@link #sfcRangesForKNN}.
  *
  * @param <K> The concrete key type (self-referential for type safety)
  * @author hal.hildebrand
@@ -56,8 +66,10 @@ public interface SpatialKey<K extends SpatialKey<K>> extends Comparable<K> {
      *     <li>{@code MortonKey} returns one range per distinct storage level present in the index — required
      *         because {@code MortonKey.compareTo} orders keys by level first, so a subMap query at level L only
      *         returns keys at level L. The level set is collected from {@code indexKeys}.</li>
-     *     <li>{@code TetreeKey} returns a single range and ignores {@code indexKeys} — its ordering is not
-     *         level-scoped.</li>
+     *     <li>{@code TetreeKey} currently returns a single range and ignores {@code indexKeys}. Note its ordering
+     *         <em>is</em> level-first (see the ordering contract above), so this single range under-covers an index
+     *         holding entities at multiple levels — a known bug tracked by {@code Luciferase-6gnb}, not a property of
+     *         the ordering.</li>
      *     <li>Implementations without an SFC range estimator (e.g. {@code PrismKey}) return the default empty
      *         iterable, signaling {@code KnnSearcher} to fall back to the breadth-first search path.</li>
      * </ul>

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeKey.java
@@ -511,9 +511,12 @@ public abstract class TetreeKey<K extends TetreeKey<K>> implements SpatialKey<Te
     /**
      * {@inheritDoc}
      *
-     * <p>{@code TetreeKey} returns a single range and ignores {@code indexKeys}. The TM-index ordering is not
-     * level-scoped, so one {@code subMap} query suffices regardless of the storage levels present. RDR-008 P3
-     * follow-up (bead Luciferase-vpl).
+     * <p>{@code TetreeKey} currently returns a single range and ignores {@code indexKeys}. <strong>This
+     * under-covers a multi-level index:</strong> {@link #compareTo} is level-first (level, then 128-bit TM-index
+     * unsigned), so a {@code subMap} bounded at the single level chosen by {@link #estimateSFCRange} only returns
+     * keys at that level — entities stored at other levels within the radius are silently skipped. The correct
+     * behaviour mirrors {@code MortonKey.sfcRangesForKNN} (one range per occupied level); tracked by
+     * {@code Luciferase-6gnb}. RDR-008 P3 follow-up (bead Luciferase-vpl).
      */
     @Override
     public Iterable<SpatialKey.SFCRange<TetreeKey<? extends TetreeKey<?>>>> sfcRangesForKNN(

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/SpatialKeyLocalityTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/SpatialKeyLocalityTest.java
@@ -172,15 +172,37 @@ class SpatialKeyLocalityTest {
         Collections.shuffle(mixedLevelKeys);
         Collections.sort(mixedLevelKeys);
 
-        // Verify that keys are sorted by tm-index value (not by level)
-        // ExtendedTetreeKey comparison is based solely on tm-index
+        // ExtendedTetreeKey ordering is LEVEL-FIRST (Luciferase-tkvb): compareTo compares level before the
+        // 128-bit TM-index. So sorting groups keys by level — every level-L key precedes every level-(L+1) key,
+        // regardless of TM-index. Verify both the non-descending order and the strict level separation.
         for (int i = 0; i < mixedLevelKeys.size() - 1; i++) {
             var current = mixedLevelKeys.get(i);
             var next = mixedLevelKeys.get(i + 1);
 
-            // Keys should be in non-descending order by tm-index
-            assertTrue(current.compareTo(next) <= 0, "Keys should be sorted in non-descending order by tm-index");
+            assertTrue(current.compareTo(next) <= 0, "Keys should be sorted in non-descending order");
+            assertTrue(current.getLevel() <= next.getLevel(),
+                       "Level-first ordering: a coarser key must never sort after a finer one (got level "
+                       + current.getLevel() + " before level " + next.getLevel() + ")");
         }
+
+        // Concrete cross-level boundary (bead Luciferase-i3e4 AC): ALL level-1 keys sort strictly before ALL
+        // level-2 keys. Assert it directly on the partition, not just via the adjacent-pair monotonicity above —
+        // the last level-1 key must come before the first level-2 key in the sorted list.
+        int lastLevel1Idx = -1;
+        int firstLevel2Idx = -1;
+        for (int i = 0; i < mixedLevelKeys.size(); i++) {
+            byte lvl = mixedLevelKeys.get(i).getLevel();
+            if (lvl == 1) {
+                lastLevel1Idx = i;
+            } else if (lvl == 2 && firstLevel2Idx == -1) {
+                firstLevel2Idx = i;
+            }
+        }
+        assertTrue(lastLevel1Idx >= 0 && firstLevel2Idx >= 0,
+                   "Test setup must produce both level-1 and level-2 keys");
+        assertTrue(lastLevel1Idx < firstLevel2Idx,
+                   "Every level-1 key must sort before every level-2 key (level-first ordering): last level-1 at "
+                   + lastLevel1Idx + ", first level-2 at " + firstLevel2Idx);
     }
 
     @Test

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeValidatorTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeValidatorTest.java
@@ -38,8 +38,11 @@ class TetreeValidatorTest {
         TetreeValidator.setValidationEnabled(true);
     }
 
+    // Re-enabled by Luciferase-i3e4: the prior @Disabled reason "t8code has known parent-child consistency
+    // issues" is stale. The t8code type alignment (Luciferase-4pd) made Tet.child()/parent() t8code-consistent,
+    // and T8codeDtetOracleTest now independently validates child/parent geometry against a t8code port. These
+    // tests exercise the TetreeValidator child()<->parent() round-trip on top of that now-validated machinery.
     @Test
-    @org.junit.jupiter.api.Disabled("t8code has known parent-child consistency issues")
     void testAssertions() {
         Tet validTet = new Tet(0, 0, 0, (byte) 0, (byte) 0);
         assertDoesNotThrow(() -> TetreeValidator.assertValidTet(validTet));
@@ -124,7 +127,6 @@ class TetreeValidatorTest {
     }
 
     @Test
-    @org.junit.jupiter.api.Disabled("t8code has known parent-child consistency issues")
     void testFamilyValidation() {
         Tet parent = new Tet(0, 0, 0, (byte) 1, (byte) 0);
 
@@ -235,7 +237,6 @@ class TetreeValidatorTest {
     }
 
     @Test
-    @org.junit.jupiter.api.Disabled("t8code has known parent-child consistency issues")
     void testParentChildValidation() {
         Tet parent = new Tet(0, 0, 0, (byte) 2, (byte) 0);
 


### PR DESCRIPTION
## Summary

Closes **Luciferase-i3e4** (chore: reconcile SpatialKey ordering contract; fix false javadoc/test claims). WS-B post-flip follow-up to the TetreeKey encoding flip (Luciferase-tkvb).

`TetreeKey.compareTo` has been **level-first** since the tkvb flip (level, then 128-bit TM-index unsigned), but two javadoc sites and a test comment still claimed its ordering was "not level-scoped" — a direct contradiction.

## Changes

- **`SpatialKey.java`** — add an explicit *Ordering contract* section: all current impls order level-first; a `subMap` bounded at level L returns only level-L keys. Fix the false "not level-scoped" bullet on `sfcRangesForKNN`.
- **`TetreeKey.java`** — `sfcRangesForKNN` single-range return is now documented as a **confirmed under-coverage bug**: a level-first `subMap` at one estimated level silently skips entities at other levels — the exact case `MortonKey.sfcRangesForKNN` already avoids by emitting one range per occupied level. Behavior fix tracked by **Luciferase-6gnb** (filed); not changed here (out of chore scope).
- **`SpatialKeyLocalityTest.java`** — drop the false "sorted by tm-index value (not by level)" comment; add explicit level-1-before-level-2 boundary assertion + per-pair level monotonicity (bead AC(c)).
- **`TetreeValidatorTest.java`** — re-enable `testAssertions` / `testFamilyValidation` / `testParentChildValidation`; the "t8code parent-child consistency issues" disable reason is stale (resolved by Luciferase-4pd type alignment + independent `T8codeDtetOracleTest`). Rationale comment added. All pass.

## Discovery

The audit surfaced that the single-range `sfcRangesForKNN` is not just mis-documented but **genuinely buggy** post-flip — filed **Luciferase-6gnb** (P2) rather than silently papering over it.

## Testing

`SpatialKeyLocalityTest` (5/5), `TetreeValidatorTest` (15/15, 0 skipped), SFC-ordering cluster (12/12), key-invariant + Compact tests — all green.

## Reviews

Stacked code-review-expert + substantive-critic: 0 Critical. Both Significant findings from the critic (explicit AC(c) boundary assertion; re-enable rationale comment) addressed in this branch.