### PR TITLE
0frcy: simulation deep-review remediation (22 beads)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/animation/VolumeAnimator.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/animation/VolumeAnimator.java
@@ -81,6 +81,11 @@ public class VolumeAnimator implements AutoCloseable {
      */
     public void setClock(Clock clock) {
         this.clock = clock;
+        // Re-seed the frame's delay baseline off the injected clock. The AnimationFrame field initializer ran
+        // during construction (before any setClock call), seeding lastActive from Clock.system().nanoTime();
+        // leaving it would poison the first cumulativeDelay with a wall-clock baseline subtracted from an
+        // injected-clock reading (Luciferase-9niuo).
+        frame.lastActive = clock.nanoTime();
     }
 
     /**
@@ -250,6 +255,24 @@ public class VolumeAnimator implements AutoCloseable {
             if (!running) {
                 return; // termination guard: stop() was called
             }
+            long duration = recordFrameTiming();
+            Kronos.sleep(VolumeAnimator.frameSleepNs(frameRateNs, duration, eventOverhead));
+            if (running) {
+                this.track(); // reschedule next frame (PrimeMover event, not real recursion)
+            }
+        }
+
+        /**
+         * Per-frame timing accounting (frameCount, cumulativeDelay, cumulativeDurations, lastActive,
+         * eventOverhead), returning this frame's compute duration for the sleep calculation.
+         * <p>
+         * Extracted from {@link #track()} as a {@link NonEvent @NonEvent} unit so the delay/duration
+         * bookkeeping can be exercised deterministically in tests WITHOUT the self-rescheduling {@code track()}
+         * loop (which infinite-recurses under untransformed bytecode). All time reads go through the injected
+         * {@code clock} (Luciferase-9niuo).
+         */
+        @NonEvent
+        long recordFrameTiming() {
             frameCount++;
             long start = clock.nanoTime();
             cumulativeDelay += start - lastActive;
@@ -261,10 +284,7 @@ public class VolumeAnimator implements AutoCloseable {
             // are not dead under literal-recursion semantics.
             lastActive = clock.nanoTime();
             eventOverhead = (lastActive - now) / 2;
-            Kronos.sleep(VolumeAnimator.frameSleepNs(frameRateNs, duration, eventOverhead));
-            if (running) {
-                this.track(); // reschedule next frame (PrimeMover event, not real recursion)
-            }
+            return duration;
         }
     }
 }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/behavior/PackHuntingBehavior.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/behavior/PackHuntingBehavior.java
@@ -168,7 +168,14 @@ public class PackHuntingBehavior implements EntityBehavior {
 
         Vector3f newVelocity;
 
-        if (role.targetPrey() != null && distance(position, role.targetPrey().position()) < chaseRange) {
+        // Hunting requires prey both present AND within chase range. This single gate drives both the velocity
+        // computation and the speed limit below; recomputing the speed-limit predicate as `targetPrey != null`
+        // alone would apply pursuitSpeed to patrol/cohesion velocity when prey is present but beyond chaseRange
+        // (mirrors PredatorBehavior.inPursuitMode).
+        boolean isHunting = role.targetPrey() != null
+                            && distance(position, role.targetPrey().position()) < chaseRange;
+
+        if (isHunting) {
             // Active hunting mode
             switch (role.role()) {
                 case LEADER -> newVelocity = computeLeaderPursuit(position, role.targetPrey().position(), velocity);
@@ -197,7 +204,6 @@ public class PackHuntingBehavior implements EntityBehavior {
         applyBoundaryAvoidance(position, newVelocity);
 
         // Speed limits
-        boolean isHunting = role.targetPrey() != null;
         float speedLimit = isHunting ? pursuitSpeed : maxSpeed;
         float speed = newVelocity.length();
         if (speed > speedLimit) {

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/MultiBubbleSimulation.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/MultiBubbleSimulation.java
@@ -272,8 +272,12 @@ public class MultiBubbleSimulation implements AutoCloseable {
 
     /**
      * Execute one simulation tick: update entities, detect migrations, sync ghosts.
+     * <p>
+     * Package-private so deterministic tests can single-step the simulation (drive N ticks explicitly) instead
+     * of {@code start()} + {@code Thread.sleep()}, which is non-deterministic (Luciferase-j6ybd). Uses a fixed
+     * {@code DEFAULT_TICK_INTERVAL_MS} delta, so per-tick entity motion does not depend on wall-clock timing.
      */
-    private void tick() {
+    void tick() {
         var startTime = executionEngine.getClock().nanoTime();
 
         try {

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeServiceImpl.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeServiceImpl.java
@@ -104,9 +104,21 @@ public class CommitteeServiceImpl extends CommitteeServiceGrpc.CommitteeServiceI
     }
 
     /**
-     * Immutable (result, completedAtMs) pair stored per proposal.
+     * Immutable per-proposal cache entry. {@code failed} distinguishes a proposal whose consensus future
+     * completed exceptionally (timeout / view change) from one that completed normally — the latter carries a
+     * real {@code result} (which may itself be {@code false} when quorum rejected the migration). Without this
+     * flag a failed proposal was indistinguishable from a still-pending one (Luciferase-933d8).
      */
-    record ResultEntry(boolean result, long completedAtMs) {
+    record ResultEntry(boolean result, long completedAtMs, boolean failed) {
+        /** Normal completion: consensus reached a decision ({@code result}). */
+        ResultEntry(boolean result, long completedAtMs) {
+            this(result, completedAtMs, false);
+        }
+
+        /** Sentinel for a proposal whose consensus future completed exceptionally. */
+        static ResultEntry failed(long completedAtMs) {
+            return new ResultEntry(false, completedAtMs, true);
+        }
     }
 
     @Override
@@ -130,6 +142,11 @@ public class CommitteeServiceImpl extends CommitteeServiceGrpc.CommitteeServiceI
                                         new ResultEntry(result, clock.currentTimeMillis()));
                     log.debug("Proposal {} consensus result: {}", proposal.proposalId(), result);
                 } else {
+                    // Record a failure sentinel so getQuorumResult can return a definitive failure rather than
+                    // the generic "not yet available" used for still-pending proposals (Luciferase-933d8).
+                    evictStaleAndOversize();
+                    proposalResults.put(proposal.proposalId().toString(),
+                                        ResultEntry.failed(clock.currentTimeMillis()));
                     log.warn("Proposal {} consensus failed", proposal.proposalId(), ex);
                 }
             });
@@ -180,7 +197,11 @@ public class CommitteeServiceImpl extends CommitteeServiceGrpc.CommitteeServiceI
             // onNext()+onCompleted() on the same StreamObserver contract.
             evictStaleAndOversize();
             var entry = proposalResults.remove(proposalId);
-            if (entry != null) {
+            if (entry != null && entry.failed()) {
+                // Definitive terminal failure (consensus future completed exceptionally). Distinct from the
+                // "not yet available" pending signal below so callers can stop polling (Luciferase-933d8).
+                responseObserver.onError(new RuntimeException("Proposal consensus failed: " + proposalId));
+            } else if (entry != null) {
                 var response = QuorumAchieved.newBuilder()
                     .setProposalId(proposalId)
                     .setResult(entry.result())
@@ -190,7 +211,7 @@ public class CommitteeServiceImpl extends CommitteeServiceGrpc.CommitteeServiceI
                 responseObserver.onNext(response);
                 responseObserver.onCompleted();
             } else {
-                // Result not yet available
+                // Result not yet available (still pending — not the same as a definitively-failed proposal).
                 responseObserver.onError(new RuntimeException("Proposal result not yet available: " + proposalId));
             }
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/CrossProcessMigration.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/CrossProcessMigration.java
@@ -73,7 +73,7 @@ import java.util.function.LongSupplier;
  *
  * @author hal.hildebrand
  */
-public class CrossProcessMigration {
+public class CrossProcessMigration implements AutoCloseable {
 
     private static final Logger                log                   = LoggerFactory.getLogger(
     CrossProcessMigration.class);
@@ -181,6 +181,15 @@ public class CrossProcessMigration {
                 Thread.currentThread().interrupt();
             }
         }
+    }
+
+    /**
+     * Delegates to {@link #stop()} so callers can manage the controller thread and cleanup scheduler with
+     * try-with-resources; cleanup then runs on exception paths too (Luciferase-rr07g).
+     */
+    @Override
+    public void close() {
+        stop();
     }
 
     /**

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/EntitySnapshot.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/EntitySnapshot.java
@@ -37,7 +37,7 @@ import java.util.UUID;
  *     sourceBubbleId,
  *     entity.getEpoch(),
  *     entity.getVersion(),
- *     System.currentTimeMillis()
+ *     clock.currentTimeMillis() // inject a Clock — never System.currentTimeMillis() (determinism mandate)
  * );
  *
  * // During ABORT: restore from snapshot

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/IdempotencyToken.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/IdempotencyToken.java
@@ -33,7 +33,7 @@ import java.util.UUID;
  *     "entity-123",
  *     sourceProcessId,
  *     destProcessId,
- *     System.currentTimeMillis(),
+ *     clock.currentTimeMillis(), // inject a Clock — never System.currentTimeMillis() (determinism mandate)
  *     UUID.randomUUID()
  * );
  * UUID tokenId = token.toUUID(); // Deterministic UUID for storage

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/MigrationMetrics.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/MigrationMetrics.java
@@ -66,9 +66,9 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * metrics.incrementConcurrent();
  * try {
- *     long startTime = System.currentTimeMillis();
+ *     long startTime = clock.currentTimeMillis(); // inject a Clock (determinism mandate), not System.*
  *     // ... perform migration ...
- *     long latency = System.currentTimeMillis() - startTime;
+ *     long latency = clock.currentTimeMillis() - startTime;
  *     metrics.recordSuccess(latency);  // Logs warning if latency > 500ms
  * } catch (Exception e) {
  *     metrics.recordFailure(e.getMessage());

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/network/GrpcBubbleNetworkChannel.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/network/GrpcBubbleNetworkChannel.java
@@ -58,6 +58,11 @@ public class GrpcBubbleNetworkChannel implements BubbleNetworkChannel, AutoClose
     private UUID localNodeId;
     private String localAddress;
     private Server server;
+    // Luciferase-3l1b5: track the JVM shutdown hook so it is registered at most once per instance and can be
+    // deregistered in close() (was leaked: a new hook added on every initialize(), never removed).
+    private volatile Thread shutdownHook;
+    private final java.util.concurrent.atomic.AtomicBoolean shutdownHookRegistered =
+        new java.util.concurrent.atomic.AtomicBoolean(false);
     private final Map<UUID, ManagedChannel> remoteChannels = new ConcurrentHashMap<>();
     private final Map<UUID, String> nodeAddresses = new ConcurrentHashMap<>();
     // Per-node consecutive terminal-failure counter for liveness gating (Luciferase-0frcy.99).
@@ -176,15 +181,19 @@ public class GrpcBubbleNetworkChannel implements BubbleNetworkChannel, AutoClose
             nodeAddresses.put(nodeId, localAddress);
             log.info("gRPC network channel initialized: {} at {}", nodeId, localAddress);
 
-            // Add shutdown hook
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                log.info("Shutting down gRPC channel via shutdown hook");
-                try {
-                    GrpcBubbleNetworkChannel.this.close();
-                } catch (Exception e) {
-                    log.error("Error during shutdown hook", e);
-                }
-            }));
+            // Register a JVM shutdown hook exactly once per instance (Luciferase-3l1b5). Without the guard a
+            // fresh hook was added on every initialize() and never removed, leaking a Thread per call.
+            if (shutdownHookRegistered.compareAndSet(false, true)) {
+                shutdownHook = new Thread(() -> {
+                    log.info("Shutting down gRPC channel via shutdown hook");
+                    try {
+                        GrpcBubbleNetworkChannel.this.close();
+                    } catch (Exception e) {
+                        log.error("Error during shutdown hook", e);
+                    }
+                });
+                Runtime.getRuntime().addShutdownHook(shutdownHook);
+            }
 
         } catch (IOException e) {
             throw new RuntimeException("Failed to initialize gRPC server", e);
@@ -410,6 +419,21 @@ public class GrpcBubbleNetworkChannel implements BubbleNetworkChannel, AutoClose
     @Override
     public void close() throws Exception {
         log.info("Shutting down gRPC channel: {}", localNodeId);
+
+        // Deregister the JVM shutdown hook so it does not leak past close() (Luciferase-3l1b5). When close() is
+        // itself running from the hook (JVM already shutting down), removeShutdownHook throws
+        // IllegalStateException — ignore it, the hook is already executing.
+        if (shutdownHookRegistered.compareAndSet(true, false)) {
+            var hook = shutdownHook;
+            shutdownHook = null;
+            if (hook != null) {
+                try {
+                    Runtime.getRuntime().removeShutdownHook(hook);
+                } catch (IllegalStateException e) {
+                    // JVM already in shutdown — hook is running and cannot be removed; safe to ignore.
+                }
+            }
+        }
 
         // Shutdown all remote channels
         for (var entry : remoteChannels.entrySet()) {

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/viz/render/RegionCache.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/viz/render/RegionCache.java
@@ -3,6 +3,7 @@ package com.hellblazer.luciferase.simulation.viz.render;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.Ticker;
 import com.github.benmanes.caffeine.cache.Weigher;
 import com.hellblazer.luciferase.common.time.Clock;
 import org.slf4j.Logger;
@@ -67,6 +68,19 @@ public class RegionCache implements AutoCloseable {
      * @param ttl Time-to-live for unpinned regions (expireAfterAccess)
      */
     public RegionCache(long maxMemoryBytes, Duration ttl) {
+        this(maxMemoryBytes, ttl, Ticker.systemTicker());
+    }
+
+    /**
+     * Create RegionCache with an explicit Caffeine {@link Ticker} driving {@code expireAfterAccess}, so TTL
+     * eviction can be tested deterministically by advancing virtual time instead of sleeping on the wall clock
+     * (Luciferase-h0hk7). Production passes {@link Ticker#systemTicker()}, so behavior is unchanged.
+     *
+     * @param maxMemoryBytes Maximum total memory (90% for unpinned, 10% headroom for pinned)
+     * @param ttl            Time-to-live for unpinned regions (expireAfterAccess)
+     * @param ticker         Time source for Caffeine expiry; {@link Ticker#systemTicker()} in production
+     */
+    public RegionCache(long maxMemoryBytes, Duration ttl, Ticker ticker) {
         this.maxMemoryBytes = maxMemoryBytes;
         this.ttl = ttl;
         this.pinnedMemoryBytes = new AtomicLong(0);
@@ -83,6 +97,7 @@ public class RegionCache implements AutoCloseable {
                 .weigher((Weigher<CacheKey, CachedRegion>) (key, value) ->
                     (int) Math.min(value.sizeBytes(), Integer.MAX_VALUE))
                 .expireAfterAccess(ttl)
+                .ticker(ticker)
                 .removalListener((CacheKey key, CachedRegion value, RemovalCause cause) -> {
                     if (value != null) {
                         log.debug("Evicted region {} LOD {} ({} bytes, cause: {})",
@@ -99,9 +114,10 @@ public class RegionCache implements AutoCloseable {
     /**
      * Set clock for deterministic testing.
      * <p>
-     * Note: Caffeine's expireAfterAccess() uses system time internally and cannot be overridden.
-     * This clock only affects lastAccessedMs tracking for pinned regions. For fully deterministic
-     * cache expiration tests, consider using short TTL values and Thread.sleep() instead.
+     * Note: this clock only affects lastAccessedMs tracking for pinned regions; it does NOT drive Caffeine's
+     * expireAfterAccess (which reads its own {@link Ticker}). For deterministic TTL-eviction tests, construct
+     * the cache with the {@link #RegionCache(long, Duration, Ticker)} overload and advance the ticker instead
+     * of sleeping (Luciferase-h0hk7).
      *
      * @param clock Clock instance
      */

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/viz/render/RenderingServer.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/viz/render/RenderingServer.java
@@ -105,11 +105,14 @@ public class RenderingServer implements AutoCloseable {
     public RenderingServer(RenderingServerConfig config) {
         this.config = config;
         this.regionManager = new AdaptiveRegionManager(config);
+        // Use the clock field (default Clock.system()) rather than a fresh Clock.system() literal so the
+        // server and its EntityStreamConsumer share one clock instance from construction — closing the
+        // construction-to-setClock() window where they could diverge (Luciferase-bshji).
         this.entityConsumer = new EntityStreamConsumer(
             config.upstreams(),
             regionManager,
             config.performance(),
-            Clock.system()
+            this.clock
         );
 
         log.info("RenderingServer created with config: port={}, regionLevel={}, upstreams={}",

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/transport/SocketTransport.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/transport/SocketTransport.java
@@ -22,6 +22,7 @@ import com.hellblazer.luciferase.simulation.bubble.RealTimeController;
 import com.hellblazer.luciferase.simulation.causality.FirefliesViewMonitor;
 import com.hellblazer.luciferase.simulation.delos.fireflies.FirefliesMembershipView;
 import com.hellblazer.luciferase.simulation.von.TransportVonMessage;
+import com.hellblazer.luciferase.common.time.Clock;
 import com.hellblazer.luciferase.simulation.von.Message;
 import com.hellblazer.luciferase.simulation.von.MessageConverter;
 import com.hellblazer.luciferase.simulation.von.MessageFactory;
@@ -61,7 +62,7 @@ public final class SocketTransport implements NetworkTransport {
     private static final Logger log = LoggerFactory.getLogger(SocketTransport.class);
 
     private final UUID localId;
-    private final MessageFactory factory;
+    private volatile MessageFactory factory;
     private final List<Consumer<Message>> handlers = new CopyOnWriteArrayList<>();
     private final MemberDirectory memberDirectory;
     private volatile ConnectionManager connectionManager;  // Non-final to support safe two-phase initialization
@@ -137,6 +138,18 @@ public final class SocketTransport implements NetworkTransport {
         this.factory = MessageFactory.system();
         this.memberDirectory = new ConcurrentMemberDirectory();
         this.connectionManager = connectionManager;  // Will be null initially, set by factory
+    }
+
+    /**
+     * Inject a clock so ACK (and other factory-built message) timestamps are deterministic under a TestClock.
+     * Rebuilds the {@link MessageFactory} with the given clock, matching the Bubble/Manager setClock pattern.
+     * The previous constructor seeded {@code MessageFactory.system()}, so ACK timestamps were wall-clock only
+     * (Luciferase-fy8ff).
+     *
+     * @param clock the clock to stamp message timestamps with; must not be null
+     */
+    public void setClock(Clock clock) {
+        this.factory = new MessageFactory(Objects.requireNonNull(clock, "clock must not be null"));
     }
 
     /**

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/animation/VolumeAnimatorClockTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/animation/VolumeAnimatorClockTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.animation;
+
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Luciferase-9niuo: AnimationFrame.lastActive was seeded from {@code Clock.system().nanoTime()} by a field
+ * initializer that runs during VolumeAnimator construction — BEFORE {@link VolumeAnimator#setClock} can swap
+ * the clock off the system source. The first {@code cumulativeDelay} therefore subtracted a wall-clock
+ * baseline from an injected-clock reading. {@code setClock} now re-seeds the baseline off the injected clock.
+ *
+ * <p>The accounting is exercised via the extracted {@code recordFrameTiming()} unit rather than {@code track()}
+ * directly: with {@code running=true}, {@code track()} self-reschedules and infinite-recurses under
+ * untransformed (non-PrimeMover) bytecode, so it cannot be unit-tested directly.
+ */
+class VolumeAnimatorClockTest {
+
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void cumulativeDelayDerivesFromInjectedClock_notWallClockBaseline() {
+        var animator = new VolumeAnimator("9niuo-clock-test");
+        try {
+            var testClock = new TestClock(0L);   // nanoTime() == 0
+            animator.setClock(testClock);        // re-seeds frame.lastActive to the injected baseline (0)
+
+            var frame = animator.getFrame();
+            testClock.advance(1L);               // +1 ms == +1_000_000 ns on the injected clock
+
+            frame.recordFrameTiming();
+
+            // start - lastActive = 1_000_000 - 0. Pre-fix lastActive held a wall-clock nanoTime captured at
+            // construction, so this would be a large (negative) garbage value, not the injected-clock delta.
+            assertEquals(1_000_000L, frame.getCumulativeDelay(),
+                         "first cumulativeDelay must be the injected-clock delta (1 ms), not a wall-clock baseline");
+        } finally {
+            try {
+                animator.close();
+            } catch (Exception ignored) {
+                // best-effort cleanup
+            }
+        }
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/behavior/PackHuntingBehaviorTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/behavior/PackHuntingBehaviorTest.java
@@ -9,6 +9,8 @@
 package com.hellblazer.luciferase.simulation.behavior;
 
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
+import com.hellblazer.luciferase.simulation.config.WorldBounds;
+import com.hellblazer.luciferase.simulation.entity.EntityType;
 import org.junit.jupiter.api.Test;
 
 import javax.vecmath.Point3f;
@@ -86,5 +88,43 @@ class PackHuntingBehaviorTest {
         var out2 = b2.computeVelocity(id, pos, vel, bubble, 0.016f);
 
         assertThat(out1).isEqualTo(out2);
+    }
+
+    /**
+     * Luciferase-w0fo8 (0frcy): the speed limit must be {@code maxSpeed} (patrol), not {@code pursuitSpeed},
+     * when prey is present-but-out-of-range. The hunting branch is gated on
+     * {@code targetPrey != null && distance < chaseRange}, but the speed-limit predicate was previously
+     * recomputed as {@code targetPrey != null} alone — so a pack member patrolling toward a far prey burst at
+     * pursuitSpeed. Mirrors the PredatorBehavior fix (BehaviorRemediationWave3Test.predatorDoesNotWander...).
+     *
+     * <p>The scenario uses the pack-cohesion patrol path (a second predator inside packRadius) with a high
+     * initial velocity: {@code computeWander} self-caps to maxSpeed, so a SOLO scenario would be vacuous, but
+     * {@code computePackCohesion} adds to the input velocity, leaving the pre-clamp speed above pursuitSpeed so
+     * the speed-limit clamp is genuinely exercised.
+     */
+    @Test
+    void packDoesNotWanderAtPursuitSpeedWhenPreyOutsideChaseRange() {
+        float aoi = 100f;
+        float maxSpeed = 5f;
+        float pursuitSpeed = 20f;
+        var pack = new PackHuntingBehavior(aoi, maxSpeed, pursuitSpeed, 1.0f,
+                                           WorldBounds.DEFAULT, new Random(42L));
+
+        var bubble = new EnhancedBubble(UUID.randomUUID(), (byte) 10, 16L);
+        var focalPos = new Point3f(50f, 50f, 50f);
+        bubble.addEntity("pred", focalPos, EntityType.PREDATOR);
+        // Second predator well inside packRadius (aoi*0.4 = 40) → pack-cohesion patrol path.
+        bubble.addEntity("pack2", new Point3f(55f, 50f, 50f), EntityType.PREDATOR);
+        // Prey present in k-NN but FAR outside chaseRange (aoi*0.95 = 95) → hunting branch NOT taken,
+        // yet determinePackRole still returns a non-null targetPrey (no distance filter on prey).
+        bubble.addEntity("prey", new Point3f(50f, 50f, 50f + (aoi * 0.96f)), EntityType.PREY);
+
+        // High initial speed (> pursuitSpeed) so the pre-clamp velocity exceeds both limits and the clamp bites.
+        var result = pack.computeVelocity("pred", focalPos, new Vector3f(25f, 0f, 0f), bubble, 0.016f);
+
+        assertThat(result.length())
+            .as("patrol velocity with prey out of chaseRange must be capped at maxSpeed (%s), not pursuitSpeed (%s)",
+                maxSpeed, pursuitSpeed)
+            .isLessThanOrEqualTo(maxSpeed + 1e-3f);
     }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/MultiBubbleSimulationMigrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/MultiBubbleSimulationMigrationTest.java
@@ -73,51 +73,62 @@ class MultiBubbleSimulationMigrationTest {
         assertEquals(0, metrics.getActiveCooldownCount());
     }
 
-    @Test
-    void testSimulationRunsWithMigration() {
-        // Start simulation
-        simulation.start();
-
-        // Let it run for a bit
-        try {
-            Thread.sleep(100);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+    /** Drive N deterministic single-step ticks (no start()/Thread.sleep) — fully reproducible (seeded behavior). */
+    private void tickDeterministically(int ticks) {
+        for (int i = 0; i < ticks; i++) {
+            simulation.tick();
         }
+    }
 
-        // Stop simulation
-        simulation.stop();
-
-        // Verify simulation ran
-        assertTrue(simulation.getTickCount() > 0);
-
-        // Migration metrics should exist (may or may not have migrations)
-        var metrics = simulation.getMigrationMetrics();
-        assertNotNull(metrics);
-        assertTrue(metrics.getTotalMigrations() >= 0);
+    /** Assert exact real-entity conservation and that no entity id resides in more than one bubble. */
+    private void assertConservedAndUnique(int expectedRealCount) {
+        var realEntities = simulation.getRealEntities();
+        assertEquals(expectedRealCount, realEntities.size(),
+                     "real entity count must be exactly conserved (no loss / no creation)");
+        var bubblesById = new java.util.HashMap<String, java.util.Set<Object>>();
+        for (var e : realEntities) {
+            bubblesById.computeIfAbsent(e.id(), k -> new java.util.HashSet<>()).add(e.bubbleKey());
+        }
+        for (var entry : bubblesById.entrySet()) {
+            assertEquals(1, entry.getValue().size(),
+                         "entity " + entry.getKey() + " must reside in exactly one bubble (no duplication), "
+                         + "found in " + entry.getValue());
+        }
     }
 
     @Test
+    void testSimulationRunsWithMigration() {
+        // Deterministic single-stepping instead of start()+Thread.sleep (Luciferase-j6ybd).
+        int initialReal = simulation.getRealEntities().size();
+        tickDeterministically(2000);
+
+        assertTrue(simulation.getTickCount() >= 2000, "simulation must have advanced the driven ticks");
+        assertNotNull(simulation.getMigrationMetrics());
+        // Invariant that holds whether or not a migration commits: the per-tick migration CHECK must never lose
+        // or duplicate an entity. (The old assertTrue(getTotalMigrations() >= 0) was trivially true.)
+        assertConservedAndUnique(initialReal);
+    }
+
+    /**
+     * Exact entity conservation across a long deterministic run (replaces the RDR-004 D3-class vacuous
+     * {@code finalEntities >= initialEntities * 0.9}, which tolerated dropping up to 10% of entities every run,
+     * and the non-deterministic Thread.sleep). Asserts no loss AND no duplication (Luciferase-j6ybd).
+     *
+     * <p><b>Finding (not silent scope reduction):</b> the original AC also asked for a positive-migration
+     * assertion ({@code getTotalMigrations() > 0}). That is NOT asserted here because this simulation commits
+     * ZERO successful migrations through normal {@code tick()} operation — verified across fixtures up to 600
+     * entities in a 15-unit world over 20,000 ticks (all yielded 0). Asserting a migration would be either
+     * impossible or contrived. The likely-dead migration-commit path is filed as a separate defect bead; this
+     * test pins the conservation/uniqueness invariants, which is the load-bearing guarantee regardless.
+     */
+    @Test
     void testNoEntityLossDuringMigration() {
-        var initialEntities = simulation.getAllEntities().size();
+        int initialReal = simulation.getRealEntities().size();
+        assertTrue(initialReal > 0, "fixture must start with real entities");
 
-        // Run simulation
-        simulation.start();
+        tickDeterministically(2000);
 
-        try {
-            Thread.sleep(200);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-
-        simulation.stop();
-
-        var finalEntities = simulation.getAllEntities().size();
-
-        // Entity count should remain stable (no loss)
-        // NOTE: May not be exact due to ghost entities, but real entities should be preserved
-        assertTrue(finalEntities >= initialEntities * 0.9,
-            "Entity count should not drop significantly");
+        assertConservedAndUnique(initialReal);
     }
 
     @Test

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/causality/EntityMigrationStateMachineConcurrencyTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/causality/EntityMigrationStateMachineConcurrencyTest.java
@@ -79,10 +79,11 @@ class EntityMigrationStateMachineConcurrencyTest {
         assertTrue(latch.await(5, TimeUnit.SECONDS), "Should complete within timeout");
         executor.shutdown();
 
-        // Only ONE thread should succeed (first one)
-        // This validates that only the first transition from OWNED->MIGRATING_OUT succeeds
-        // Subsequent attempts from MIGRATING_OUT->MIGRATING_OUT will fail
-        assertTrue(successCount.get() > 0, "At least one transition should succeed");
+        // EXACTLY one thread must succeed (the single-owner invariant). assertTrue(>0) was vacuous: it passed
+        // for 1..N successes, so a regression letting multiple concurrent OWNED->MIGRATING_OUT transitions
+        // commit would go undetected (Luciferase-pja48).
+        assertEquals(1, successCount.get(),
+                     "Exactly one concurrent OWNED->MIGRATING_OUT transition must succeed (single-owner invariant)");
 
         // Final state should be consistent
         var finalState = fsm.getState(entityId);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/causality/EntityMigrationTimeoutIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/causality/EntityMigrationTimeoutIntegrationTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -461,6 +462,10 @@ class EntityMigrationTimeoutIntegrationTest {
     @Test
     @DisplayName("Timeout performance scaling: O(n) acceptable with 1000 entities")
     @Tag("performance")
+    @DisabledIfEnvironmentVariable(named = "CI", matches = "true",
+        disabledReason = "Wall-clock perf assertions (checkMs<10, processMs<50) vary with CI runner load; "
+                         + "the O(n) scaling logic is covered by the deterministic functional assertions "
+                         + "(Luciferase-38uf3)")
     void testTimeoutPerformanceScalingCheck() {
         // Given: FSM with 1000 entities in various states
         var config = EntityMigrationStateMachine.Configuration.builder()
@@ -473,7 +478,10 @@ class EntityMigrationTimeoutIntegrationTest {
         // Create 1000 entities in different states
         int totalEntities = 1000;
         int migrating = 0;
-        long startTimeMs = System.currentTimeMillis();
+        // Fixed deadline base — checkTimeouts/processTimeouts take an explicit deadline, so no wall clock is
+        // needed here (determinism mandate, Luciferase-38uf3). The System.nanoTime() spans below remain: they
+        // measure this micro-benchmark's elapsed time, and their assertions are CI-gated above.
+        long startTimeMs = 1_000_000L;
 
         for (int i = 0; i < totalEntities; i++) {
             var entityId = "entity-" + i;

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeServiceImplTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeServiceImplTest.java
@@ -26,7 +26,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.google.protobuf.Empty;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -140,6 +142,48 @@ public class CommitteeServiceImplTest {
     // ------------------------------------------------------------------
     // Test 3: read-then-evict path returns correct result and removes entry
     // ------------------------------------------------------------------
+
+    // ------------------------------------------------------------------
+    // Luciferase-933d8: a definitively-failed proposal must be distinguishable
+    // from a still-pending one (not the generic "not yet available").
+    // ------------------------------------------------------------------
+
+    @Test
+    void getQuorumResult_failedProposal_returnsDistinctTerminalFailure_notPending() {
+        // Consensus future completes EXCEPTIONALLY (timeout / view change). failedFuture is already completed,
+        // so submitMigrationProposal's whenComplete runs synchronously and stores the failure sentinel.
+        var mockConsensus = Mockito.mock(ViewCommitteeConsensus.class);
+        when(mockConsensus.requestConsensus(Mockito.any()))
+            .thenReturn(CompletableFuture.failedFuture(new RuntimeException("boom: view change")));
+        var mockVoting = Mockito.mock(CommitteeVotingProtocol.class);
+        var failingService = new CommitteeServiceImpl(mockConsensus, mockVoting);
+        failingService.setClock(testClock);
+
+        var proposalId = UUID.randomUUID();
+        var proto = buildProto(proposalId);
+
+        failingService.submitMigrationProposal(proto, new StreamObserver<>() {
+            @Override public void onNext(Empty v) {}
+            @Override public void onError(Throwable t) {}
+            @Override public void onCompleted() {}
+        });
+
+        var resultHolder = new AtomicReference<Boolean>();
+        var errorHolder = new AtomicReference<Throwable>();
+        failingService.getQuorumResult(proto, new StreamObserver<>() {
+            @Override public void onNext(QuorumAchieved v) { resultHolder.set(v.getResult()); }
+            @Override public void onError(Throwable t) { errorHolder.set(t); }
+            @Override public void onCompleted() {}
+        });
+
+        assertNull(resultHolder.get(), "a failed proposal must not deliver a QuorumAchieved result");
+        assertNotNull(errorHolder.get(), "a failed proposal must signal a terminal error");
+        var msg = errorHolder.get().getMessage();
+        assertTrue(msg != null && msg.contains("consensus failed"),
+                   "failed proposal must yield the definitive failure signal, got: " + msg);
+        assertFalse(msg.contains("not yet available"),
+                    "a definitively-failed proposal must NOT be reported as still-pending");
+    }
 
     @Test
     void readThenEvict_returnsResultAndTombstonesEntry() {

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeVotingProtocolTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeVotingProtocolTest.java
@@ -17,6 +17,8 @@
 
 package com.hellblazer.luciferase.simulation.consensus.committee;
 
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+
 import com.hellblazer.delos.context.DynamicContext;
 import com.hellblazer.delos.cryptography.Digest;
 import com.hellblazer.delos.cryptography.DigestAlgorithm;
@@ -48,6 +50,8 @@ import static org.mockito.Mockito.when;
  * @author hal.hildebrand
  */
 class CommitteeVotingProtocolTest {
+    // Fixed-base clock for proposal/vote timestamps (determinism mandate, Luciferase-ze0eq).
+    private static final TestClock ZE0EQ_CLOCK = new TestClock(1_000L);
 
     private DynamicContext<Member> mockContext;
     private CommitteeConfig config;
@@ -188,7 +192,7 @@ class CommitteeVotingProtocolTest {
             DigestAlgorithm.DEFAULT.digest("source"),
             DigestAlgorithm.DEFAULT.digest("target"),
             oldViewId,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
         var committee = createCommittee(3);
 
@@ -306,7 +310,7 @@ class CommitteeVotingProtocolTest {
             DigestAlgorithm.DEFAULT.digest("source"),
             DigestAlgorithm.DEFAULT.digest("target"),
             oldViewId,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
         // committee of 3: quorum = (3-1)/2 + 1 = 2 votes needed
         var committee = createCommittee(3);
@@ -384,7 +388,7 @@ class CommitteeVotingProtocolTest {
             DigestAlgorithm.DEFAULT.digest("source"),
             DigestAlgorithm.DEFAULT.digest("target"),
             viewId,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
     }
 

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeConsensusTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeConsensusTest.java
@@ -17,6 +17,8 @@
 
 package com.hellblazer.luciferase.simulation.consensus.committee;
 
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+
 import com.hellblazer.delos.context.DynamicContext;
 import com.hellblazer.delos.cryptography.Digest;
 import com.hellblazer.delos.cryptography.DigestAlgorithm;
@@ -52,6 +54,8 @@ import static org.mockito.Mockito.when;
  * @author hal.hildebrand
  */
 public class ViewCommitteeConsensusTest {
+    // Fixed-base clock for proposal/vote timestamps (determinism mandate, Luciferase-ze0eq).
+    private static final TestClock ZE0EQ_CLOCK = new TestClock(1_000L);
 
     private DynamicContext<Member> context;
     private ViewCommitteeSelector selector;
@@ -119,7 +123,7 @@ public class ViewCommitteeConsensusTest {
             members.get(0).getId(),  // Valid source from members
             members.get(1).getId(),  // Valid target from members
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future = consensus.requestConsensus(proposal);
@@ -137,7 +141,7 @@ public class ViewCommitteeConsensusTest {
             members.get(0).getId(),  // Valid source from members
             members.get(1).getId(),  // Valid target from members
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future = consensus.requestConsensus(proposal);
@@ -162,7 +166,7 @@ public class ViewCommitteeConsensusTest {
             members.get(0).getId(),
             members.get(1).getId(),
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future = consensus.requestConsensus(proposal);
@@ -187,7 +191,7 @@ public class ViewCommitteeConsensusTest {
             members.get(0).getId(),
             members.get(1).getId(),
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future = consensus.requestConsensus(proposal);
@@ -211,7 +215,7 @@ public class ViewCommitteeConsensusTest {
             members.get(0).getId(),
             members.get(1).getId(),
             view1,  // Proposal tagged with view1
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         // Change view BEFORE submitting proposal
@@ -235,13 +239,13 @@ public class ViewCommitteeConsensusTest {
         var first = new MigrationProposal(
             UUID.randomUUID(), entityId,
             members.get(0).getId(), members.get(1).getId(),
-            view1, System.currentTimeMillis());
+            view1, ZE0EQ_CLOCK.currentTimeMillis());
 
         // Second, concurrent proposal for the SAME entity but a DIFFERENT target.
         var second = new MigrationProposal(
             UUID.randomUUID(), entityId,
             members.get(0).getId(), members.get(2).getId(),
-            view1, System.currentTimeMillis());
+            view1, ZE0EQ_CLOCK.currentTimeMillis());
 
         var firstFuture = consensus.requestConsensus(first);
         assertFalse(firstFuture.isDone(), "First proposal should remain in-flight pending votes");
@@ -264,7 +268,7 @@ public class ViewCommitteeConsensusTest {
         var third = new MigrationProposal(
             UUID.randomUUID(), entityId,
             members.get(0).getId(), members.get(1).getId(),
-            view1, System.currentTimeMillis());
+            view1, ZE0EQ_CLOCK.currentTimeMillis());
         var thirdFuture = consensus.requestConsensus(third);
         assertFalse(thirdFuture.isDone(),
                     "A new proposal for the entity must be accepted once the prior one completes");
@@ -281,7 +285,7 @@ public class ViewCommitteeConsensusTest {
             members.get(0).getId(),
             members.get(1).getId(),
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future = consensus.requestConsensus(proposal);
@@ -301,7 +305,7 @@ public class ViewCommitteeConsensusTest {
             members.get(0).getId(),
             nonExistentNode,  // ATTACK: target not in view
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future = consensus.requestConsensus(proposal);
@@ -321,7 +325,7 @@ public class ViewCommitteeConsensusTest {
             sourceAndTarget,  // ATTACK: source == target
             sourceAndTarget,
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future = consensus.requestConsensus(proposal);
@@ -339,7 +343,7 @@ public class ViewCommitteeConsensusTest {
             null,  // ATTACK: null sourceNodeId
             members.get(1).getId(),
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future = consensus.requestConsensus(proposal);
@@ -357,7 +361,7 @@ public class ViewCommitteeConsensusTest {
             members.get(0).getId(),
             null,  // ATTACK: null targetNodeId
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future = consensus.requestConsensus(proposal);
@@ -377,7 +381,7 @@ public class ViewCommitteeConsensusTest {
             nonExistentNode,  // ATTACK: source not in view
             members.get(1).getId(),
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future = consensus.requestConsensus(proposal);
@@ -398,7 +402,7 @@ public class ViewCommitteeConsensusTest {
             members.get(0).getId(),
             members.get(1).getId(),
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future = consensus.requestConsensus(invalidProposal);
@@ -419,7 +423,7 @@ public class ViewCommitteeConsensusTest {
             members.get(0).getId(),
             members.get(1).getId(),
             view2,  // Proposal for view2
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         // Change to view2
@@ -453,7 +457,7 @@ public class ViewCommitteeConsensusTest {
             fakeId1,  // ATTACK: fake source member
             members.get(1).getId(),
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var proposal2 = new MigrationProposal(
@@ -462,7 +466,7 @@ public class ViewCommitteeConsensusTest {
             fakeId2,  // ATTACK: another fake source member
             members.get(1).getId(),
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future1 = consensus.requestConsensus(proposal1);
@@ -486,7 +490,7 @@ public class ViewCommitteeConsensusTest {
             members.get(0).getId(),
             members.get(1).getId(),
             view1,  // Proposal for view1
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         // Start with view1
@@ -510,7 +514,7 @@ public class ViewCommitteeConsensusTest {
             members.get(1).getId(),
             members.get(2).getId(),
             view2,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future2 = consensus.requestConsensus(proposal2);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewIdRaceConditionTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewIdRaceConditionTest.java
@@ -208,9 +208,15 @@ public class ViewIdRaceConditionTest {
         // CRITICAL: Use actual committee member IDs, not arbitrary hashes
         votingProtocol.recordVote(new Vote(proposal.proposalId(), members.get(1).getId(), true, view2));
 
-        // Wait a bit - should NOT complete (only 1/2 votes with correct viewId)
-        Thread.sleep(200);
-        assertFalse(future.isDone(), "Proposal should not complete with votes from wrong view");
+        // recordVote evaluates quorum synchronously and ignores wrong-view votes inline, so the future's state
+        // is settled the moment recordVote returns — no Thread.sleep needed (Luciferase-lch80). With only one
+        // valid (view1) vote counted, quorum is not reached.
+        assertFalse(future.isDone(), "wrong-view vote must not count toward quorum: future must stay pending");
+
+        // Positive control: a SECOND valid (view1) vote reaches quorum and completes consensus, proving the
+        // only thing missing was a valid vote — i.e. the view2 vote was genuinely rejected, not merely slow.
+        votingProtocol.recordVote(new Vote(proposal.proposalId(), members.get(1).getId(), true, view1));
+        assertTrue(future.get(2, TimeUnit.SECONDS), "two valid same-view votes must reach quorum");
     }
 
     @Test

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewIdRaceConditionTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewIdRaceConditionTest.java
@@ -17,6 +17,8 @@
 
 package com.hellblazer.luciferase.simulation.consensus.committee;
 
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+
 import com.hellblazer.delos.context.DynamicContext;
 import com.hellblazer.delos.cryptography.Digest;
 import com.hellblazer.delos.cryptography.DigestAlgorithm;
@@ -58,6 +60,8 @@ import static org.mockito.Mockito.when;
  * @author hal.hildebrand
  */
 public class ViewIdRaceConditionTest {
+    // Fixed-base clock for proposal/vote timestamps (determinism mandate, Luciferase-ze0eq).
+    private static final TestClock ZE0EQ_CLOCK = new TestClock(1_000L);
 
     private DynamicContext<Member> context;
     private ViewCommitteeSelector selector;
@@ -135,7 +139,7 @@ public class ViewIdRaceConditionTest {
             source,
             targetA,
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future1 = consensus.requestConsensus(proposal1);
@@ -161,7 +165,7 @@ public class ViewIdRaceConditionTest {
             source,
             targetB,
             view2,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future2 = consensus.requestConsensus(proposal2);
@@ -191,7 +195,7 @@ public class ViewIdRaceConditionTest {
             members.get(0).getId(),  // source
             members.get(1).getId(),  // target
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future = consensus.requestConsensus(proposal);
@@ -220,7 +224,7 @@ public class ViewIdRaceConditionTest {
             members.get(0).getId(),  // source
             members.get(1).getId(),  // target
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future = consensus.requestConsensus(proposal);
@@ -256,7 +260,7 @@ public class ViewIdRaceConditionTest {
             members.get(0).getId(),  // source
             members.get(1).getId(),  // target
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var future = consensus.requestConsensus(proposal);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/VirtualSynchronyTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/VirtualSynchronyTest.java
@@ -17,6 +17,8 @@
 
 package com.hellblazer.luciferase.simulation.consensus.committee;
 
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+
 import com.hellblazer.delos.context.DynamicContext;
 import com.hellblazer.delos.cryptography.Digest;
 import com.hellblazer.delos.cryptography.DigestAlgorithm;
@@ -54,6 +56,8 @@ import static org.mockito.Mockito.when;
  * @author hal.hildebrand
  */
 public class VirtualSynchronyTest {
+    // Fixed-base clock for proposal/vote timestamps (determinism mandate, Luciferase-ze0eq).
+    private static final TestClock ZE0EQ_CLOCK = new TestClock(1_000L);
 
     private DynamicContext<Member> context;
     private ViewCommitteeSelector selector;
@@ -165,7 +169,7 @@ public class VirtualSynchronyTest {
             members.get(0).getId(),
             members.get(1).getId(),
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         // Submit proposal in view1
@@ -203,7 +207,7 @@ public class VirtualSynchronyTest {
             members.get(0).getId(),
             members.get(1).getId(),
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         var proposal2 = new MigrationProposal(
@@ -212,7 +216,7 @@ public class VirtualSynchronyTest {
             members.get(0).getId(),
             members.get(2).getId(),
             view1,
-            System.currentTimeMillis()
+            ZE0EQ_CLOCK.currentTimeMillis()
         );
 
         // Submit two proposals in view1

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/EndToEndMigrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/EndToEndMigrationTest.java
@@ -189,21 +189,14 @@ public class EndToEndMigrationTest {
         // Request consensus
         var future = consensus.requestConsensus(proposal);
 
-        // Simulate asynchronous voting
-        CompletableFuture.runAsync(() -> {
-            try {
-                Thread.sleep(50); // Simulate network delay
-                votingProtocol.recordVote(new Vote(proposal.proposalId(), members.get(1).getId(), true, viewId));
-                Thread.sleep(30);
-                votingProtocol.recordVote(new Vote(proposal.proposalId(), members.get(2).getId(), true, viewId));
-                Thread.sleep(20);
-                votingProtocol.recordVote(new Vote(proposal.proposalId(), members.get(3).getId(), true, viewId));
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        });
+        // Cast the committee votes. recordVote evaluates quorum synchronously and vote order is irrelevant, so
+        // the previous runAsync + Thread.sleep "network delay" sequencing was cosmetic and non-deterministic;
+        // record the votes inline instead (Luciferase-lch80). The future is completed the moment quorum lands.
+        votingProtocol.recordVote(new Vote(proposal.proposalId(), members.get(1).getId(), true, viewId));
+        votingProtocol.recordVote(new Vote(proposal.proposalId(), members.get(2).getId(), true, viewId));
+        votingProtocol.recordVote(new Vote(proposal.proposalId(), members.get(3).getId(), true, viewId));
 
-        // Wait for consensus
+        // Gate on completion (already done once quorum was reached above).
         var approved = future.get(2, TimeUnit.SECONDS);
         assertTrue(approved);
 

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/CrossProcessMigrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/CrossProcessMigrationTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -71,6 +72,32 @@ class CrossProcessMigrationTest {
         dedup = new IdempotencyStore(300_000); // 5 min TTL
         metrics = new MigrationMetrics();
         migration = new CrossProcessMigration(dedup, metrics);
+    }
+
+    /**
+     * Luciferase-rr07g: CrossProcessMigration implements AutoCloseable so try-with-resources cleans up the
+     * RealTimeController thread + cleanupScheduler even on the exception path. Asserts deterministically that
+     * close()->stop() shut the cleanup scheduler when the try block throws (reflection on the scheduler;
+     * {@code shutdown()} sets {@code isShutdown()} synchronously, no thread-count race).
+     */
+    @Test
+    void close_runsCleanupOnExceptionPath() throws Exception {
+        var m = new CrossProcessMigration(new IdempotencyStore(300_000), new MigrationMetrics());
+        var schedulerField = CrossProcessMigration.class.getDeclaredField("cleanupScheduler");
+        schedulerField.setAccessible(true);
+        var scheduler = (ExecutorService) schedulerField.get(m);
+        assertFalse(scheduler.isShutdown(), "cleanup scheduler must be running before close()");
+
+        // try-with-resources over an existing resource; the body throws so close() runs on the exception path.
+        assertThrows(IllegalStateException.class, () -> {
+            try (m) {
+                throw new IllegalStateException("boom inside try-with-resources");
+            }
+        });
+
+        assertTrue(scheduler.isShutdown(),
+                   "try-with-resources must invoke close()->stop() and shut the cleanup scheduler on the "
+                   + "exception path");
     }
 
     @AfterEach

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/MigrationLogPersistenceTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/MigrationLogPersistenceTest.java
@@ -84,6 +84,38 @@ class MigrationLogPersistenceTest {
         assertEquals(TransactionState.MigrationPhase.PREPARE, recovered_state.phase());
     }
 
+    /**
+     * Luciferase-rtffx: every case here passed a null snapshot, so a regression in serializing a non-null
+     * TransactionState.snapshot would go undetected in this file. Record a PREPARE carrying a populated
+     * SerializedSnapshot and assert it survives recordPrepare -> loadIncomplete (the Point3d-free
+     * SerializedSnapshot is Jackson-round-trippable; the old EntitySnapshot/Point3d field was not).
+     */
+    @Test
+    void testRecordAndLoadTransactionWithNonNullSnapshot() throws IOException {
+        var txnId = UUID.randomUUID();
+        var authority = UUID.randomUUID();
+        var snap = new TransactionState.SerializedSnapshot("entity-x", authority, 7L, 3L, 4242L);
+
+        var state = new TransactionState(
+            txnId, "entity-x", UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
+            snap, UUID.randomUUID(), TransactionState.MigrationPhase.PREPARE, 1000L
+        );
+
+        persistence.recordPrepare(state);
+
+        var recovered = new TestMigrationLogPersistence(processId, tempDir);
+        var incomplete = recovered.loadIncomplete();
+
+        assertEquals(1, incomplete.size(), "the PREPARE record with a non-null snapshot must be recoverable");
+        var roundTripped = incomplete.get(0).snapshot();
+        assertNotNull(roundTripped, "non-null snapshot must survive recordPrepare -> loadIncomplete");
+        assertEquals("entity-x", roundTripped.entityId());
+        assertEquals(authority, roundTripped.authorityBubbleId());
+        assertEquals(7L, roundTripped.epoch());
+        assertEquals(3L, roundTripped.version());
+        assertEquals(4242L, roundTripped.timestamp());
+    }
+
     @Test
     void testCommitMarksTransactionComplete() throws IOException {
         var txnId = UUID.randomUUID();

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/network/GrpcBubbleNetworkChannelTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/network/GrpcBubbleNetworkChannelTest.java
@@ -599,4 +599,34 @@ public class GrpcBubbleNetworkChannelTest {
             ch2.close();
         }
     }
+
+    /**
+     * Luciferase-3l1b5: initialize() registered a fresh JVM shutdown hook on every call and never removed it,
+     * leaking a Thread per call. The hook is now registered at most once per instance and deregistered in
+     * close(). Probe: {@code removeShutdownHook} returns {@code false} when the hook is not currently
+     * registered — so after close() it must return false (close already removed it); pre-fix it would return
+     * true (leak).
+     */
+    @Test
+    void shutdownHook_deregisteredOnClose_andLifecycleIdempotent() throws Exception {
+        var channel = new GrpcBubbleNetworkChannel(true);
+        channel.initialize(UUID.randomUUID(), "localhost:0");
+
+        var hookField = GrpcBubbleNetworkChannel.class.getDeclaredField("shutdownHook");
+        hookField.setAccessible(true);
+        var hook = (Thread) hookField.get(channel);
+        assertNotNull(hook, "initialize() must register a shutdown hook");
+
+        channel.close();
+        assertFalse(Runtime.getRuntime().removeShutdownHook(hook),
+                    "close() must deregister the shutdown hook (no leak)");
+
+        // Re-initialize + close again must not throw and must register/deregister a fresh single hook.
+        channel.initialize(UUID.randomUUID(), "localhost:0");
+        var hook2 = (Thread) hookField.get(channel);
+        assertNotNull(hook2, "re-initialize() after close() must register a new hook");
+        channel.close();
+        assertFalse(Runtime.getRuntime().removeShutdownHook(hook2),
+                    "second close() must also deregister its hook");
+    }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/ghost/GhostStateManagerNullSafetyTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/ghost/GhostStateManagerNullSafetyTest.java
@@ -18,6 +18,7 @@
 package com.hellblazer.luciferase.simulation.ghost;
 
 import com.hellblazer.luciferase.simulation.bubble.BubbleBounds;
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
 import com.hellblazer.luciferase.simulation.entity.StringEntityID;
 import com.hellblazer.luciferase.simulation.events.EntityUpdateEvent;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +45,10 @@ class GhostStateManagerNullSafetyTest {
     private GhostStateManager manager;
     private BubbleBounds bounds;
     private UUID sourceBubbleId;
+    private TestClock testClock;
+
+    // Fixed injected-clock base so event/query timestamps are deterministic (Luciferase-qqx7i).
+    private static final long CLOCK_BASE_MS = 1_000L;
 
     @BeforeEach
     void setUp() {
@@ -52,6 +57,8 @@ class GhostStateManagerNullSafetyTest {
         bounds = BubbleBounds.fromTetreeKey(rootKey);
 
         manager = new GhostStateManager(bounds, 1000); // 1000 max ghosts
+        testClock = new TestClock(CLOCK_BASE_MS);
+        manager.setClock(testClock);
         sourceBubbleId = UUID.randomUUID();
     }
 
@@ -71,7 +78,7 @@ class GhostStateManagerNullSafetyTest {
                 entityId,
                 null,  // null position - should throw
                 new Point3f(1.0f, 0.0f, 0.0f),
-                System.currentTimeMillis(),
+                testClock.currentTimeMillis(),
                 100L // lamport clock
             );
             manager.updateGhost(sourceBubbleId, event);
@@ -134,13 +141,13 @@ class GhostStateManagerNullSafetyTest {
             entityId,
             initialPosition,
             new Point3f(0.0f, 0.0f, 0.0f), // zero velocity
-            System.currentTimeMillis(),
+            testClock.currentTimeMillis(),
             100L
         );
         manager.updateGhost(sourceBubbleId, event);
 
         // Get position at much later time (dead reckoning may return null for old ghost)
-        var futureTime = System.currentTimeMillis() + 100_000; // 100 seconds later
+        var futureTime = testClock.currentTimeMillis() + 100_000; // 100 seconds later
         var position = manager.getGhostPosition(entityId, futureTime);
 
         // Should not throw NullPointerException (position guaranteed non-null)
@@ -171,7 +178,7 @@ class GhostStateManagerNullSafetyTest {
                 entityId,
                 position,
                 new Point3f(1.0f, 0.0f, 0.0f),
-                System.currentTimeMillis(),
+                testClock.currentTimeMillis(),
                 100L + i
             );
 
@@ -182,7 +189,7 @@ class GhostStateManagerNullSafetyTest {
         }
 
         // Get positions for all ghosts (stress test getGhostPosition)
-        var currentTime = System.currentTimeMillis();
+        var currentTime = testClock.currentTimeMillis();
         for (int i = 0; i < entityCount; i++) {
             var entityId = new StringEntityID("entity" + i);
 

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/lifecycle/GatedComponent.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/lifecycle/GatedComponent.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.lifecycle;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A {@link LifecycleComponent} whose start() async body blocks on an external {@link CountDownLatch} gate
+ * (instead of a fixed Thread.sleep) before performing the guarded STARTING→RUNNING transition. This makes the
+ * interleaving of a mid-STARTING stop()/rollback with a late doStart completion fully deterministic
+ * (Luciferase-yy3r4), with no timing race window.
+ *
+ * <p>{@code enteredStart} fires once the async start body has begun and is about to await the gate, so a test
+ * can deterministically know the component is in STARTING before it triggers a stop()/rollback and then
+ * releases the gate. The STARTING→RUNNING transition mirrors {@link MockComponent}: it only commits under
+ * {@code stateLock} if the state is still STARTING, so a stop() that ran while the gate was held suppresses
+ * the late RUNNING transition.
+ *
+ * @author hal.hildebrand
+ */
+public class GatedComponent implements LifecycleComponent {
+    private final String componentName;
+    private final List<String> componentDependencies;
+    private final AtomicReference<LifecycleState> state = new AtomicReference<>(LifecycleState.CREATED);
+    private final Object stateLock = new Object();
+
+    private final CountDownLatch startGate;
+    private final CountDownLatch enteredStart = new CountDownLatch(1);
+
+    public GatedComponent(String name, CountDownLatch startGate) {
+        this.componentName = name;
+        this.componentDependencies = new ArrayList<>();
+        this.startGate = startGate;
+    }
+
+    /** Becomes ready once the async start body is running and about to await the gate. */
+    public CountDownLatch enteredStart() {
+        return enteredStart;
+    }
+
+    @Override
+    public CompletableFuture<Void> start() {
+        var currentState = state.get();
+        if (currentState != LifecycleState.CREATED && currentState != LifecycleState.STOPPED) {
+            throw new LifecycleException("Cannot start from state: " + currentState);
+        }
+        state.set(LifecycleState.STARTING);
+
+        return CompletableFuture.runAsync(() -> {
+            enteredStart.countDown();
+            try {
+                startGate.await(); // gate the doStart completion — deterministic, not a sleep race
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                state.set(LifecycleState.FAILED);
+                throw new LifecycleException("Start interrupted", e);
+            }
+            // Only commit STARTING→RUNNING if a concurrent stop()/rollback did not already move us off STARTING.
+            synchronized (stateLock) {
+                if (state.get() == LifecycleState.STARTING) {
+                    state.set(LifecycleState.RUNNING);
+                }
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<Void> stop() {
+        synchronized (stateLock) {
+            var currentState = state.get();
+            if (currentState != LifecycleState.STARTING && currentState != LifecycleState.RUNNING) {
+                throw new LifecycleException("Cannot stop from state: " + currentState);
+            }
+            state.set(LifecycleState.STOPPING);
+        }
+        return CompletableFuture.runAsync(() -> state.set(LifecycleState.STOPPED));
+    }
+
+    @Override
+    public LifecycleState getState() {
+        return state.get();
+    }
+
+    @Override
+    public String name() {
+        return componentName;
+    }
+
+    @Override
+    public List<String> dependencies() {
+        return new ArrayList<>(componentDependencies);
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/lifecycle/LifecycleCoordinatorTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/lifecycle/LifecycleCoordinatorTest.java
@@ -46,6 +46,37 @@ class LifecycleCoordinatorTest {
     }
 
     /**
+     * Luciferase-yy3r4: a component stopped (rolled back) while still STARTING must not later resurrect itself
+     * to RUNNING when its deferred doStart completes. Previously only a fixed Thread.sleep race window
+     * exercised this; here the component's start body is gated on a CountDownLatch so the interleaving —
+     * stop() lands mid-STARTING, THEN doStart completes — is fully deterministic. The guarded
+     * STARTING→RUNNING transition (committed only if still STARTING, under the component's stateLock) is what
+     * LifecycleCoordinator.rollback/stopLayer relies on.
+     */
+    @Test
+    void lateDoStartTransitionSuppressedWhenStoppedDuringStarting() throws Exception {
+        var gate = new CountDownLatch(1);
+        var component = new GatedComponent("Gated", gate);
+
+        // Begin start: the async body runs and blocks on the gate, before the STARTING→RUNNING transition.
+        var startFuture = component.start();
+        assertTrue(component.enteredStart().await(5, TimeUnit.SECONDS), "start body must begin");
+        assertEquals(LifecycleState.STARTING, component.getState(), "component must be STARTING while gated");
+
+        // Rollback: stop() the component while it is still STARTING — exactly what stopLayer does for a
+        // previously-started layer when a later layer fails.
+        component.stop().get(5, TimeUnit.SECONDS);
+
+        // Release the gate: the late doStart completion must NOT move the component back to RUNNING.
+        gate.countDown();
+        startFuture.get(5, TimeUnit.SECONDS);
+
+        assertEquals(LifecycleState.STOPPED, component.getState(),
+                     "a component stopped during STARTING must end STOPPED — the late STARTING→RUNNING "
+                     + "transition must be suppressed (no spurious RUNNING-after-STOPPED)");
+    }
+
+    /**
      * Test 1: Verify components start in dependency order.
      * <p>
      * Setup: C depends on B, B depends on A

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/BubbleMergerTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/BubbleMergerTest.java
@@ -16,6 +16,8 @@
  */
 package com.hellblazer.luciferase.simulation.topology;
 
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+
 import com.hellblazer.delos.cryptography.DigestAlgorithm;
 import com.hellblazer.luciferase.simulation.bubble.TetreeBubbleGrid;
 import com.hellblazer.luciferase.simulation.distributed.integration.EntityAccountant;
@@ -46,6 +48,7 @@ import static org.mockito.Mockito.doReturn;
  * @author hal.hildebrand
  */
 class BubbleMergerTest {
+    private static final TestClock JC1KH_CLOCK = new TestClock(1_000L); // determinism mandate (Luciferase-jc1kh)
 
     private TetreeBubbleGrid bubbleGrid;
     private EntityAccountant accountant;
@@ -81,7 +84,7 @@ class BubbleMergerTest {
             bubble1.id(),
             bubble2.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         // Execute merge
@@ -140,7 +143,7 @@ class BubbleMergerTest {
             bubble1.id(),
             bubble2.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = merger.execute(proposal);
@@ -173,7 +176,7 @@ class BubbleMergerTest {
             bubble1.id(),
             bubble2.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = merger.execute(proposal);
@@ -198,7 +201,7 @@ class BubbleMergerTest {
             UUID.randomUUID(), // Non-existent bubble1
             bubble2.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = merger.execute(proposal);
@@ -217,7 +220,7 @@ class BubbleMergerTest {
             bubble1.id(),
             UUID.randomUUID(), // Non-existent bubble2
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = merger.execute(proposal);
@@ -242,7 +245,7 @@ class BubbleMergerTest {
             bubble1.id(),
             bubble2.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = merger.execute(proposal);
@@ -314,7 +317,7 @@ class BubbleMergerTest {
             bubble1.id(),
             bubble2.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = failingMerger.execute(proposal);
@@ -366,7 +369,7 @@ class BubbleMergerTest {
             bubble1.id(),
             bubble2.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = merger.execute(proposal);
@@ -420,7 +423,7 @@ class BubbleMergerTest {
             bubble1.id(),
             bubble2.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         // Must NOT throw even though rollback moves also fail.
@@ -477,7 +480,7 @@ class BubbleMergerTest {
         var proposal = new MergeProposal(
             UUID.randomUUID(), srcId, dstId,
             com.hellblazer.delos.cryptography.DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis());
+            JC1KH_CLOCK.currentTimeMillis());
 
         // Concurrent: merge thread + simulated-migration thread, released simultaneously.
         // The migration thread acquires BOTH locks in UUID.compareTo() order (same order as

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/BubbleMoverTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/BubbleMoverTest.java
@@ -16,6 +16,8 @@
  */
 package com.hellblazer.luciferase.simulation.topology;
 
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+
 import com.hellblazer.delos.cryptography.DigestAlgorithm;
 import com.hellblazer.luciferase.simulation.bubble.TetreeBubbleGrid;
 import com.hellblazer.luciferase.simulation.distributed.integration.EntityAccountant;
@@ -35,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author hal.hildebrand
  */
 class BubbleMoverTest {
+    private static final TestClock JC1KH_CLOCK = new TestClock(1_000L); // determinism mandate (Luciferase-jc1kh)
 
     private TetreeBubbleGrid bubbleGrid;
     private EntityAccountant accountant;
@@ -83,7 +86,7 @@ class BubbleMoverTest {
             newCenter,
             clusterCentroid,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         // Execute move
@@ -112,7 +115,7 @@ class BubbleMoverTest {
             new Point3f(1.0f, 1.0f, 1.0f),
             new Point3f(2.0f, 2.0f, 2.0f),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = mover.execute(proposal);
@@ -134,7 +137,7 @@ class BubbleMoverTest {
             new Point3f(1.0f, 1.0f, 1.0f),
             new Point3f(2.0f, 2.0f, 2.0f),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = mover.execute(proposal);
@@ -171,7 +174,7 @@ class BubbleMoverTest {
             newCenter,
             clusterCentroid,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = mover.execute(proposal);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/BubbleSplitterStrategyIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/BubbleSplitterStrategyIntegrationTest.java
@@ -16,6 +16,8 @@
  */
 package com.hellblazer.luciferase.simulation.topology;
 
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+
 import com.hellblazer.delos.cryptography.DigestAlgorithm;
 import com.hellblazer.luciferase.simulation.bubble.BubbleBounds;
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
@@ -45,6 +47,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author hal.hildebrand
  */
 class BubbleSplitterStrategyIntegrationTest {
+    private static final TestClock JC1KH_CLOCK = new TestClock(1_000L); // determinism mandate (Luciferase-jc1kh)
 
     private TetreeBubbleGrid bubbleGrid;
     private EntityAccountant accountant;
@@ -90,7 +93,7 @@ class BubbleSplitterStrategyIntegrationTest {
             bubble.id(),
             SplitPlane.yAxis((float) centroid.getY()), // Intentionally wrong axis
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = splitter.execute(proposal);
@@ -133,7 +136,7 @@ class BubbleSplitterStrategyIntegrationTest {
             bubble.id(),
             SplitPlane.xAxis((float) centroid.getX()), // X-axis should be used by strategy
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = splitter.execute(proposal);
@@ -171,7 +174,7 @@ class BubbleSplitterStrategyIntegrationTest {
             bubble.id(),
             SplitPlane.xAxis((float) centroid.getX()),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         splitter.execute(proposal);
@@ -222,7 +225,7 @@ class BubbleSplitterStrategyIntegrationTest {
             bubble1.id(),
             SplitPlane.xAxis((float) centroid.getX()),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var yProposal = new SplitProposal(
@@ -230,7 +233,7 @@ class BubbleSplitterStrategyIntegrationTest {
             bubble2.id(),
             SplitPlane.yAxis((float) centroid.getY()),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var xResult = xAxisSplitter.execute(xProposal);
@@ -304,7 +307,7 @@ class BubbleSplitterStrategyIntegrationTest {
             bubble.id(),
             SplitPlane.alongLongestAxis(bounds),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = splitter.execute(proposal);
@@ -343,7 +346,7 @@ class BubbleSplitterStrategyIntegrationTest {
                 bubble.id(),
                 SplitPlane.xAxis((float) centroid.getX()),
                 DigestAlgorithm.DEFAULT.getOrigin(),
-                System.currentTimeMillis()
+                JC1KH_CLOCK.currentTimeMillis()
             );
             splitter.execute(proposal);
         }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/BubbleSplitterTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/BubbleSplitterTest.java
@@ -16,6 +16,8 @@
  */
 package com.hellblazer.luciferase.simulation.topology;
 
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+
 import com.hellblazer.delos.cryptography.DigestAlgorithm;
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
 import com.hellblazer.luciferase.simulation.bubble.TetreeBubbleGrid;
@@ -38,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author hal.hildebrand
  */
 class BubbleSplitterTest {
+    private static final TestClock JC1KH_CLOCK = new TestClock(1_000L); // determinism mandate (Luciferase-jc1kh)
 
     private TetreeBubbleGrid bubbleGrid;
     private EntityAccountant accountant;
@@ -74,7 +77,7 @@ class BubbleSplitterTest {
             bubble.id(),
             splitPlane,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         // Execute split
@@ -121,7 +124,7 @@ class BubbleSplitterTest {
             bubble.id(),
             splitPlane,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = splitter.execute(proposal);
@@ -145,7 +148,7 @@ class BubbleSplitterTest {
             UUID.randomUUID(), // Non-existent bubble
             splitPlane,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = splitter.execute(proposal);
@@ -167,7 +170,7 @@ class BubbleSplitterTest {
             bubble.id(),
             splitPlane,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = splitter.execute(proposal);
@@ -196,7 +199,7 @@ class BubbleSplitterTest {
             bubble.id(),
             splitPlane,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = splitter.execute(proposal);
@@ -257,7 +260,7 @@ class BubbleSplitterTest {
             bubble.id(),
             splitPlane,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = failingSplitter.execute(proposal);
@@ -309,7 +312,7 @@ class BubbleSplitterTest {
             bubble.id(),
             splitPlane,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = splitter.execute(proposal);
@@ -401,7 +404,7 @@ class BubbleSplitterTest {
             bubble.id(),
             splitPlane,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         // Must NOT throw even though rollback moves also fail.

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/DynamicTopologyDemo.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/DynamicTopologyDemo.java
@@ -16,6 +16,8 @@
  */
 package com.hellblazer.luciferase.simulation.topology;
 
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+
 import com.hellblazer.delos.cryptography.DigestAlgorithm;
 import com.hellblazer.luciferase.simulation.bubble.TetreeBubbleGrid;
 import com.hellblazer.luciferase.simulation.distributed.integration.EntityAccountant;
@@ -37,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author hal.hildebrand
  */
 class DynamicTopologyDemo {
+    private static final TestClock JC1KH_CLOCK = new TestClock(1_000L); // determinism mandate (Luciferase-jc1kh)
 
     private static final int SPLIT_THRESHOLD = 5000;
     private static final int MERGE_THRESHOLD = 500;
@@ -92,7 +95,7 @@ class DynamicTopologyDemo {
             bubble0.id(),
             splitPlane0,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         System.out.println("Executing split proposal...");
@@ -122,7 +125,7 @@ class DynamicTopologyDemo {
             bubble1.id(),
             splitPlane1,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         System.out.println("Executing split proposal...");
@@ -159,7 +162,7 @@ class DynamicTopologyDemo {
                     bubble2.id(),
                     bubble3.id(),
                     DigestAlgorithm.DEFAULT.getOrigin(),
-                    System.currentTimeMillis()
+                    JC1KH_CLOCK.currentTimeMillis()
                 );
 
                 // Note: This will fail validation if bubble2 is still above threshold
@@ -206,7 +209,7 @@ class DynamicTopologyDemo {
                 newCenter,
                 clusterCentroid,
                 DigestAlgorithm.DEFAULT.getOrigin(),
-                System.currentTimeMillis()
+                JC1KH_CLOCK.currentTimeMillis()
             );
 
             System.out.println("Executing move proposal...");
@@ -276,7 +279,7 @@ class DynamicTopologyDemo {
                     bubble.id(),
                     splitPlane,
                     DigestAlgorithm.DEFAULT.getOrigin(),
-                    System.currentTimeMillis()
+                    JC1KH_CLOCK.currentTimeMillis()
                 );
 
                 var result = executor.execute(proposal);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/MergeIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/MergeIntegrationTest.java
@@ -16,6 +16,8 @@
  */
 package com.hellblazer.luciferase.simulation.topology;
 
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+
 import com.hellblazer.delos.cryptography.DigestAlgorithm;
 import com.hellblazer.luciferase.simulation.bubble.TetreeBubbleGrid;
 import com.hellblazer.luciferase.simulation.distributed.integration.EntityAccountant;
@@ -49,6 +51,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author hal.hildebrand
  */
 class MergeIntegrationTest {
+    private static final TestClock JC1KH_CLOCK = new TestClock(1_000L); // determinism mandate (Luciferase-jc1kh)
 
     private static final Logger log = LoggerFactory.getLogger(MergeIntegrationTest.class);
 
@@ -110,7 +113,7 @@ class MergeIntegrationTest {
             bubble1.id(),
             bubble2.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         log.info("Executing merge: {} + {}", bubble1.id(), bubble2.id());
@@ -175,7 +178,7 @@ class MergeIntegrationTest {
             bubble1.id(),
             bubble2.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = executor.execute(mergeProposal);
@@ -215,7 +218,7 @@ class MergeIntegrationTest {
             bubble1.id(),
             bubble2.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = executor.execute(mergeProposal);
@@ -258,7 +261,7 @@ class MergeIntegrationTest {
             bubble1.id(),
             bubble2.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         executor.execute(mergeProposal);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/MoveIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/MoveIntegrationTest.java
@@ -16,6 +16,8 @@
  */
 package com.hellblazer.luciferase.simulation.topology;
 
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+
 import com.hellblazer.delos.cryptography.DigestAlgorithm;
 import com.hellblazer.luciferase.simulation.bubble.TetreeBubbleGrid;
 import com.hellblazer.luciferase.simulation.distributed.integration.EntityAccountant;
@@ -50,6 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     + "does not occur; re-enable when bubble re-keying lands. Unit contract is covered by "
     + "BubbleMoverTest (deferred-failure assertions).")
 class MoveIntegrationTest {
+    private static final TestClock JC1KH_CLOCK = new TestClock(1_000L); // determinism mandate (Luciferase-jc1kh)
 
     private static final Logger log = LoggerFactory.getLogger(MoveIntegrationTest.class);
 
@@ -100,7 +103,7 @@ class MoveIntegrationTest {
             clusterCentroid,
             clusterCentroid,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         log.info("Executing move toward cluster centroid: ({}, {}, {})",
@@ -153,7 +156,7 @@ class MoveIntegrationTest {
             clusterCentroid,
             clusterCentroid,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = executor.execute(moveProposal);
@@ -193,7 +196,7 @@ class MoveIntegrationTest {
             clusterCentroid,
             clusterCentroid,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         executor.execute(moveProposal);
@@ -227,7 +230,7 @@ class MoveIntegrationTest {
             clusterCentroid,
             clusterCentroid,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = mover.execute(moveProposal);
@@ -261,7 +264,7 @@ class MoveIntegrationTest {
             clusterCentroid,
             clusterCentroid,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = mover.execute(moveProposal);
@@ -300,7 +303,7 @@ class MoveIntegrationTest {
             clusterCentroid,
             clusterCentroid,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = executor.execute(moveProposal);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/TopologyEvolutionTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/TopologyEvolutionTest.java
@@ -16,6 +16,8 @@
  */
 package com.hellblazer.luciferase.simulation.topology;
 
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+
 import com.hellblazer.delos.cryptography.DigestAlgorithm;
 import com.hellblazer.luciferase.simulation.bubble.TetreeBubbleGrid;
 import com.hellblazer.luciferase.simulation.distributed.integration.EntityAccountant;
@@ -35,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author hal.hildebrand
  */
 class TopologyEvolutionTest {
+    private static final TestClock JC1KH_CLOCK = new TestClock(1_000L); // determinism mandate (Luciferase-jc1kh)
 
     private TetreeBubbleGrid bubbleGrid;
     private EntityAccountant accountant;
@@ -75,7 +78,7 @@ class TopologyEvolutionTest {
             bubble.id(),
             splitPlane,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         // Execute split
@@ -118,7 +121,7 @@ class TopologyEvolutionTest {
             bubble1.id(),
             bubble2.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         // Execute merge
@@ -173,7 +176,7 @@ class TopologyEvolutionTest {
             newCenter,
             clusterCentroid,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         // Execute move
@@ -223,7 +226,7 @@ class TopologyEvolutionTest {
             bubble1.id(),
             splitPlane,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         int bubbleCountBefore = bubbleGrid.getAllBubbles().size();
@@ -276,7 +279,7 @@ class TopologyEvolutionTest {
             bubble1.id(),
             splitPlane,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         int bubbleCountBefore = bubbleGrid.getAllBubbles().size();
@@ -296,7 +299,7 @@ class TopologyEvolutionTest {
             bubble2.id(),
             bubble3.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         executor.execute(mergeProposal);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/TopologyExecutorTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/TopologyExecutorTest.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author hal.hildebrand
  */
 class TopologyExecutorTest {
+    private static final TestClock JC1KH_CLOCK = new TestClock(1_000L); // determinism mandate (Luciferase-jc1kh)
 
     private TetreeBubbleGrid bubbleGrid;
     private EntityAccountant accountant;
@@ -74,7 +75,7 @@ class TopologyExecutorTest {
             bubble.id(),
             splitPlane,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         // Execute
@@ -110,7 +111,7 @@ class TopologyExecutorTest {
             bubble1.id(),
             bubble2.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         // Execute
@@ -158,7 +159,7 @@ class TopologyExecutorTest {
             newCenter,
             clusterCentroid,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         // Execute
@@ -200,7 +201,7 @@ class TopologyExecutorTest {
             bubble.id(),
             splitPlane,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         // Execute
@@ -259,7 +260,7 @@ class TopologyExecutorTest {
             bubble.id(),
             splitPlane,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var proposal2 = new SplitProposal(
@@ -267,7 +268,7 @@ class TopologyExecutorTest {
             bubble.id(),
             splitPlane,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         // Execute sequentially (second should fail because first already split)
@@ -305,7 +306,7 @@ class TopologyExecutorTest {
             bubble1.id(),
             bubble2.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         // Execute
@@ -344,7 +345,7 @@ class TopologyExecutorTest {
 
         var proposal1 = new MergeProposal(
             UUID.randomUUID(), bubbles1.get(0).id(), bubbles1.get(1).id(),
-            DigestAlgorithm.DEFAULT.getOrigin(), System.currentTimeMillis()
+            DigestAlgorithm.DEFAULT.getOrigin(), JC1KH_CLOCK.currentTimeMillis()
         );
         var result1 = executor1.execute(proposal1);
         assertTrue(result1.success(), "Merge 1 should succeed");
@@ -366,7 +367,7 @@ class TopologyExecutorTest {
 
         var proposal2 = new MergeProposal(
             UUID.randomUUID(), bubbles2.get(0).id(), bubbles2.get(1).id(),
-            DigestAlgorithm.DEFAULT.getOrigin(), System.currentTimeMillis()
+            DigestAlgorithm.DEFAULT.getOrigin(), JC1KH_CLOCK.currentTimeMillis()
         );
         var result2 = executor2.execute(proposal2);
         assertTrue(result2.success(), "Merge 2 should succeed");
@@ -438,7 +439,7 @@ class TopologyExecutorTest {
             bubble1.id(),
             bubble2.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         // Execute
@@ -479,7 +480,7 @@ class TopologyExecutorTest {
 
         var proposal1 = new MergeProposal(
             UUID.randomUUID(), bubbles1.get(0).id(), bubbles1.get(1).id(),
-            DigestAlgorithm.DEFAULT.getOrigin(), System.currentTimeMillis()
+            DigestAlgorithm.DEFAULT.getOrigin(), JC1KH_CLOCK.currentTimeMillis()
         );
         var result1 = executor1.execute(proposal1);
         assertTrue(result1.success(), "Merge 1 should succeed");
@@ -501,7 +502,7 @@ class TopologyExecutorTest {
 
         var proposal2 = new MergeProposal(
             UUID.randomUUID(), bubbles2.get(0).id(), bubbles2.get(1).id(),
-            DigestAlgorithm.DEFAULT.getOrigin(), System.currentTimeMillis()
+            DigestAlgorithm.DEFAULT.getOrigin(), JC1KH_CLOCK.currentTimeMillis()
         );
         var result2 = executor2.execute(proposal2);
         assertTrue(result2.success(), "Merge 2 should succeed");
@@ -578,7 +579,7 @@ class TopologyExecutorTest {
             bubble.id(),
             splitPlane,
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         // Execute — must fail at executor-level validate (not at splitter level)
@@ -667,7 +668,7 @@ class TopologyExecutorTest {
             bubble1.id(),
             bubble2.id(),
             DigestAlgorithm.DEFAULT.getOrigin(),
-            System.currentTimeMillis()
+            JC1KH_CLOCK.currentTimeMillis()
         );
 
         var result = executor2.execute(proposal);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/TopologyExecutorTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/TopologyExecutorTest.java
@@ -30,6 +30,7 @@ import javax.vecmath.Point3f;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -178,6 +179,145 @@ class TopologyExecutorTest {
         // Verify accountant validation passes
         var validation = accountant.validate();
         assertTrue(validation.success(), "Entity validation should pass: " + validation.details());
+    }
+
+    // ---- Luciferase-iveyb: concurrency, removed-bubble safety, split-event coverage ----
+
+    /**
+     * (c) execute(MoveProposal) on a bubble removed from the grid between proposal creation and execute()
+     * must return a clean failure, never an NPE on getBubbleById()==null (TopologyExecutor 0frcy.48 path).
+     */
+    @Test
+    void testRemovedBubbleMoveNoNpe() {
+        bubbleGrid.createBubbles(1, (byte) 1, 10);
+        var bubble = bubbleGrid.getAllBubbles().iterator().next();
+        addEntities(bubble, 100);
+
+        var c = bubble.bounds().centroid();
+        var move = new MoveProposal(
+            UUID.randomUUID(), bubble.id(),
+            new Point3f((float) c.getX() + 0.1f, (float) c.getY() + 0.1f, (float) c.getZ() + 0.1f),
+            new Point3f((float) c.getX() + 0.5f, (float) c.getY() + 0.5f, (float) c.getZ() + 0.5f),
+            DigestAlgorithm.DEFAULT.getOrigin(), JC1KH_CLOCK.currentTimeMillis());
+
+        // The bubble disappears from the grid after the proposal references it.
+        assertTrue(bubbleGrid.removeBubble(bubble.id()), "bubble must be removed from the grid");
+
+        var result = assertDoesNotThrow(() -> executor.execute(move),
+                                        "execute() on a removed bubble must not throw (no NPE on null bubble)");
+        assertFalse(result.success(), "a move targeting a removed bubble must fail cleanly");
+    }
+
+    /**
+     * (d) a successful split of a populated bubble must emit a SplitEvent whose entitiesMoved is positive.
+     */
+    @Test
+    void testSplitEntitiesMovedPositive() {
+        bubbleGrid.createBubbles(1, (byte) 1, 10);
+        var bubble = bubbleGrid.getAllBubbles().iterator().next();
+        addEntities(bubble, 5100);
+
+        var captured = new java.util.concurrent.atomic.AtomicReference<SplitEvent>();
+        executor.addListener(event -> {
+            if (event instanceof SplitEvent se) {
+                captured.set(se);
+            }
+        });
+
+        var centroid = bubble.centroid();
+        var splitPlane = new SplitPlane(new Point3f(1.0f, 0.0f, 0.0f), (float) centroid.getX());
+        var proposal = new SplitProposal(UUID.randomUUID(), bubble.id(), splitPlane,
+                                         DigestAlgorithm.DEFAULT.getOrigin(), JC1KH_CLOCK.currentTimeMillis());
+
+        var result = executor.execute(proposal);
+        assertTrue(result.success(), "split should succeed: " + result.message());
+
+        var event = captured.get();
+        assertNotNull(event, "a SplitEvent must be emitted on a successful split");
+        assertTrue(event.entitiesMoved() > 0,
+                   "splitting a populated bubble must move a positive entity count, got " + event.entitiesMoved());
+    }
+
+    /**
+     * (a) Two operations (split + merge) touching the SAME bubble submitted concurrently. execute() is guarded
+     * by executionLock, so they serialize: the load-bearing safety property is that they run without exception
+     * and WITHOUT corrupting entity accounting (no loss / no duplication), regardless of interleaving.
+     *
+     * <p>Note: contrary to the original finding's "exactly one success and one failure" assumption, BOTH
+     * operations can legitimately succeed — split and merge both reuse {@code bubble1}'s id, so they compose
+     * (split-then-merge or merge-then-split) rather than hard-conflict. The real invariant is serialized,
+     * conservation-preserving execution, which is what this test pins.
+     *
+     * <p>(b) The executor wires NO consensus protocol — it executes already-approved proposals — so there is no
+     * consensus call to verify here (documented invariant; TopologyExecutor exposes no consensus seam).
+     */
+    @Test
+    void testConcurrentSplitMergeSameBubble() throws Exception {
+        bubbleGrid.createBubbles(2, (byte) 1, 10);
+        var bubbles = bubbleGrid.getAllBubbles().stream().toList();
+        var bubble1 = bubbles.get(0);
+        var bubble2 = bubbles.get(1);
+        addEntities(bubble1, 5100); // splittable
+        addEntities(bubble2, 200);
+
+        var centroid = bubble1.centroid();
+        var splitPlane = new SplitPlane(new Point3f(1.0f, 0.0f, 0.0f), (float) centroid.getX());
+        var split = new SplitProposal(UUID.randomUUID(), bubble1.id(), splitPlane,
+                                      DigestAlgorithm.DEFAULT.getOrigin(), JC1KH_CLOCK.currentTimeMillis());
+        var merge = new MergeProposal(UUID.randomUUID(), bubble1.id(), bubble2.id(),
+                                      DigestAlgorithm.DEFAULT.getOrigin(), JC1KH_CLOCK.currentTimeMillis());
+
+        var barrier = new java.util.concurrent.CyclicBarrier(2);
+        var pool = java.util.concurrent.Executors.newFixedThreadPool(2);
+        var results = new java.util.concurrent.ConcurrentLinkedQueue<TopologyExecutionResult>();
+        var errors = new java.util.concurrent.ConcurrentLinkedQueue<Throwable>();
+
+        Runnable runSplit = () -> {
+            try { barrier.await(); results.add(executor.execute(split)); }
+            catch (Throwable t) { errors.add(t); }
+        };
+        Runnable runMerge = () -> {
+            try { barrier.await(); results.add(executor.execute(merge)); }
+            catch (Throwable t) { errors.add(t); }
+        };
+        pool.submit(runSplit);
+        pool.submit(runMerge);
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS), "both operations must finish");
+
+        assertTrue(errors.isEmpty(), "executionLock must serialize the operations without exceptions: " + errors);
+        assertEquals(2, results.size(), "both operations must produce a result");
+        // The load-bearing invariant: serialized execution must not corrupt entity accounting (no loss/dup),
+        // whichever interleaving occurred.
+        var validation = accountant.validate();
+        assertTrue(validation.success(),
+                   "entity accounting must remain valid after the serialized concurrent operations: "
+                   + validation.details());
+    }
+
+    /**
+     * (e) A degenerate SplitPlane positioned far outside the bubble (all entities on one side) must be handled
+     * without exception or entity loss — the executor either splits with an empty side or fails cleanly, but
+     * accounting stays conserved either way.
+     */
+    @Test
+    void testDegenerateSplitPlaneHandled() {
+        bubbleGrid.createBubbles(1, (byte) 1, 10);
+        var bubble = bubbleGrid.getAllBubbles().iterator().next();
+        addEntities(bubble, 5100);
+
+        // Plane offset far below every entity's x (entities have x = i*0.01 >= 0) → all entities one side.
+        var degenerate = new SplitPlane(new Point3f(1.0f, 0.0f, 0.0f), -1_000_000f);
+        var proposal = new SplitProposal(UUID.randomUUID(), bubble.id(), degenerate,
+                                         DigestAlgorithm.DEFAULT.getOrigin(), JC1KH_CLOCK.currentTimeMillis());
+
+        var result = assertDoesNotThrow(() -> executor.execute(proposal),
+                                        "a degenerate split plane must not throw");
+        assertNotNull(result, "execute must return a result for a degenerate plane");
+        // Whether it succeeds (empty side) or fails cleanly, accounting must stay conserved (validate() checks
+        // the global no-loss / no-duplication invariant).
+        var validation = accountant.validate();
+        assertTrue(validation.success(), "entity accounting must stay valid: " + validation.details());
     }
 
     @Test

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/metrics/BoundaryStressAnalyzerTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/metrics/BoundaryStressAnalyzerTest.java
@@ -16,6 +16,8 @@
  */
 package com.hellblazer.luciferase.simulation.topology.metrics;
 
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +31,10 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author hal.hildebrand
  */
 class BoundaryStressAnalyzerTest {
+    // Per-instance injected clock (determinism mandate, Luciferase-jc1kh). The analyzer's sliding-window "now"
+    // and the recorded migration timestamps must share one virtual clock — the recorded timestamps are
+    // load-bearing here (window math), so a fixed base alone would fall outside the analyzer's real-time window.
+    private TestClock testClock;
 
     private BoundaryStressAnalyzer analyzer;
     private UUID bubble1;
@@ -36,14 +42,16 @@ class BoundaryStressAnalyzerTest {
 
     @BeforeEach
     void setUp() {
+        testClock = new TestClock(1_000L);
         analyzer = new BoundaryStressAnalyzer(60000); // 60-second window
+        analyzer.setClock(testClock);
         bubble1 = UUID.randomUUID();
         bubble2 = UUID.randomUUID();
     }
 
     @Test
     void testMigrationRateCalculation() {
-        long now = System.currentTimeMillis();
+        long now = testClock.currentTimeMillis();
 
         // Record 20 migrations over 2 seconds (10 per second)
         for (int i = 0; i < 20; i++) {
@@ -56,7 +64,7 @@ class BoundaryStressAnalyzerTest {
 
     @Test
     void testSlidingWindowExpiration() {
-        long now = System.currentTimeMillis();
+        long now = testClock.currentTimeMillis();
 
         // Record migrations at T=0
         for (int i = 0; i < 10; i++) {
@@ -77,7 +85,7 @@ class BoundaryStressAnalyzerTest {
 
     @Test
     void testHotspotDetection() {
-        long now = System.currentTimeMillis();
+        long now = testClock.currentTimeMillis();
 
         // Bubble 1: High stress (15 migrations/second)
         for (int i = 0; i < 150; i++) {
@@ -97,7 +105,7 @@ class BoundaryStressAnalyzerTest {
 
     @Test
     void testMultipleBubbleTracking() {
-        long now = System.currentTimeMillis();
+        long now = testClock.currentTimeMillis();
 
         var bubble3 = UUID.randomUUID();
 
@@ -140,7 +148,7 @@ class BoundaryStressAnalyzerTest {
 
     @Test
     void testRecentWindow() {
-        long now = System.currentTimeMillis();
+        long now = testClock.currentTimeMillis();
 
         // Old migrations (outside window)
         for (int i = 0; i < 10; i++) {

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/viz/render/RateLimiterTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/viz/render/RateLimiterTest.java
@@ -12,6 +12,13 @@ import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -39,6 +46,46 @@ class RateLimiterTest {
             assertTrue(rateLimiter.allowRequest("192.168.1.1"),
                        "Request " + (i + 1) + " should be allowed");
         }
+    }
+
+    /**
+     * Luciferase-csdn1 (0frcy.121): under a concurrent flood from ONE ip, the per-IP synchronized critical
+     * section in allowRequest must admit at most maxRequestsPerMinute. The clock is fixed (one window), and a
+     * CyclicBarrier releases all threads at once to maximize the TOCTOU window; without the synchronized
+     * prune-check-offer, multiple threads could each observe size<max and all offer, overshooting the limit.
+     */
+    @Test
+    void concurrentAllowRequest_sameIp_neverExceedsLimit() throws Exception {
+        int max = 5; // matches the RateLimiter(5, ...) built in setUp
+        int threads = 64;
+        var ip = "10.0.0.7";
+
+        var barrier = new CyclicBarrier(threads);
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        var allowed = new AtomicInteger(0);
+        var done = new CountDownLatch(threads);
+
+        for (int i = 0; i < threads; i++) {
+            pool.submit(() -> {
+                try {
+                    barrier.await();
+                    if (rateLimiter.allowRequest(ip)) {
+                        allowed.incrementAndGet();
+                    }
+                } catch (Exception ignored) {
+                    // barrier/interrupt — irrelevant to the invariant
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        assertTrue(done.await(10, TimeUnit.SECONDS), "all request threads must finish");
+        pool.shutdownNow();
+
+        assertEquals(max, allowed.get(),
+                     "exactly maxRequestsPerMinute requests may be accepted for one IP in a single window under "
+                     + "concurrency (no TOCTOU overflow); accepted=" + allowed.get());
     }
 
     @Test

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/viz/render/RegionBuilderTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/viz/render/RegionBuilderTest.java
@@ -8,7 +8,13 @@ import org.junit.jupiter.api.Test;
 import javax.vecmath.Point3f;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -424,6 +430,76 @@ class RegionBuilderTest {
 
         } finally {
             smallBuilder.close();
+        }
+    }
+
+    /**
+     * Luciferase-csdn1 (0frcy.39): the backpressure admission (check queueSize, evict-or-reject, offer,
+     * increment) must be atomic. Saturate a single-worker builder with a concurrent flood of invisible builds
+     * (rejected, never evicted, when full) and assert the queue depth NEVER exceeds maxQueueDepth — a sampler
+     * records the running max. Without the synchronized admissionLock, concurrent callers could all observe
+     * queueSize<max and all offer, overshooting the cap.
+     */
+    @Test
+    void concurrentBuildSubmission_neverExceedsMaxQueueDepth() throws Exception {
+        int maxQueueDepth = 5;
+        // Heavy-ish voxel set so each build occupies the single worker long enough to keep the queue saturated
+        // during the burst (exercising the cap under real contention).
+        var positions = new ArrayList<Point3f>();
+        for (int i = 0; i < 400; i++) {
+            positions.add(new Point3f((i % 64) / 64f, ((i / 64) % 64) / 64f, ((i / 512) % 64) / 64f));
+        }
+        var bounds = new RegionBounds(0, 0, 0, 1, 1, 1);
+
+        try (var builder = new RegionBuilder(1, maxQueueDepth, 10, 64)) { // single worker → queue saturates
+            int threads = 48;
+            var barrier = new CyclicBarrier(threads);
+            ExecutorService pool = Executors.newFixedThreadPool(threads);
+            var done = new CountDownLatch(threads);
+            var maxObserved = new AtomicInteger(0);
+            var stopSampler = new AtomicBoolean(false);
+
+            var sampler = new Thread(() -> {
+                while (!stopSampler.get()) {
+                    maxObserved.accumulateAndGet(builder.getQueueDepth(), Math::max);
+                }
+            });
+            sampler.start();
+
+            for (int t = 0; t < threads; t++) {
+                final int id = t;
+                pool.submit(() -> {
+                    try {
+                        barrier.await();
+                        for (int k = 0; k < 8; k++) {
+                            var req = new RegionBuilder.BuildRequest(
+                                new RegionId(id * 100 + k, 0), positions, bounds, 0,
+                                false, // invisible → rejected (not evicting) when full, so it stresses the cap
+                                RegionBuilder.BuildType.ESVO, 1000L + id);
+                            try {
+                                builder.build(req);
+                            } catch (RegionBuilder.BuildQueueFullException
+                                     | RegionBuilder.CircuitBreakerOpenException ignored) {
+                                // expected once the queue saturates
+                            }
+                        }
+                    } catch (Exception ignored) {
+                        // barrier/interrupt — irrelevant to the invariant
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            assertTrue(done.await(60, TimeUnit.SECONDS), "submitters must finish");
+            stopSampler.set(true);
+            sampler.join(2000);
+            pool.shutdownNow();
+
+            assertTrue(maxObserved.get() <= maxQueueDepth,
+                       "queue depth must never exceed maxQueueDepth under concurrent submission (no TOCTOU "
+                       + "overflow); observed max " + maxObserved.get() + " > " + maxQueueDepth);
+            assertTrue(builder.getQueueDepth() <= maxQueueDepth, "final queue depth must be within the cap");
         }
     }
 

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/viz/render/RegionCacheTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/viz/render/RegionCacheTest.java
@@ -1,10 +1,12 @@
 package com.hellblazer.luciferase.simulation.viz.render;
 
+import com.github.benmanes.caffeine.cache.Ticker;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -43,6 +45,29 @@ class RegionCacheTest {
 
         assertTrue(retrieved.isPresent(), "Region should be cached");
         assertEquals(cachedRegion, retrieved.get());
+    }
+
+    /**
+     * Luciferase-h0hk7: TTL eviction must be testable by advancing virtual time, not the wall clock. The
+     * {@code RegionCache(long, Duration, Ticker)} overload wires a Caffeine {@link Ticker} into
+     * {@code expireAfterAccess}, so advancing the ticker past the TTL expires the entry with no Thread.sleep.
+     */
+    @Test
+    void ttlEvictionIsDeterministicWithInjectedTicker() {
+        var nanos = new AtomicLong(0);
+        Ticker ticker = nanos::get;
+        try (var tickedCache = new RegionCache(10_000, Duration.ofSeconds(1), ticker)) {
+            var regionId = new RegionId(1L, 0);
+            var key = new RegionCache.CacheKey(regionId, 0);
+            tickedCache.put(key, RegionCache.CachedRegion.from(createTestRegion(regionId, 1000), 0L));
+            assertTrue(tickedCache.get(key).isPresent(), "entry must be present before the TTL elapses");
+
+            // Advance virtual time past the 1s TTL — purely via the injected ticker, no real sleep.
+            nanos.addAndGet(Duration.ofSeconds(2).toNanos());
+
+            assertFalse(tickedCache.get(key).isPresent(),
+                        "entry must be evicted by expireAfterAccess once the injected ticker passes the TTL");
+        }
     }
 
     @Test

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/viz/render/RenderingServerTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/viz/render/RenderingServerTest.java
@@ -57,6 +57,34 @@ class RenderingServerTest {
         assertFalse(server.isStarted(), "Server should be stopped");
     }
 
+    /**
+     * Luciferase-bshji: the EntityStreamConsumer must be constructed with the server's own {@code clock}
+     * field (default Clock.system()), not a separate {@code Clock.system()} literal. Since Clock.system()
+     * returns a fresh instance per call, a literal would hand the consumer a different clock object than the
+     * server holds, so they could diverge during the construction-to-setClock() window. Asserts the two are
+     * the same instance from construction.
+     */
+    @Test
+    void entityConsumerSharesServerClockInstanceAtConstruction() throws Exception {
+        var config = RenderingServerConfig.testing();
+        server = new RenderingServer(config);
+
+        var serverClockField = RenderingServer.class.getDeclaredField("clock");
+        serverClockField.setAccessible(true);
+        var serverClock = serverClockField.get(server);
+
+        var consumerField = RenderingServer.class.getDeclaredField("entityConsumer");
+        consumerField.setAccessible(true);
+        var consumer = consumerField.get(server);
+        var consumerClockField = consumer.getClass().getDeclaredField("clock");
+        consumerClockField.setAccessible(true);
+        var consumerClock = consumerClockField.get(consumer);
+
+        assertSame(serverClock, consumerClock,
+                   "EntityStreamConsumer must share the server's clock instance from construction "
+                   + "(Luciferase-bshji); a separate Clock.system() literal would diverge");
+    }
+
     @Test
     void testDynamicPortAssignment() {
         var config = RenderingServerConfig.testing();  // port = 0

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/MessageConverterTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/MessageConverterTest.java
@@ -239,15 +239,20 @@ class MessageConverterTest {
         var sourceBubbleId = UUID.randomUUID();
         var ghosts = new ArrayList<Message.TransportGhost>();
 
+        // Fixed (non-wall-clock) epoch/version/timestamp so the round-trip assertions below are deterministic
+        // and a converter regression that drops/zeros any field is caught (Luciferase-r7yba).
+        long epoch = 11L;
+        long version = 7L;
+        long timestamp = 1234L;
         var ghost1 = new Message.TransportGhost(
             "entity-1",
             new javax.vecmath.Point3f(1.0f, 2.0f, 3.0f),
             "TestContent",
             "test-value",
             "tree-1",
-            1L,
-            1L,
-            System.currentTimeMillis(),
+            epoch,
+            version,
+            timestamp,
             new javax.vecmath.Vector3f(0f, 0f, 0f)
         );
         ghosts.add(ghost1);
@@ -272,7 +277,12 @@ class MessageConverterTest {
         assertEquals(sourceBubbleId, recoveredGhostSync.sourceBubbleId());
         assertEquals(42L, recoveredGhostSync.bucket());
         assertEquals(1, recoveredGhostSync.ghosts().size());
-        assertEquals("entity-1", recoveredGhostSync.ghosts().get(0).entityId());
+        var recoveredGhost = recoveredGhostSync.ghosts().get(0);
+        assertEquals("entity-1", recoveredGhost.entityId());
+        // epoch/version/timestamp must survive toTransport -> fromTransport (Luciferase-r7yba).
+        assertEquals(epoch, recoveredGhost.epoch(), "ghost epoch must round-trip");
+        assertEquals(version, recoveredGhost.version(), "ghost version must round-trip");
+        assertEquals(timestamp, recoveredGhost.timestamp(), "ghost timestamp must round-trip");
     }
 
     @Test
@@ -507,15 +517,17 @@ class MessageConverterTest {
         var ghosts = new ArrayList<Message.TransportGhost>();
 
         for (int i = 0; i < 5; i++) {
+            // Fixed, per-ghost-distinct epoch/version/timestamp (no wall clock) so the round-trip checks below
+            // are deterministic and catch a converter regression on any field (Luciferase-r7yba).
             ghosts.add(new Message.TransportGhost(
                 "entity-" + i,
                 new javax.vecmath.Point3f(i, i + 1, i + 2),
                 "Content" + i,
                 "value-" + i,
                 "tree-" + i,
-                (long) i,
-                (long) i,
-                System.currentTimeMillis(),
+                (long) (100 + i),
+                (long) (200 + i),
+                (long) (1000 + i),
                 new javax.vecmath.Vector3f(0f, 0f, 0f)
             ));
         }
@@ -531,7 +543,11 @@ class MessageConverterTest {
         assertEquals(5, recoveredGhostSync.ghosts().size());
 
         for (int i = 0; i < 5; i++) {
-            assertEquals("entity-" + i, recoveredGhostSync.ghosts().get(i).entityId());
+            var g = recoveredGhostSync.ghosts().get(i);
+            assertEquals("entity-" + i, g.entityId());
+            assertEquals(100 + i, g.epoch(), "ghost " + i + " epoch must round-trip");
+            assertEquals(200 + i, g.version(), "ghost " + i + " version must round-trip");
+            assertEquals(1000 + i, g.timestamp(), "ghost " + i + " timestamp must round-trip");
         }
     }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/transport/SocketTransportCompositionTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/transport/SocketTransportCompositionTest.java
@@ -23,8 +23,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -66,25 +64,30 @@ class SocketTransportCompositionTest {
         // Create two transports with Fireflies infrastructure
         var uuid1 = UUID.randomUUID();
         var uuid2 = UUID.randomUUID();
-        var addr1 = ProcessAddress.localhost("p1", findAvailablePort());
-        var addr2 = ProcessAddress.localhost("p2", findAvailablePort());
+        // Bind to an ephemeral port (0) and read back the OS-assigned address — no find-then-bind TOCTOU
+        // window (Luciferase-fehvz). createTestTransport does not listen, so myAddress is only a hint.
+        var bind1 = ProcessAddress.localhost("p1", 0);
+        var bind2 = ProcessAddress.localhost("p2", 0);
 
-        transport1 = TestTransportFactory.createTestTransport(uuid1, addr1);
-        transport2 = TestTransportFactory.createTestTransport(uuid2, addr2);
+        transport1 = TestTransportFactory.createTestTransport(uuid1, bind1);
+        transport2 = TestTransportFactory.createTestTransport(uuid2, bind2);
 
-        // Phase 1: Verify MemberDirectory works (register and lookup)
+        // Phase 2: Verify ConnectionManager works (listen, then read the actual bound address for routing)
+        assertFalse(transport1.isConnected(), "Not running before listenOn/connectTo");
+
+        transport1.listenOn(bind1);
+        assertTrue(transport1.isConnected(), "Running after listenOn (bug fix)");
+        transport2.listenOn(bind2);
+
+        var addr1 = transport1.getBoundAddress();
+        var addr2 = transport2.getBoundAddress();
+
+        // Phase 1: Verify MemberDirectory works (register and lookup) against the actual bound address
         transport1.registerMember(uuid2, addr2);
         var memberInfo = transport1.lookupMember(uuid2);
         assertTrue(memberInfo.isPresent(), "Member should be registered");
         assertEquals(uuid2, memberInfo.get().nodeId(), "Member ID should match");
 
-        // Phase 2: Verify ConnectionManager works (listen and connect)
-        assertFalse(transport1.isConnected(), "Not running before listenOn/connectTo");
-
-        transport1.listenOn(addr1);
-        assertTrue(transport1.isConnected(), "Running after listenOn (bug fix)");
-
-        transport2.listenOn(addr2);
         transport1.connectTo(addr2);
         assertTrue(transport1.isConnected(), "Still running after connectTo");
 
@@ -118,30 +121,23 @@ class SocketTransportCompositionTest {
     @Test
     void testComponentIsolation() throws Exception {
         var uuid1 = UUID.randomUUID();
-        var addr1 = ProcessAddress.localhost("p1", findAvailablePort());
+        // Bind ephemeral port 0; no find-then-bind TOCTOU (Luciferase-fehvz).
+        var bind1 = ProcessAddress.localhost("p1", 0);
 
-        transport1 = TestTransportFactory.createTestTransport(uuid1, addr1);
+        transport1 = TestTransportFactory.createTestTransport(uuid1, bind1);
 
-        // MemberDirectory operation should work before connection
+        // MemberDirectory operation should work before connection. addr2 is a routing entry only — uuid2 is
+        // never bound/connected here — so a fixed placeholder port is fine (no port allocation needed).
         var uuid2 = UUID.randomUUID();
-        var addr2 = ProcessAddress.localhost("p2", findAvailablePort());
+        var addr2 = ProcessAddress.localhost("p2", 1);
         transport1.registerMember(uuid2, addr2);
 
         assertTrue(transport1.lookupMember(uuid2).isPresent(), "Member registration independent of connection");
         assertFalse(transport1.isConnected(), "Not connected yet");
 
         // ConnectionManager operation should work without members
-        transport1.listenOn(addr1);
+        transport1.listenOn(bind1);
         assertTrue(transport1.isConnected(), "Connection independent of members");
         assertTrue(transport1.lookupMember(uuid2).isPresent(), "Member still registered");
-    }
-
-    private int findAvailablePort() {
-        try (var socket = new ServerSocket(0)) {
-            socket.setReuseAddress(true);
-            return socket.getLocalPort();
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to find available port", e);
-        }
     }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/transport/SocketTransportFirefliesAckTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/transport/SocketTransportFirefliesAckTest.java
@@ -26,6 +26,7 @@ import com.hellblazer.luciferase.simulation.causality.FirefliesViewMonitor;
 import com.hellblazer.luciferase.simulation.delos.fireflies.FirefliesMembershipView;
 import com.hellblazer.luciferase.simulation.delos.mock.MockFirefliesView;
 import com.hellblazer.luciferase.simulation.von.Message;
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
 import com.hellblazer.luciferase.simulation.von.MessageFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -156,6 +157,25 @@ class SocketTransportFirefliesAckTest {
         var ack = ackFuture.get(500, TimeUnit.MILLISECONDS);
         assertNotNull(ack, "ACK should complete when view is stable");
         assertTrue(ackFuture.isDone(), "ACK future should be done");
+    }
+
+    /**
+     * Luciferase-fy8ff: SocketTransport's MessageFactory was hardwired to {@code MessageFactory.system()}, so
+     * ACK timestamps were wall-clock only. {@code setClock} now rebuilds the factory with an injectable clock;
+     * the ACK produced on the send path must carry the injected clock's time.
+     */
+    @Test
+    void ackTimestampUsesInjectedClock() throws Exception {
+        long base = 123_456_789L;
+        transport1.setClock(new TestClock(base)); // rebuilds transport1's MessageFactory with the test clock
+
+        var message = factory.createAck(UUID.randomUUID(), transport2BubbleId);
+        var ackFuture = transport1.sendToNeighborAsync(transport2BubbleId, message);
+
+        var ack = ackFuture.get(500, TimeUnit.MILLISECONDS);
+        assertNotNull(ack, "ACK should complete when view is stable");
+        assertEquals(base, ack.timestamp(),
+                     "ACK timestamp must be stamped by the injected clock (Luciferase-fy8ff), not wall-clock");
     }
 
     /**


### PR DESCRIPTION
Completes remediation of all 22 open children of the simulation deep-review epic **Luciferase-0frcy**. Every fix has a non-vacuous proving test (verified to fail pre-fix where a behavioral change is involved).

## Real production bugs
- **w0fo8** PackHuntingBehavior burst-speed while patrolling toward far prey (chaseRange gate)
- **933d8** CommitteeServiceImpl conflated failed vs pending proposals → distinct terminal failure
- **rr07g** CrossProcessMigration now AutoCloseable (controller thread leak)
- **3l1b5** GrpcBubbleNetworkChannel leaked a JVM shutdown hook per initialize()
- **9niuo** VolumeAnimator delay baseline seeded from system clock before injection

## Production clock-injection
- **bshji** RenderingServer shares its clock instance with EntityStreamConsumer
- **h0hk7** RegionCache gains a Ticker overload for deterministic TTL-eviction
- **fy8ff** SocketTransport setClock rebuilds MessageFactory → deterministic ACK timestamps

## Test hardening
- **pja48** vacuous single-owner assertion → exact count
- **r7yba** GhostSync round-trip asserts epoch/version/timestamp
- **5szpt** @example javadoc shows clock.currentTimeMillis() not System.*
- **qqx7i** GhostStateManagerNullSafetyTest injects a TestClock
- **38uf3** deterministic baseline + CI-gated perf asserts in timeout scaling test
- **ze0eq** 31 committee-test System.currentTimeMillis() sites → fixed-base clock
- **jc1kh** ~69 topology-test sites → injected clock (BoundaryStressAnalyzer clock wired in)
- **rtffx** non-null snapshot WAL round-trip coverage
- **fehvz** removed find-then-bind port TOCTOU (bind port 0 + getBoundAddress)
- **lch80** removed Thread.sleep timing dependencies in consensus tests
- **csdn1** concurrency regressions: RateLimiter per-IP + RegionBuilder queue admission
- **iveyb** TopologyExecutor concurrency + removed-bubble + split-event coverage
- **yy3r4** deterministic mid-STARTING rollback suppression (latch-gated component)
- **j6ybd** exact entity conservation via deterministic ticks (replaces 10%-loss-tolerant assertion)

## Finding surfaced
`j6ybd` revealed that `MultiBubbleSimulation` commits **zero** successful migrations via `tick()` across all probed fixtures (up to 600 entities / 20k ticks) — a likely-dead live migration-commit path, filed as **Luciferase-0frcy.131** rather than papered over with a contrived test. Likewise `iveyb` corrected the finding's "exactly one success/one failure" premise (split+merge legitimately compose).