### PR TITLE
fix(Luciferase-567m): uniform TetreeKey equals/hashCode across all impls

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/CompactTetreeKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/CompactTetreeKey.java
@@ -98,16 +98,8 @@ public class CompactTetreeKey extends TetreeKey<CompactTetreeKey> {
         return Long.compareUnsigned(tmIndex, other.getLowBits());
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof CompactTetreeKey that)) {
-            return false;
-        }
-        return level == that.level && tmIndex == that.tmIndex;
-    }
+    // equals() is final in TetreeKey (Luciferase-567m): uniform (level, lowBits, highBits) comparison across all
+    // implementations. The old instanceof-CompactTetreeKey form was asymmetric vs ExtendedTetreeKey.
 
     @Override
     public long getHighBits() {
@@ -128,10 +120,8 @@ public class CompactTetreeKey extends TetreeKey<CompactTetreeKey> {
         return tmIndex;
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(level, tmIndex);
-    }
+    // hashCode() is final in TetreeKey (Luciferase-567m): Objects.hash(level, lowBits, highBits), aligned to the
+    // final equals() so all implementations hash identically for equal keys.
 
     @Override
     public boolean isValid() {

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/ExtendedTetreeKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/ExtendedTetreeKey.java
@@ -108,19 +108,9 @@ public class ExtendedTetreeKey extends CompactTetreeKey {
         return Long.compareUnsigned(getLowBits(), other.getLowBits());
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof ExtendedTetreeKey tetreeKey)) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-        return highBits == tetreeKey.highBits;
-    }
+    // equals()/hashCode() are final in TetreeKey (Luciferase-567m): uniform (level, lowBits, highBits) across all
+    // implementations. The old instanceof-ExtendedTetreeKey equals was asymmetric vs CompactTetreeKey, and the
+    // inherited Compact hashCode ignored highBits.
 
     @Override
     public long getHighBits() {

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/LazyTetreeKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/LazyTetreeKey.java
@@ -28,7 +28,6 @@ import java.util.Objects;
 public class LazyTetreeKey extends ExtendedTetreeKey {
 
     private final    Tet                            tet;
-    private final    int                            lazyHashCode;
     private volatile TetreeKey<? extends TetreeKey<?>> resolved;
 
     /**
@@ -39,20 +38,6 @@ public class LazyTetreeKey extends ExtendedTetreeKey {
     public LazyTetreeKey(Tet tet) {
         super(tet.l(), 0L, 0L);  // Use actual level, placeholder values
         this.tet = Objects.requireNonNull(tet, "Tet cannot be null");
-        this.lazyHashCode = computeLazyHash(tet);
-    }
-
-    /**
-     * Compute a hash code based on Tet coordinates for HashMap efficiency. This allows the key to be used in HashMap
-     * without resolving tmIndex.
-     */
-    private static int computeLazyHash(Tet tet) {
-        int hash = 31 * tet.x();
-        hash = 31 * hash + tet.y();
-        hash = 31 * hash + tet.z();
-        hash = 31 * hash + tet.l();
-        hash = 31 * hash + tet.type();
-        return hash;
     }
 
     @Override
@@ -73,23 +58,11 @@ public class LazyTetreeKey extends ExtendedTetreeKey {
         return resolved.compareTo(other);
     }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-
-        if (obj instanceof LazyTetreeKey other) {
-            // Both lazy - compare Tet directly without resolution
-            return tet.equals(other.tet);
-        } else if (obj instanceof TetreeKey<? extends TetreeKey<?>>) {
-            // Must resolve to compare with regular TetreeKey<? extends TetreeKey<?>>
-            ensureResolved();
-            return resolved.equals(obj);
-        }
-
-        return false;
-    }
+    // equals()/hashCode() are final in TetreeKey (Luciferase-567m). The old lazy overrides were the source of the
+    // asymmetry bug: lazy.equals(concrete) resolved while concrete.equals(lazy) did not, and lazyHashCode used a
+    // Tet-coordinate polynomial that never matched the concrete key's tmIndex hash. The uniform base versions
+    // resolve this key's bits (via getLowBits/getHighBits) so equal lazy/concrete keys are mutually equal and share
+    // a hashCode. compareTo (below) keeps its lazy-vs-lazy fast path — it is not part of the equals/hashCode contract.
 
     @Override
     public long getHighBits() {
@@ -116,12 +89,6 @@ public class LazyTetreeKey extends ExtendedTetreeKey {
      */
     public Tet getTet() {
         return tet;
-    }
-
-    @Override
-    public int hashCode() {
-        // Use pre-computed hash for HashMap efficiency
-        return lazyHashCode;
     }
 
     /**

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeKey.java
@@ -177,6 +177,26 @@ public abstract class TetreeKey<K extends TetreeKey<K>> implements SpatialKey<Te
     }
 
     /**
+     * Uniform equality across all {@code TetreeKey} implementations (Luciferase-567m). Two keys are equal iff they
+     * share {@code (level, lowBits, highBits)}, regardless of runtime class. Declared {@code final} so the three
+     * implementations ({@code CompactTetreeKey}, {@code ExtendedTetreeKey}, {@code LazyTetreeKey}) cannot
+     * reintroduce the {@code instanceof}-keyed-to-own-class asymmetry that violated {@link Object#equals} symmetry
+     * and diverged from {@code compareTo == 0}. A {@code LazyTetreeKey} resolves its bits here (via the overridden
+     * {@code getLowBits}/{@code getHighBits}); the spatial index's {@code compareTo}-based skip-list path is
+     * unaffected since it never calls this method.
+     */
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TetreeKey<?> that)) {
+            return false;
+        }
+        return level == that.getLevel() && getLowBits() == that.getLowBits() && getHighBits() == that.getHighBits();
+    }
+
+    /**
      * Get the low bits of the TM-index (index bits 0-63). Coarsest-at-MSB layout (Luciferase-tkvb):
      * these are the deeper refinement steps, with the leaf group at bits 0-5. For levels <= 10 the
      * whole index fits here and the high bits are 0.
@@ -199,8 +219,14 @@ public abstract class TetreeKey<K extends TetreeKey<K>> implements SpatialKey<Te
         return (byte) (rawGroupAt(targetLevel) & 0x7);
     }
 
+    /**
+     * Hash aligned to {@link #equals} on the {@code (level, lowBits, highBits)} tuple. Declared {@code final}
+     * (Luciferase-567m) so every implementation hashes identically for equal keys — in particular a
+     * {@code LazyTetreeKey} resolves to the same hash as the concrete key it represents, rather than the old
+     * Tet-coordinate polynomial that diverged from the concrete tmIndex hash.
+     */
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         return Objects.hash(level, getLowBits(), getHighBits());
     }
 

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeKeyInvariantTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeKeyInvariantTest.java
@@ -1,7 +1,6 @@
 package com.hellblazer.luciferase.lucien.tetree;
 
 import com.hellblazer.luciferase.geometry.MortonCurve;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Random;
@@ -21,11 +20,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * {@code parent()} round-trip ({@link #parentRoundTrip_allLevels()}) and level-21 decode round-trip
  * ({@link #decodeRoundTrip_L21()}) invariants now hold and their tests are enabled.
  *
- * <p>Two tests remain {@link Disabled @Disabled} pending bead Luciferase-567m (equals/hashCode are
- * not uniform across {@link CompactTetreeKey}/{@link ExtendedTetreeKey}/{@link LazyTetreeKey}): its
- * acceptance criterion is to remove those markers and have the tests pass. The other tests lock in
- * the encoding contract (decode round-trip L1-20, parent round-trip, equals/compareTo consistency
- * for concrete keys, distinct-key ordering) as regression guards.
+ * <p>The cross-implementation equals/hashCode symmetry tests ({@link #equalsSymmetry_crossImpl()},
+ * {@link #equalsSymmetry_lazyVsConcrete()}) are now enabled: bead Luciferase-567m made equals/hashCode
+ * uniform across {@link CompactTetreeKey}/{@link ExtendedTetreeKey}/{@link LazyTetreeKey} by hoisting
+ * them into {@link TetreeKey} as {@code final} methods over {@code (level, lowBits, highBits)}. The
+ * other tests lock in the encoding contract (decode round-trip L1-20, parent round-trip,
+ * equals/compareTo consistency for concrete keys, distinct-key ordering) as regression guards.
  *
  * <p>Ground truth for the parent/round-trip invariants is the geometric/topological {@link Tet}
  * (its {@link Tet#parent()} and {@link Tet#tmIndex()} are independently validated against the t8code
@@ -174,8 +174,6 @@ class TetreeKeyInvariantTest {
      * The fix (567m) is to compare on (level, lowBits, highBits) uniformly across all implementations.
      */
     @Test
-    @Disabled("RED until Luciferase-567m: Compact/Extended equals is asymmetric (instanceof keyed to "
-              + "own class); equal-bits keys of different impls are not mutually equal")
     void equalsSymmetry_crossImpl() {
         // Same level (10), same bits, different runtime classes: Compact vs Extended-with-zero-high.
         long bits = 0x1234567L;
@@ -197,9 +195,6 @@ class TetreeKeyInvariantTest {
      * lazy/concrete keys have different hash codes — 567m must align hashCode, not just equals.
      */
     @Test
-    @Disabled("RED until Luciferase-567m: LazyTetreeKey.equals is asymmetric vs Compact/Extended keys, "
-              + "and LazyTetreeKey.hashCode() uses a Tet-coordinate polynomial rather than the tmIndex "
-              + "hash, so equal lazy/concrete keys have different hash codes")
     void equalsSymmetry_lazyVsConcrete() {
         var rnd = new Random(0x1A2B3CL);
         for (byte target = 1; target <= 20; target++) {


### PR DESCRIPTION
## Summary

Closes **Luciferase-567m** (P2 bug). `TetreeKey.equals`/`hashCode` were not uniform across the three implementations, violating the `Object.equals`/`hashCode` contract and breaking hash-based collections when the impls coexist.

### Root cause
`ExtendedTetreeKey extends CompactTetreeKey extends TetreeKey`, and `LazyTetreeKey extends ExtendedTetreeKey`. Each `equals()` used an `instanceof` keyed to its **own** class:
- `compact.equals(extended) == true` but `extended.equals(compact) == false` for identical `(level, bits)` — a symmetry violation that also diverged from `compareTo == 0`.
- `LazyTetreeKey.hashCode()` returned a Tet-coordinate polynomial that never matched the concrete key's tmIndex hash.

### Fix
- Hoist `equals()` into the abstract base `TetreeKey` as a **`final`** method comparing `(level, getLowBits(), getHighBits())` uniformly.
- Make the pre-existing base `hashCode()` **`final`** (it already used `Objects.hash(level, getLowBits(), getHighBits())`).
- Remove the `equals` overrides from all three subclasses and the `hashCode` overrides from Compact/Lazy; delete `LazyTetreeKey.lazyHashCode` + `computeLazyHash`.
- `LazyTetreeKey` keeps its `compareTo` lazy-vs-lazy fast path; `equals`/`hashCode` resolve its bits (the `ConcurrentSkipListMap` spatial-index path orders by `compareTo` and is unaffected).

## Two latent bugs fixed as consequences (surfaced in review)

1. **`TetreeNeighborDetector` self-removal** — its `HashSet<TetreeKey> neighbors.remove(element)` was passed a `LazyTetreeKey` from the spatial-index keySet under `useLazyEvaluation`; the old lazy hashCode hit the wrong bucket, the remove silently failed, and the query tet was left in its own neighbor list.
2. **`ExtendedTetreeKey` hash collision** — it had no `hashCode` override and inherited Compact's, which hashed only the low 64 bits, so level>10 keys differing only in `highBits` collided.

## Testing

Re-enables the two RED tests `equalsSymmetry_crossImpl` and `equalsSymmetry_lazyVsConcrete` in `TetreeKeyInvariantTest` (the bead AC) — both pass. **Full lucien suite: 2777 pass, 0 failures, 0 errors.**

## Reviews

Stacked code-review-expert + substantive-critic: **0 Critical, 0 Significant**. Both independently verified equals symmetry/transitivity/hashCode-consistency and confirmed the skip-list path is untouched.