### PR TITLE
P2-but-Critical tranche (Wave 2): lucien substantive-critique remediation (Luciferase-yzrg0)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/CrossPartitionBalancePhase.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/CrossPartitionBalancePhase.java
@@ -380,17 +380,16 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
      * @param roundNumber the current round number
      * @param targetRounds the target number of rounds
      * @param balanceChecker the checker to detect violations
-     * @param coordinator the coordinator to send requests (accessed via reflection for sendRequestsParallel)
-     * @param <Coord> the coordinator type parameter
+     * @param sender the {@link RefinementRequestSender} seam that dispatches the requests
      * @return RoundResult with violations processed, round status, and timing
      * @throws java.util.concurrent.TimeoutException if requests timeout
      * @throws InterruptedException if interrupted while waiting
      */
-    public <Coord> RefinementCoordinator.RoundResult identifyRefinementNeeds(
+    public RefinementCoordinator.RoundResult identifyRefinementNeeds(
         int roundNumber,
         int targetRounds,
         TwoOneBalanceChecker<Key, ID, Content> balanceChecker,
-        Coord coordinator
+        RefinementRequestSender<Key, ID, Content> sender
     ) throws java.util.concurrent.TimeoutException, InterruptedException {
         var startTime = System.currentTimeMillis();
 
@@ -451,33 +450,13 @@ public class CrossPartitionBalancePhase<Key extends SpatialKey<Key>, ID extends 
                      roundNumber, sourceRank, groupViolations.size(), maxLevel);
         }
 
-        // Step 4: Send async requests via coordinator using reflection.
-        // This 4-arg overload is a TEST-ONLY entry point (no production caller); the production round path is
-        // execute() -> executeRefinementRound(int), which detects violations and sends per-target-rank requests
-        // directly via the exchange (Luciferase-uhsn). Tests pass a coordinator exposing a PUBLIC sendRequestsParallel, so
-        // getMethod (public-only) resolves it — byte-identical to the pre-inversion behavior. We keep
-        // getMethod (not getDeclaredMethod/setAccessible) precisely to preserve that behavior: against a
-        // real RefinementCoordinator (private method) this throws NoSuchMethodException, exactly as before.
-        // Erasure-matched: List.class covers the generic List<RefinementRequest<Key>> at the call site.
-        List<java.util.concurrent.CompletableFuture<RefinementResponse<Key, ID, Content>>> futures;
-        try {
-            var method = coordinator.getClass().getMethod("sendRequestsParallel", List.class);
-            @SuppressWarnings("unchecked")
-            var result = (List<java.util.concurrent.CompletableFuture<RefinementResponse<Key, ID, Content>>>) method.invoke(coordinator, requests);
-            futures = result;
-        } catch (java.lang.reflect.InvocationTargetException e) {
-            // Unwrap exceptions thrown by sendRequestsParallel()
-            var cause = e.getCause();
-            if (cause instanceof RuntimeException rte) {
-                log.warn("Round {}: Coordinator threw exception: {}", roundNumber, rte.getMessage());
-                throw rte;  // Propagate RuntimeException directly
-            }
-            log.error("Failed to send requests via coordinator", e);
-            throw new RuntimeException("Coordinator sendRequestsParallel failed", cause);
-        } catch (Exception e) {
-            log.error("Failed to send requests via coordinator (reflection)", e);
-            throw new RuntimeException("Coordinator sendRequestsParallel failed", e);
-        }
+        // Step 4: Send async requests via the RefinementRequestSender seam (Luciferase-ln6wu — was a
+        // reflective getMethod("sendRequestsParallel") lookup, a runtime-only failure mode). This 4-arg
+        // form is a TEST-ONLY entry point (no production caller); the production round path is
+        // execute() -> executeRefinementRound(int), which sends per-target-rank requests directly via the
+        // exchange (Luciferase-uhsn). A RuntimeException from the sender propagates directly to the caller.
+        List<java.util.concurrent.CompletableFuture<RefinementResponse<Key, ID, Content>>> futures =
+            sender.sendRequestsParallel(requests);
 
         // Step 5: Await all futures with timeout
         var responses = new java.util.ArrayList<RefinementResponse<Key, ID, Content>>();

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementRequestSender.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/RefinementRequestSender.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.balancing;
+
+import com.hellblazer.luciferase.lucien.SpatialKey;
+import com.hellblazer.luciferase.lucien.entity.EntityID;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Seam for dispatching a batch of {@link RefinementRequest}s to remote partitions in parallel.
+ *
+ * <p>This is the test seam for {@link CrossPartitionBalancePhase#identifyRefinementNeeds}, whose
+ * 4-arg form has no production caller — the production round path is
+ * {@code CrossPartitionBalancePhase.execute() -> executeRefinementRound(int)}, which sends
+ * per-target-rank requests directly via the exchange (Luciferase-uhsn). Expressing the dispatch as
+ * this interface (rather than a reflective {@code getMethod("sendRequestsParallel", ...)} lookup,
+ * Luciferase-ln6wu) makes a missing or mis-typed seam a <em>compile</em> error at the call site
+ * instead of a {@code NoSuchMethodException} surfaced at runtime.</p>
+ *
+ * @param <Key>     the spatial key type
+ * @param <ID>      the entity identifier type
+ * @param <Content> the entity content type
+ * @author hal.hildebrand
+ */
+@FunctionalInterface
+public interface RefinementRequestSender<Key extends SpatialKey<Key>, ID extends EntityID, Content> {
+
+    /**
+     * Send the given refinement requests in parallel, returning one future per request.
+     *
+     * @param requests the refinement requests to dispatch
+     * @return a future per request, completing with the remote partition's {@link RefinementResponse}
+     */
+    List<CompletableFuture<RefinementResponse<Key, ID, Content>>> sendRequestsParallel(
+        List<RefinementRequest<Key>> requests);
+}

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/occlusion/DsocController.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/occlusion/DsocController.java
@@ -51,7 +51,13 @@ import java.util.stream.Collectors;
  *
  * <p>The owning {@code AbstractSpatialIndex} façade constructs one of these when DSOC is enabled and delegates its
  * public DSOC API and three integration seams (frustum-cull entry, entity-update visibility/TBV, occlusion-aware
- * node creation) to it. Shared storage and concurrency come from {@link SpatialIndexCore}; the four façade operations
+ * node creation) to it. Auto-disable methodology (Luciferase-vdv4p): the {@code > 20%} overhead safety valve does
+ * <em>not</em> compare the average DSOC frame against the average non-DSOC frame — those are different query
+ * populations (active occlusion frames vs cheap skip frames), which biases the ratio. Instead, on 1 in
+ * {@code SHADOW_SAMPLE_INTERVAL} DSOC frames it re-runs the standard cull on the <em>same</em> query and times both;
+ * the ratio is computed from those paired same-query measurements only.
+ *
+ * <p>Shared storage and concurrency come from {@link SpatialIndexCore}; the four façade operations
  * the DSOC machinery still needs (frustum traversal order, the subclass frustum-node test, node bounds, cached entity
  * position) arrive through {@link FrustumGeometry}. The standard non-DSOC cull fallback — the path that runs when
  * DSOC's Z-buffer is inactive or auto-disable engages — lives in the P4 cull cluster and arrives through a separate
@@ -71,6 +77,14 @@ public final class DsocController<Key extends SpatialKey<Key>, ID extends Entity
     private static final double PERFORMANCE_THRESHOLD_MULTIPLIER = 1.2; // 20% overhead tolerance
     private static final int    EVALUATION_INTERVAL             = 50;   // Check every 50 frames
     private static final int    MIN_ENTITIES_FOR_DSOC           = 50;
+    // Shadow-baseline sampling: on 1 in SHADOW_SAMPLE_INTERVAL DSOC frames, also run the standard path on the
+    // SAME query to build a comparable baseline (Luciferase-vdv4p). 16 keeps the added cost to ~6% of DSOC frames.
+    // Latency tradeoff: combined with MIN_FRAMES_FOR_EVALUATION (10 shadow samples), the earliest auto-disable can
+    // fire is 10*16 = 160 active DSOC frames (~2.7s at 60fps). Lower SHADOW_SAMPLE_INTERVAL to trade overhead for a
+    // faster safety-valve response. Known residual bias (conservative): the DSOC op runs first and warms caches the
+    // shadow standard op then benefits from, so the standard time skews low and the ratio skews high — auto-disable
+    // can false-positive but never false-negative.
+    private static final int    SHADOW_SAMPLE_INTERVAL          = 16;
 
     private final SpatialIndexCore<Key, ID, Content>     core;
     private final FrustumGeometry<Key, ID, Content>      callback;
@@ -91,6 +105,16 @@ public final class DsocController<Key extends SpatialKey<Key>, ID extends Entity
     private final java.util.concurrent.atomic.AtomicLong dsocTotalTime      = new java.util.concurrent.atomic.AtomicLong();
     private final java.util.concurrent.atomic.AtomicLong standardFrameCount = new java.util.concurrent.atomic.AtomicLong();
     private final java.util.concurrent.atomic.AtomicLong standardTotalTime  = new java.util.concurrent.atomic.AtomicLong();
+
+    // Shadow-baseline counters (Luciferase-vdv4p). The dsoc*/standard* counters above mix DIFFERENT query
+    // populations — standard* collects cheap skip frames (entities < MIN_ENTITIES_FOR_DSOC, inactive Z-buffer)
+    // while dsoc* collects only the expensive active frames — so dsocAvg/standardAvg is not apples-to-apples.
+    // These three accumulate, on a sampled fraction of DSOC frames, the DSOC-path time AND the standard-path time
+    // measured on the SAME query (same frustum + camera). The auto-disable ratio is computed from these, so it
+    // compares comparable populations. shadowSampleCount is the shared denominator for both totals.
+    private final java.util.concurrent.atomic.AtomicLong shadowSampleCount       = new java.util.concurrent.atomic.AtomicLong();
+    private final java.util.concurrent.atomic.AtomicLong shadowDsocTotalTime     = new java.util.concurrent.atomic.AtomicLong();
+    private final java.util.concurrent.atomic.AtomicLong shadowStandardTotalTime = new java.util.concurrent.atomic.AtomicLong();
     private volatile boolean autoDisabled       = false;
 
     // Injectable time source so the auto-disable path is deterministically testable (Luciferase-cvtaa). Defaults to
@@ -103,6 +127,13 @@ public final class DsocController<Key extends SpatialKey<Key>, ID extends Entity
         dsocTotalTime.set(dsocTimeNanos);
         standardFrameCount.set(standardFrames);
         standardTotalTime.set(standardTimeNanos);
+    }
+
+    /** Seed the shadow-baseline counters for tests (Luciferase-vdv4p) — the apples-to-apples auto-disable inputs. */
+    void setShadowCountersForTest(long samples, long shadowDsocTimeNanos, long shadowStandardTimeNanos) {
+        shadowSampleCount.set(samples);
+        shadowDsocTotalTime.set(shadowDsocTimeNanos);
+        shadowStandardTotalTime.set(shadowStandardTimeNanos);
     }
 
     /**
@@ -173,6 +204,10 @@ public final class DsocController<Key extends SpatialKey<Key>, ID extends Entity
             stats.put("currentFrame", getCurrentFrame());
             stats.put("dsocFrameCount", dsocFrameCount.get());
             stats.put("standardFrameCount", standardFrameCount.get());
+            // Shadow-baseline inputs to the auto-disable decision (Luciferase-vdv4p) — exposed for diagnosis.
+            stats.put("shadowSampleCount", shadowSampleCount.get());
+            stats.put("shadowDsocTotalTime", shadowDsocTotalTime.get());
+            stats.put("shadowStandardTotalTime", shadowStandardTotalTime.get());
             if (visibilityManager != null) {
                 stats.putAll(visibilityManager.getStatistics());
             }
@@ -267,7 +302,8 @@ public final class DsocController<Key extends SpatialKey<Key>, ID extends Entity
             if (shouldSkipDSOC()) {
                 return measureAndExecute(() -> cullProvider.frustumCullVisibleStandard(frustum, cameraPosition), false);
             }
-            return measureAndExecute(() -> frustumCullVisibleWithDSOC(frustum, cameraPosition), true);
+            return measureDsocFrame(() -> frustumCullVisibleWithDSOC(frustum, cameraPosition),
+                                    () -> cullProvider.frustumCullVisibleStandard(frustum, cameraPosition));
         }
 
         // Standard path, still measured so the perf comparison stays meaningful
@@ -401,37 +437,83 @@ public final class DsocController<Key extends SpatialKey<Key>, ID extends Entity
         }
     }
 
+    /**
+     * Run the authoritative DSOC cull and, on a sampled fraction of frames (Luciferase-vdv4p), also run the standard
+     * cull on the SAME query purely to time it. The shadow standard run's result is discarded — the DSOC result is
+     * authoritative — but its duration, paired with the DSOC duration for the same frame, feeds the shadow-baseline
+     * counters so the auto-disable ratio compares comparable query populations instead of the biased
+     * expensive-DSOC-vs-cheap-skip mix.
+     */
+    private List<FrustumIntersection<ID, Content>> measureDsocFrame(
+    Supplier<List<FrustumIntersection<ID, Content>>> dsocOp,
+    Supplier<List<FrustumIntersection<ID, Content>>> shadowStandardOp) {
+        // Deterministic sampling on the pre-increment frame index — no RNG (CLAUDE.md determinism mandate).
+        boolean sample = dsocFrameCount.get() % SHADOW_SAMPLE_INTERVAL == 0;
+
+        long startTime = nanoTimeSource.getAsLong();
+        long dsocDuration;
+        try {
+            return dsocOp.get();
+        } finally {
+            dsocDuration = nanoTimeSource.getAsLong() - startTime;
+            dsocFrameCount.incrementAndGet();
+            dsocTotalTime.addAndGet(dsocDuration);
+            if (sample) {
+                // try/CATCH, not try/finally: this runs inside the outer finally, so an exception escaping here would
+                // abandon the pending DSOC return and propagate to the caller. Swallow it — the shadow run is a
+                // best-effort measurement; a failed sample is simply skipped (the sample floor still protects).
+                long shadowStart = nanoTimeSource.getAsLong();
+                try {
+                    shadowStandardOp.get(); // measurement only — result discarded
+                    long shadowStandardDuration = nanoTimeSource.getAsLong() - shadowStart;
+                    // Pair the two same-query durations under one denominator (shadowSampleCount).
+                    shadowDsocTotalTime.addAndGet(dsocDuration);
+                    shadowStandardTotalTime.addAndGet(shadowStandardDuration);
+                    shadowSampleCount.incrementAndGet();
+                } catch (RuntimeException e) {
+                    log.debug("Shadow standard-baseline measurement failed; sample skipped", e);
+                }
+            }
+        }
+    }
+
     /** Inject a deterministic time source for tests (Luciferase-cvtaa). */
     void setNanoTimeSource(java.util.function.LongSupplier source) {
         this.nanoTimeSource = java.util.Objects.requireNonNull(source, "nanoTimeSource");
     }
 
     private boolean shouldEvaluatePerformance() {
+        // Cheap throttle on how often we *attempt* an evaluation; it is deliberately decoupled from the decision
+        // gate. The effective gate is the shadow-sample floor in shouldAutoDisableDSOC — an attempt with fewer than
+        // MIN_FRAMES_FOR_EVALUATION shadow samples is a no-op (e.g. a pure-skip workload never disables, correctly).
         return (dsocFrameCount.get() + standardFrameCount.get()) % EVALUATION_INTERVAL == 0;
     }
 
     private boolean shouldAutoDisableDSOC() {
-        // Snapshot each counter once. Separate AtomicLong.get() calls are NOT atomic together, so the average may be
-        // skewed by at most ±1 in-flight frame — negligible noise against the 20% threshold and the 10-frame floor.
-        long dFrames = dsocFrameCount.get();
-        long sFrames = standardFrameCount.get();
-        if (dFrames < MIN_FRAMES_FOR_EVALUATION || sFrames < MIN_FRAMES_FOR_EVALUATION) {
+        // Apples-to-apples comparison (Luciferase-vdv4p): both totals are measured on the SAME sampled DSOC frames,
+        // sharing the shadowSampleCount denominator, so this is the DSOC marginal cost vs the standard cost of the
+        // identical query — not the old biased expensive-DSOC-vs-cheap-skip mix. The sample floor gives warmup-spike
+        // protection (a transient early spike cannot trip auto-disable before enough comparable samples accrue).
+        long samples = shadowSampleCount.get();
+        if (samples < MIN_FRAMES_FOR_EVALUATION) {
             return false;
         }
-        double dsocAvgTime = (double) dsocTotalTime.get() / dFrames;
-        double standardAvgTime = (double) standardTotalTime.get() / sFrames;
+        double dsocAvgTime = (double) shadowDsocTotalTime.get() / samples;
+        double standardAvgTime = (double) shadowStandardTotalTime.get() / samples;
         return dsocAvgTime > PERFORMANCE_THRESHOLD_MULTIPLIER * standardAvgTime;
     }
 
     private double getOverheadMultiplier() {
-        long dFrames = dsocFrameCount.get();
-        long sFrames = standardFrameCount.get();
-        if (dFrames == 0 || sFrames == 0) {
+        long samples = shadowSampleCount.get();
+        if (samples == 0) {
             return 1.0;
         }
-        double dsocAvgTime = (double) dsocTotalTime.get() / dFrames;
-        double standardAvgTime = (double) standardTotalTime.get() / sFrames;
-        return dsocAvgTime / standardAvgTime;
+        long standardTotal = shadowStandardTotalTime.get();
+        if (standardTotal == 0) {
+            return 1.0;
+        }
+        // Equivalent to (dsocTotal/samples)/(standardTotal/samples); the shared denominator cancels.
+        return (double) shadowDsocTotalTime.get() / standardTotal;
     }
 
     private boolean shouldSkipDSOC() {
@@ -441,7 +523,8 @@ public final class DsocController<Key extends SpatialKey<Key>, ID extends Entity
         if (occlusionCuller != null && !occlusionCuller.isActivated()) {
             return true;
         }
-        return dsocFrameCount.get() >= 5 && getOverheadMultiplier() > PERFORMANCE_THRESHOLD_MULTIPLIER * 2;
+        // Use the shadow-baseline overhead (Luciferase-vdv4p); only meaningful once a few comparable samples exist.
+        return shadowSampleCount.get() >= 5 && getOverheadMultiplier() > PERFORMANCE_THRESHOLD_MULTIPLIER * 2;
     }
 
     private float[] createIdentityMatrix() {

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/Tet.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/Tet.java
@@ -352,34 +352,30 @@ public class Tet implements Spatial.aabt, HybridElement {
     }
 
     /**
-     * Locate a point in the S0 Bey subdivision tree using O(1) per-level traversal.
+     * Locate the t8code dtet at {@code targetLevel} whose Kuhn-simplex region contains the point.
      *
-     * <p>This method implements proper top-down traversal through the S0-rooted Bey
-     * subdivision tree. Unlike the S0-S5 cube partition approach, this ensures that
-     * child types are derived correctly from parent types using the Bey refinement
-     * tables.</p>
+     * <p><b>Algorithm (RDR-010 Luciferase-4pd):</b> the type at any level is a pure function of the
+     * point's coordinate <em>ordering</em> within that level's grid cell (the t8code/Kuhn partition),
+     * so the type is classified <em>directly at the target level</em> — there is no per-level parent→child
+     * walk. Snap the point to the target-level grid anchor, then map the local-coordinate ordering to a
+     * type via {@link #typeForOrdering(double, double, double)} (t0 x&ge;z&ge;y, t1 x&ge;y&ge;z,
+     * t2 y&ge;x&ge;z, t3 y&ge;z&ge;x, t4 z&ge;y&ge;x, t5 z&ge;x&ge;y). This is provably consistent
+     * with {@link #coordinates()} and {@link #contains12DOP}, and agrees with the SFC locate methods
+     * (proven by {@code T8codeDtetOracleTest.locateMethodsAgreeAndContainPoint}).</p>
      *
-     * <p><b>Algorithm:</b></p>
-     * <ol>
-     *   <li>Start at root (level 0, type 0)</li>
-     *   <li>For each level down to target:
-     *     <ul>
-     *       <li>Compute cube ID (which octant) from point position</li>
-     *       <li>Get Bey child ID: TYPE_CID_TO_BEYID[parentType][cubeId]</li>
-     *       <li>Get child type: PARENT_TYPE_TO_CHILD_TYPE[parentType][beyId]</li>
-     *     </ul>
-     *   </li>
-     *   <li>Return tetrahedron at target level with computed type</li>
-     * </ol>
+     * <p><b>Superseded:</b> the earlier implementation traced down from the root via
+     * {@code TYPE_CID_TO_BEYID} → {@code PARENT_TYPE_TO_CHILD_TYPE} and assumed the Bey-tree types did
+     * not match the S0-S5 geometry. That downward root-trace mis-indexed the Bey table by parent type,
+     * was not t8code-consistent (wrong types at depth &ge; 2), and has been <em>deleted</em>. The current
+     * t8code type numbering <em>does</em> match the geometry; do not reintroduce a downward Bey trace.</p>
      *
-     * <p>This is O(targetLevel) with O(1) per level, compared to O(8) per level
-     * for the brute-force containment-checking approach.</p>
+     * <p>Cost: O(1) — direct classification, independent of {@code targetLevel}.</p>
      *
      * @param px          x-coordinate (must be non-negative)
      * @param py          y-coordinate (must be non-negative)
      * @param pz          z-coordinate (must be non-negative)
      * @param targetLevel the target level (0-21)
-     * @return the tetrahedron at targetLevel in the S0 tree containing the point
+     * @return the tetrahedron at targetLevel containing the point
      */
     public static Tet locatePointS0Tree(float px, float py, float pz, byte targetLevel) {
         // Validate inputs
@@ -1100,7 +1096,7 @@ public class Tet implements Spatial.aabt, HybridElement {
      * 12-DOP exact containment test using the permutohedron ordering structure. AABB check (6 comparisons) + local
      * coordinate subtraction (3 ops) + type-specific ordering test (2 comparisons) = 11 ops total.
      * <p>
-     * The ordering for each S-type is derived from the Kuhn simplex vertex paths in {@link #coordinates()}. Uses
+     * The ordering for each type is derived from the Kuhn simplex vertex paths in {@link #coordinates()}. Uses
      * closed-simplex convention ({@code >=}) — points on shared faces may be contained by adjacent types.
      *
      * @param px X coordinate of the point to test
@@ -1116,8 +1112,8 @@ public class Tet implements Spatial.aabt, HybridElement {
         // Local coordinates (3 subtractions)
         float u = px - x, v = py - y, w = pz - z;
         // Ordering test (2 comparisons) — t8code dtet vertex geometry (Kuhn simplex edge paths).
-        // RDR-010 Luciferase-4pd: type k IS t8code dtet type k; constants re-permuted from the old
-        // S0-S5 labeling via T8_TO_LUC={4,0,1,5,3,2} (same 6 Kuhn simplices, same 6 axes, same op count).
+        // RDR-010 Luciferase-4pd: type k IS t8code dtet type k. These orderings are the canonical
+        // per-type interior orderings of the 6 Kuhn simplices (6 axes, same op count).
         return switch (type) {
             case 0 -> u >= w && w >= v;  // x ≥ z ≥ y
             case 1 -> u >= v && v >= w;  // x ≥ y ≥ z
@@ -1133,14 +1129,16 @@ public class Tet implements Spatial.aabt, HybridElement {
      * 12-DOP tet-vs-tet intersection test. Two tetrahedra intersect iff their projections overlap
      * on all 6 axes: 3 AABB axes and 3 difference axes (d_xy, d_xz, d_yz).
      * <p>
-     * Each S-type's difference-axis slab is either [0,h] (sign=0) or [-h,0] (sign=1):
+     * Each t8code dtet type's difference-axis slab is either {@code [0,h]} (+, sign 0) or
+     * {@code [-h,0]} (-, sign 1). RDR-010 Luciferase-4pd type numbering — this table mirrors
+     * {@link #slabBounds12DOP} exactly (the old pre-migration S0-S5 sign table was wrong here):
      * <pre>
-     *   S0: d_xy=+, d_xz=+, d_yz=+
-     *   S1: d_xy=-, d_xz=+, d_yz=+
-     *   S2: d_xy=+, d_xz=-, d_yz=-
-     *   S3: d_xy=-, d_xz=-, d_yz=-
-     *   S4: d_xy=+, d_xz=+, d_yz=-
-     *   S5: d_xy=-, d_xz=-, d_yz=+
+     *   t0: d_xy=+, d_xz=+, d_yz=-
+     *   t1: d_xy=+, d_xz=+, d_yz=+
+     *   t2: d_xy=-, d_xz=+, d_yz=+
+     *   t3: d_xy=-, d_xz=-, d_yz=+
+     *   t4: d_xy=-, d_xz=-, d_yz=-
+     *   t5: d_xy=+, d_xz=-, d_yz=-
      * </pre>
      * Global slab for axis diff = anchor_diff, sign s, size h:
      * {@code lo = diff - s*h,  hi = diff + (1-s)*h}.
@@ -1182,7 +1180,7 @@ public class Tet implements Spatial.aabt, HybridElement {
      * @param ay    anchor y
      * @param az    anchor z
      * @param level refinement level
-     * @param type  S-type (0-5)
+     * @param type  t8code dtet type (0-5)
      * @return int[6] of global slab bounds
      */
     private static int[] slabBounds12DOP(int ax, int ay, int az, byte level, byte type) {
@@ -1192,8 +1190,8 @@ public class Tet implements Spatial.aabt, HybridElement {
         final int dyz = ay - az;
         // sign encoding: 0 means slab [0,h] (lo=diff, hi=diff+h)
         //                1 means slab [-h,0] (lo=diff-h, hi=diff)
-        // RDR-010 Luciferase-4pd: t8code dtet typing; per-type signs re-permuted from old S0-S5 via
-        // T8_TO_LUC={4,0,1,5,3,2}.
+        // RDR-010 Luciferase-4pd: t8code dtet typing — per-type signs are the canonical t8code dtet
+        // type-k slab signs (see the table on intersectsTet12DOP).
         return switch (type) {
             case 0 -> // d_xy=+, d_xz=+, d_yz=-
                 new int[]{ dxy,     dxy + h, dxz,     dxz + h, dyz - h, dyz     };
@@ -1237,8 +1235,8 @@ public class Tet implements Spatial.aabt, HybridElement {
         // Step 3: Compute tet's global slab ranges and check overlap (6 comparisons)
         // Local slab [0,h] or [-h,0] is shifted by anchor differences (axy = x-y, etc.)
         int axy = x - y, axz = x - z, ayz = y - z;
-        // RDR-010 Luciferase-4pd: t8code dtet typing; per-type slabs re-permuted from old S0-S5 via
-        // T8_TO_LUC={4,0,1,5,3,2}.
+        // RDR-010 Luciferase-4pd: t8code dtet typing — per-type slabs are the canonical t8code dtet
+        // type-k slabs (see the table on intersectsTet12DOP).
         return switch (type) {
             case 0 ->
                 dxyMax >= axy && dxyMin <= axy + h && dxzMax >= axz && dxzMin <= axz + h && dyzMax >= ayz - h
@@ -1294,8 +1292,8 @@ public class Tet implements Spatial.aabt, HybridElement {
         float dyzMin = eyMin - ezMax, dyzMax = eyMax - ezMin;
         // Step 3: Compute tet's global slab ranges and check overlap (6 comparisons)
         int axy = x - y, axz = x - z, ayz = y - z;
-        // RDR-010 Luciferase-4pd: t8code dtet typing; per-type slabs re-permuted from old S0-S5 via
-        // T8_TO_LUC={4,0,1,5,3,2}.
+        // RDR-010 Luciferase-4pd: t8code dtet typing — per-type slabs are the canonical t8code dtet
+        // type-k slabs (see the table on intersectsTet12DOP).
         return switch (type) {
             case 0 ->
                 dxyMax >= axy && dxyMin <= axy + h && dxzMax >= axz && dxzMin <= axz + h && dyzMax >= ayz - h
@@ -2295,14 +2293,17 @@ public class Tet implements Spatial.aabt, HybridElement {
     }
 
     /**
-     * Compute parent type by tracing from root through S0 Bey tree.
+     * Compute the parent's type via t8code's canonical O(1) parent-type lookup (RDR-010 Luciferase-4pd,
+     * {@code t8_dtet_parent}).
      *
-     * <p><b>Key Insight:</b> The CUBE_ID_TYPE_TO_PARENT_TYPE reverse lookup table
-     * is NOT a unique inverse - multiple parent types can produce the same child type
-     * at the same cubeId. For consistency with the S0-rooted Bey tree, we must trace
-     * from root to determine the correct parent type.</p>
+     * <p>The parent is exactly one level above this tet, so its type is
+     * {@code CID_TYPE_TO_PARENTTYPE[childCubeId][childType]} keyed by THIS tet's cube-id and type —
+     * a single table lookup, no per-level walk. This is the same upward step used by {@link #parent()},
+     * {@link #computeType(byte)}, and {@link #consecutiveIndex()}.</p>
      *
-     * <p>This is O(parentLevel) but ensures consistency with locatePointS0Tree.</p>
+     * <p><b>Superseded:</b> the deleted implementation traced down from the root through the Bey tree
+     * (O(parentLevel)) on the false premise that the reverse lookup was not a unique inverse; the t8code
+     * {@code CID_TYPE_TO_PARENTTYPE} table keyed by (cubeId, childType) is the correct O(1) inverse.</p>
      */
     private byte computeParentType(int parentX, int parentY, int parentZ, byte parentLevel) {
         if (parentLevel == 0) {

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/Tetree.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/Tetree.java
@@ -2868,17 +2868,17 @@ extends AbstractSpatialIndex<TetreeKey<? extends TetreeKey<?>>, ID, Content> {
     /**
      * Locate the tetrahedron containing a point at a given level.
      *
-     * <p><b>CRITICAL:</b> This method uses S0-S5 cube partitioning geometry to find the
-     * tetrahedron type. This is required because the {@link Tet#contains(Tuple3f)} method
-     * uses S0-S5 cube partitioning for containment testing.</p>
+     * <p>Snaps the point to the level's grid anchor, then returns the first of the 6 Kuhn
+     * tetrahedron types (0-5) whose region contains the point per {@link Tet#contains(Tuple3f)}
+     * (which uses {@link Tet#contains12DOP}). This brute-force "test all 6" form is O(6) per call
+     * but needs no type tables; it agrees with the direct O(1) classification in
+     * {@link Tet#locatePointS0Tree} (both are validated against each other and the SFC locate by
+     * {@code T8codeDtetOracleTest.locateMethodsAgreeAndContainPoint}).</p>
      *
-     * <p>The algorithm tests all 6 tetrahedron types (S0-S5) at the computed grid cell
-     * and returns the first one that contains the point. This ensures consistency with
-     * the containment geometry used by Tet.contains().</p>
-     *
-     * <p><b>Note:</b> The Bey tree traversal approach (Tet.locatePointS0Tree) produces
-     * types based on parent-child relationships which do NOT match S0-S5 cube partitioning
-     * geometry and should not be used for locate operations.</p>
+     * <p><b>Note (RDR-010 Luciferase-4pd):</b> the current t8code dtet type numbering <em>does</em>
+     * match the {@code coordinates()}/{@code contains12DOP} geometry, so {@link Tet#locatePointS0Tree}
+     * is interchangeable here. The deleted downward Bey root-trace (which produced types that did not
+     * match the geometry at depth &ge; 2) must not be reintroduced.</p>
      */
     protected Tet locate(Tuple3f point, byte level) {
         // Special case: level 0 is always the root tetrahedron of type 0

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeBits.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeBits.java
@@ -21,11 +21,21 @@ public final class TetreeBits {
      * Find the level of the lowest common ancestor of two tetrahedra. Based on t8code's t8_dtri_nearest_common_ancestor
      * algorithm.
      *
+     * <p>Pyramid-rooted tetrahedra ({@code minTetLevel != }{@link Tet#NO_TET_ANCESTOR}) are not
+     * supported: the type comparison below relies on {@link Tet#computeType(byte)}, whose ancestor
+     * walk is undefined above the tet/pyramid boundary (deferred to Luciferase-q3p). This method
+     * rejects such inputs up front with an attributable {@link IllegalArgumentException} rather than
+     * letting the failure surface as a deep, unattributed throw from {@code computeType}.</p>
+     *
      * @param tet1 first tetrahedron
      * @param tet2 second tetrahedron
      * @return level of lowest common ancestor
+     * @throws IllegalArgumentException if either tetrahedron is pyramid-rooted
      */
     public static byte lowestCommonAncestorLevel(Tet tet1, Tet tet2) {
+        requirePureTetree(tet1, "tet1");
+        requirePureTetree(tet2, "tet2");
+
         // Find the level of the NCA using XOR to find differing bits
         int exclorx = tet1.x() ^ tet2.x();
         int exclory = tet1.y() ^ tet2.y();
@@ -61,5 +71,19 @@ public final class TetreeBits {
 
         assert r_level >= 0 : "Failed to find common ancestor level";
         return r_level;
+    }
+
+    /**
+     * Guard against pyramid-rooted tetrahedra reaching {@link Tet#computeType(byte)} unattributed.
+     * The deep tet/pyramid path is infrastructure-only (RDR-012) and ancestor-type resolution above
+     * the boundary is deferred to Luciferase-q3p; fail loud here, naming the operation.
+     */
+    private static void requirePureTetree(Tet tet, String arg) {
+        if (tet.minTetLevel() != Tet.NO_TET_ANCESTOR) {
+            throw new IllegalArgumentException(
+            "TetreeBits.lowestCommonAncestorLevel does not support pyramid-rooted tetrahedra: " + arg
+            + " has minTetLevel=" + tet.minTetLevel() + " (!= NO_TET_ANCESTOR). Pyramid ancestor-type "
+            + "resolution is deferred to Luciferase-q3p.");
+        }
     }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/CrossPartitionBalancePhaseTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/CrossPartitionBalancePhaseTest.java
@@ -674,16 +674,17 @@ public class CrossPartitionBalancePhaseTest {
         public int getBarrierCount() { return barrierCount.get(); }
     }
 
-    /** Mock coordinator for D.5 tests — works via reflection from identifyRefinementNeeds(). */
+    /** Mock sender for D.5 tests — implements {@link RefinementRequestSender} for direct typed dispatch (Luciferase-ln6wu). */
     private static class MockRefinementCoordinator<K extends SpatialKey<K>,
                                                     I extends EntityID,
-                                                    C> {
+                                                    C> implements RefinementRequestSender<K, I, C> {
         private final AtomicInteger requestsSent = new AtomicInteger(0);
         private final List<RefinementRequest<K>> capturedRequests =
             Collections.synchronizedList(new ArrayList<>());
         private boolean shouldTimeout = false;
         private boolean shouldThrowException = false;
 
+        @Override
         public List<CompletableFuture<RefinementResponse<K, I, C>>> sendRequestsParallel(
                 List<RefinementRequest<K>> requests) {
             requestsSent.addAndGet(requests.size());

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/occlusion/DsocAutoDisableDeterministicTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/occlusion/DsocAutoDisableDeterministicTest.java
@@ -112,9 +112,11 @@ class DsocAutoDisableDeterministicTest {
         var controller = controllerOf(octree);
         assertTrue(octree.isDSOCEnabled(), "DSOC starts enabled");
 
-        // 25 DSOC frames averaging 1000ns vs 25 standard averaging 100ns -> 10x overhead, far above the 1.2x (20%)
-        // tolerance. Total = 50 so shouldEvaluatePerformance (every 50 frames) fires on the next cull.
+        // dsoc+standard total = 50 so shouldEvaluatePerformance (every 50 frames) fires on the next cull.
         controller.setCountersForTest(25, 25 * 1000L, 25, 25 * 100L);
+        // Auto-disable now reads the apples-to-apples shadow baseline (Luciferase-vdv4p): 10 sampled frames at
+        // 1000ns DSOC vs 100ns same-query standard -> 10x overhead, far above the 1.2x (20%) tolerance.
+        controller.setShadowCountersForTest(10, 10 * 1000L, 10 * 100L);
 
         octree.frustumCullVisible(frustum(), new Point3f(0.5f, 0.5f, -1));
 
@@ -128,8 +130,9 @@ class DsocAutoDisableDeterministicTest {
         octree.enableDSOC(config(), 256, 256);
         var controller = controllerOf(octree);
 
-        // 1.1x overhead, within the 1.2x tolerance: must NOT auto-disable.
-        controller.setCountersForTest(25, 25 * 110L, 25, 25 * 100L);
+        controller.setCountersForTest(25, 25 * 110L, 25, 25 * 100L); // trigger evaluation (total 50)
+        // Shadow baseline at 1.1x overhead, within the 1.2x tolerance: must NOT auto-disable (Luciferase-vdv4p).
+        controller.setShadowCountersForTest(10, 10 * 110L, 10 * 100L);
 
         octree.frustumCullVisible(frustum(), new Point3f(0.5f, 0.5f, -1));
 

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/occlusion/DsocShadowBaselineTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/occlusion/DsocShadowBaselineTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.occlusion;
+
+import com.hellblazer.luciferase.lucien.AbstractSpatialIndex;
+import com.hellblazer.luciferase.lucien.Frustum3D;
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.octree.Octree;
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3f;
+import javax.vecmath.Vector3f;
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Deterministic coverage for the DSOC shadow-baseline auto-disable methodology (Luciferase-vdv4p).
+ *
+ * <p>Before this fix the {@code >20%} auto-disable ratio compared the average DSOC frame against the average
+ * non-DSOC frame, but {@code shouldSkipDSOC} routes cheap frames (entities {@code <} MIN_ENTITIES_FOR_DSOC,
+ * inactive Z-buffer) into the standard bucket and only the expensive active frames into the DSOC bucket — different
+ * query populations, a structurally biased baseline. The fix re-runs the standard cull on the SAME query on a
+ * sampled fraction of DSOC frames and computes the ratio from those paired same-query measurements.
+ *
+ * @author hal.hildebrand
+ */
+class DsocShadowBaselineTest {
+
+    private static DSOCConfiguration config() {
+        return DSOCConfiguration.defaultConfig()
+                                .withEnabled(true)
+                                .withAutoDynamicsEnabled(true)
+                                .withEnableHierarchicalOcclusion(true);
+    }
+
+    private static Frustum3D frustum() {
+        return Frustum3D.createPerspective(new Point3f(0.5f, 0.5f, -1), new Point3f(0.5f, 0.5f, 0.5f),
+                                           new Vector3f(0, 1, 0), (float) Math.toRadians(60.0), 1.0f, 0.1f, 10.0f);
+    }
+
+    private static DsocController<?, ?, ?> controllerOf(AbstractSpatialIndex<?, ?, ?> index) throws Exception {
+        Field f = AbstractSpatialIndex.class.getDeclaredField("dsoc");
+        f.setAccessible(true);
+        return (DsocController<?, ?, ?>) f.get(index);
+    }
+
+    private static long counter(DsocController<?, ?, ?> controller, String name) throws Exception {
+        Field f = DsocController.class.getDeclaredField(name);
+        f.setAccessible(true);
+        return ((AtomicLong) f.get(controller)).get();
+    }
+
+    private static void populate(Octree<LongEntityID, String> octree, int count) {
+        for (int i = 0; i < count; i++) {
+            octree.insert(new LongEntityID(i), new Point3f(0.1f + (i % 8) * 0.1f, 0.1f, 0.1f), (byte) 10, "e" + i);
+        }
+    }
+
+    /**
+     * The shadow sample runs the STANDARD path on the SAME query as the DSOC frame, so the baseline is drawn from
+     * a comparable population — not the cheap skip frames. The first DSOC frame (index 0) is sampled.
+     */
+    @Test
+    void shadowSampleTimesStandardPathOnTheSameQuery() throws Exception {
+        var octree = new Octree<LongEntityID, String>(new SequentialLongIDGenerator());
+        octree.enableDSOC(config(), 256, 256);
+        populate(octree, 60); // >= MIN_ENTITIES_FOR_DSOC so DSOC runs
+        var controller = controllerOf(octree);
+        controller.forceZBufferActivation(); // activate the Z-buffer so the DSOC path (not skip) runs
+
+        final long delta = 321L;
+        var clock = new AtomicLong(0);
+        controller.setNanoTimeSource(() -> clock.getAndAdd(delta)); // each measured span reads twice -> exactly delta
+
+        octree.frustumCullVisible(frustum(), new Point3f(0.5f, 0.5f, -1));
+
+        assertEquals(1, counter(controller, "dsocFrameCount"), "the DSOC path ran");
+        assertEquals(1, counter(controller, "shadowSampleCount"), "the first DSOC frame was shadow-sampled");
+        assertEquals(delta, counter(controller, "shadowStandardTotalTime"),
+                     "the standard path was timed on the SAME query as the DSOC frame (Luciferase-vdv4p)");
+        assertEquals(delta, counter(controller, "shadowDsocTotalTime"),
+                     "the DSOC duration was paired with the shadow standard duration under one denominator");
+    }
+
+    /** A 3x-cost DSOC measured against its same-query standard baseline DOES auto-disable. */
+    @Test
+    void threeXOverheadAgainstShadowBaselineAutoDisables() throws Exception {
+        var octree = new Octree<LongEntityID, String>(new SequentialLongIDGenerator());
+        octree.enableDSOC(config(), 256, 256);
+        var controller = controllerOf(octree);
+        assertTrue(octree.isDSOCEnabled(), "DSOC starts enabled");
+
+        // Old-style counters at 1.0x (NOT over threshold): the legacy formula would NOT disable here, so a passing
+        // test isolates that the SHADOW ratio drives the decision (would catch a formula reversion). Total 50 still
+        // triggers evaluation on the next cull.
+        controller.setCountersForTest(25, 25 * 100L, 25, 25 * 100L);
+        controller.setShadowCountersForTest(10, 10 * 300L, 10 * 100L); // 3x same-query overhead, 10 samples
+
+        octree.frustumCullVisible(frustum(), new Point3f(0.5f, 0.5f, -1));
+
+        assertFalse(octree.isDSOCEnabled(),
+                    "a 3x DSOC measured against the same-query baseline must auto-disable (Luciferase-vdv4p)");
+    }
+
+    /**
+     * A warmup spike (a few very expensive early frames) must NOT permanently disable: the sample floor requires
+     * enough comparable measurements before the safety valve can engage.
+     */
+    @Test
+    void warmupSpikeBelowSampleFloorDoesNotDisable() throws Exception {
+        var octree = new Octree<LongEntityID, String>(new SequentialLongIDGenerator());
+        octree.enableDSOC(config(), 256, 256);
+        var controller = controllerOf(octree);
+
+        controller.setCountersForTest(25, 25 * 1000L, 25, 25 * 100L); // trigger evaluation
+        // 10x overhead but only 3 samples — below MIN_FRAMES_FOR_EVALUATION (10): a transient spike, not a trend.
+        controller.setShadowCountersForTest(3, 3 * 1000L, 3 * 100L);
+
+        octree.frustumCullVisible(frustum(), new Point3f(0.5f, 0.5f, -1));
+
+        assertTrue(octree.isDSOCEnabled(),
+                   "a warmup spike below the sample floor must not permanently disable DSOC (Luciferase-vdv4p)");
+    }
+
+    /**
+     * The crux: a biased standard bucket (cheap skip frames) that would have tripped the OLD ratio must NOT disable
+     * when the same-query shadow baseline shows DSOC is actually within tolerance. This is the regression the bias
+     * fix targets — the decision now ignores the structurally cheaper skip-frame bucket.
+     */
+    @Test
+    void biasedCheapSkipBucketDoesNotDisableWhenShadowBaselineIsFair() throws Exception {
+        var octree = new Octree<LongEntityID, String>(new SequentialLongIDGenerator());
+        octree.enableDSOC(config(), 256, 256);
+        var controller = controllerOf(octree);
+
+        // OLD biased inputs: dsoc avg 1000ns vs cheap skip-frame standard avg 100ns = 10x. The pre-fix code would
+        // auto-disable here. trigger evaluation as well (total 50).
+        controller.setCountersForTest(25, 25 * 1000L, 25, 25 * 100L);
+        // FAIR same-query baseline: DSOC marginal cost is actually only 1.0x the standard cost of the SAME query.
+        controller.setShadowCountersForTest(10, 10 * 100L, 10 * 100L);
+
+        octree.frustumCullVisible(frustum(), new Point3f(0.5f, 0.5f, -1));
+
+        assertTrue(octree.isDSOCEnabled(),
+                   "the biased cheap-skip baseline must not drive auto-disable; the fair same-query baseline governs "
+                   + "(Luciferase-vdv4p)");
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeBitsTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeBitsTest.java
@@ -21,6 +21,7 @@ import com.hellblazer.luciferase.lucien.Constants;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -144,5 +145,34 @@ class TetreeBitsTest {
         assertTrue(ncaLevel >= 0, "NCA level should be non-negative");
         assertTrue(ncaLevel <= Math.min(tet1.l(), tet2.l()),
                    "NCA level should not exceed minimum of the two input levels");
+    }
+
+    @Test
+    void testLowestCommonAncestorLevel_RejectsPyramidRootedFirstArg() {
+        // Luciferase-rzn79: a pyramid-rooted Tet (minTetLevel != NO_TET_ANCESTOR) must be rejected
+        // with an attributable IllegalArgumentException at the call site, not a deep IllegalStateException
+        // from Tet.computeType. Build a pyramid-rooted tet via the 6-arg constructor.
+        int cellSize = Constants.lengthAtLevel((byte) 5);
+        Tet pure = new Tet(2 * cellSize, 2 * cellSize, 2 * cellSize, (byte) 5, (byte) 0);
+        Tet pyramidRooted = new Tet(2 * cellSize, 2 * cellSize, 2 * cellSize, (byte) 5, (byte) 0, (byte) 2);
+
+        var ex = assertThrows(IllegalArgumentException.class,
+                              () -> TetreeBits.lowestCommonAncestorLevel(pyramidRooted, pure));
+        assertTrue(ex.getMessage().contains("lowestCommonAncestorLevel"),
+                   "message must name the operation, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("Luciferase-q3p"),
+                   "message must reference the deferral, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("tet1"), "message must name the offending arg");
+    }
+
+    @Test
+    void testLowestCommonAncestorLevel_RejectsPyramidRootedSecondArg() {
+        int cellSize = Constants.lengthAtLevel((byte) 5);
+        Tet pure = new Tet(2 * cellSize, 2 * cellSize, 2 * cellSize, (byte) 5, (byte) 0);
+        Tet pyramidRooted = new Tet(2 * cellSize, 2 * cellSize, 2 * cellSize, (byte) 5, (byte) 0, (byte) 2);
+
+        var ex = assertThrows(IllegalArgumentException.class,
+                              () -> TetreeBits.lowestCommonAncestorLevel(pure, pyramidRooted));
+        assertTrue(ex.getMessage().contains("tet2"), "message must name the offending arg");
     }
 }

--- a/render/src/main/java/com/hellblazer/luciferase/esvt/builder/ESVTBuilder.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvt/builder/ESVTBuilder.java
@@ -550,9 +550,19 @@ public class ESVTBuilder {
      *   <li>beyId + parentType → Morton index (via BEY_NUMBER_TO_INDEX)</li>
      * </ol>
      */
-    private byte computeMortonChildIndex(Tet tet) {
+    // Package-private for direct unit testing of the pyramid-rooted precondition guard (Luciferase-rzn79).
+    byte computeMortonChildIndex(Tet tet) {
         if (tet.l() == 0) {
             return 0; // Root has no parent, return 0
+        }
+        if (tet.minTetLevel() != Tet.NO_TET_ANCESTOR) {
+            // Pyramid-rooted tet: computeType's ancestor walk is undefined above the tet/pyramid
+            // boundary (deferred to Luciferase-q3p). Fail loud at the call site rather than let a
+            // deep, unattributed IllegalStateException surface from Tet.computeType.
+            throw new IllegalArgumentException(
+            "ESVTBuilder.computeMortonChildIndex does not support pyramid-rooted tetrahedra: tet has "
+            + "minTetLevel=" + tet.minTetLevel() + " (!= NO_TET_ANCESTOR). Pyramid ancestor-type "
+            + "resolution is deferred to Luciferase-q3p.");
         }
         byte childCubeId = tet.cubeId(tet.l());
         byte parentType = tet.computeType((byte) (tet.l() - 1));

--- a/render/src/test/java/com/hellblazer/luciferase/esvt/builder/ESVTBuilderPyramidGuardTest.java
+++ b/render/src/test/java/com/hellblazer/luciferase/esvt/builder/ESVTBuilderPyramidGuardTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.esvt.builder;
+
+import com.hellblazer.luciferase.lucien.Constants;
+import com.hellblazer.luciferase.lucien.tetree.Tet;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Luciferase-rzn79: {@link ESVTBuilder#computeMortonChildIndex} calls {@link Tet#computeType(byte)},
+ * which is undefined for pyramid-rooted tetrahedra (deferred to Luciferase-q3p). Verify the call site
+ * fails loud and attributable rather than letting a deep IllegalStateException surface.
+ *
+ * @author hal.hildebrand
+ */
+class ESVTBuilderPyramidGuardTest {
+
+    @Test
+    void computeMortonChildIndex_rejectsPyramidRootedTet() {
+        var builder = new ESVTBuilder();
+        int cellSize = Constants.lengthAtLevel((byte) 5);
+        // 6-arg constructor: pyramid-rooted (minTetLevel in [0, l]).
+        Tet pyramidRooted = new Tet(2 * cellSize, 2 * cellSize, 2 * cellSize, (byte) 5, (byte) 0, (byte) 2);
+
+        var ex = assertThrows(IllegalArgumentException.class,
+                              () -> builder.computeMortonChildIndex(pyramidRooted));
+        assertTrue(ex.getMessage().contains("computeMortonChildIndex"),
+                   "message must name the operation, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("Luciferase-q3p"),
+                   "message must reference the deferral, got: " + ex.getMessage());
+    }
+
+    @Test
+    void computeMortonChildIndex_acceptsPureTetree() {
+        var builder = new ESVTBuilder();
+        int cellSize = Constants.lengthAtLevel((byte) 5);
+        Tet pure = new Tet(2 * cellSize, 2 * cellSize, 2 * cellSize, (byte) 5, (byte) 0);
+        assertDoesNotThrow(() -> builder.computeMortonChildIndex(pure));
+    }
+}


### PR DESCRIPTION
Wave 2 of the lucien substantive-critique remediation (epic Luciferase-yzrg0): the four P2-filed-but-Critical-severity findings. Stacked on the merged Wave-1 (PR #189), rebased onto main.

## Beads (4 commits, one per bead)

| Bead | Type | Change |
|------|------|--------|
| **Luciferase-rzn79** | fix | Guard the two unguarded `Tet.computeType()` call sites (`TetreeBits.lowestCommonAncestorLevel`, render `ESVTBuilder.computeMortonChildIndex`) against pyramid-rooted `Tet` with an attributable `IllegalArgumentException` naming the `Luciferase-q3p` deferral. Latent/defensive (deep-tet is infrastructure-only per RDR-012). |
| **Luciferase-dcath** | docs | Rewrite stale javadocs that documented the **deleted** downward `TYPE_CID_TO_BEYID → PARENT_TYPE_TO_CHILD_TYPE` trace and falsely claimed Bey types don't match the geometry. `locatePointS0Tree`, `Tetree.locate`, the `intersectsTet12DOP` slab-sign table (verified vs `slabBounds12DOP`), `computeParentType` O-claim; dropped deleted-`T8_TO_LUC`/pre-migration S-label references. |
| **Luciferase-ln6wu** | fix | Replace the reflective `getMethod("sendRequestsParallel").invoke()` dispatch with a `@FunctionalInterface RefinementRequestSender` seam — a missing/mistyped seam is now a **compile** error, not a runtime `NoSuchMethodException`. |
| **Luciferase-vdv4p** | fix | Shadow-baseline DSOC auto-disable: on 1/16 DSOC frames, also run the standard cull on the **same query** and compute the >20% overhead ratio from those paired measurements (was a structurally biased expensive-DSOC-vs-cheap-skip comparison). try/catch isolation so a shadow exception never abandons the authoritative DSOC result; documented overhead/latency/cache-warming bias; shadow counters exposed via `getStatistics`. |

## Gates
- **Stacked review per bead** (code-review-expert + substantive-critic). All Critical/High/Significant findings fixed — notably a real Critical in vdv4p (shadow exception in an outer `finally` would abandon the DSOC return) and a Significant `computeParentType` O-notation falsehood in dcath.
- **Full suite green locally** post-rebase: lucien, lucien-distributed, render all SUCCESS, 0 failures.

## Follow-on (noted, out of scope)
- render `ESVTBuilder.buildTreeFromLeaves` javadoc still uses stale "S0 Bey tree" wording (outside dcath's named sites).
- vdv4p's shadow-exception path has no dedicated unit test (harness can't inject a throwing `FrustumCullProvider`; the try/catch fix is structurally correct).