### PR TITLE
docs(rdr): close RDR-014 (implemented)

### DIFF
--- a/docs/rdr/RDR-014-cross-level-tet-edge-vertex-neighbors.md
+++ b/docs/rdr/RDR-014-cross-level-tet-edge-vertex-neighbors.md
@@ -1,9 +1,11 @@
 ---
 id: RDR-014
 title: Cross-Level Tetrahedral Edge/Vertex Neighbor Traversal for TetreeNeighborFinder
-status: accepted
+status: closed
 date: 2026-06-05
 accepted_date: 2026-06-05
+closed_date: 2026-06-06
+close_reason: implemented
 reviewed-by: self
 supersedes: []
 related: [RDR-010, RDR-012]


### PR DESCRIPTION
Marks RDR-014 `status: closed` (close_reason: implemented) now that PR #197 is merged to main.

All 6 acceptance criteria met; all RDR-014 beads (umbrella `Luciferase-7wzml.20` + children 11d54/ij6zm/ytn4r/ww9qe/8rr7a) closed; full lucien suite green (3181/0). No post-mortem — implementation matched the accepted design and the single scope decision (vertex ±1 vs the original 'full-depth' wording) is recorded inline in the RDR's implementation-time decision section.

Frontmatter-only change.