### PR TITLE
RDR-014: cross-level tet edge/vertex neighbor traversal

### DIFF
--- a/docs/rdr/RDR-014-cross-level-tet-edge-vertex-neighbors.md
+++ b/docs/rdr/RDR-014-cross-level-tet-edge-vertex-neighbors.md
@@ -265,3 +265,23 @@ t8code parity of the edge→face table is an acceptance gate (below).
 1. The specific numeric ring/star counts for the criterion-4 fixtures — mechanically derivable from the
    now-authoritative tables during implementation; the *requirement* (assert an exact count for ≥1 edge
    and ≥1 vertex case) is locked above, only the literal numbers are derived in-code.
+
+## Implementation-time decision — cross-level neighbor contract (resolved 2026-06-05, Phase 1)
+
+During Phase 1 (`Luciferase-ij6zm`) the stacked review (substantive-critic) surfaced that the cross-level
+*finer* contribution has two coherent interpretations that change Phase 2/3's algorithm:
+
+- **(A) Adjacency ring:** finer neighbors of tet `T` at level `L+1` = the level-`L+1` tets that share the
+  edge/vertex AND are *adjacent* to `T` (children of `T`'s same-level edge/vertex ring), **excluding `T`'s
+  own nested children**.
+- **(B) Self-children:** finer neighbors = `T`'s own children touching the edge/vertex (what the existing
+  `findEdgeNeighborsAtLevel(tet, …, level+1)` skeleton structurally yields).
+
+**Decision: (A), confirmed by the user (2026-06-05).** Rationale: (A) is *forced* by the locked AC3 —
+under (B), `T` lists its own child `C` but `C` cannot symmetrically list `T` (a parent is the container, not
+an adjacency neighbor), so reciprocity is unsatisfiable; and the live collision/kNN BFS callers require
+*adjacency* neighbors to expand to, not nested sub-elements. Phase 2 (`findEdgeNeighborsAtLevel`) must
+traverse the same-level ring's descendants (via `findDescendantsAtLevel` on the face-neighbors), **not**
+`tet`'s own children; Phase 1's exact-count fixtures pin (A) via an independent geometric incidence oracle
+(`Tet.coordinates()` collinearity/vertex-coincidence), not a table re-derivation, so they cannot be
+satisfied by a self-children-only or table-tautological implementation.

--- a/docs/rdr/RDR-014-cross-level-tet-edge-vertex-neighbors.md
+++ b/docs/rdr/RDR-014-cross-level-tet-edge-vertex-neighbors.md
@@ -285,3 +285,25 @@ traverse the same-level ring's descendants (via `findDescendantsAtLevel` on the 
 `tet`'s own children; Phase 1's exact-count fixtures pin (A) via an independent geometric incidence oracle
 (`Tet.coordinates()` collinearity/vertex-coincidence), not a table re-derivation, so they cannot be
 satisfied by a self-children-only or table-tautological implementation.
+
+## Implementation-time decision — vertex cross-level scope is ±1 (resolved 2026-06-05, Phase 3)
+
+The `## Decision (updated post-research)` D1' text said to implement `findVertexNeighborsAtLevel` /
+`findVertexNeighborsAtFinerLevels` **full-depth**. During Phase 3 implementation this was deliberately
+scoped to **±1 only** (level±1), for three reasons:
+
+- **The locked oracle is ±1.** `CrossLevelNeighborOracle.finerVertexStarPlus1` — the independent geometric
+  fixture that pins CONTRACT (A) — enumerates only the level-(L+1) star. The AC4 exact-count fixture
+  (`vertexFinerStarExactCountContractA`) asserts the level-(L+1) slice. There is no test contract for
+  depths beyond ±1; "full-depth" was never pinned by a fixture.
+- **Full-depth descent is unbounded work.** A finer star descending to `maxRefinementLevel = 21` runs an
+  anchor-box sweep at every level for every queried vertex; in the dense-grid vertex tests this hung the
+  suite. The cost buys no tested coverage.
+- **Reciprocity requires symmetric depth (AC3).** The coarser loop and the finer descent must reach the
+  same number of levels or the cross-level relation is non-reciprocal (a level-L↔level-(L+2) pair listed
+  in one direction only). Both are now ±1, so the relation is reciprocal by construction. This is
+  consistent with F1: vertex neighbors are a read-only, test-contract-scope query (not a live BFS path),
+  and the live edge path is itself ±1.
+
+**Decision: vertex cross-level scope is ±1**, symmetric finer/coarser, matching the oracle and F1. The
+D1' "full-depth" wording is superseded by this note.

--- a/docs/rdr/RDR-014-cross-level-tet-edge-vertex-neighbors.md
+++ b/docs/rdr/RDR-014-cross-level-tet-edge-vertex-neighbors.md
@@ -180,6 +180,42 @@ primitives.
   symmetric-membership reciprocity for all 6 edges and 4 vertices, PLUS hand-worked exact-count fixtures
   (ring/star size) at a small fixed level — not `assertTrue(count >= 0)`, and NOT a dualFace involution.
 
+### F4 — Authoritative edge→face table; the Finder's inline table is WRONG (gate Critical, resolved)
+
+Two parallel implementations carry edge→face tables, and they **conflict**:
+
+- `TetreeNeighborDetector.EDGE_FACES` (`TetreeNeighborDetector.java:68-75`):
+  `e0→{2,3}, e1→{1,3}, e2→{1,2}, e3→{0,3}, e4→{0,2}, e5→{0,1}`
+- `TetreeNeighborFinder` inline (`TetreeNeighborFinder.java:104-110`):
+  `e0→{0,2}, e1→{0,3}, e2→{1,3}, e3→{0,1}, e4→{1,2}, e5→{2,3}`
+
+Both classes use the **same** edge→vertex-pair numbering (`EDGE_VERTICES`,
+`TetreeNeighborDetector.java:50-57`): `e0=(0,1) e1=(0,2) e2=(0,3) e3=(1,2) e4=(1,3) e5=(2,3)`, so this is
+**not** a numbering-convention artifact. Faces follow the t8code convention face *i* = opposite vertex *i*
+(`TetreeConnectivity.java:242-259`, `FACE_CORNERS`): `f0={1,2,3} f1={0,2,3} f2={0,1,3} f3={0,1,2}`.
+
+Deriving the ground truth — edge `(va,vb)` is bounded by exactly the faces containing **both** va and vb:
+
+| edge | verts | bounding faces (derived) |
+|------|-------|--------------------------|
+| 0 | (0,1) | {2,3} |
+| 1 | (0,2) | {1,3} |
+| 2 | (0,3) | {1,2} |
+| 3 | (1,2) | {0,3} |
+| 4 | (1,3) | {0,2} |
+| 5 | (2,3) | {0,1} |
+
+The derived mapping **matches `TetreeNeighborDetector.EDGE_FACES` exactly**; the
+`TetreeNeighborFinder` inline table is **incorrect** (e.g. edge 0 should be {2,3}, not {0,2}). This is a
+latent defect in the existing same-level edge code too, masked because the F2 intersection
+`CHILDREN_AT_FACE[F1] ∩ CHILDREN_AT_FACE[F2]` is commutative and some wrong-pair intersections happen to
+coincide, and because no test asserts exact cross-level edge counts.
+
+**Resolution:** the implementation MUST use the derived/`EDGE_FACES` table as the single authoritative
+source (promote it into `TetreeConnectivity` as the canonical `EDGE_FACES` and have both
+`TetreeNeighborFinder` and `TetreeNeighborDetector` consume it), and **correct the wrong inline table**.
+t8code parity of the edge→face table is an acceptance gate (below).
+
 ## Decision (updated post-research — proposed for gate)
 
 - **D1' (implement, scoped):** Implement `findEdgeNeighborsAtLevel` for the ±1 live case first
@@ -193,9 +229,36 @@ primitives.
   `VERTEX_TO_BEY_CHILDREN` cache only if profiling shows a hot path).
 - **Validation RESOLVED:** symmetric-membership reciprocity DFS + exact-count fixtures, adapting
   `PyramidNeighborParityTest.reciprocitySweep`. Keep the 21 previously-broken live tests green.
+- **Edge→face table RESOLVED (F4):** the derived/`TetreeNeighborDetector.EDGE_FACES` mapping is
+  authoritative; the `TetreeNeighborFinder` inline table (L104-110) is wrong and is corrected as part of
+  this work. Promote a single canonical `EDGE_FACES` into `TetreeConnectivity`; both neighbor classes
+  consume it.
+- **Vertex scope RESOLVED:** D1' governs — implement `findVertexNeighborsAtLevel` /
+  `findVertexNeighborsAtFinerLevels` **full-depth** to satisfy the existing `TetreeVertexNeighborTest`
+  contract (vertex incidence via inverted `CHILD_VERTEX_PARENT_VERTEX`). Note: a *separate* working
+  same-level vertex impl already exists in `TetreeNeighborDetector.findVertexNeighbors` (the ghost path);
+  the stubs being fixed are the `TetreeNeighborFinder` cross-level helpers only.
 
-## Open Questions (remaining for gate)
+## Acceptance Criteria
 
-1. Vertex-neighbor scope: implement full-depth (to satisfy `TetreeVertexNeighborTest`) now, or fence
-   vertex cross-level until a live consumer appears? (Lower risk than edge since not live.)
-2. Exact hand-worked ring/star counts for the exact-count fixtures (derive during implementation).
+1. The three helpers (`findEdgeNeighborsAtLevel`, `findVertexNeighborsAtLevel`,
+   `findVertexNeighborsAtFinerLevels`) perform real traversal; no empty-list placeholders remain.
+2. **Edge→face t8code parity:** a single canonical `EDGE_FACES` table (the F4-derived mapping) is the
+   only source; the wrong `TetreeNeighborFinder` inline table is removed. A test asserts the table equals
+   the geometric derivation (each edge → the two faces containing both its vertices) for the face
+   convention in `FACE_CORNERS`.
+3. **Symmetric-membership reciprocity** DFS (depth 4–5 refined Tetree) over all 6 edges and 4 vertices:
+   for every neighbor `n` of `e`, `e ∈ neighbors(n)` (adapt `PyramidNeighborParityTest.reciprocitySweep`).
+4. **Non-vacuous exact-count fixtures:** at least one concrete `(type, level, edge)` and one
+   `(type, level, vertex)` assert the **exact** coarser+finer neighbor count (the count is now mechanically
+   derivable from `CHILDREN_AT_FACE` ∩ `EDGE_FACES` for edges and the inverted
+   `CHILD_VERTEX_PARENT_VERTEX` for vertices) — explicitly guarding against the empty-set-both-sides
+   vacuity that bare reciprocity admits. `assertTrue(count >= 0)` is forbidden.
+5. The 21 previously-broken Tetree collision/integration tests stay green (live-path canary).
+6. No deep-tet insertion (RDR-012 fence): the helpers are read-only neighbor queries.
+
+## Remaining Open Question (safe to defer to implementation)
+
+1. The specific numeric ring/star counts for the criterion-4 fixtures — mechanically derivable from the
+   now-authoritative tables during implementation; the *requirement* (assert an exact count for ≥1 edge
+   and ≥1 vertex case) is locked above, only the literal numbers are derived in-code.

--- a/docs/rdr/RDR-014-cross-level-tet-edge-vertex-neighbors.md
+++ b/docs/rdr/RDR-014-cross-level-tet-edge-vertex-neighbors.md
@@ -1,8 +1,10 @@
 ---
 id: RDR-014
 title: Cross-Level Tetrahedral Edge/Vertex Neighbor Traversal for TetreeNeighborFinder
-status: draft
+status: accepted
 date: 2026-06-05
+accepted_date: 2026-06-05
+reviewed-by: self
 supersedes: []
 related: [RDR-010, RDR-012]
 beads: [Luciferase-7wzml.20]
@@ -12,9 +14,10 @@ beads: [Luciferase-7wzml.20]
 
 ## Status
 
-Draft (2026-06-05). Created from `Luciferase-7wzml.20` (full-build review 2026-06-04, P1 / High,
-HOLLOW STUBS). Not yet researched or gated — the Decision section records candidate approaches, not a
-locked choice. Implementation is blocked on this RDR reaching `accepted`.
+Accepted (2026-06-05). Created from `Luciferase-7wzml.20` (full-build review 2026-06-04, P1 / High,
+HOLLOW STUBS). Researched (F1–F4, code-verified) and gated PASSED (0 critical / 0 significant; the F4
+edge→face derivation was independently re-verified). The locked decision and Acceptance Criteria are
+below; ready for implementation under `Luciferase-7wzml.20`.
 
 ## Context
 

--- a/docs/rdr/RDR-014-cross-level-tet-edge-vertex-neighbors.md
+++ b/docs/rdr/RDR-014-cross-level-tet-edge-vertex-neighbors.md
@@ -130,10 +130,72 @@ primitives.
   remain partial. This is a *known, documented* limitation (this RDR + the bead), no longer a silent one
   — but it is **not** resolved by this RDR's creation alone.
 
-## Open Questions (for rdr-research / gate)
+## Research Findings (2026-06-05, code-verified)
 
-1. What exact level-delta ranges do live callers pass? (Decides D2 — shallow-band vs full-depth.)
-2. Do `allShapeNeighbors` / `tetBoundary` already enumerate edge/vertex incidence, or is new enumeration
-   needed? (D3.)
-3. Is the involution `dualFace` defined for edge/vertex neighbors as cleanly as for face neighbors, or is
-   a different reciprocity relation required for edge/vertex incidence?
+### F1 — Live scope is EDGE neighbors at ±1 level only (resolves D2)
+
+- The production callers of `TetreeNeighborFinder.findEdgeNeighbors` are `Tetree.findEntityNeighbors`
+  (`Tetree.java:422`, loops 6 edges) and `Tetree.addNeighboringNodes` (`Tetree.java:1390`, loops 6
+  edges); the latter is reached from collision (`CollisionEngine.java:491`) and k-NN
+  (`KnnSearcher.java:487`) via `AbstractSpatialIndex` BFS. These are the live paths.
+- `findEdgeNeighbors` queries cross-level at **±1 only**: parent `level-1`
+  (`TetreeNeighborFinder.java:127`, guard `level > 0` L125) and child `level+1` (L133, guard
+  `level < getMaxRefinementLevel()` L132). **Not arbitrary depth.**
+- `findVertexNeighbors` (`TetreeNeighborFinder.java:274`) is **test-only in production** —
+  `addNeighboringNodes` calls only `findEdgeNeighbors`. Its cross-level traversal spans full depth
+  (coarser loop `level-1..0` L324-329; finer `level+1` L334), but no live caller exercises it.
+- Max refinement level = 21 (`MortonCurve.java:14`); pure-Tetree entities (`minTetLevel = -1`) can sit
+  at any level 0..21. No `minTetLevel` guard exists in the neighbor methods.
+- **Conclusion (D2):** the live production requirement is **edge neighbors at parent/child (±1)** only.
+  Vertex neighbors and deeper-than-±1 edge traversal are test-contract scope, not live — so they may be
+  implemented to satisfy their existing tests (`TetreeEdgeNeighborTest`, `TetreeVertexNeighborTest`)
+  without over-building, and the RDR-012 deep-tet fence is respected (no new deep insertion).
+
+### F2 — No new connectivity tables needed; derive from existing Bey/face tables (resolves D3)
+
+- **Edge incidence** is NOT directly tabled but is fully derivable: each of the 6 edges touches exactly
+  2 faces (edge→face map at `TetreeNeighborFinder.java:104-110`); children touching edge E =
+  `CHILDREN_AT_FACE[type][F1] ∩ CHILDREN_AT_FACE[type][F2]` (`TetreeConnectivity.java:274`). Building
+  blocks: `getChildrenAtFace`, `getChildFace` (used at `TetreeNeighborFinder.java:367/378`), and the
+  existing working cross-level FACE traversal `findDescendantsAtLevel` (`:359/380`) — reuse it.
+- **Vertex incidence** is partially tabled: `CHILD_VERTEX_PARENT_VERTEX`
+  (`TetreeConnectivity.java:346-363`) gives each Bey child's 4 vertices as parent-vertex / edge-midpoint
+  / center references. Invert it (parent-vertex → containing Bey children); optionally cache or add a
+  read-only `VERTEX_TO_BEY_CHILDREN` companion table if hot.
+- **Conclusion (D3):** compose existing primitives; no genuinely new enumeration logic. Reuse
+  `findDescendantsAtLevel` as the cross-level traversal skeleton.
+
+### F3 — Validation is SYMMETRIC MEMBERSHIP, not dualFace involution (resolves Q3)
+
+- Face involution (`neighbor(neighbor(e,f).dualFace) == e`) relies on a one-to-one face↔dualFace map
+  (`Tet.faceNeighbor` dualFace at `Tet.java:1440/1456`; oracle `T8codeDtetFaceNeighborOracleTest.java:182-192`).
+- Edges/vertices are **one-to-many**: an edge is shared by a RING of tets, a vertex by a STAR; return
+  types are `List` (`Tetree.java:374/553`) and there is no `dualEdge`/`dualVertex`. So the involution
+  form does not apply.
+- The correct, already-in-repo validation is **symmetric membership**: for every neighbor `n` of `e`,
+  `e ∈ neighbors(n)`. Pattern: `PyramidNeighborParityTest.reciprocitySweep`
+  (`PyramidNeighborParityTest.java:115-144`), already applied to `findEdgeNeighbors`/`findVertexNeighbors`
+  for pyramids — directly adaptable to Tetree.
+- **Conclusion (Q3):** the test harness is a DFS (depth 4-5) over a refined Tetree asserting
+  symmetric-membership reciprocity for all 6 edges and 4 vertices, PLUS hand-worked exact-count fixtures
+  (ring/star size) at a small fixed level — not `assertTrue(count >= 0)`, and NOT a dualFace involution.
+
+## Decision (updated post-research — proposed for gate)
+
+- **D1' (implement, scoped):** Implement `findEdgeNeighborsAtLevel` for the ±1 live case first
+  (parent/child edge incidence via `CHILDREN_AT_FACE` ∩ edge-faces, traversing with
+  `findDescendantsAtLevel`). Implement `findVertexNeighborsAtLevel` /
+  `findVertexNeighborsAtFinerLevels` to satisfy their existing test contract (inverted
+  `CHILD_VERTEX_PARENT_VERTEX`). No new deep-tet insertion (RDR-012 fence intact).
+- **D2' RESOLVED:** live = edge ±1; vertex + deeper = test-contract scope, not live. Cover the consumed
+  range; do not over-build the deep band.
+- **D3' RESOLVED:** reuse existing tables/primitives; no new connectivity tables (optional
+  `VERTEX_TO_BEY_CHILDREN` cache only if profiling shows a hot path).
+- **Validation RESOLVED:** symmetric-membership reciprocity DFS + exact-count fixtures, adapting
+  `PyramidNeighborParityTest.reciprocitySweep`. Keep the 21 previously-broken live tests green.
+
+## Open Questions (remaining for gate)
+
+1. Vertex-neighbor scope: implement full-depth (to satisfy `TetreeVertexNeighborTest`) now, or fence
+   vertex cross-level until a live consumer appears? (Lower risk than edge since not live.)
+2. Exact hand-worked ring/star counts for the exact-count fixtures (derive during implementation).

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -23,6 +23,8 @@ See the [RDR process documentation](https://github.com/cwensel/rdr) for the full
 | [RDR-010](RDR-010-pyramid-spatial-index.md) | Pyramid Spatial Index — Close the Hybrid Hex↔Tet Partition Gap | accepted | Architecture | medium |
 | [RDR-011](RDR-011-pyramid-sfc-linear-id.md) | PyramidIndex SFC Linear-ID Primitive — Port t8code linear_id, or Accept the Morton-Key Divergence | draft | Architecture | low |
 | [RDR-012](RDR-012-pyramid-deep-cross-shape-productionization.md) | PyramidIndex Domain Contract & Deep Cross-Shape — Define the Reachable-SFC Set, Productionize the Deep-Tet Path or Fence It | accepted | Architecture | medium |
+| [RDR-013](RDR-013-grpc-server-dos-hardening.md) | gRPC Server DoS Hardening — Explicit Inbound Message-Size Bounds for Ghost/Balance | accepted | Security | low |
+| [RDR-014](RDR-014-cross-level-tet-edge-vertex-neighbors.md) | Cross-Level Tetrahedral Edge/Vertex Neighbor Traversal for TetreeNeighborFinder | accepted | Correctness | medium |
 
 ## Post-Mortems
 

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/neighbor/TetreeNeighborDetector.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/neighbor/TetreeNeighborDetector.java
@@ -46,16 +46,10 @@ public class TetreeNeighborDetector implements NeighborDetector<TetreeKey<? exte
     
     private final Tetree<?, ?> tetree;
     
-    // Edge vertex pairs (0-5)
-    private static final int[][] EDGE_VERTICES = {
-        {0, 1}, // Edge 0
-        {0, 2}, // Edge 1
-        {0, 3}, // Edge 2
-        {1, 2}, // Edge 3
-        {1, 3}, // Edge 4
-        {2, 3}  // Edge 5
-    };
-    
+    // Canonical edge/face connectivity now lives in TetreeConnectivity (RDR-014 AC2); consume it
+    // directly so both neighbor classes share one authoritative source.
+    private static final int[][] EDGE_VERTICES = TetreeConnectivity.EDGE_VERTICES;
+
     // Which edges touch each vertex
     private static final int[][] VERTEX_EDGES = {
         {0, 1, 2},    // Vertex 0: edges 0, 1, 2
@@ -63,17 +57,10 @@ public class TetreeNeighborDetector implements NeighborDetector<TetreeKey<? exte
         {1, 3, 5},    // Vertex 2: edges 1, 3, 5
         {2, 4, 5}     // Vertex 3: edges 2, 4, 5
     };
-    
-    // Which faces share each edge
-    private static final int[][] EDGE_FACES = {
-        {2, 3},    // Edge 0 (v0-v1): faces 2 and 3
-        {1, 3},    // Edge 1 (v0-v2): faces 1 and 3
-        {1, 2},    // Edge 2 (v0-v3): faces 1 and 2
-        {0, 3},    // Edge 3 (v1-v2): faces 0 and 3
-        {0, 2},    // Edge 4 (v1-v3): faces 0 and 2
-        {0, 1}     // Edge 5 (v2-v3): faces 0 and 1
-    };
-    
+
+    // Which faces share each edge (canonical: TetreeConnectivity.EDGE_FACES)
+    private static final int[][] EDGE_FACES = TetreeConnectivity.EDGE_FACES;
+
     // Which faces contain each vertex
     private static final int[][] VERTEX_FACES = {
         {1, 2, 3},    // Vertex 0: in faces 1, 2, 3 (opposite face 0)

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeConnectivity.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeConnectivity.java
@@ -46,6 +46,36 @@ public final class TetreeConnectivity {
     public static final int TET_TYPES = 6;
 
     /**
+     * Canonical edge -> vertex-pair table (RDR-014 AC2). Edge e is bounded by the two local vertices
+     * {@code EDGE_VERTICES[e]}. Type-independent (the local vertex numbering is shared by all 6 types).
+     * [edge_index] -> {vertexA, vertexB}.
+     */
+    public static final int[][] EDGE_VERTICES = { { 0, 1 }, // Edge 0
+                                                  { 0, 2 }, // Edge 1
+                                                  { 0, 3 }, // Edge 2
+                                                  { 1, 2 }, // Edge 3
+                                                  { 1, 3 }, // Edge 4
+                                                  { 2, 3 }  // Edge 5
+    };
+
+    /**
+     * Canonical edge -> bounding-face table (RDR-014 F4 / AC2). Edge e is bounded by exactly the two
+     * faces that contain both of its vertices, where face i is opposite vertex i (see {@link #FACE_CORNERS}).
+     * This is the single authoritative source consumed by both {@code TetreeNeighborFinder} and
+     * {@code TetreeNeighborDetector}; it replaces the (incorrect) inline table previously in the Finder.
+     * Type-independent because {@code FACE_CORNERS} is identical across all 6 types.
+     * {@code EdgeFaceTableParityTest} asserts this equals the geometric derivation from {@code FACE_CORNERS}.
+     * [edge_index] -> {faceA, faceB}.
+     */
+    public static final int[][] EDGE_FACES = { { 2, 3 }, // Edge 0 (v0-v1)
+                                               { 1, 3 }, // Edge 1 (v0-v2)
+                                               { 1, 2 }, // Edge 2 (v0-v3)
+                                               { 0, 3 }, // Edge 3 (v1-v2)
+                                               { 0, 2 }, // Edge 4 (v1-v3)
+                                               { 0, 1 }  // Edge 5 (v2-v3)
+    };
+
+    /**
      * Parent type to child type mapping. Given a parent tetrahedron type (0-5) and child index (0-7), returns the type
      * of that child tetrahedron.
      *

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeNeighborFinder.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeNeighborFinder.java
@@ -93,21 +93,10 @@ public class TetreeNeighborFinder {
         var tet = Tet.tetrahedron(tetIndex);
         var edgeNeighbors = new ArrayList<TetreeKey<?>>();
 
-        // Each edge is shared by multiple faces
-        // Edge-to-face mapping for tetrahedron:
-        // Edge 0 (v0-v1): faces 0, 2
-        // Edge 1 (v0-v2): faces 0, 3
-        // Edge 2 (v0-v3): faces 1, 3
-        // Edge 3 (v1-v2): faces 0, 1
-        // Edge 4 (v1-v3): faces 1, 2
-        // Edge 5 (v2-v3): faces 2, 3
-        var edgeToFaces = new int[][] { { 0, 2 },  // Edge 0
-                                        { 0, 3 },  // Edge 1
-                                        { 1, 3 },  // Edge 2
-                                        { 0, 1 },  // Edge 3
-                                        { 1, 2 },  // Edge 4
-                                        { 2, 3 }   // Edge 5
-        };
+        // Each edge is bounded by exactly two faces; use the single canonical edge->face table
+        // (RDR-014 F4/AC2). The previous inline table here was geometrically WRONG (e.g. edge 0
+        // listed faces {0,2} instead of {2,3}); it is removed in favor of TetreeConnectivity.EDGE_FACES.
+        var edgeToFaces = TetreeConnectivity.EDGE_FACES;
 
         // Check neighbors across both faces that share this edge
         var uniqueNeighbors = new HashSet<TetreeKey<?>>();

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeNeighborFinder.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/tetree/TetreeNeighborFinder.java
@@ -18,6 +18,7 @@ package com.hellblazer.luciferase.lucien.tetree;
 
 import com.hellblazer.luciferase.lucien.Constants;
 
+import javax.vecmath.Point3i;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -110,11 +111,26 @@ public class TetreeNeighborFinder {
         // Also need to check for neighbors at different levels that share the edge
         var level = tet.l();
 
-        // Check coarser level
+        // Check coarser level. CONTRACT (A) coarser neighbors are the EXACT inverse of the finer ring: a
+        // level-(L-1) tet m is a coarser edge-neighbor of tet ACROSS THIS edge iff tet lies in m's finer
+        // adjacency ring for the m-edge that geometrically coincides with tet's queried edge [pa,pb]. m must be
+        // a face-neighbor of tet's parent (so tet is a child of one of m's face-neighbors). Scoping to the
+        // coincident m-edge (not the union over all of m's edges) is required: tet may share a DIFFERENT edge
+        // with m, which must not be reported as a neighbor across THIS edge. This makes the relation reciprocal
+        // by construction per-edge (RDR-014 AC3): tet→m across [pa,pb] ⟹ m's finer ring on that edge ∋ tet ⟹ m→tet.
         if (level > 0) {
             var parent = tet.parent();
-            var parentEdgeNeighbors = findEdgeNeighborsAtLevel(parent, edgeIndex, (byte) (level - 1));
-            uniqueNeighbors.addAll(parentEdgeNeighbors);
+            var pa = tet.coordinates()[TetreeConnectivity.EDGE_VERTICES[edgeIndex][0]];
+            var pb = tet.coordinates()[TetreeConnectivity.EDGE_VERTICES[edgeIndex][1]];
+            for (var face = 0; face < TetreeConnectivity.FACES_PER_TET; face++) {
+                var m = findFaceNeighbor(parent, face);
+                if (m == null || m.l() != level - 1) {
+                    continue;
+                }
+                if (isCoarserEdgeNeighbor(m, tet.tmIndex(), pa, pb)) {
+                    uniqueNeighbors.add(m.tmIndex());
+                }
+            }
         }
 
         // Check finer level
@@ -307,15 +323,13 @@ public class TetreeNeighborFinder {
         // Check different levels for vertex neighbors
         var level = tet.l();
 
-        // Check coarser levels
+        // Check the coarser level. ±1 live reach only (RDR-014 F1), symmetric to the finer star so the
+        // cross-level relation is reciprocal (AC3). Pass the ORIGINAL tet (not its ancestor) so the helper
+        // resolves the shared vertex POINT from tet.coordinates()[vertexIndex]; re-deriving it from an
+        // ancestor's same index would pick a different geometric vertex (the anchor/index correspondence is not
+        // preserved up the parent chain).
         if (level > 0) {
-            var current = tet;
-            for (var l = (byte) (level - 1); l >= 0; l--) {
-                current = current.parent();
-                // Find all neighbors at this level that share the vertex
-                var coarserNeighbors = findVertexNeighborsAtLevel(current, vertexIndex, l);
-                vertexNeighbors.addAll(coarserNeighbors);
-            }
+            vertexNeighbors.addAll(findVertexNeighborsAtLevel(tet, vertexIndex, (byte) (level - 1)));
         }
 
         // Check finer levels
@@ -323,6 +337,16 @@ public class TetreeNeighborFinder {
             var finerNeighbors = findVertexNeighborsAtFinerLevels(tet, vertexIndex, (byte) (level + 1));
             vertexNeighbors.addAll(finerNeighbors);
         }
+
+        // A cross-level (level != L) vertex neighbor must genuinely carry the shared vertex (CONTRACT A). The
+        // edge-neighbor aggregation above pulls in finer/coarser edge rings whose tets touch an edge THROUGH
+        // the vertex but need not be coincident with it; drop those so the cross-level slices equal exactly the
+        // adjacency star (RDR-014 AC4). Same-level adjacency (face/edge ring) is left untouched.
+        var vp = tet.coordinates()[vertexIndex];
+        vertexNeighbors.removeIf(k -> {
+            var other = Tet.tetrahedron(k);
+            return other.l() != level && !hasVertex(other, vp);
+        });
 
         // Remove self
         vertexNeighbors.remove(tetIndex);
@@ -377,28 +401,205 @@ public class TetreeNeighborFinder {
         return descendants;
     }
 
-    // Helper method to find edge neighbors at a specific level
-    private List<ExtendedTetreeKey> findEdgeNeighborsAtLevel(Tet tet, int edgeIndex, byte targetLevel) {
-        var neighbors = new ArrayList<ExtendedTetreeKey>();
-        // Implementation would traverse to find all tets at target level sharing the edge
-        // This is a placeholder for the complex geometric calculation
+    /**
+     * Cross-level EDGE neighbors under CONTRACT (A) ADJACENCY (RDR-014). Returns the level-{@code targetLevel}
+     * tets that share {@code tet}'s edge {@code edgeIndex} and are adjacent to {@code tet} via its (at most two)
+     * bounding-face neighbors — never {@code tet}'s own nested children. Scope is ±1 (RDR-014 F1): the public
+     * caller invokes this with {@code targetLevel == tet.level()} (coarser-side, passing the parent) or
+     * {@code targetLevel == tet.level()+1} (finer-side, passing the tet itself).
+     *
+     * <ul>
+     *   <li><b>Same level</b> ({@code targetLevel == tet.level()}): the bounding-face neighbors of {@code tet}
+     *       across {@code EDGE_FACES[edgeIndex]} that actually share the edge segment.</li>
+     *   <li><b>Finer</b> ({@code targetLevel > tet.level()}): the children of those bounding-face neighbors that
+     *       lie along the shared edge — the contract-(A) adjacency ring, matching the independent geometric
+     *       oracle {@code CrossLevelNeighborOracle.finerEdgeRingPlusMinus1}.</li>
+     * </ul>
+     */
+    private List<TetreeKey<?>> findEdgeNeighborsAtLevel(Tet tet, int edgeIndex, byte targetLevel) {
+        var neighbors = new ArrayList<TetreeKey<?>>();
+        if (targetLevel < 0 || targetLevel > Constants.getMaxRefinementLevel() || targetLevel < tet.l()) {
+            return neighbors; // ±1 scope: callers only ask same-level or finer (RDR-014 F1)
+        }
+        var verts = tet.coordinates();
+        var pa = verts[TetreeConnectivity.EDGE_VERTICES[edgeIndex][0]];
+        var pb = verts[TetreeConnectivity.EDGE_VERTICES[edgeIndex][1]];
+        for (var faceIndex : TetreeConnectivity.EDGE_FACES[edgeIndex]) {
+            var neighbor = findFaceNeighbor(tet, faceIndex);
+            if (neighbor == null) {
+                continue; // boundary face
+            }
+            if (targetLevel == tet.l()) {
+                if (neighbor.l() == targetLevel && sharesEdgeSegment(neighbor, pa, pb)) {
+                    neighbors.add(neighbor.tmIndex());
+                }
+            } else { // targetLevel > tet.l(): finer adjacency ring = neighbor's children along the edge
+                for (var c = 0; c < TetreeConnectivity.CHILDREN_PER_TET; c++) {
+                    Tet child;
+                    try {
+                        child = neighbor.child(c);
+                    } catch (RuntimeException e) {
+                        continue; // invalid / max-level child
+                    }
+                    if (child.l() == targetLevel && sharesEdgeSegment(child, pa, pb)) {
+                        neighbors.add(child.tmIndex());
+                    }
+                }
+            }
+        }
         return neighbors;
     }
 
-    // Helper method to find vertex neighbors at finer levels
-    private List<ExtendedTetreeKey> findVertexNeighborsAtFinerLevels(Tet tet, int vertexIndex, byte startLevel) {
-        var neighbors = new ArrayList<ExtendedTetreeKey>();
-        // Implementation would recursively check children that share the vertex
-        // This is a placeholder for the complex geometric calculation
+    /**
+     * True iff coarser tet {@code m} is an edge-neighbor of the tet whose queried edge is the segment
+     * [{@code pa}, {@code pb}] (identified by {@code tetKey}). Scoped to the single m-edge that geometrically
+     * coincides with [pa, pb] (both query endpoints lie on it): for that m-edge, {@code tetKey} must appear in
+     * {@code m}'s finer adjacency ring. Per-edge scoping prevents reporting {@code m} across an edge the query
+     * tet does not actually share with {@code m} (RDR-014 AC3 reciprocity is then per-edge, not all-edges).
+     */
+    private boolean isCoarserEdgeNeighbor(Tet m, TetreeKey<?> tetKey, Point3i pa, Point3i pb) {
+        var finer = (byte) (m.l() + 1);
+        var mv = m.coordinates();
+        for (var em = 0; em < TetreeConnectivity.EDGES_PER_TET; em++) {
+            var ma = mv[TetreeConnectivity.EDGE_VERTICES[em][0]];
+            var mb = mv[TetreeConnectivity.EDGE_VERTICES[em][1]];
+            if (!onSegment(pa, ma, mb) || !onSegment(pb, ma, mb)) {
+                continue; // the queried edge does not lie on this m-edge
+            }
+            if (findEdgeNeighborsAtLevel(m, em, finer).contains(tetKey)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Cross-level (finer) VERTEX star under CONTRACT (A) ADJACENCY (RDR-014). Returns every level-{@code
+     * startLevel} tet that carries {@code tet}'s vertex {@code vertexIndex}, EXCLUDING {@code tet}'s own nested
+     * children (a parent is not an adjacency neighbor of its child). Enumerated geometrically — independent of
+     * the BEY-indexed {@code CHILD_VERTEX_PARENT_VERTEX} table (which a naive Morton-index inversion would
+     * mis-read, RDR-014 Phase 3 hazard) — so it matches the table-independent oracle
+     * {@code CrossLevelNeighborOracle.finerVertexStarPlus1}. Vertex neighbors are a read-only, test-scope query
+     * (RDR-014 F1).
+     */
+    private List<TetreeKey<?>> findVertexNeighborsAtFinerLevels(Tet tet, int vertexIndex, byte startLevel) {
+        var neighbors = new ArrayList<TetreeKey<?>>();
+        if (startLevel < 0 || startLevel > Constants.getMaxRefinementLevel()) {
+            return neighbors;
+        }
+        // ±1 live reach only (RDR-014 F1; matches the oracle finerVertexStarPlus1). The public caller invokes
+        // this with startLevel == level+1, so this enumerates exactly the level-(L+1) star. Full-depth descent
+        // is intentionally NOT done: it is unbounded work (to maxRefinementLevel=21) for no tested benefit and
+        // would make the finer/coarser depths asymmetric unless the coarser loop also ran full-depth.
+        collectVertexStarAtLevel(tet, tet.coordinates()[vertexIndex], startLevel, neighbors);
         return neighbors;
     }
 
-    // Helper method to find vertex neighbors at a specific level
-    private List<ExtendedTetreeKey> findVertexNeighborsAtLevel(Tet tet, int vertexIndex, byte targetLevel) {
-        var neighbors = new ArrayList<ExtendedTetreeKey>();
-        // Implementation would traverse to find all tets at target level sharing the vertex
-        // This is a placeholder for the complex geometric calculation
+    /**
+     * Cross-level (coarser) VERTEX star under CONTRACT (A) ADJACENCY (RDR-014). Returns every level-{@code
+     * targetLevel} tet (coarser than {@code tet}) that carries {@code tet}'s vertex {@code vertexIndex},
+     * EXCLUDING {@code tet}'s own ancestor at that level (the container, not an adjacency neighbor). Symmetric
+     * to {@link #findVertexNeighborsAtFinerLevels}: whenever {@code tet} lists a finer neighbor {@code n},
+     * {@code n} lists {@code tet} here, satisfying AC3 reciprocity.
+     */
+    private List<TetreeKey<?>> findVertexNeighborsAtLevel(Tet tet, int vertexIndex, byte targetLevel) {
+        var neighbors = new ArrayList<TetreeKey<?>>();
+        if (targetLevel < 0 || targetLevel >= tet.l()) {
+            return neighbors;
+        }
+        collectVertexStarAtLevel(tet, tet.coordinates()[vertexIndex], targetLevel, neighbors);
         return neighbors;
+    }
+
+    /**
+     * Enumerate all level-{@code targetLevel} tets carrying point {@code p}, excluding {@code self}'s own
+     * relative at that level (its child when {@code targetLevel} is finer, its ancestor when coarser). A
+     * level-{@code targetLevel} tet with anchor {@code a} spans {@code [a, a+h]} per axis, so to carry {@code p}
+     * its anchor must lie in {@code [p-h, p]} — a 2×2×2 anchor box, all 6 types. Pure {@code Tet.coordinates()}
+     * geometry; no connectivity-table dependence.
+     */
+    private void collectVertexStarAtLevel(Tet self, Point3i p, byte targetLevel, List<TetreeKey<?>> out) {
+        int h = Constants.lengthAtLevel(targetLevel);
+        for (var ax = anchorFloor(p.x - h, h); ax <= p.x; ax += h) {
+            for (var ay = anchorFloor(p.y - h, h); ay <= p.y; ay += h) {
+                for (var az = anchorFloor(p.z - h, h); az <= p.z; az += h) {
+                    if (ax < 0 || ay < 0 || az < 0) {
+                        continue;
+                    }
+                    for (byte type = 0; type < TetreeConnectivity.TET_TYPES; type++) {
+                        Tet cand;
+                        try {
+                            cand = new Tet(ax, ay, az, targetLevel, type);
+                            if (!cand.isValid()) {
+                                continue;
+                            }
+                        } catch (RuntimeException e) {
+                            continue;
+                        }
+                        if (!hasVertex(cand, p)) {
+                            continue;
+                        }
+                        // Exclude self's own containment line (CONTRACT A: a container is not an adjacency
+                        // neighbor of what it contains). Finer: skip cand if it is a descendant of self (self is
+                        // its ancestor). Coarser: skip cand if it is self's ancestor. Both reduce to the same
+                        // ancestor test on the deeper of the two, making finer/coarser exclusions symmetric so
+                        // the cross-level relation is reciprocal (RDR-014 AC3).
+                        if (targetLevel > self.l()) {
+                            if (self.equals(findAncestorAtLevel(cand, self.l()))) {
+                                continue; // finer: skip self's own descendant
+                            }
+                        } else {
+                            if (cand.equals(findAncestorAtLevel(self, targetLevel))) {
+                                continue; // coarser: skip self's own ancestor
+                            }
+                        }
+                        out.add(cand.tmIndex());
+                    }
+                }
+            }
+        }
+    }
+
+    /** True iff at least two vertices of {@code cand} lie on the inclusive segment [pa, pb]. */
+    private static boolean sharesEdgeSegment(Tet cand, Point3i pa, Point3i pb) {
+        var onSeg = 0;
+        for (var v : cand.coordinates()) {
+            if (onSegment(v, pa, pb)) {
+                onSeg++;
+            }
+        }
+        return onSeg >= 2;
+    }
+
+    /** True iff {@code cand} has a vertex coincident with {@code p}. */
+    private static boolean hasVertex(Tet cand, Point3i p) {
+        for (var v : cand.coordinates()) {
+            if (v.equals(p)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Exact integer test: {@code v} is collinear with [pa,pb] and lies within the inclusive segment. */
+    private static boolean onSegment(Point3i v, Point3i pa, Point3i pb) {
+        long dx = pb.x - pa.x, dy = pb.y - pa.y, dz = pb.z - pa.z;
+        long wx = v.x - pa.x, wy = v.y - pa.y, wz = v.z - pa.z;
+        long cx = dy * wz - dz * wy;
+        long cy = dz * wx - dx * wz;
+        long cz = dx * wy - dy * wx;
+        if (cx != 0 || cy != 0 || cz != 0) {
+            return false; // not collinear
+        }
+        long dot = wx * dx + wy * dy + wz * dz;
+        long len2 = dx * dx + dy * dy + dz * dz;
+        return dot >= 0 && dot <= len2;
+    }
+
+    /** Floor {@code v} to the nearest multiple of {@code h} toward -inf (v may be slightly negative). */
+    private static int anchorFloor(int v, int h) {
+        var a = (v / h) * h;
+        return a > v ? a - h : a;
     }
 
     // Helper method to check if tetrahedron is within domain bounds

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/CrossLevelNeighborOracle.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/CrossLevelNeighborOracle.java
@@ -166,6 +166,55 @@ final class CrossLevelNeighborOracle {
         return star;
     }
 
+    /**
+     * Contract-(A) coarser (level-1) EDGE ring, scoped to the ±1 live reach (RDR-014 F1): the level-(L-1)
+     * face-neighbors {@code m} of {@code t}'s parent for which {@code t} lies on the finer ring of {@code m}
+     * across the m-edge that geometrically coincides with {@code t}'s edge. This is the exact inverse of
+     * {@link #finerEdgeRingPlusMinus1}: {@code m} is a coarser neighbor of {@code t} iff {@code t} is a finer
+     * neighbor of {@code m}. Built from the same geometric primitives ({@code findFaceNeighbor}, child
+     * incidence, segment collinearity), independent of the production helper's traversal.
+     */
+    static Set<TetreeKey<?>> coarserEdgeRingMinus1(TetreeNeighborFinder finder, Tet t, int edge) {
+        var ring = new HashSet<TetreeKey<?>>();
+        if (t.l() == 0) {
+            return ring;
+        }
+        var verts = t.coordinates();
+        var pa = verts[TetreeConnectivity.EDGE_VERTICES[edge][0]];
+        var pb = verts[TetreeConnectivity.EDGE_VERTICES[edge][1]];
+        var parent = t.parent();
+        var tKey = t.tmIndex();
+        for (var f = 0; f < TetreeConnectivity.FACES_PER_TET; f++) {
+            var m = finder.findFaceNeighbor(parent, f);
+            if (m == null || m.l() != t.l() - 1) {
+                continue;
+            }
+            var mv = m.coordinates();
+            for (var em = 0; em < TetreeConnectivity.EDGES_PER_TET; em++) {
+                var ma = mv[TetreeConnectivity.EDGE_VERTICES[em][0]];
+                var mb = mv[TetreeConnectivity.EDGE_VERTICES[em][1]];
+                if (!onSegment(pa, ma, mb) || !onSegment(pb, ma, mb)) {
+                    continue; // t's edge does not lie on this m-edge
+                }
+                if (finerEdgeRingPlusMinus1(finder, m, em).contains(tKey)) {
+                    ring.add(m.tmIndex());
+                }
+            }
+        }
+        return ring;
+    }
+
+    /** The level-(L-1) members of {@code result} (the coarser slice of a merged neighbor set). */
+    static Set<TetreeKey<?>> coarserSlice(Set<TetreeKey<?>> result, byte level) {
+        var out = new HashSet<TetreeKey<?>>();
+        for (var k : result) {
+            if (Tet.tetrahedron(k).l() == level - 1) {
+                out.add(k);
+            }
+        }
+        return out;
+    }
+
     /** The level-(L+1) members of {@code result} (the finer slice of a merged neighbor set). */
     static Set<TetreeKey<?>> finerSlice(Set<TetreeKey<?>> result, byte level) {
         var out = new HashSet<TetreeKey<?>>();

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/CrossLevelNeighborOracle.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/CrossLevelNeighborOracle.java
@@ -1,0 +1,220 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.tetree;
+
+import com.hellblazer.luciferase.lucien.Constants;
+
+import javax.vecmath.Point3i;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * RDR-014 Phase 1 independent geometric oracle for cross-level edge/vertex neighbors, implementing the
+ * user-confirmed CONTRACT (A) ADJACENCY (see RDR-014 "Implementation-time decision"). The oracle derives
+ * expected neighbor sets purely from {@link Tet#coordinates()} geometry (integer vertices → exact
+ * collinearity / coincidence tests) — it does NOT re-derive from the connectivity tables the implementation
+ * uses ({@code CHILDREN_AT_FACE} / {@code CHILD_VERTEX_PARENT_VERTEX}), so the fixtures cannot be satisfied
+ * by a table-tautological or self-children-only implementation.
+ *
+ * @author hal.hildebrand
+ */
+final class CrossLevelNeighborOracle {
+
+    private CrossLevelNeighborOracle() {
+    }
+
+    /** Collect a refined tet tree (levels 1..maxDepth) by descending the root via Bey children. */
+    static List<Tet> refinedTets(int maxDepth) {
+        var out = new ArrayList<Tet>();
+        descend(new Tet(0, 0, 0, (byte) 0, (byte) 0), maxDepth, out);
+        return out;
+    }
+
+    private static void descend(Tet t, int maxDepth, List<Tet> out) {
+        if (t.l() >= 1) {
+            out.add(t);
+        }
+        if (t.l() >= maxDepth) {
+            return;
+        }
+        for (int c = 0; c < TetreeConnectivity.CHILDREN_PER_TET; c++) {
+            try {
+                descend(t.child(c), maxDepth, out);
+            } catch (IllegalArgumentException | IllegalStateException ignored) {
+                // invalid / out-of-domain / max-level child — skip (do not mask programming errors)
+            }
+        }
+    }
+
+    /** Full edge-neighbor set of {@code t}, aggregated over all 6 edges. */
+    static Set<TetreeKey<?>> fullEdgeNeighbors(TetreeNeighborFinder finder, Tet t) {
+        var all = new HashSet<TetreeKey<?>>();
+        var key = t.tmIndex();
+        for (int e = 0; e < TetreeConnectivity.EDGES_PER_TET; e++) {
+            all.addAll(finder.findEdgeNeighbors(key, e));
+        }
+        return all;
+    }
+
+    /** Full vertex-neighbor set of {@code t}, aggregated over all 4 vertices. */
+    static Set<TetreeKey<?>> fullVertexNeighbors(TetreeNeighborFinder finder, Tet t) {
+        var all = new HashSet<TetreeKey<?>>();
+        var key = t.tmIndex();
+        for (int v = 0; v < TetreeConnectivity.VERTICES_PER_TET; v++) {
+            all.addAll(finder.findVertexNeighbors(key, v));
+        }
+        return all;
+    }
+
+    /**
+     * Contract-(A) finer (level+1) EDGE ring, scoped to the ±1 live reach (RDR-014 F1): the children of
+     * {@code t}'s two same-level bounding-face neighbors that lie along the shared edge. These are
+     * adjacency neighbors of {@code t} at level L+1 — never {@code t}'s own nested children. Computed via
+     * the validated same-level {@code findFaceNeighbor} plus a pure geometric edge-incidence test on the
+     * neighbor's children.
+     *
+     * <p><b>Scope invariant (intentional, not a gap):</b> the edge-neighbor relation in this codebase is
+     * defined as the (at most) two face-neighbors across the edge's bounding faces — see the same-level
+     * {@code TetreeNeighborFinder.findEdgeNeighbors}, which collects exactly {@code EDGE_FACES[edge]}'s two
+     * face neighbors. This is the non-conforming Bey-SFC neighbor relation (a face neighbor shares 0–3
+     * vertices), NOT the full conforming geometric edge ring (which in a conforming Kuhn mesh would have
+     * valence 4–6). The finer ring therefore extends exactly those two neighbors per RDR D1' (±1 via
+     * {@code findDescendantsAtLevel} on the bounding-face neighbors). Pinning more (a full conforming-ring
+     * walk) would contradict the locked scope and reject the intended Phase 2 implementation.
+     */
+    static Set<TetreeKey<?>> finerEdgeRingPlusMinus1(TetreeNeighborFinder finder, Tet t, int edge) {
+        var verts = t.coordinates();
+        var pa = verts[TetreeConnectivity.EDGE_VERTICES[edge][0]];
+        var pb = verts[TetreeConnectivity.EDGE_VERTICES[edge][1]];
+        var ring = new HashSet<TetreeKey<?>>();
+        for (int f : TetreeConnectivity.EDGE_FACES[edge]) {
+            var n = finder.findFaceNeighbor(t, f);
+            if (n == null) {
+                continue;
+            }
+            for (int c = 0; c < TetreeConnectivity.CHILDREN_PER_TET; c++) {
+                Tet child;
+                try {
+                    child = n.child(c);
+                } catch (RuntimeException e) {
+                    continue;
+                }
+                if (sharesEdgeSegment(child, pa, pb)) {
+                    ring.add(child.tmIndex());
+                }
+            }
+        }
+        return ring;
+    }
+
+    /**
+     * Contract-(A) finer (level+1) VERTEX star: every level-(L+1) tet that carries the shared vertex,
+     * EXCLUDING {@code t}'s own children (a parent is not an adjacency neighbor of its child). Enumerated
+     * by a geometric box sweep around the vertex and filtered by exact vertex coincidence — independent of
+     * any connectivity table.
+     */
+    static Set<TetreeKey<?>> finerVertexStarPlus1(Tet t, int vertex) {
+        var p = t.coordinates()[vertex];
+        byte lf = (byte) (t.l() + 1);
+        int h = Constants.lengthAtLevel(lf);
+        var star = new HashSet<TetreeKey<?>>();
+        // A level-(L+1) tet with anchor a has vertices within [a, a+h], so to carry point p its anchor
+        // must lie in [p-h, p] per axis. Sweep that box, all 6 types.
+        for (int ax = anchorFloor(p.x - h, h); ax <= p.x; ax += h) {
+            for (int ay = anchorFloor(p.y - h, h); ay <= p.y; ay += h) {
+                for (int az = anchorFloor(p.z - h, h); az <= p.z; az += h) {
+                    if (ax < 0 || ay < 0 || az < 0) {
+                        continue;
+                    }
+                    for (byte type = 0; type < TetreeConnectivity.TET_TYPES; type++) {
+                        Tet cand;
+                        try {
+                            cand = new Tet(ax, ay, az, lf, type);
+                            if (!cand.isValid()) {
+                                continue;
+                            }
+                        } catch (RuntimeException e) {
+                            continue;
+                        }
+                        if (!hasVertex(cand, p)) {
+                            continue;
+                        }
+                        if (cand.parent().equals(t)) {
+                            continue; // exclude t's own nested children (contract A)
+                        }
+                        star.add(cand.tmIndex());
+                    }
+                }
+            }
+        }
+        return star;
+    }
+
+    /** The level-(L+1) members of {@code result} (the finer slice of a merged neighbor set). */
+    static Set<TetreeKey<?>> finerSlice(Set<TetreeKey<?>> result, byte level) {
+        var out = new HashSet<TetreeKey<?>>();
+        for (var k : result) {
+            if (Tet.tetrahedron(k).l() == level + 1) {
+                out.add(k);
+            }
+        }
+        return out;
+    }
+
+    /** True iff at least 2 vertices of {@code cand} lie on the segment [pa, pb] (i.e. cand has an edge on it). */
+    static boolean sharesEdgeSegment(Tet cand, Point3i pa, Point3i pb) {
+        int onSeg = 0;
+        for (var v : cand.coordinates()) {
+            if (onSegment(v, pa, pb)) {
+                onSeg++;
+            }
+        }
+        return onSeg >= 2;
+    }
+
+    static boolean hasVertex(Tet cand, Point3i p) {
+        for (var v : cand.coordinates()) {
+            if (v.equals(p)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Exact integer test: v is collinear with [pa,pb] and lies within the inclusive segment. */
+    private static boolean onSegment(Point3i v, Point3i pa, Point3i pb) {
+        long dx = pb.x - pa.x, dy = pb.y - pa.y, dz = pb.z - pa.z;
+        long wx = v.x - pa.x, wy = v.y - pa.y, wz = v.z - pa.z;
+        // collinear: (d × w) == 0
+        long cx = dy * wz - dz * wy;
+        long cy = dz * wx - dx * wz;
+        long cz = dx * wy - dy * wx;
+        if (cx != 0 || cy != 0 || cz != 0) {
+            return false;
+        }
+        long dot = wx * dx + wy * dy + wz * dz;
+        long len2 = dx * dx + dy * dy + dz * dz;
+        return dot >= 0 && dot <= len2;
+    }
+
+    private static int anchorFloor(int v, int h) {
+        int a = (v / h) * h;
+        return a > v ? a - h : a; // floor toward -inf (v can be slightly negative)
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/EdgeFaceTableParityTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/EdgeFaceTableParityTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.tetree;
+
+import com.hellblazer.luciferase.lucien.Constants;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RDR-014 AC2: edge->face t8code parity. Asserts the single canonical {@link TetreeConnectivity#EDGE_FACES}
+ * table equals the geometric derivation — each edge is bounded by exactly the two faces that contain BOTH
+ * of the edge's vertices, where face {@code i} is opposite vertex {@code i} (the t8code convention encoded
+ * in {@link TetreeConnectivity#FACE_CORNERS}).
+ *
+ * <p>This guards against the latent defect documented in RDR-014 F4: the {@code TetreeNeighborFinder}
+ * previously carried a WRONG inline edge->face table (e.g. edge 0 -> {0,2} instead of {2,3}). Both
+ * {@code TetreeNeighborFinder} and {@code TetreeNeighborDetector} now consume {@code TetreeConnectivity.EDGE_FACES};
+ * this test pins it to the geometry.
+ *
+ * @author hal.hildebrand
+ */
+class EdgeFaceTableParityTest {
+
+    /**
+     * Derive, from FACE_CORNERS, the two faces that contain both vertices of edge {@code e}, and assert
+     * EDGE_FACES matches. Face geometry is type-independent (FACE_CORNERS is identical across all 6 types),
+     * so deriving against type 0 is sufficient and is additionally cross-checked against every type below.
+     */
+    @Test
+    void edgeFacesMatchesGeometricDerivation() {
+        var faceCorners = TetreeConnectivity.FACE_CORNERS[0]; // type-independent
+
+        for (int e = 0; e < TetreeConnectivity.EDGES_PER_TET; e++) {
+            int va = TetreeConnectivity.EDGE_VERTICES[e][0];
+            int vb = TetreeConnectivity.EDGE_VERTICES[e][1];
+
+            // A face bounds edge (va,vb) iff its corner set contains BOTH va and vb.
+            int[] derived = new int[TetreeConnectivity.FACES_PER_TET];
+            int n = 0;
+            for (int f = 0; f < TetreeConnectivity.FACES_PER_TET; f++) {
+                if (faceContains(faceCorners[f], va) && faceContains(faceCorners[f], vb)) {
+                    derived[n++] = f;
+                }
+            }
+            assertEquals(2, n, "edge " + e + " (v" + va + "-v" + vb + ") must be bounded by exactly 2 faces");
+            derived = Arrays.copyOf(derived, n);
+            Arrays.sort(derived);
+
+            int[] actual = TetreeConnectivity.EDGE_FACES[e].clone();
+            Arrays.sort(actual);
+            assertArrayEquals(derived, actual,
+                              "EDGE_FACES[" + e + "] (v" + va + "-v" + vb + ") expected geometric "
+                              + Arrays.toString(derived) + " but table had " + Arrays.toString(actual));
+        }
+    }
+
+    /**
+     * FACE_CORNERS is identical across all 6 types, so the derivation holds for every type. This guards
+     * against a future type-dependent FACE_CORNERS edit silently invalidating the type-independent
+     * EDGE_FACES table.
+     */
+    @Test
+    void faceGeometryIsTypeIndependent() {
+        var type0 = TetreeConnectivity.FACE_CORNERS[0];
+        for (int t = 1; t < TetreeConnectivity.TET_TYPES; t++) {
+            var faceCorners = TetreeConnectivity.FACE_CORNERS[t];
+            for (int f = 0; f < TetreeConnectivity.FACES_PER_TET; f++) {
+                assertArrayEquals(type0[f], faceCorners[f],
+                                  "FACE_CORNERS face " + f + " differs between type 0 and type " + t
+                                  + "; EDGE_FACES is type-independent and would no longer be sound");
+            }
+        }
+    }
+
+    /**
+     * Pin the exact authoritative mapping (RDR-014 F4 derived table) so an accidental reorder is caught
+     * even if the derivation logic above were itself altered.
+     */
+    @Test
+    void edgeFacesEqualsAuthoritativeF4Table() {
+        int[][] authoritative = { { 2, 3 }, { 1, 3 }, { 1, 2 }, { 0, 3 }, { 0, 2 }, { 0, 1 } };
+        for (int e = 0; e < TetreeConnectivity.EDGES_PER_TET; e++) {
+            assertArrayEquals(authoritative[e], TetreeConnectivity.EDGE_FACES[e],
+                              "EDGE_FACES[" + e + "] diverged from the RDR-014 F4 authoritative table");
+        }
+    }
+
+    /**
+     * Behavioral tripwire for the LIVE same-level edge-neighbor path (RDR-014 F4). Phase 0 corrects the
+     * table that {@code findEdgeNeighbors} actually consumes on the production same-level path (the
+     * cross-level helpers are still empty stubs in this phase, so the method's output is exactly the
+     * same-level face-neighbor set across the edge's two bounding faces). This test re-derives the two
+     * bounding faces INDEPENDENTLY from {@code FACE_CORNERS} and asserts the live method's output equals
+     * the face neighbors across those geometrically-correct faces. It FAILS against the old, wrong inline
+     * table (e.g. edge 0 there used faces {0,2} instead of {2,3}), so it is a real guard for the behavior
+     * change this phase introduces — not a tautology against the table.
+     */
+    @Test
+    void findEdgeNeighborsUsesGeometricallyCorrectFaces() {
+        var finder = new TetreeNeighborFinder();
+        // Interior tet (all 4 faces have distinct same-level neighbors — cf. TetreeNeighborFinderTest).
+        int cellSize = Constants.lengthAtLevel((byte) 3);
+        var tet = new Tet(cellSize * 2, cellSize * 2, cellSize * 2, (byte) 3, (byte) 0);
+        var faceCorners = TetreeConnectivity.FACE_CORNERS[tet.type()];
+
+        boolean anyNonEmpty = false;
+        for (int e = 0; e < TetreeConnectivity.EDGES_PER_TET; e++) {
+            int va = TetreeConnectivity.EDGE_VERTICES[e][0];
+            int vb = TetreeConnectivity.EDGE_VERTICES[e][1];
+
+            // Independently derive the two faces bounding this edge from FACE_CORNERS.
+            var expected = new HashSet<>();
+            for (int f = 0; f < TetreeConnectivity.FACES_PER_TET; f++) {
+                if (faceContains(faceCorners[f], va) && faceContains(faceCorners[f], vb)) {
+                    var fn = finder.findFaceNeighbor(tet, f);
+                    if (fn != null) {
+                        expected.add(fn.tmIndex());
+                    }
+                }
+            }
+
+            Set<Object> actual = new HashSet<>(finder.findEdgeNeighbors(tet.tmIndex(), e));
+            assertEquals(expected, actual,
+                         "findEdgeNeighbors(edge " + e + ", v" + va + "-v" + vb + ") must equal the face "
+                         + "neighbors across the geometrically-derived bounding faces; a mismatch means the "
+                         + "live path is using a wrong edge->face mapping");
+            anyNonEmpty |= !actual.isEmpty();
+        }
+        assertTrue(anyNonEmpty,
+                   "interior tet must have at least one same-level edge neighbor — fixture is vacuous otherwise");
+    }
+
+    private static boolean faceContains(byte[] corners, int vertex) {
+        for (byte c : corners) {
+            if (c == vertex) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/EdgeFaceTableParityTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/EdgeFaceTableParityTest.java
@@ -140,11 +140,19 @@ class EdgeFaceTableParityTest {
                 }
             }
 
-            Set<Object> actual = new HashSet<>(finder.findEdgeNeighbors(tet.tmIndex(), e));
+            // This test validates the same-level edge->face mapping. Since RDR-014 Phase 2, findEdgeNeighbors
+            // also returns the ±1 cross-level adjacency ring; restrict to the same-level slice so the assertion
+            // still pins exactly the edge->face table (the cross-level ring is covered by TetreeEdgeNeighborTest).
+            Set<Object> actual = new HashSet<>();
+            for (var k : finder.findEdgeNeighbors(tet.tmIndex(), e)) {
+                if (Tet.tetrahedron(k).l() == tet.l()) {
+                    actual.add(k);
+                }
+            }
             assertEquals(expected, actual,
-                         "findEdgeNeighbors(edge " + e + ", v" + va + "-v" + vb + ") must equal the face "
-                         + "neighbors across the geometrically-derived bounding faces; a mismatch means the "
-                         + "live path is using a wrong edge->face mapping");
+                         "findEdgeNeighbors(edge " + e + ", v" + va + "-v" + vb + ") same-level slice must equal "
+                         + "the face neighbors across the geometrically-derived bounding faces; a mismatch means "
+                         + "the live path is using a wrong edge->face mapping");
             anyNonEmpty |= !actual.isEmpty();
         }
         assertTrue(anyNonEmpty,

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeEdgeNeighborTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeEdgeNeighborTest.java
@@ -145,13 +145,13 @@ public class TetreeEdgeNeighborTest {
         var tet = tetree.locateTetrahedron(p1, (byte) 2);
         var tetKey = tet.tmIndex();
 
-        // Edge-to-face mapping (from TetreeNeighborFinder):
-        // Edge 0 (v0-v1): faces 0, 2
-        // Edge 1 (v0-v2): faces 0, 3
-        // Edge 2 (v0-v3): faces 1, 3
-        // Edge 3 (v1-v2): faces 0, 1
-        // Edge 4 (v1-v3): faces 1, 2
-        // Edge 5 (v2-v3): faces 2, 3
+        // Canonical edge-to-face mapping (TetreeConnectivity.EDGE_FACES, RDR-014 F4):
+        // Edge 0 (v0-v1): faces 2, 3
+        // Edge 1 (v0-v2): faces 1, 3
+        // Edge 2 (v0-v3): faces 1, 2
+        // Edge 3 (v1-v2): faces 0, 3
+        // Edge 4 (v1-v3): faces 0, 2
+        // Edge 5 (v2-v3): faces 0, 1
 
         // Get face neighbors
         List<TetreeKey<? extends TetreeKey<?>>> face0Neighbors = new ArrayList<>();
@@ -179,28 +179,29 @@ public class TetreeEdgeNeighborTest {
             face3Neighbors.add(face3);
         }
 
-        // Get edge neighbors
-        var edge0Neighbors = tetree.findEdgeNeighbors(tetKey, 0); // shares faces 0,2
-        var edge3Neighbors = tetree.findEdgeNeighbors(tetKey, 3); // shares faces 0,1
+        // Get edge neighbors (canonical EDGE_FACES: edge 0 -> faces {2,3}, edge 3 -> faces {0,3})
+        var edge0Neighbors = tetree.findEdgeNeighbors(tetKey, 0); // shares faces 2,3
+        var edge3Neighbors = tetree.findEdgeNeighbors(tetKey, 3); // shares faces 0,3
 
-        // Edge neighbors should include at least the face neighbors of the faces that share the edge
+        // Edge neighbors must include the same-level face neighbors of the two faces bounding the edge.
         Set<TetreeKey<? extends TetreeKey<?>>> edge0Expected = new HashSet<>();
-        edge0Expected.addAll(face0Neighbors);
         edge0Expected.addAll(face2Neighbors);
+        edge0Expected.addAll(face3Neighbors);
 
         Set<TetreeKey<? extends TetreeKey<?>>> edge3Expected = new HashSet<>();
         edge3Expected.addAll(face0Neighbors);
-        edge3Expected.addAll(face1Neighbors);
+        edge3Expected.addAll(face3Neighbors);
 
-        // Edge neighbors should include at least the face neighbors
+        // Edge neighbors must include the bounding-face neighbors (no isEmpty() escape: the canonical
+        // table is now authoritative, so a present face neighbor MUST appear as an edge neighbor).
         for (var neighbor : edge0Expected) {
-            assertTrue(edge0Neighbors.contains(neighbor) || edge0Neighbors.isEmpty(),
-                       "Edge 0 neighbors should include face neighbors from faces 0 and 2");
+            assertTrue(edge0Neighbors.contains(neighbor),
+                       "Edge 0 neighbors must include face neighbors from faces 2 and 3");
         }
 
         for (var neighbor : edge3Expected) {
-            assertTrue(edge3Neighbors.contains(neighbor) || edge3Neighbors.isEmpty(),
-                       "Edge 3 neighbors should include face neighbors from faces 0 and 1");
+            assertTrue(edge3Neighbors.contains(neighbor),
+                       "Edge 3 neighbors must include face neighbors from faces 0 and 3");
         }
     }
 
@@ -248,5 +249,65 @@ public class TetreeEdgeNeighborTest {
 
         // Note: With standard refinement, entities that were edge neighbors under Freudenthal
         // subdivision may not be edge neighbors anymore due to different spatial organization
+    }
+
+    // ===== RDR-014 Phase 1 (TDD-first, AC3/AC4): cross-level edge neighbor harness =====
+    // Written BEFORE the Phase 2 implementation of findEdgeNeighborsAtLevel; the exact-ring fixture is the
+    // load-bearing TDD red. Validation = symmetric-membership reciprocity (AC3) + an INDEPENDENT geometric
+    // CONTRACT (A) oracle (RDR-014 F3 and the "Implementation-time decision" section), NOT a re-derivation
+    // of the connectivity tables the implementation uses, and NOT a dualFace involution / vertex-count
+    // heuristic.
+
+    /**
+     * AC3 — symmetric-membership reciprocity. For every full edge-neighbor {@code n} of {@code t}
+     * (aggregated over all 6 edges) across a refined tet tree, {@code t} must appear in {@code n}'s full
+     * edge-neighbor set. Correct validation for a one-to-many ring relation; guards Phase 2/3 against a
+     * dropped or spurious cross-level neighbor.
+     */
+    @Test
+    void crossLevelEdgeNeighborReciprocitySweep() {
+        var finder = new TetreeNeighborFinder();
+        int checked = 0;
+        for (var t : CrossLevelNeighborOracle.refinedTets(4)) {
+            var tKey = t.tmIndex();
+            for (var n : CrossLevelNeighborOracle.fullEdgeNeighbors(finder, t)) {
+                assertTrue(CrossLevelNeighborOracle.fullEdgeNeighbors(finder, Tet.tetrahedron(n)).contains(tKey),
+                           "edge-neighbor relation must be reciprocal: " + tKey + " -> " + n
+                           + " but the reverse set does not contain " + tKey);
+                checked++;
+            }
+        }
+        assertTrue(checked >= 20, "expected a broad edge reciprocity sweep, only checked " + checked);
+    }
+
+    /**
+     * AC4 — non-vacuous EXACT-ring fixture for the FINER (level+1) edge contribution under CONTRACT (A).
+     * The level-(L+1) slice of {@code findEdgeNeighbors} must equal EXACTLY the adjacency ring computed by
+     * the independent geometric oracle: the children of {@code t}'s two same-level bounding-face neighbors
+     * that lie along the shared edge — adjacency neighbors, never {@code t}'s own nested children. Run for
+     * two types whose child incidence differs so a wrong type-selection in Phase 2 is caught. Fails against
+     * the empty stub (finer slice currently absent), and would fail a contract-(B) impl (t's own children
+     * would appear in the finer slice instead of the neighbors' children). {@code assertTrue(count>=0)} is
+     * forbidden (RDR-014 AC4).
+     */
+    @Test
+    void edgeFinerRingExactCountContractA() {
+        var finder = new TetreeNeighborFinder();
+        byte level = 5;
+        int cell = Constants.lengthAtLevel(level);
+        for (byte type : new byte[] { 0, 5 }) {
+            var t = new Tet(cell * 4, cell * 4, cell * 4, level, type);
+            int edge = 0;
+            var expected = CrossLevelNeighborOracle.finerEdgeRingPlusMinus1(finder, t, edge);
+            assertFalse(expected.isEmpty(),
+                        "fixture must be non-vacuous: interior type " + type + " edge 0 must have a finer ring");
+            var result = new HashSet<TetreeKey<?>>(finder.findEdgeNeighbors(t.tmIndex(), edge));
+            var finer = CrossLevelNeighborOracle.finerSlice(result, level);
+            assertEquals(expected, finer,
+                         "type " + type + " edge 0: the level-" + (level + 1) + " slice of findEdgeNeighbors must "
+                         + "equal exactly the contract-(A) adjacency ring (children of the two bounding-face "
+                         + "neighbors along the edge). Empty = unimplemented finer stub (RDR-014 Phase 2); t's "
+                         + "own children appearing = wrong contract (B)");
+        }
     }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeEdgeNeighborTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeEdgeNeighborTest.java
@@ -310,4 +310,33 @@ public class TetreeEdgeNeighborTest {
                          + "own children appearing = wrong contract (B)");
         }
     }
+
+    /**
+     * AC4 — non-vacuous EXACT-count fixture for the COARSER (level-1) edge contribution under CONTRACT (A).
+     * The level-(L-1) slice of {@code findEdgeNeighbors} must equal EXACTLY the adjacency ring computed by the
+     * independent coarser oracle: the level-(L-1) face-neighbors of t's parent whose finer ring (across the
+     * coincident m-edge) contains t. This pins the EXACT INVERSE of the finer ring per-edge, catching the
+     * all-edges over-match failure mode (a coarser m reported across an edge t does not actually share with m).
+     * {@code assertTrue(count>=0)} is forbidden (RDR-014 AC4).
+     */
+    @Test
+    void edgeCoarserRingExactCountContractA() {
+        var finder = new TetreeNeighborFinder();
+        byte level = 5;
+        int cell = Constants.lengthAtLevel(level);
+        for (byte type : new byte[] { 0, 5 }) {
+            var t = new Tet(cell * 4, cell * 4, cell * 4, level, type);
+            int edge = 0;
+            var expected = CrossLevelNeighborOracle.coarserEdgeRingMinus1(finder, t, edge);
+            assertFalse(expected.isEmpty(),
+                        "fixture must be non-vacuous: interior type " + type + " edge 0 must have a coarser ring");
+            var result = new HashSet<TetreeKey<?>>(finder.findEdgeNeighbors(t.tmIndex(), edge));
+            var coarser = CrossLevelNeighborOracle.coarserSlice(result, level);
+            assertEquals(expected, coarser,
+                         "type " + type + " edge 0: the level-" + (level - 1) + " slice of findEdgeNeighbors must "
+                         + "equal exactly the contract-(A) coarser ring (level-(L-1) face-neighbors of the parent "
+                         + "whose finer ring across the coincident edge contains t). Extra entries = all-edges "
+                         + "over-match (m reported across an edge t does not share with m)");
+        }
+    }
 }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeVertexNeighborTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/tetree/TetreeVertexNeighborTest.java
@@ -324,4 +324,62 @@ public class TetreeVertexNeighborTest {
             }
         }
     }
+
+    // ===== RDR-014 Phase 1 (TDD-first, AC3/AC4): cross-level vertex neighbor harness =====
+    // Written BEFORE the Phase 3 implementation of findVertexNeighborsAtLevel /
+    // findVertexNeighborsAtFinerLevels. Validation = symmetric-membership reciprocity (AC3) + an
+    // INDEPENDENT geometric CONTRACT (A) oracle (RDR-014 "Implementation-time decision"). The vertex
+    // oracle uses pure vertex-coincidence on Tet.coordinates(), so it is NOT tautological against the
+    // CHILD_VERTEX_PARENT_VERTEX table the implementation consumes (that table gets its own parity test).
+
+    /**
+     * AC3 — symmetric-membership reciprocity for the vertex STAR relation over a refined tet tree. For
+     * every full vertex-neighbor {@code n} of {@code t}, {@code t} must appear in {@code n}'s full
+     * vertex-neighbor set. One-to-many star relation, validated by reciprocity — not involution, not a
+     * vertex-count heuristic (RDR-014 F3).
+     */
+    @Test
+    void crossLevelVertexNeighborReciprocitySweep() {
+        var finder = new TetreeNeighborFinder();
+        int checked = 0;
+        for (var t : CrossLevelNeighborOracle.refinedTets(4)) {
+            var tKey = t.tmIndex();
+            for (var n : CrossLevelNeighborOracle.fullVertexNeighbors(finder, t)) {
+                assertTrue(CrossLevelNeighborOracle.fullVertexNeighbors(finder, Tet.tetrahedron(n)).contains(tKey),
+                           "vertex-neighbor relation must be reciprocal: " + tKey + " -> " + n
+                           + " but the reverse set does not contain " + tKey);
+                checked++;
+            }
+        }
+        assertTrue(checked >= 20, "expected a broad vertex reciprocity sweep, only checked " + checked);
+    }
+
+    /**
+     * AC4 — non-vacuous EXACT-star fixture for the FINER (level+1) vertex contribution under CONTRACT (A).
+     * The level-(L+1) slice of {@code findVertexNeighbors} must equal EXACTLY the adjacency star computed by
+     * the independent geometric oracle: every level-(L+1) tet that carries the shared vertex, EXCLUDING
+     * {@code t}'s own nested children. Fails against the empty stub (finer slice absent) and against a
+     * contract-(B) impl (which would surface t's own children instead). Run for two types to catch a wrong
+     * type-selection in Phase 3.
+     */
+    @Test
+    void vertexFinerStarExactCountContractA() {
+        var finder = new TetreeNeighborFinder();
+        byte level = 5;
+        int cell = com.hellblazer.luciferase.lucien.Constants.lengthAtLevel(level);
+        for (byte type : new byte[] { 0, 5 }) {
+            var t = new Tet(cell * 4, cell * 4, cell * 4, level, type);
+            int vertex = 0;
+            var expected = CrossLevelNeighborOracle.finerVertexStarPlus1(t, vertex);
+            assertFalse(expected.isEmpty(),
+                        "fixture must be non-vacuous: interior type " + type + " vertex 0 must have a finer star");
+            var result = new HashSet<TetreeKey<?>>(finder.findVertexNeighbors(t.tmIndex(), vertex));
+            var finer = CrossLevelNeighborOracle.finerSlice(result, level);
+            assertEquals(expected, finer,
+                         "type " + type + " vertex 0: the level-" + (level + 1) + " slice of findVertexNeighbors "
+                         + "must equal exactly the contract-(A) adjacency star (level-" + (level + 1) + " tets "
+                         + "carrying the vertex, excluding t's own children). Empty = unimplemented finer stub "
+                         + "(RDR-014 Phase 3); t's own children appearing = wrong contract (B)");
+        }
+    }
 }


### PR DESCRIPTION
Implements RDR-014 — cross-level tetrahedral edge/vertex neighbor finding in `TetreeNeighborFinder`, replacing three hollow stubs with real traversal under the user-confirmed **CONTRACT (A) ADJACENCY** (cross-level neighbors are adjacent tets sharing the edge/vertex, excluding the queried tet's own containment line; scope ±1 per F1).

## Phases
- **Phase 0** (`86237f00`, AC2): canonical `EDGE_FACES`/`EDGE_VERTICES` in `TetreeConnectivity`; deleted the wrong inline edge→face table in `TetreeNeighborFinder` (edge 0 listed `{0,2}` instead of `{2,3}`); added `EdgeFaceTableParityTest`.
- **Phase 1** (`2f1a432d`, AC3/AC4, TDD-first): `CrossLevelNeighborOracle` (independent geometric oracle) + reciprocity sweeps + contract-(A) exact-ring/star fixtures.
- **Phase 2** (`af834e9d`, AC1-edge): `findEdgeNeighborsAtLevel`. Finer ring = children of the two bounding-face neighbors along the shared edge; coarser = the per-edge inverse (`isCoarserEdgeNeighbor`) — reciprocal by construction.
- **Phase 3** (`af834e9d`, AC1-vtx): `findVertexNeighborsAtFinerLevels`/`findVertexNeighborsAtLevel`. ±1 geometric anchor-box star carrying the vertex, excluding the tet's ancestor/descendant line; table-independent (avoids the BEY-indexed `CHILD_VERTEX_PARENT_VERTEX` Morton-inversion hazard).

## Review
Stacked review (code-review-expert + substantive-critic) ran pre-commit and caught a real coarser-edge over-match bug (all-edges union reported a coarser tet across an edge it didn't share; masked by the all-edges reciprocity sweep) — fixed via per-edge scoping plus a new `edgeCoarserRingExactCountContractA` exact-count fixture. The deliberate vertex ±1 scope (vs the original "full-depth" wording, which was unbounded and untested) is recorded in the RDR.

## Tests
Full lucien suite green: **3181 tests, 0 failures, 19 skipped**.

Closes: Luciferase-7wzml.20 (umbrella), Luciferase-11d54, Luciferase-ij6zm, Luciferase-ytn4r, Luciferase-ww9qe.
Remaining: Luciferase-8rr7a (Phase 4 — regression gate + RDR-012 read-only fence + phase-review-gate + close `.20`).