### PR TITLE
fix(Luciferase-6gnb): one SFC range per occupied level in TetreeKey.sfcRangesForKNN

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/SpatialKey.java
@@ -66,10 +66,9 @@ public interface SpatialKey<K extends SpatialKey<K>> extends Comparable<K> {
      *     <li>{@code MortonKey} returns one range per distinct storage level present in the index — required
      *         because {@code MortonKey.compareTo} orders keys by level first, so a subMap query at level L only
      *         returns keys at level L. The level set is collected from {@code indexKeys}.</li>
-     *     <li>{@code TetreeKey} currently returns a single range and ignores {@code indexKeys}. Note its ordering
-     *         <em>is</em> level-first (see the ordering contract above), so this single range under-covers an index
-     *         holding entities at multiple levels — a known bug tracked by {@code Luciferase-6gnb}, not a property of
-     *         the ordering.</li>
+     *     <li>{@code TetreeKey} also returns one range per distinct storage level in {@code indexKeys} — required
+     *         because its ordering is level-first (see the ordering contract above), so a {@code subMap} bounded at
+     *         level L only returns level-L keys. The level set is collected from {@code indexKeys} (Luciferase-6gnb).</li>
      *     <li>Implementations without an SFC range estimator (e.g. {@code PrismKey}) return the default empty
      *         iterable, signaling {@code KnnSearcher} to fall back to the breadth-first search path.</li>
      * </ul>

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/cache/KnnSearcher.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/cache/KnnSearcher.java
@@ -69,7 +69,8 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * <p>{@link #performKNNSFCRangePruning} delegates to {@link SpatialKey#sfcRangesForKNN} on the index's first key,
  * which returns the iterable of SFC ranges this implementation should scan ({@code MortonKey} returns one range
- * per distinct storage level; {@code TetreeKey} returns a single range; key types without an estimator return
+ * per distinct storage level; {@code TetreeKey} likewise returns one range per distinct storage level
+ * (Luciferase-6gnb); key types without an estimator return
  * the default empty iterable, which signals a fall back to the legacy breadth-first
  * {@link #performKNNSFCBasedSearch}). RDR-008 P3 follow-up (bead Luciferase-vpl) replaced the prior
  * {@code instanceof MortonKey / TetreeKey} dispatch that coupled this class to the concrete key packages.
@@ -214,8 +215,8 @@ implements KnnProvider<Key, ID> {
      * Optimized SFC range-based k-NN search using range pruning. RDR-008 P3 follow-up (bead Luciferase-vpl)
      * removed the per-key-type {@code instanceof MortonKey / TetreeKey} dispatch by hoisting the per-key SFC range
      * estimator to {@link SpatialKey#sfcRangesForKNN}. Each {@code SpatialKey} implementation returns the
-     * appropriate iterable of SFC ranges (Morton returns one per distinct storage level; Tetree returns a single
-     * range; PrismKey or any other implementation without an estimator returns the default empty iterable,
+     * appropriate iterable of SFC ranges (Morton and Tetree each return one range per distinct storage level —
+     * Luciferase-6gnb; PrismKey or any other implementation without an estimator returns the default empty iterable,
      * signaling a fallback to the legacy breadth-first search). Any exception raised during range estimation also
      * falls back.
      */

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeKey.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeKey.java
@@ -21,7 +21,8 @@ import com.hellblazer.luciferase.lucien.Constants;
 import com.hellblazer.luciferase.lucien.SpatialKey;
 
 import javax.vecmath.Point3f;
-import java.util.List;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.NavigableSet;
 import java.util.Objects;
 
@@ -409,22 +410,33 @@ public abstract class TetreeKey<K extends TetreeKey<K>> implements SpatialKey<Te
      * @return SFCRange covering the spherical region (conservative estimate)
      */
     public static SFCRange estimateSFCRange(Point3f center, float radius) {
+        return estimateSFCRange(center, radius, estimateSFCDepth(radius));
+    }
+
+    /**
+     * Estimate the SFC range covering a spherical region at a specific storage level. Because {@code TetreeKey}
+     * ordering is level-first (Luciferase-tkvb), a {@code subMap} bounded by keys at {@code storageLevel} only
+     * returns keys at that level — so callers covering a multi-level index must call this once per occupied level
+     * (see {@link #sfcRangesForKNN}), mirroring {@code MortonKey.estimateSFCRange}. Luciferase-6gnb.
+     *
+     * @param center       the center point of the search sphere
+     * @param radius       the search radius (positive)
+     * @param storageLevel the level at which the returned bounds are constructed
+     * @return SFCRange covering the spherical region at {@code storageLevel} (conservative estimate)
+     */
+    public static SFCRange estimateSFCRange(Point3f center, float radius, byte storageLevel) {
         if (radius <= 0) {
             throw new IllegalArgumentException("Search radius must be positive, got: " + radius);
         }
-        
-        // Step 1: Estimate appropriate depth for this radius
-        byte level = estimateSFCDepth(radius);
-        float cellSize = Constants.lengthAtLevel(level);
-        
-        // Step 2: Compute AABB around sphere
-        // Expand by cell size to ensure complete coverage (conservative)
+
+        float cellSize = Constants.lengthAtLevel(storageLevel);
+
+        // Compute AABB around sphere. Expand by one cell to ensure complete coverage (conservative).
         float expansion = cellSize;
-        
-        // Clamp coordinates to valid range [0, MAX_COORD]
-        // MAX_COORD = 2^21 - 1 = 2,097,151
+
+        // Clamp coordinates to valid range [0, MAX_COORD]. MAX_COORD = 2^21 - 1 = 2,097,151.
         float maxCoord = Constants.MAX_COORD;
-        
+
         Point3f min = new Point3f(
             Math.max(0, center.x - radius - expansion),
             Math.max(0, center.y - radius - expansion),
@@ -435,33 +447,30 @@ public abstract class TetreeKey<K extends TetreeKey<K>> implements SpatialKey<Te
             Math.min(maxCoord, center.y + radius + expansion),
             Math.min(maxCoord, center.z + radius + expansion)
         );
-        
-        // Step 3: Find tetrahedra containing the AABB corners
-        // Use Tet.locatePointBeyRefinementFromRoot to find the tetrahedral cell at this level
-        Tet minTet = Tet.locatePointBeyRefinementFromRoot(min.x, min.y, min.z, level);
-        Tet maxTet = Tet.locatePointBeyRefinementFromRoot(max.x, max.y, max.z, level);
-        
+
+        // Find tetrahedra containing the AABB corners at storageLevel.
+        Tet minTet = Tet.locatePointBeyRefinementFromRoot(min.x, min.y, min.z, storageLevel);
+        Tet maxTet = Tet.locatePointBeyRefinementFromRoot(max.x, max.y, max.z, storageLevel);
+
         if (minTet == null || maxTet == null) {
             // Fallback: use root tetrahedron range
             return new SFCRange(getRoot(), getRoot());
         }
-        
+
         // Convert to TetreeKeys
         TetreeKey<?> minKey = minTet.tmIndex();
         TetreeKey<?> maxKey = maxTet.tmIndex();
-        
+
         // Ensure proper ordering (min <= max)
         if (minKey.compareTo(maxKey) > 0) {
             var tmp = minKey;
             minKey = maxKey;
             maxKey = tmp;
         }
-        
-        // Step 4: Create inclusive range
-        // For subMap(), we need [lower, upper) 
-        // We need to increment the upper bound, which requires getting the next key
+
+        // Create inclusive range. For subMap() we need [lower, upper), so increment the upper bound.
         TetreeKey<?> upperBound = getNextKey(maxKey);
-        
+
         return new SFCRange(minKey, upperBound);
     }
     
@@ -496,33 +505,36 @@ public abstract class TetreeKey<K extends TetreeKey<K>> implements SpatialKey<Te
             return create(level, 0L, highBits + 1);
         }
 
-        // Both halves are all-ones (the maximum key at this level) - use a sentinel at parent level.
-        if (level > 0) {
-            var parent = key.parent();
-            if (parent != null) {
-                return getNextKey((TetreeKey<?>) parent);
-            }
-        }
-
-        // At root and overflowed - return maximum possible key.
+        // Both halves are all-ones: the maximum 128-bit value at this level. Saturate at the same-level all-ones
+        // sentinel, mirroring MortonKey.estimateSFCRange (which caps at Long.MAX_VALUE at the same level). A
+        // coarser-level sentinel would be wrong: ordering is level-first, so a level-(L-1) key sorts before every
+        // level-L key, making subMap(lower@L, sentinel@L-1) an empty range. (Unreachable from real coordinate
+        // inputs — a valid level-L key never sets all 128 bits — but kept correct as an exclusive upper bound.)
         return create(level, -1L, -1L);
     }
 
     /**
      * {@inheritDoc}
      *
-     * <p>{@code TetreeKey} currently returns a single range and ignores {@code indexKeys}. <strong>This
-     * under-covers a multi-level index:</strong> {@link #compareTo} is level-first (level, then 128-bit TM-index
-     * unsigned), so a {@code subMap} bounded at the single level chosen by {@link #estimateSFCRange} only returns
-     * keys at that level — entities stored at other levels within the radius are silently skipped. The correct
-     * behaviour mirrors {@code MortonKey.sfcRangesForKNN} (one range per occupied level); tracked by
-     * {@code Luciferase-6gnb}. RDR-008 P3 follow-up (bead Luciferase-vpl).
+     * <p>{@code TetreeKey} returns one range per distinct storage level present in {@code indexKeys} (Luciferase-6gnb).
+     * Because {@link #compareTo} is level-first (level, then 128-bit TM-index unsigned), a {@code subMap} bounded at
+     * level L only returns keys at level L — entities can be stored at different levels, so a single range covering
+     * one estimated level would silently skip the rest. The level set is collected from {@code indexKeys} and each
+     * range is built at that level via {@link #estimateSFCRange(Point3f, float, byte)}, mirroring
+     * {@code MortonKey.sfcRangesForKNN}. RDR-008 P3 follow-up (bead Luciferase-vpl).
      */
     @Override
     public Iterable<SpatialKey.SFCRange<TetreeKey<? extends TetreeKey<?>>>> sfcRangesForKNN(
         Point3f center, float radius, NavigableSet<TetreeKey<? extends TetreeKey<?>>> indexKeys) {
-        var range = estimateSFCRange(center, radius);
-        return List.of(
-            new SpatialKey.SFCRange<TetreeKey<? extends TetreeKey<?>>>(range.lower(), range.upper()));
+        var levels = new LinkedHashSet<Byte>();
+        for (var key : indexKeys) {
+            levels.add(key.getLevel());
+        }
+        var ranges = new ArrayList<SpatialKey.SFCRange<TetreeKey<? extends TetreeKey<?>>>>(levels.size());
+        for (var level : levels) {
+            var range = estimateSFCRange(center, radius, level);
+            ranges.add(new SpatialKey.SFCRange<TetreeKey<? extends TetreeKey<?>>>(range.lower(), range.upper()));
+        }
+        return ranges;
     }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeKeyInvariantTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeKeyInvariantTest.java
@@ -287,5 +287,14 @@ class TetreeKeyInvariantTest {
         var ordinary = TetreeKey.create((byte) 11, 0x123L, 0L);
         assertEquals(TetreeKey.create((byte) 11, 0x124L, 0L), TetreeKey.getNextKey(ordinary),
                      "ordinary increment must add 1 to lowBits");
+
+        // Both halves all-ones: the 128-bit maximum at this level. getNextKey must saturate at the SAME level's
+        // all-ones sentinel (Luciferase-6gnb), not walk to a coarser level — ordering is level-first, so a
+        // level-(L-1) sentinel would sort before all level-L keys and make the subMap upper bound empty.
+        var atMax = TetreeKey.create((byte) 21, -1L, -1L);
+        var nextMax = TetreeKey.getNextKey(atMax);
+        assertEquals((byte) 21, nextMax.getLevel(), "saturated sentinel must stay at the same level");
+        assertEquals(TetreeKey.create((byte) 21, -1L, -1L), nextMax,
+                     "both-all-ones must saturate at the same-level all-ones sentinel");
     }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeKnnSfcRangeTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeKnnSfcRangeTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.tetree;
+
+import com.hellblazer.luciferase.lucien.Constants;
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3f;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for Luciferase-6gnb: {@link TetreeKey#sfcRangesForKNN} must emit one SFC range per occupied
+ * storage level, not a single range at one estimated level.
+ *
+ * <p>{@code TetreeKey.compareTo} is level-first (Luciferase-tkvb), so a {@code subMap} bounded at level L only
+ * returns level-L keys. The previous single-range implementation silently dropped entities stored at any other
+ * level within the radius. These tests pin the per-level coverage directly (deterministic, fails against the old
+ * single-range code) and check end-to-end k-NN equivalence with a brute-force full scan.
+ *
+ * @author hal.hildebrand
+ */
+class TetreeKnnSfcRangeTest {
+
+    /**
+     * Direct, deterministic guard: with index keys present at several distinct levels, the ranges returned must
+     * cover EVERY occupied level — one lower-bound per level. The old single-range implementation returned exactly
+     * one range (at the radius-estimated level), so this assertion fails against it.
+     */
+    @Test
+    void sfcRangesCoverEveryOccupiedLevel() {
+        // Build a key set at distinct levels spanning the compact (<=10) and extended (>10) ranges.
+        byte[] occupiedLevels = { 3, 6, 9, 12, 15 };
+        var indexKeys = new TreeSet<TetreeKey<? extends TetreeKey<?>>>();
+        for (byte level : occupiedLevels) {
+            int cellSize = Constants.lengthAtLevel(level);
+            // A handful of distinct cells per level so each level is genuinely represented.
+            for (int c = 0; c < 3; c++) {
+                int coord = (c + 1) * cellSize;
+                var tet = Tet.locatePointBeyRefinementFromRoot(coord, coord, coord, level);
+                if (tet != null) {
+                    indexKeys.add(tet.tmIndex());
+                }
+            }
+        }
+
+        var center = new Point3f(50_000, 50_000, 50_000);
+        float radius = 4_000f;
+
+        var ranges = TetreeKey.getRoot().sfcRangesForKNN(center, radius, indexKeys);
+
+        // Collect the levels of the lower bounds actually produced.
+        var coveredLevels = new HashSet<Byte>();
+        int rangeCount = 0;
+        for (var range : ranges) {
+            coveredLevels.add(range.lower().getLevel());
+            rangeCount++;
+        }
+
+        var expected = new HashSet<Byte>();
+        for (byte level : occupiedLevels) {
+            expected.add(level);
+        }
+        assertEquals(expected, coveredLevels,
+                     "sfcRangesForKNN must emit a range for every occupied storage level (Luciferase-6gnb)");
+        assertEquals(occupiedLevels.length, rangeCount,
+                     "exactly one range per occupied level expected, got " + rangeCount);
+    }
+
+    /**
+     * An empty index yields no ranges (signals {@code KnnSearcher} to fall back to breadth-first search), matching
+     * {@code MortonKey.sfcRangesForKNN}.
+     */
+    @Test
+    void emptyIndexYieldsNoRanges() {
+        var empty = new TreeSet<TetreeKey<? extends TetreeKey<?>>>();
+        var ranges = TetreeKey.getRoot().sfcRangesForKNN(new Point3f(1000, 1000, 1000), 500f, empty);
+        assertTrue(!ranges.iterator().hasNext(), "empty index must yield no SFC ranges");
+    }
+
+    /**
+     * End-to-end: a k-NN query against a Tetree holding entities at many distinct levels must actually scan more
+     * than one level (proving the per-level ranges reach the whole index), and every returned entity must be a
+     * genuine in-range result (precision). Deterministic via a seeded RNG.
+     *
+     * <p>Note on scope: this does NOT assert pruned-k-NN == full-scan-k-NN. Even with per-level coverage the
+     * Tetree SFC range is a conservative min/max-corner estimate that is not SFC-contiguous <em>within</em> a
+     * level, so exact recall is a separate (pre-existing) limitation outside Luciferase-6gnb's scope. What 6gnb
+     * fixes — and what this test pins — is that no occupied level is silently excluded from the scan.
+     */
+    @Test
+    void prunedKnnScansMultipleLevelsAndStaysPrecise() {
+        var tetree = new Tetree<LongEntityID, String>(new SequentialLongIDGenerator());
+        var rnd = new Random(0x6_9B_4Dl);
+
+        // Cluster entities tightly around a center so one radius covers them all, but insert them at a spread of
+        // levels (5..14) so a single-level range would have missed most of them. Track each id's inserted level.
+        var center = new Point3f(100_000, 100_000, 100_000);
+        var insertedLevel = new java.util.HashMap<LongEntityID, Byte>();
+        int span = 2_000;
+        int n = 120;
+        for (int i = 0; i < n; i++) {
+            float x = center.x + rnd.nextInt(2 * span + 1) - span;
+            float y = center.y + rnd.nextInt(2 * span + 1) - span;
+            float z = center.z + rnd.nextInt(2 * span + 1) - span;
+            byte level = (byte) (5 + rnd.nextInt(10)); // levels 5..14
+            var id = tetree.insert(new Point3f(x, y, z), level, "E" + i);
+            insertedLevel.put(id, level);
+        }
+
+        int k = 12;
+        // < MAX_COORD so the SFC-pruning path is taken (KnnSearcher routes maxDistance >= MAX_COORD to a full scan).
+        float maxDistance = 8_000f;
+
+        var pruned = tetree.kNearestNeighbors(center, k, maxDistance);
+        var positions = tetree.getEntitiesWithPositions();
+
+        assertTrue(!pruned.isEmpty(), "k-NN over a populated cluster must return results");
+        assertTrue(pruned.size() <= k, "k-NN must not return more than k results");
+
+        // Precision: every returned entity is genuinely within the search radius (no out-of-range false positives).
+        for (var id : pruned) {
+            assertTrue(distance(center, positions.get(id)) <= maxDistance + 1e-3,
+                       "k-NN returned an out-of-range entity: " + id);
+        }
+
+        // Multi-level reach: the returned entities span at least two distinct inserted levels. This is a
+        // supplementary end-to-end signal, NOT the authoritative guard — KnnSearcher's expanding-radius fallback
+        // (fires when SFC candidates < k) could in principle also surface other levels. The rigorous, fallback-
+        // independent regression guard is sfcRangesCoverEveryOccupiedLevel above, which asserts one range per
+        // occupied level directly on sfcRangesForKNN.
+        var returnedLevels = new HashSet<Byte>();
+        for (var id : pruned) {
+            returnedLevels.add(insertedLevel.get(id));
+        }
+        assertTrue(returnedLevels.size() >= 2,
+                   "SFC-pruned k-NN must reach entities across multiple storage levels (Luciferase-6gnb); "
+                   + "got levels " + returnedLevels);
+    }
+
+    private static double distance(Point3f a, Point3f b) {
+        double dx = a.x - b.x, dy = a.y - b.y, dz = a.z - b.z;
+        return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    }
+}


### PR DESCRIPTION
## Summary

Closes **Luciferase-6gnb** (P2 bug, filed during the i3e4 audit). `TetreeKey.sfcRangesForKNN` returned a single SFC range built at one estimated level, but `TetreeKey.compareTo` is level-first (Luciferase-tkvb), so `KnnSearcher`'s `subMap(lower, upper)` bounded at level L only returned level-L keys — entities stored at other levels within the radius were silently skipped. This is the exact failure `MortonKey.sfcRangesForKNN` already documents and avoids.

> **Stacked on #184 (Luciferase-i3e4).** Base is the i3e4 branch; merge/rebase after #184 lands. i3e4 documented this as a known bug; this PR fixes it.

## Fix (mirrors MortonKey)

- Refactor `estimateSFCRange(center, radius)` to delegate to a new level-parameterized `estimateSFCRange(center, radius, byte storageLevel)`.
- Rewrite `sfcRangesForKNN` to collect distinct occupied levels from `indexKeys` and emit one range per level.
- `getNextKey`: the unreachable both-halves-all-ones branch now saturates at the **same-level** all-ones sentinel instead of walking to a coarser level (a level-(L-1) sentinel sorts before all level-L keys → empty `subMap` upper bound). Regression case added.
- Update now-stale "single range" javadoc in `SpatialKey` and `KnnSearcher`.

## Tests (`TetreeKnnSfcRangeTest`)

- `sfcRangesCoverEveryOccupiedLevel` — deterministic, **fails against the old single-range code** (authoritative guard).
- `emptyIndexYieldsNoRanges`.
- `prunedKnnScansMultipleLevelsAndStaysPrecise` — end-to-end multi-level reach + precision (supplementary; the structural test is authoritative since KnnSearcher's expanding-radius fallback could otherwise mask).

**Full lucien suite: 2780 pass, 0 failures, 0 errors.**

## Scope note

This fixes the cross-level (level-first) under-coverage only. Exact `pruned-k-NN == full-scan-k-NN` is **not** asserted: the Tetree SFC range is also approximate *within* a level (the min/max-corner tm-index interval is not SFC-contiguous for the tetrahedral Bey-refinement curve) — a separate pre-existing limitation, now tracked by **Luciferase-701x** (P3). Both reviewers independently confirmed this non-contiguity.

## Reviews

Stacked code-review-expert + substantive-critic: **0 Critical**. All findings addressed (stale KnnSearcher javadoc, getNextKey saturation, imports, test-vacuity comment, 701x follow-up bead).