### PR TITLE
feat(Luciferase-1ugmx): add Prism and Pyramid index types to SpatialInspector demo

### DIFF
--- a/portal/src/main/java/com/hellblazer/luciferase/portal/web/dto/CreateIndexRequest.java
+++ b/portal/src/main/java/com/hellblazer/luciferase/portal/web/dto/CreateIndexRequest.java
@@ -5,7 +5,7 @@ import com.hellblazer.luciferase.portal.web.service.SpatialIndexService.IndexTyp
 /**
  * Request to create a new spatial index.
  *
- * @param indexType          Type of spatial index (OCTREE, TETREE, SFC)
+ * @param indexType          Type of spatial index (OCTREE, TETREE, SFC, PRISM, PYRAMID)
  * @param maxDepth           Maximum tree depth (default: 10)
  * @param maxEntitiesPerNode Maximum entities per node before subdivision (default: 10)
  */

--- a/portal/src/main/java/com/hellblazer/luciferase/portal/web/service/SpatialIndexService.java
+++ b/portal/src/main/java/com/hellblazer/luciferase/portal/web/service/SpatialIndexService.java
@@ -5,6 +5,8 @@ import com.hellblazer.luciferase.lucien.Spatial;
 import com.hellblazer.luciferase.lucien.SpatialIndex;
 import com.hellblazer.luciferase.lucien.entity.UUIDEntityID;
 import com.hellblazer.luciferase.lucien.octree.Octree;
+import com.hellblazer.luciferase.lucien.prism.Prism;
+import com.hellblazer.luciferase.lucien.pyramid.PyramidIndex;
 import com.hellblazer.luciferase.lucien.sfc.SFCArrayIndex;
 import com.hellblazer.luciferase.lucien.tetree.Tetree;
 import com.hellblazer.luciferase.portal.web.dto.*;
@@ -18,7 +20,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Service for managing spatial indices via REST API.
- * Supports Octree, Tetree, and SFCArrayIndex types.
+ * Supports Octree, Tetree, SFCArrayIndex, Prism, and Pyramid types.
  */
 public class SpatialIndexService {
 
@@ -375,6 +377,20 @@ public class SpatialIndexService {
                     maxDepth,
                     maxEntitiesPerNode
             );
+            case PRISM -> new SpatialIndexHolder(
+                    // Prism normalizes coordinates by worldSize; the demo operates in the
+                    // unit cube, so worldSize=1.0 matches the inserted [0,1) coordinates.
+                    new Prism<UUIDEntityID, Object>(UUIDEntityID::new, 1.0f, maxDepth),
+                    IndexType.PRISM,
+                    maxDepth,
+                    maxEntitiesPerNode
+            );
+            case PYRAMID -> new SpatialIndexHolder(
+                    new PyramidIndex<UUIDEntityID, Object>(UUIDEntityID::new, maxEntitiesPerNode, maxDepth),
+                    IndexType.PYRAMID,
+                    maxDepth,
+                    maxEntitiesPerNode
+            );
         };
     }
 
@@ -382,7 +398,7 @@ public class SpatialIndexService {
      * Enum for spatial index types.
      */
     public enum IndexType {
-        OCTREE, TETREE, SFC
+        OCTREE, TETREE, SFC, PRISM, PYRAMID
     }
 
     /**

--- a/portal/src/main/resources/web/shared/color-schemes.js
+++ b/portal/src/main/resources/web/shared/color-schemes.js
@@ -44,6 +44,8 @@ export function createColorSchemes(THREE) {
                 case 'OCTREE': return new THREE.Color(0x3b82f6); // Blue
                 case 'TETREE': return new THREE.Color(0x22c55e); // Green
                 case 'SFC': return new THREE.Color(0xf59e0b); // Amber
+                case 'PRISM': return new THREE.Color(0xec4899); // Pink
+                case 'PYRAMID': return new THREE.Color(0x8b5cf6); // Purple
                 default: return new THREE.Color(0x9ca3af); // Gray
             }
         },

--- a/portal/src/main/resources/web/spatial.html
+++ b/portal/src/main/resources/web/spatial.html
@@ -332,6 +332,8 @@
             <option value="TETREE">Tetree</option>
             <option value="OCTREE">Octree</option>
             <option value="SFC">SFC Array</option>
+            <option value="PRISM">Prism</option>
+            <option value="PYRAMID">Pyramid</option>
         </select>
 
         <label>Shape</label>

--- a/portal/src/main/resources/web/spatial.js
+++ b/portal/src/main/resources/web/spatial.js
@@ -22,7 +22,9 @@ const ENTITY_SIZE = 0.015;    // Base entity size
 const INDEX_COLORS = {
     TETREE: new THREE.Color(0x34d399),  // Green
     OCTREE: new THREE.Color(0x60a5fa),  // Blue
-    SFC: new THREE.Color(0xfbbf24)       // Orange/Yellow
+    SFC: new THREE.Color(0xfbbf24),     // Orange/Yellow
+    PRISM: new THREE.Color(0xf472b6),   // Pink
+    PYRAMID: new THREE.Color(0xa78bfa)  // Purple
 };
 
 // Initialize color schemes from shared module
@@ -122,6 +124,13 @@ const cubeGeometry = new THREE.BoxGeometry(ENTITY_SIZE * 1.6, ENTITY_SIZE * 1.6,
 // Tetrahedron geometry for Tetree
 const tetGeometry = new THREE.TetrahedronGeometry(ENTITY_SIZE * 1.8, 0);
 
+// Triangular-prism geometry for Prism (CylinderGeometry with 3 radial segments)
+const prismGeometry = new THREE.CylinderGeometry(
+    ENTITY_SIZE * 1.4, ENTITY_SIZE * 1.4, ENTITY_SIZE * 2.0, 3);
+
+// Square-pyramid geometry for Pyramid (ConeGeometry with 4 radial segments)
+const pyramidGeometry = new THREE.ConeGeometry(ENTITY_SIZE * 1.6, ENTITY_SIZE * 2.0, 4);
+
 // Current primitive mode: 'sphere' or 'index'
 let currentPrimitive = 'sphere';
 
@@ -137,6 +146,10 @@ function getEntityGeometry() {
             return cubeGeometry;
         case 'TETREE':
             return tetGeometry;
+        case 'PRISM':
+            return prismGeometry;
+        case 'PYRAMID':
+            return pyramidGeometry;
         default:
             return sphereGeometry;
     }

--- a/portal/src/test/java/com/hellblazer/luciferase/portal/web/SpatialIndexEndpointTest.java
+++ b/portal/src/test/java/com/hellblazer/luciferase/portal/web/SpatialIndexEndpointTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for Spatial Index REST API endpoints.
- * Tests all three index types: OCTREE, TETREE, SFC.
+ * Tests all index types: OCTREE, TETREE, SFC, PRISM, PYRAMID.
  */
 class SpatialIndexEndpointTest {
 


### PR DESCRIPTION
## Summary

Wires `PRISM` and `PYRAMID` into the web SpatialInspector explorer (the Stanford Bunny demo) alongside the existing `OCTREE`/`TETREE`/`SFC` types.

## Changes

**Backend** (`SpatialIndexService`, `CreateIndexRequest`):
- Extend `IndexType` enum with `PRISM`, `PYRAMID`.
- Add `createIndexHolder` switch cases.
  - `PyramidIndex` is a drop-in — same constructor signature as Octree/Tetree.
  - `Prism` uses `worldSize=1.0` to match the demo's unit-cube `[0,1)` domain. No `worldSize` plumbing needed: all generated shapes are clamped to `[0.01, 0.99]` and bunny voxels are normalized to `(0,1)`, so nothing hits Prism's out-of-bounds throw.

**Frontend** (`spatial.html`, `spatial.js`, `shared/color-schemes.js`):
- Dropdown options for Prism and Pyramid.
- Native primitive geometries: triangular prism (3-segment cylinder), square pyramid (4-segment cone).
- Color entries (pink / purple) in both the legacy `INDEX_COLORS` map and the shared `INDEX_TYPE` scheme.

The separate ESVO/ESVT renderer (`render.html/js`) maps ESVO→Octree, ESVT→Tetree and has no Prism/Pyramid analog — intentionally left untouched.

## Testing

Existing `@EnumSource(IndexType.class)` parameterized tests now cover create + insert for all five types:
- `SpatialIndexEndpointTest`: 20 tests pass
- `SpatialQueryEndpointTest`: 8 tests pass

This exercises the real risk path (Prism rejecting out-of-domain coordinates — it doesn't, since the demo stays in the unit cube).