### PR TITLE
RDR-015: Revive the dead simulation migration path (single-level bubble-grid partition)

### DIFF
--- a/docs/rdr/RDR-015-simulation-bubble-grid-coordinate-space.md
+++ b/docs/rdr/RDR-015-simulation-bubble-grid-coordinate-space.md
@@ -1,9 +1,12 @@
 ---
 id: RDR-015
 title: Reconcile Simulation Bubble-Grid Coordinate Space — Revive the Dead Migration Path
-status: accepted
+status: closed
 date: 2026-06-06
 accepted_date: 2026-06-06
+closed_date: 2026-06-06
+close_reason: implemented
+post_mortem: post-mortem/015-revive-dead-migration-path.md
 reviewed-by: self
 supersedes: []
 related: [RDR-003]

--- a/docs/rdr/RDR-015-simulation-bubble-grid-coordinate-space.md
+++ b/docs/rdr/RDR-015-simulation-bubble-grid-coordinate-space.md
@@ -203,6 +203,20 @@ partition. Option B's construction uses `TetreeNeighborFinder.findFaceNeighbor`/
 RDR-014 work) to enumerate adjacent same-level tets via reciprocity-correct BFS (validate adjacency by
 involution, NOT shared-vertex count — the Bey-SFC face neighbor is non-conforming).
 
+**F6 — Adaptive bubble bounds are a THIRD, independent dead-migration cause (discovered during P3
+implementation, 2026-06-06).** The original root-cause analysis (coordinate-space mismatch + mixed-level
+non-partition) was necessary but **not sufficient**. After P1 (single-level partition) + P2 (partition-level
+router), an end-to-end diagnostic still committed ZERO migrations. Cause:
+`TetrahedralContainmentChecker.checkMigrations` tested escape against `EnhancedBubble.bounds()`, which is the
+**adaptive entity-derived AABB** — `BubbleBoundsTracker.onEntityMoved → recalculateBounds →
+BubbleBounds.fromEntityPositions` recomputes `rdgMin/rdgMax` to the entities' own min/max every tick. That box
+always wraps its own entities, so `!bounds.contains(position)` is never true and no migration candidate is ever
+produced (the same false-negative also gated `migrationCandidate`'s hysteresis). **Fix (P3):** containment and
+hysteresis test against the bubble's **fixed registration cell** (`EnhancedBubble.spatialKey()` →
+`BubbleBounds.fromTetreeKey`), which does not move. After the fix the live `tick()` path commits migrations
+(≈1982 over 3000 ticks at 200 entities, 0 failures, exact conservation). The directed regression (AC5) was
+upgraded from a unit-level router probe to a true end-to-end subsystem test that exercises this gate.
+
 **F5 — RDR-003 reinforces Option B and conflicts with Option C.** RDR-003's `SpatialLevelHeuristic` is built
 on the explicit premise that "VoN entity positions are placed directly into [Tetree absolute coordinate
 space] without rescaling, so AoI radii are comparable to cell-edges 1:1" — i.e. WorldBounds-scale Cartesian.

--- a/docs/rdr/post-mortem/015-revive-dead-migration-path.md
+++ b/docs/rdr/post-mortem/015-revive-dead-migration-path.md
@@ -1,0 +1,62 @@
+# Post-Mortem: RDR-015 — Reconcile Simulation Bubble-Grid Coordinate Space (Revive the Dead Migration Path)
+
+**Closed:** 2026-06-06 · **Reason:** implemented · **Branch:** `feature/j8p8n-rdr-015-coordinate-space` (commits `5a88ec2b..6e251328`)
+
+## What shipped
+
+`MultiBubbleSimulation`'s bubble-to-bubble migration was dead on the live path (`tick()` committed
+zero migrations). Under Option B it now commits migrations end-to-end — ≈1982 over 3000 ticks at 200
+entities, **0 failures, exact entity conservation**.
+
+The fix had three independent parts:
+1. **Coordinate contract (AC1):** entities are WorldBounds-scale Cartesian, placed directly into the
+   Tetree absolute coordinate space without rescaling. The aspirational "RDGCS coordinates" javadoc was
+   corrected; no world↔RDGCS scale transform was introduced (Option C rejected).
+2. **Single-level partition (AC2/AC3, AC4):** `TetreeBubbleGrid.createBubbles(int, WorldBounds, long)`
+   builds a same-level adjacent partition tiling the world domain (level chosen by
+   `lengthAtLevel(L) <= size/cbrt(N)`, seed at centre, BFS over involution-reciprocal face neighbors,
+   cell-AABB-overlap inclusion for boundary coverage). The router queries the partition level directly
+   instead of a level-0-first scan.
+3. **Fixed-cell containment (AC5/AC6):** escape is tested against each bubble's fixed registration cell
+   (`EnhancedBubble.spatialKey`), not the adaptive entity-derived bounds.
+
+## Key divergence — incomplete root-cause analysis (the main lesson)
+
+The RDR's accepted root-cause analysis named **two** causes (coordinate-space mismatch + mixed-level
+non-partition grid). After P1 + P2 fixed both, an end-to-end diagnostic still committed **zero
+migrations**. A **third, independent cause** surfaced only during P3 implementation (recorded as finding
+**F6**): `checkMigrations` tested escape against `EnhancedBubble.bounds()` — the *adaptive* AABB that
+`BubbleBoundsTracker` recomputes from the entities every tick. That box always wraps its own entities,
+so `!contains(position)` was never true, and the hysteresis gate shared the same false negative.
+
+Why the analysis missed it: the diagnostic evidence in the RDR (`escapedBounds=0`) is equally explained
+by *either* the scale mismatch *or* the adaptive bounds. The investigation attributed the symptom to the
+first cause it found and stopped. **Lesson:** when a symptom has multiple sufficient explanations, fixing
+one and re-measuring is the only way to confirm — a green unit test at one layer (the directed router
+probe) masked a dead gate one layer up. The directed regression was consequently upgraded from a
+unit-level router probe to a true end-to-end subsystem test.
+
+## Process notes
+
+- The stacked review (code-review-expert + substantive-critic) returned **0 Critical**; both caught real
+  Significant items. Applied immediately: boundary-coverage tiling + coverage test, negative-bounds
+  guard, seed null-check, doc corrections.
+- **F6 was added to an already-accepted RDR** without re-running the gate (critic finding #4). This is a
+  process gap: the gate record predates the third cause. It was accepted here because the fix is squarely
+  in service of the RDR's title ("revive the dead path") and was documented, not silent — but a stricter
+  reading would re-gate.
+
+## Deferred (filed, not silent)
+
+- `Luciferase-9eyqy` — dynamic topology (`BubbleSplitter` inserts `parentLevel+1` children) re-breaks the
+  same-level partition; explicitly out of scope per the RDR Scope decision (AC7).
+- `Luciferase-6kod9` — escape uses an RDG-AABB outer approximation, not exact tetrahedral containment.
+  This is why the directed test asserts the specific *containing* cell (anti-catch-all, non-vacuous) but
+  not strict *face*-adjacency; the exact-containment switch also reworks the hysteresis gate.
+- `Luciferase-0941e` — the partition over-produces bubbles vs the requested count (~162 for N=8); `count`
+  is effectively a granularity hint.
+
+## ACs
+
+All eight satisfied. AC1→P2, AC2→P1, AC3→P0/P1, AC4→P2, AC5→P3, AC6→P3, AC7→`9eyqy` (P4),
+AC8→`0frcy.131` closed (P4). phase-review-gate PASSED.

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/BubbleGridOrchestrator.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/BubbleGridOrchestrator.java
@@ -17,6 +17,7 @@
 package com.hellblazer.luciferase.simulation.bubble;
 
 import com.hellblazer.luciferase.lucien.tetree.Tetree;
+import com.hellblazer.luciferase.simulation.config.WorldBounds;
 import com.hellblazer.luciferase.simulation.entity.StringEntityID;
 
 /**
@@ -107,5 +108,19 @@ public class BubbleGridOrchestrator {
      */
     public void createBubbles(int bubbleCount, int entityCount, int maxEntitiesPerBubble) {
         TetreeBubbleFactory.createBubbles(bubbleGrid, bubbleCount, maxLevel, maxEntitiesPerBubble);
+    }
+
+    /**
+     * Build the bubble grid as a single-level spatial partition tiling the world domain (RDR-015 AC2,
+     * Option B), so a face-crossing entity routes to a real neighbor bubble. Replaces the legacy
+     * mixed-level {@link #createBubbles(int, int, int)} on the migration-live path.
+     *
+     * @param bubbleCount   granularity hint (drives partition-level selection)
+     * @param worldBounds   the entity world domain to tile
+     * @param targetFrameMs per-bubble frame-time budget
+     * @return the chosen partition level {@code L}
+     */
+    public byte createPartition(int bubbleCount, WorldBounds worldBounds, long targetFrameMs) {
+        return bubbleGrid.createBubbles(bubbleCount, worldBounds, targetFrameMs);
     }
 }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/EnhancedBubble.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/EnhancedBubble.java
@@ -1,6 +1,7 @@
 package com.hellblazer.luciferase.simulation.bubble;
 
 import com.hellblazer.luciferase.lucien.entity.EntityData;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
 import com.hellblazer.luciferase.simulation.entity.StringEntityID;
 import com.hellblazer.luciferase.simulation.ghost.GhostChannel;
 import com.hellblazer.luciferase.simulation.ghost.GhostStateManager;
@@ -68,6 +69,15 @@ public class EnhancedBubble implements AutoCloseable {
     /** True only when this bubble created (owns) the RealTimeController. */
     private final boolean ownsController;
     private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    /**
+     * The grid registration key — the FIXED partition cell this bubble owns (RDR-015). Assigned by
+     * {@link TetreeBubbleGrid} when the bubble is registered; {@code null} for a bubble not in a grid.
+     * Migration containment must test entities against this cell's bounds (which do not move), not the
+     * adaptive entity-derived {@link #bounds()} (which re-wrap the entities every tick and so can never
+     * report an escape).
+     */
+    private volatile TetreeKey<?> spatialKey;
 
     /**
      * Create an enhanced bubble with spatial indexing and monitoring.
@@ -206,6 +216,26 @@ public class EnhancedBubble implements AutoCloseable {
      */
     public BubbleBounds bounds() {
         return boundsTracker.bounds();
+    }
+
+    /**
+     * The grid registration key (FIXED partition cell), or {@code null} if this bubble is not registered
+     * in a {@link TetreeBubbleGrid}. Set by the grid at registration time.
+     *
+     * @return the registration {@link TetreeKey}, or {@code null}
+     */
+    public TetreeKey<?> spatialKey() {
+        return spatialKey;
+    }
+
+    /**
+     * Record the grid registration key (FIXED partition cell). Called by {@link TetreeBubbleGrid} on
+     * registration; not for general use.
+     *
+     * @param spatialKey the registration key
+     */
+    void setSpatialKey(TetreeKey<?> spatialKey) {
+        this.spatialKey = spatialKey;
     }
 
     /**

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/EntityDistribution.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/EntityDistribution.java
@@ -64,7 +64,10 @@ public class EntityDistribution {
      * Records entity identity, position, and optional velocity for initialization.
      *
      * @param id       Entity identifier (must be unique)
-     * @param position Entity position in RDGCS coordinates
+     * @param position Entity position in WorldBounds-scale Cartesian coordinates, placed directly into
+     *                 the Tetree absolute coordinate space without rescaling (RDR-015 AC1, F1/F5). The
+     *                 earlier "RDGCS coordinates" wording was aspirational and never implemented — there
+     *                 is no world&harr;RDGCS scale transform (Option C rejected).
      * @param velocity Entity velocity (may be null, initialized later if needed)
      */
     public record EntitySpec(String id, Point3f position, Vector3f velocity) {
@@ -86,7 +89,16 @@ public class EntityDistribution {
         this.bubbleGrid = Objects.requireNonNull(grid, "TetreeBubbleGrid cannot be null");
         this.tetree = Objects.requireNonNull(tetree, "Tetree cannot be null");
         this.entityToBubbleMapping = new ConcurrentHashMap<>();
-        this.defaultLevel = 10; // Middle-range level for locating entities
+        this.defaultLevel = 10; // Fallback locate level for legacy (non-partition) grids
+    }
+
+    /**
+     * The level at which to locate entities: the grid's partition level when it is a single-level
+     * spatial partition (RDR-015), otherwise the legacy {@link #defaultLevel}.
+     */
+    private byte effectiveLevel() {
+        byte partitionLevel = bubbleGrid.getPartitionLevel();
+        return partitionLevel > 0 ? partitionLevel : defaultLevel;
     }
 
     /**
@@ -127,10 +139,13 @@ public class EntityDistribution {
      * @throws IllegalArgumentException if entity position is invalid or out of bounds
      */
     private void distributeEntity(EntitySpec entity) {
-        // Locate tetrahedron containing this position
+        // Locate tetrahedron containing this position. On a single-level partition (RDR-015) entities
+        // must be placed at the partition level L so they land in the bubble that actually contains them;
+        // a coarser/finer default level would mis-key the entity and force the arbitrary nearest-bubble
+        // fallback (which breaks face-crossing migration).
         Tet tet;
         try {
-            tet = tetree.locateTetrahedron(entity.position, defaultLevel);
+            tet = tetree.locateTetrahedron(entity.position, effectiveLevel());
         } catch (Exception e) {
             throw new IllegalArgumentException(
                 "Failed to locate tetrahedron for entity " + entity.id +
@@ -294,7 +309,7 @@ public class EntityDistribution {
             // Locate where entity should be based on position
             Tet tet;
             try {
-                tet = tetree.locateTetrahedron(entity.position, defaultLevel);
+                tet = tetree.locateTetrahedron(entity.position, effectiveLevel());
             } catch (Exception e) {
                 return false; // Position invalid
             }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/MultiBubbleSimulation.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/MultiBubbleSimulation.java
@@ -159,7 +159,7 @@ public class MultiBubbleSimulation implements AutoCloseable {
         this.queryService = new SimulationQueryService(bubbleGrid, ghostSyncAdapter, populationManager, metrics);
 
         // Setup simulation: create bubbles and distribute entities
-        initializeSimulation(bubbleCount, entityCount);
+        initializeSimulation(bubbleCount, entityCount, worldBounds);
 
         // Phase 5D: Initialize migration log and manager
         this.migrationLog = new MigrationLog();
@@ -185,10 +185,12 @@ public class MultiBubbleSimulation implements AutoCloseable {
      * @param bubbleCount Number of bubbles to create
      * @param entityCount Number of entities to spawn
      */
-    private void initializeSimulation(int bubbleCount, int entityCount) {
-        // Step 1: Create bubbles distributed across tree levels
-        var maxEntitiesPerBubble = (entityCount / bubbleCount) + 50; // +50 buffer for migration
-        gridOrchestrator.createBubbles(bubbleCount, entityCount, maxEntitiesPerBubble);
+    private void initializeSimulation(int bubbleCount, int entityCount, WorldBounds worldBounds) {
+        // Step 1: Create bubbles as a single-level spatial partition tiling the world domain (RDR-015
+        // Option B). This replaces the legacy mixed-level distribution whose L0 root catch-all + nested
+        // keys made the migration path dead: entities confined to the world corner never escaped their
+        // (astronomically larger) bubble bounds, so no migration candidate was ever produced.
+        gridOrchestrator.createPartition(bubbleCount, worldBounds, DEFAULT_TICK_INTERVAL_MS);
 
         // Step 2: Generate entity positions
         var entities = populationManager.populateEntities(entityCount);

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetrahedralContainmentChecker.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetrahedralContainmentChecker.java
@@ -81,33 +81,26 @@ public class TetrahedralContainmentChecker {
         Objects.requireNonNull(bubble, "Bubble cannot be null");
 
         var migrations = new ArrayList<MigrationRecord>();
-        var bounds = bubble.bounds();
 
-        // Early return if no bounds (no entities)
-        if (bounds == null) {
-            return migrations;
-        }
-
-        // Get the bubble's TetreeKey directly from its own bounds — O(1).
-        // The previous implementation scanned bubbleGrid.getAllBubbles() to find
-        // the matching bubble and then called findBubbleKey(), which scanned the
-        // same list a SECOND time, for an O(n) cost per call. Since checkMigrations
-        // is invoked once per bubble per tick, that made the overall cost O(n^2)
-        // in bubble count every tick (Luciferase-0frcy.59). The source key is
-        // simply this bubble's root key — no grid scan is required.
-        TetreeKey<?> bubbleKey = bubble.bounds().rootKey();
-
+        // Source key is the bubble's FIXED registration cell — O(1), stable across ticks (RDR-015).
+        // The previous implementation tested escape against bubble.bounds(), the ADAPTIVE entity-derived
+        // AABB that BubbleBoundsTracker recomputes from the entities every tick. That box always wraps
+        // its own entities, so !contains(position) was never true and NO migration candidate was ever
+        // produced — a dead-migration cause independent of the coordinate-space mismatch. Containment
+        // must be tested against the fixed partition cell the bubble owns.
+        TetreeKey<?> bubbleKey = bubble.spatialKey();
         if (bubbleKey == null) {
-            // Bubble has no key (no bounds) - skip migration check
+            // Bubble not registered in a partition grid (e.g. legacy/standalone) - skip migration check.
             return migrations;
         }
+        var cellBounds = BubbleBounds.fromTetreeKey(bubbleKey);
 
         // Check each entity for containment
         for (var entity : bubble.getAllEntityRecords()) {
             var position = entity.position();
 
-            // Containment check: is entity still within bubble bounds?
-            if (!bounds.contains(position)) {
+            // Containment check: is entity still within the fixed partition-cell bounds?
+            if (!cellBounds.contains(position)) {
                 // Entity escaped - find destination
                 var destKey = locateDestinationBubble(position);
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetrahedralContainmentChecker.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetrahedralContainmentChecker.java
@@ -147,8 +147,22 @@ public class TetrahedralContainmentChecker {
      */
     public TetreeKey<?> locateDestinationBubble(Point3f position) {
         try {
-            // Use Tetree to find containing tetrahedron
-            // Try at multiple levels to find a bubble that exists
+            // When the grid is a single-level spatial partition (RDR-015 AC4), the destination is the
+            // bubble at the partition level L directly containing the position — NOT the first level in a
+            // 0..N scan. The old level-0-first scan resolved escaped entities to the all-containing L0
+            // root (a catch-all) on the mixed-level grid, and could not reach a partition deeper than the
+            // scan's level cap at all (returning null). Query at L directly.
+            byte partitionLevel = bubbleGrid.getPartitionLevel();
+            if (partitionLevel > 0) {
+                var tet = tetree.locateTetrahedron(position, partitionLevel);
+                if (tet == null) {
+                    return null;
+                }
+                var key = tet.tmIndex();
+                return bubbleGrid.containsBubble(key) ? key : null;
+            }
+
+            // Legacy fallback (non-partition grid): scan a level range for the first existing bubble.
             for (byte level = 0; level <= 10; level++) {
                 var tet = tetree.locateTetrahedron(position, level);
                 if (tet == null) {

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetrahedralMigration.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetrahedralMigration.java
@@ -142,8 +142,11 @@ public class TetrahedralMigration {
         for (var bubble : bubbleGrid.getAllBubbles()) {
             var bubbleMigrations = checker.checkMigrations(bubble);
 
-            // Filter by migration candidate criteria
-            var bounds = bubble.bounds();
+            // Hysteresis is measured against the FIXED partition cell, consistent with the escape test
+            // (RDR-015). The adaptive bubble.bounds() wraps its entities, so overshoot past it is ~0 and
+            // would re-suppress every migration the containment check just admitted.
+            var cellKey = bubble.spatialKey();
+            var bounds = cellKey != null ? BubbleBounds.fromTetreeKey(cellKey) : bubble.bounds();
             for (var migration : bubbleMigrations) {
                 if (migrationCandidate(migration, currentTick, bounds)) {
                     allMigrations.add(migration);

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetrahedralMigrationRouter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetrahedralMigrationRouter.java
@@ -85,9 +85,27 @@ public class TetrahedralMigrationRouter {
                          bubbleGrid.getBubble(migration.destBubbleKey()) : null;
 
         if (destBubble == null) {
-            // Fallback: try to relocate using current position
+            // Fallback: try to relocate using current position.
             try {
-                // Try multiple levels to find a bubble
+                // On a single-level partition (RDR-015 AC4), relocate at the partition level L directly
+                // instead of scanning levels 0..10 (which resolves to a catch-all or misses a partition
+                // deeper than the cap).
+                byte partitionLevel = bubbleGrid.getPartitionLevel();
+                if (partitionLevel > 0) {
+                    var tet = tetree.locateTetrahedron(migration.position(), partitionLevel);
+                    if (tet != null && bubbleGrid.containsBubble(tet.tmIndex())) {
+                        return new MigrationDecision(
+                            migration.entityId(),
+                            migration.sourceBubbleKey(),
+                            tet.tmIndex(),
+                            1.0f,
+                            false
+                        );
+                    }
+                    return null;
+                }
+
+                // Legacy fallback (non-partition grid): scan a level range.
                 for (byte level = 0; level <= 10; level++) {
                     var tet = tetree.locateTetrahedron(migration.position(), level);
                     if (tet != null) {

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGrid.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGrid.java
@@ -168,6 +168,9 @@ public class TetreeBubbleGrid {
                 var bounds = BubbleBounds.fromTetreeKey(key);
                 var location = new BubbleLocation(key, bounds);
 
+                // Record the fixed registration cell on the bubble.
+                bubble.setSpatialKey(key);
+
                 // Register in maps
                 bubblesByKey.put(key, bubble);
 
@@ -619,6 +622,9 @@ public class TetreeBubbleGrid {
         if (bubblesByKey.containsKey(key)) {
             throw new IllegalArgumentException("Bubble already exists at key: " + key);
         }
+
+        // Record the fixed registration cell on the bubble so migration containment can test against it.
+        bubble.setSpatialKey(key);
 
         // Add to key map
         bubblesByKey.put(key, bubble);

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGrid.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGrid.java
@@ -57,6 +57,14 @@ public class TetreeBubbleGrid {
     private final byte maxLevel;
 
     /**
+     * The single level at which all bubbles reside when this grid was built as a spatial partition
+     * (RDR-015 AC2). {@code -1} means "not a single-level partition" — the grid is empty or was built
+     * via the legacy mixed-level {@link #createBubbles(int, byte, long)}. Routing/distribution query
+     * directly at this level when it is {@code > 0}, instead of scanning levels.
+     */
+    private volatile byte partitionLevel = -1;
+
+    /**
      * Create a new TetreeBubbleGrid.
      *
      * @param maxLevel Maximum refinement level for bubble distribution
@@ -106,8 +114,9 @@ public class TetreeBubbleGrid {
             throw new IllegalArgumentException("Target frame time must be positive, got: " + targetFrameMs);
         }
 
-        // Clear existing bubbles
+        // Clear existing bubbles. Legacy mixed-level distribution is NOT a single-level partition.
         bubblesByKey.clear();
+        partitionLevel = -1;
 
         // Determine number of levels to use
         int numLevels = Math.min(maxLevel + 1, count);
@@ -263,7 +272,20 @@ public class TetreeBubbleGrid {
             addBubble(bubble, entry.getKey());
         }
 
+        partitionLevel = level;
         return level;
+    }
+
+    /**
+     * The single level at which all bubbles reside when this grid is a spatial partition (RDR-015 AC2),
+     * or {@code -1} if the grid is empty or was built via the legacy mixed-level
+     * {@link #createBubbles(int, byte, long)}. Routing and distribution query the Tetree directly at
+     * this level instead of scanning a level range.
+     *
+     * @return the partition level {@code L > 0}, or {@code -1} if not a single-level partition
+     */
+    public byte getPartitionLevel() {
+        return partitionLevel;
     }
 
     /**
@@ -667,5 +689,6 @@ public class TetreeBubbleGrid {
     public void clear() {
         bubblesByKey.clear();
         neighborFinder.clearCache();
+        partitionLevel = -1;
     }
 }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGrid.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGrid.java
@@ -16,9 +16,11 @@
  */
 package com.hellblazer.luciferase.simulation.bubble;
 
+import com.hellblazer.luciferase.lucien.Constants;
 import com.hellblazer.luciferase.lucien.tetree.Tet;
 import com.hellblazer.luciferase.lucien.tetree.Tetree;
 import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+import com.hellblazer.luciferase.simulation.config.WorldBounds;
 import com.hellblazer.luciferase.simulation.entity.StringEntityID;
 import com.hellblazer.luciferase.simulation.entity.StringEntityIDGenerator;
 
@@ -173,6 +175,122 @@ public class TetreeBubbleGrid {
                 createdCount++;
             }
         }
+    }
+
+    /**
+     * Build the bubble grid as a SINGLE-LEVEL adjacent spatial partition tiling the
+     * {@link WorldBounds} domain (RDR-015 AC2, Option B).
+     * <p>
+     * Unlike the legacy {@link #createBubbles(int, byte, long)} — which distributes bubbles across
+     * <em>mixed</em> tree levels (an L0 root catch-all plus nested children) and is therefore not a
+     * spatial partition — this method emits a set of <em>same-level</em>, face-adjacent tetrahedra
+     * that tile the world domain, so an entity crossing a bubble face lands in a real neighbor bubble
+     * and the migration path is well-defined.
+     * <p>
+     * Coordinates are placed directly into the Tetree absolute integer-coordinate space without
+     * rescaling (RDR-003 / RDR-015 F5): a world coordinate {@code w} is the Tetree coordinate {@code w}.
+     * <p>
+     * <b>Level selection.</b> The partition level {@code L} is the finest level whose cell-edge is no
+     * coarser than the requested granularity: {@code lengthAtLevel(L) <= WorldBounds.size() / cbrt(N)}.
+     * {@code L} is clamped to {@code [1, MAX_REFINEMENT_LEVEL]} — never the L0 root.
+     * <p>
+     * <b>Seeding + tiling.</b> Seeds from the level-{@code L} tet containing the world centre, then
+     * BFS over <b>same-level face neighbors</b>, including a neighbor iff its centroid lies inside the
+     * world bounds. Adjacency is confirmed by <b>involution reciprocity</b>
+     * ({@code faceNeighbor(faceNeighbor(t,f).face()).tet() == t}), never a shared-vertex count: the
+     * Bey-SFC face neighbor is non-conforming (shares 0–3 vertices — see CLAUDE.md). The in-bounds
+     * level-{@code L} tet set is finite, so BFS terminates.
+     *
+     * @param targetBubbleCount granularity hint {@code N} (drives level selection; the realized count
+     *                          is the number of in-bounds level-{@code L} tets, which may exceed {@code N})
+     * @param worldBounds       the entity world domain to tile
+     * @param targetFrameMs     per-bubble frame-time budget
+     * @return the chosen partition level {@code L}
+     * @throws IllegalArgumentException if {@code targetBubbleCount <= 0} or {@code targetFrameMs <= 0}
+     * @throws NullPointerException     if {@code worldBounds} is null
+     */
+    public byte createBubbles(int targetBubbleCount, WorldBounds worldBounds, long targetFrameMs) {
+        if (targetBubbleCount <= 0) {
+            throw new IllegalArgumentException("Target bubble count must be positive, got: " + targetBubbleCount);
+        }
+        Objects.requireNonNull(worldBounds, "WorldBounds cannot be null");
+        if (targetFrameMs <= 0) {
+            throw new IllegalArgumentException("Target frame time must be positive, got: " + targetFrameMs);
+        }
+
+        var level = choosePartitionLevel(worldBounds, targetBubbleCount);
+
+        // Seed from the level-L tet containing the world centre.
+        var centre = worldBounds.center();
+        var seed = Tet.locatePointBeyRefinementFromRoot(centre, centre, centre, level);
+
+        // BFS over same-level reciprocal face neighbors whose centroid lies inside the world domain.
+        var partition = new LinkedHashMap<TetreeKey<?>, Tet>();
+        var queue = new ArrayDeque<Tet>();
+        partition.put(seed.tmIndex(), seed);
+        queue.add(seed);
+
+        while (!queue.isEmpty()) {
+            var current = queue.poll();
+            for (int face = 0; face < 4; face++) {
+                var fn = current.faceNeighbor(face);
+                if (fn == null) {
+                    continue; // domain boundary
+                }
+                // Involution reciprocity: the dual face must point back to current.
+                var back = fn.tet().faceNeighbor(fn.face());
+                if (back == null || !current.equals(back.tet())) {
+                    continue;
+                }
+                var neighbor = fn.tet();
+                if (!centroidInBounds(neighbor, worldBounds)) {
+                    continue;
+                }
+                var key = neighbor.tmIndex();
+                if (partition.containsKey(key)) {
+                    continue;
+                }
+                partition.put(key, neighbor);
+                queue.add(neighbor);
+            }
+        }
+
+        // Materialize the partition.
+        bubblesByKey.clear();
+        neighborFinder.clearCache();
+        for (var entry : partition.entrySet()) {
+            var bubble = new EnhancedBubble(UUID.randomUUID(), level, targetFrameMs);
+            addBubble(bubble, entry.getKey());
+        }
+
+        return level;
+    }
+
+    /**
+     * Choose the finest partition level whose cell-edge is no coarser than
+     * {@code WorldBounds.size() / cbrt(targetBubbleCount)} (RDR-015 AC2). Clamped to
+     * {@code [1, MAX_REFINEMENT_LEVEL]} so the partition is never the L0 root.
+     */
+    private static byte choosePartitionLevel(WorldBounds worldBounds, int targetBubbleCount) {
+        double cellTarget = worldBounds.size() / Math.cbrt(targetBubbleCount);
+        byte maxLevel = Constants.getMaxRefinementLevel();
+        // lengthAtLevel(L) = 2^(maxLevel - L); want 2^(maxLevel - L) <= cellTarget.
+        for (byte level = 1; level < maxLevel; level++) {
+            if (Constants.lengthAtLevel(level) <= cellTarget) {
+                return level;
+            }
+        }
+        return maxLevel;
+    }
+
+    /** True iff the tetrahedral centroid of {@code tet} lies within the world bounds (raw coordinates). */
+    private static boolean centroidInBounds(Tet tet, WorldBounds worldBounds) {
+        var c = tet.coordinates();
+        double cx = (c[0].x + c[1].x + c[2].x + c[3].x) / 4.0;
+        double cy = (c[0].y + c[1].y + c[2].y + c[3].y) / 4.0;
+        double cz = (c[0].z + c[1].z + c[2].z + c[3].z) / 4.0;
+        return worldBounds.contains((float) cx) && worldBounds.contains((float) cy)
+               && worldBounds.contains((float) cz);
     }
 
     /**

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGrid.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGrid.java
@@ -229,14 +229,32 @@ public class TetreeBubbleGrid {
         if (targetFrameMs <= 0) {
             throw new IllegalArgumentException("Target frame time must be positive, got: " + targetFrameMs);
         }
+        // The Tetree coordinate domain is non-negative ([0, 2^21)); WorldBounds-Cartesian entity positions are
+        // placed directly into it without rescaling (RDR-015 F1/F5). A negative world bound would yield entity
+        // positions that fail Tetree.locateTetrahedron at distribution/migration time — fail loud at setup.
+        if (worldBounds.min() < 0f) {
+            throw new IllegalArgumentException(
+                "WorldBounds.min must be >= 0 for a Tetree partition (non-negative coordinate domain), got: "
+                + worldBounds.min());
+        }
 
         var level = choosePartitionLevel(worldBounds, targetBubbleCount);
 
         // Seed from the level-L tet containing the world centre.
         var centre = worldBounds.center();
         var seed = Tet.locatePointBeyRefinementFromRoot(centre, centre, centre, level);
+        if (seed == null) {
+            throw new IllegalArgumentException(
+                "World centre " + centre + " is outside the Tetree domain [0, 2^21); check WorldBounds");
+        }
 
-        // BFS over same-level reciprocal face neighbors whose centroid lies inside the world domain.
+        // NOTE: construction is not thread-safe; callers must build the partition before exposing the grid to
+        // concurrent readers. partitionLevel is published last, so a racing reader could transiently observe an
+        // empty/partial grid with partitionLevel == -1 (legacy fallback). Acceptable: MultiBubbleSimulation
+        // builds the grid in its constructor, single-threaded, before tick().
+        //
+        // BFS over same-level reciprocal face neighbors whose CELL overlaps the world domain (so the tiling
+        // covers the WorldBounds boundary shell, not just cells whose centroid is interior).
         var partition = new LinkedHashMap<TetreeKey<?>, Tet>();
         var queue = new ArrayDeque<Tet>();
         partition.put(seed.tmIndex(), seed);
@@ -255,7 +273,7 @@ public class TetreeBubbleGrid {
                     continue;
                 }
                 var neighbor = fn.tet();
-                if (!centroidInBounds(neighbor, worldBounds)) {
+                if (!cellOverlapsBounds(neighbor, worldBounds)) {
                     continue;
                 }
                 var key = neighbor.tmIndex();
@@ -292,8 +310,10 @@ public class TetreeBubbleGrid {
     }
 
     /**
-     * Choose the finest partition level whose cell-edge is no coarser than
-     * {@code WorldBounds.size() / cbrt(targetBubbleCount)} (RDR-015 AC2). Clamped to
+     * Choose the coarsest partition level whose cell-edge is no larger than
+     * {@code WorldBounds.size() / cbrt(targetBubbleCount)} (RDR-015 AC2) — i.e. cells are no coarser than the
+     * requested granularity. Iterates from level 1 upward (coarse → fine) and returns the first level that
+     * fits, so the partition uses the fewest cells satisfying the granularity bound. Clamped to
      * {@code [1, MAX_REFINEMENT_LEVEL]} so the partition is never the L0 root.
      */
     private static byte choosePartitionLevel(WorldBounds worldBounds, int targetBubbleCount) {
@@ -308,14 +328,24 @@ public class TetreeBubbleGrid {
         return maxLevel;
     }
 
-    /** True iff the tetrahedral centroid of {@code tet} lies within the world bounds (raw coordinates). */
-    private static boolean centroidInBounds(Tet tet, WorldBounds worldBounds) {
+    /**
+     * True iff the tetrahedral cell's axis-aligned bounding box overlaps the world bounds. Used as the BFS
+     * inclusion criterion so the partition covers the entire WorldBounds domain — including the boundary shell,
+     * where a cell can contain in-bounds points (reachable by entities clamped to the world wall) while its
+     * centroid lies just outside. AABB-overlap is a superset of "the cell contains an in-bounds point", so it
+     * guarantees coverage (at the cost of a few empty boundary cells).
+     */
+    private static boolean cellOverlapsBounds(Tet tet, WorldBounds worldBounds) {
         var c = tet.coordinates();
-        double cx = (c[0].x + c[1].x + c[2].x + c[3].x) / 4.0;
-        double cy = (c[0].y + c[1].y + c[2].y + c[3].y) / 4.0;
-        double cz = (c[0].z + c[1].z + c[2].z + c[3].z) / 4.0;
-        return worldBounds.contains((float) cx) && worldBounds.contains((float) cy)
-               && worldBounds.contains((float) cz);
+        int minX = Math.min(Math.min(c[0].x, c[1].x), Math.min(c[2].x, c[3].x));
+        int maxX = Math.max(Math.max(c[0].x, c[1].x), Math.max(c[2].x, c[3].x));
+        int minY = Math.min(Math.min(c[0].y, c[1].y), Math.min(c[2].y, c[3].y));
+        int maxY = Math.max(Math.max(c[0].y, c[1].y), Math.max(c[2].y, c[3].y));
+        int minZ = Math.min(Math.min(c[0].z, c[1].z), Math.min(c[2].z, c[3].z));
+        int maxZ = Math.max(Math.max(c[0].z, c[1].z), Math.max(c[2].z, c[3].z));
+        float lo = worldBounds.min();
+        float hi = worldBounds.max();
+        return maxX >= lo && minX <= hi && maxY >= lo && minY <= hi && maxZ >= lo && minZ <= hi;
     }
 
     /**

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/DirectedMigrationRegressionTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/DirectedMigrationRegressionTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.simulation.bubble;
+
+import com.hellblazer.luciferase.lucien.tetree.Tet;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3f;
+import javax.vecmath.Point3i;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Directed-migration regression for RDR-015 (AC5) — <b>non-vacuous</b>.
+ * <p>
+ * Places a probe at a position strictly inside a KNOWN same-level face-neighbor bubble {@code B}
+ * of a source bubble {@code S} and asserts the router resolves that position to <b>{@code B}
+ * specifically</b> ({@code destinationBubbleKey == expectedNeighborKey}), NOT merely
+ * {@code getTotalMigrations() > 0} — a catch-all router (the current level-0-first scan that
+ * resolves almost everything to the all-containing L0 root) would satisfy the weak form while
+ * routing to the wrong bubble.
+ * <p>
+ * <b>TDD status (RDR-015 P0): RED against current code, intentionally.</b> Two ways it fails today:
+ * <ol>
+ *   <li>{@link TetreeBubbleGrid#createBubbles} builds a mixed-level (non-partition) grid, so a
+ *       same-level in-grid face-neighbor pair may not exist — the setup {@code assertNotNull}
+ *       fails meaningfully (grid is not a connected same-level partition).</li>
+ *   <li>Even when a neighbor pair exists, {@link TetrahedralContainmentChecker#locateDestinationBubble}
+ *       scans levels 0..10 and returns the first match — the L0 root catch-all — instead of the
+ *       partition-level neighbor {@code B}.</li>
+ * </ol>
+ * Goes green once P1 reworks {@code createBubbles} into a single-level partition (AC2) and P2
+ * replaces the router's level-0-first scan with a direct lookup at the partition level
+ * {@code L} (AC4).
+ *
+ * @author hal.hildebrand
+ */
+class DirectedMigrationRegressionTest {
+
+    private static final int  BUBBLE_COUNT = 8;
+    private static final byte MAX_LEVEL    = (byte) 3;
+    private static final long TARGET_FRAME = 10L;
+
+    @Test
+    void escapedEntityRoutesToTheSpecificAdjacentNeighbor() {
+        var grid = new TetreeBubbleGrid(MAX_LEVEL);
+        grid.createBubbles(BUBBLE_COUNT, MAX_LEVEL, TARGET_FRAME);
+
+        var keySet = new HashSet<>(grid.getBubblesWithKeys().keySet());
+
+        // Find a source bubble S with a same-level, in-grid, involution-reciprocal face neighbor B.
+        TetreeKey<?> expectedNeighborKey = null;
+        Tet neighborTet = null;
+        for (var key : keySet) {
+            var s = key.toTet();
+            var b = firstSameLevelNeighborInGrid(s, keySet);
+            if (b != null) {
+                neighborTet = b;
+                expectedNeighborKey = b.tmIndex();
+                break;
+            }
+        }
+
+        assertNotNull(expectedNeighborKey,
+                      "RDR-015 AC5 setup: the grid must expose a same-level in-grid face-neighbor pair "
+                      + "(a connected partition). If null, createBubbles is not a single-level partition (P1).");
+
+        // Probe: a point strictly inside neighbor B (its tetrahedral centroid). An entity that has
+        // crossed the shared S->B face and now sits here MUST route to B specifically.
+        var probe = centroid(neighborTet);
+
+        var checker = new TetrahedralContainmentChecker(grid.getSpatialIndex(), grid);
+        var destinationBubbleKey = checker.locateDestinationBubble(probe);
+
+        assertEquals(expectedNeighborKey, destinationBubbleKey,
+                     "router must route an escaped entity to the specific adjacent neighbor bubble B, "
+                     + "not a level-0 catch-all (RDR-015 AC4/AC5)");
+    }
+
+    /**
+     * First face neighbor of {@code s} that is (a) present in the partition and (b) involution-reciprocal
+     * ({@code faceNeighbor(faceNeighbor(s,f).face()).tet() == s}). The Bey-SFC face neighbor is
+     * non-conforming (shares 0–3 vertices), so reciprocity — not shared-vertex count — is the correct
+     * adjacency test (CLAUDE.md "Face-neighbor testing caveat").
+     */
+    private static Tet firstSameLevelNeighborInGrid(Tet s, Set<TetreeKey<?>> partition) {
+        for (int face = 0; face < 4; face++) {
+            var fn = s.faceNeighbor(face);
+            if (fn == null) {
+                continue;
+            }
+            var back = fn.tet().faceNeighbor(fn.face());
+            if (back == null || !s.equals(back.tet())) {
+                continue;
+            }
+            if (partition.contains(fn.tet().tmIndex())) {
+                return fn.tet();
+            }
+        }
+        return null;
+    }
+
+    private static Point3f centroid(Tet tet) {
+        Point3i[] c = tet.coordinates();
+        float cx = (c[0].x + c[1].x + c[2].x + c[3].x) / 4.0f;
+        float cy = (c[0].y + c[1].y + c[2].y + c[3].y) / 4.0f;
+        float cz = (c[0].z + c[1].z + c[2].z + c[3].z) / 4.0f;
+        return new Point3f(cx, cy, cz);
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/DirectedMigrationRegressionTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/DirectedMigrationRegressionTest.java
@@ -18,6 +18,7 @@ package com.hellblazer.luciferase.simulation.bubble;
 
 import com.hellblazer.luciferase.lucien.tetree.Tet;
 import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+import com.hellblazer.luciferase.simulation.config.WorldBounds;
 import org.junit.jupiter.api.Test;
 
 import javax.vecmath.Point3f;
@@ -55,14 +56,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 class DirectedMigrationRegressionTest {
 
-    private static final int  BUBBLE_COUNT = 8;
-    private static final byte MAX_LEVEL    = (byte) 3;
-    private static final long TARGET_FRAME = 10L;
+    private static final int         BUBBLE_COUNT = 8;
+    private static final long        TARGET_FRAME = 10L;
+    private static final WorldBounds WORLD        = new WorldBounds(0.0f, 100.0f);
 
     @Test
     void escapedEntityRoutesToTheSpecificAdjacentNeighbor() {
-        var grid = new TetreeBubbleGrid(MAX_LEVEL);
-        grid.createBubbles(BUBBLE_COUNT, MAX_LEVEL, TARGET_FRAME);
+        var grid = new TetreeBubbleGrid((byte) 21);
+        grid.createBubbles(BUBBLE_COUNT, WORLD, TARGET_FRAME);
 
         var keySet = new HashSet<>(grid.getBubblesWithKeys().keySet());
 

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/DirectedMigrationRegressionTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/DirectedMigrationRegressionTest.java
@@ -34,11 +34,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Directed-migration regression for RDR-015 (AC5) — <b>non-vacuous and end-to-end</b>.
  * <p>
  * Drives the full migration subsystem ({@link TetrahedralMigration#checkMigrations}: containment →
- * routing → two-phase execute) and asserts a known entity, placed inside a specific face-neighbor
- * bubble {@code B} of its source bubble {@code S}, actually <b>migrates to {@code B} specifically</b> —
- * it leaves {@code S} and arrives in {@code B}, with exactly one successful migration recorded. This is
- * the load-bearing guarantee the RDR exists to restore; asserting merely
+ * routing → two-phase execute) and asserts a known entity, placed at a position that escapes its source
+ * cell {@code S} and lies in a specific other partition cell {@code B}, actually <b>migrates to {@code B}
+ * specifically</b> — it leaves {@code S} and arrives in {@code B}, with exactly one successful migration
+ * recorded. This is the load-bearing, anti-catch-all guarantee the RDR exists to restore; asserting merely
  * {@code getTotalMigrations() > 0} would be satisfied by a catch-all router routing to the wrong bubble.
+ * <p>
+ * <b>Limitation (tracked follow-up):</b> {@code B} is the cell that geometrically contains the escaped
+ * position, not necessarily the immediate face-adjacent neighbor of {@code S}. Escape is currently tested
+ * against the cell's RDG-AABB (an outer approximation of the tetrahedron), so a point inside the immediate
+ * face neighbor still lies within {@code S}'s AABB and does not register as escaped; only points ~1.5
+ * cell-edges out escape, landing a cell or two away. Asserting strict face-adjacency requires switching the
+ * escape test to exact tetrahedral containment ({@code locateTetrahedron(pos,L) != cellKey}), filed as a
+ * follow-up (it also reworks the spatial-hysteresis gate). The anti-catch-all guarantee here is unaffected.
  * <p>
  * The migration path was dead through three independent causes, all resolved across RDR-015 P1–P3:
  * (1) entity coordinates decoupled from the bubble-grid domain; (2) a mixed-level non-partition grid
@@ -76,6 +84,9 @@ class DirectedMigrationRegressionTest {
             var sc = centroid(key.toTet());
             for (var offset : displacements(edge)) {
                 var p = new Point3f(sc.x + offset[0], sc.y + offset[1], sc.z + offset[2]);
+                if (p.x < 0 || p.y < 0 || p.z < 0) {
+                    continue; // Tetree coordinate domain is non-negative
+                }
                 if (cell.contains(p)) {
                     continue; // not escaped from S's fixed cell
                 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/DirectedMigrationRegressionTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/DirectedMigrationRegressionTest.java
@@ -16,6 +16,7 @@
  */
 package com.hellblazer.luciferase.simulation.bubble;
 
+import com.hellblazer.luciferase.lucien.Constants;
 import com.hellblazer.luciferase.lucien.tetree.Tet;
 import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
 import com.hellblazer.luciferase.simulation.config.WorldBounds;
@@ -23,34 +24,27 @@ import org.junit.jupiter.api.Test;
 
 import javax.vecmath.Point3f;
 import javax.vecmath.Point3i;
-import java.util.HashSet;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Directed-migration regression for RDR-015 (AC5) — <b>non-vacuous</b>.
+ * Directed-migration regression for RDR-015 (AC5) — <b>non-vacuous and end-to-end</b>.
  * <p>
- * Places a probe at a position strictly inside a KNOWN same-level face-neighbor bubble {@code B}
- * of a source bubble {@code S} and asserts the router resolves that position to <b>{@code B}
- * specifically</b> ({@code destinationBubbleKey == expectedNeighborKey}), NOT merely
- * {@code getTotalMigrations() > 0} — a catch-all router (the current level-0-first scan that
- * resolves almost everything to the all-containing L0 root) would satisfy the weak form while
- * routing to the wrong bubble.
+ * Drives the full migration subsystem ({@link TetrahedralMigration#checkMigrations}: containment →
+ * routing → two-phase execute) and asserts a known entity, placed inside a specific face-neighbor
+ * bubble {@code B} of its source bubble {@code S}, actually <b>migrates to {@code B} specifically</b> —
+ * it leaves {@code S} and arrives in {@code B}, with exactly one successful migration recorded. This is
+ * the load-bearing guarantee the RDR exists to restore; asserting merely
+ * {@code getTotalMigrations() > 0} would be satisfied by a catch-all router routing to the wrong bubble.
  * <p>
- * <b>TDD status (RDR-015 P0): RED against current code, intentionally.</b> Two ways it fails today:
- * <ol>
- *   <li>{@link TetreeBubbleGrid#createBubbles} builds a mixed-level (non-partition) grid, so a
- *       same-level in-grid face-neighbor pair may not exist — the setup {@code assertNotNull}
- *       fails meaningfully (grid is not a connected same-level partition).</li>
- *   <li>Even when a neighbor pair exists, {@link TetrahedralContainmentChecker#locateDestinationBubble}
- *       scans levels 0..10 and returns the first match — the L0 root catch-all — instead of the
- *       partition-level neighbor {@code B}.</li>
- * </ol>
- * Goes green once P1 reworks {@code createBubbles} into a single-level partition (AC2) and P2
- * replaces the router's level-0-first scan with a direct lookup at the partition level
- * {@code L} (AC4).
+ * The migration path was dead through three independent causes, all resolved across RDR-015 P1–P3:
+ * (1) entity coordinates decoupled from the bubble-grid domain; (2) a mixed-level non-partition grid
+ * with an L0 catch-all; (3) escape tested against the <em>adaptive</em> entity-derived bounds (which
+ * re-wrap the entities every tick and so never report an escape). Containment now tests against each
+ * bubble's FIXED partition cell.
  *
  * @author hal.hildebrand
  */
@@ -61,62 +55,75 @@ class DirectedMigrationRegressionTest {
     private static final WorldBounds WORLD        = new WorldBounds(0.0f, 100.0f);
 
     @Test
-    void escapedEntityRoutesToTheSpecificAdjacentNeighbor() {
+    void escapedEntityMigratesToTheSpecificAdjacentNeighbor() {
         var grid = new TetreeBubbleGrid((byte) 21);
         grid.createBubbles(BUBBLE_COUNT, WORLD, TARGET_FRAME);
 
-        var keySet = new HashSet<>(grid.getBubblesWithKeys().keySet());
+        byte level = grid.getPartitionLevel();
+        assertTrue(level > 0, "grid must be a single-level partition");
+        var spatial = grid.getSpatialIndex();
+        int edge = Constants.lengthAtLevel(level);
 
-        // Find a source bubble S with a same-level, in-grid, involution-reciprocal face neighbor B.
-        TetreeKey<?> expectedNeighborKey = null;
-        Tet neighborTet = null;
-        for (var key : keySet) {
-            var s = key.toTet();
-            var b = firstSameLevelNeighborInGrid(s, keySet);
-            if (b != null) {
-                neighborTet = b;
-                expectedNeighborKey = b.tmIndex();
-                break;
+        // Find a source cell S and a displaced position P that (a) provably escapes S's fixed cell and
+        // (b) lands in a DIFFERENT existing partition cell B. Using the actual containing cell of P as
+        // the expected destination keeps the assertion specific (== B), not a weak "some migration".
+        TetreeKey<?> sourceKey = null;
+        TetreeKey<?> expectedDestKey = null;
+        Point3f probe = null;
+        outer:
+        for (var key : grid.getBubblesWithKeys().keySet()) {
+            var cell = BubbleBounds.fromTetreeKey(key);
+            var sc = centroid(key.toTet());
+            for (var offset : displacements(edge)) {
+                var p = new Point3f(sc.x + offset[0], sc.y + offset[1], sc.z + offset[2]);
+                if (cell.contains(p)) {
+                    continue; // not escaped from S's fixed cell
+                }
+                var destTet = spatial.locateTetrahedron(p, level);
+                if (destTet == null) {
+                    continue;
+                }
+                var destKey = destTet.tmIndex();
+                if (destKey.equals(key) || !grid.containsBubble(destKey)) {
+                    continue; // must be a different, existing partition cell
+                }
+                sourceKey = key;
+                expectedDestKey = destKey;
+                probe = p;
+                break outer;
             }
         }
+        assertNotNull(expectedDestKey,
+                      "setup: partition must expose a source cell with an escaped position landing in a "
+                      + "different existing cell");
 
-        assertNotNull(expectedNeighborKey,
-                      "RDR-015 AC5 setup: the grid must expose a same-level in-grid face-neighbor pair "
-                      + "(a connected partition). If null, createBubbles is not a single-level partition (P1).");
+        var sourceBubble = grid.getBubble(sourceKey);
+        var destBubble = grid.getBubble(expectedDestKey);
 
-        // Probe: a point strictly inside neighbor B (its tetrahedral centroid). An entity that has
-        // crossed the shared S->B face and now sits here MUST route to B specifically.
-        var probe = centroid(neighborTet);
+        var entityId = "directed-1";
+        sourceBubble.addEntity(entityId, probe, probe);
 
-        var checker = new TetrahedralContainmentChecker(grid.getSpatialIndex(), grid);
-        var destinationBubbleKey = checker.locateDestinationBubble(probe);
+        var migration = new TetrahedralMigration(grid, spatial);
+        migration.checkMigrations(1L);
 
-        assertEquals(expectedNeighborKey, destinationBubbleKey,
-                     "router must route an escaped entity to the specific adjacent neighbor bubble B, "
-                     + "not a level-0 catch-all (RDR-015 AC4/AC5)");
+        assertEquals(1, migration.getMetrics().getTotalMigrations(), "exactly one entity must migrate");
+        assertEquals(0, migration.getMetrics().getFailureCount(), "no migration may fail");
+        assertTrue(containsEntity(destBubble, entityId),
+                   "entity must arrive in the specific destination bubble that contains its position");
+        assertFalse(containsEntity(sourceBubble, entityId),
+                    "entity must no longer reside in the source bubble S");
     }
 
-    /**
-     * First face neighbor of {@code s} that is (a) present in the partition and (b) involution-reciprocal
-     * ({@code faceNeighbor(faceNeighbor(s,f).face()).tet() == s}). The Bey-SFC face neighbor is
-     * non-conforming (shares 0–3 vertices), so reciprocity — not shared-vertex count — is the correct
-     * adjacency test (CLAUDE.md "Face-neighbor testing caveat").
-     */
-    private static Tet firstSameLevelNeighborInGrid(Tet s, Set<TetreeKey<?>> partition) {
-        for (int face = 0; face < 4; face++) {
-            var fn = s.faceNeighbor(face);
-            if (fn == null) {
-                continue;
-            }
-            var back = fn.tet().faceNeighbor(fn.face());
-            if (back == null || !s.equals(back.tet())) {
-                continue;
-            }
-            if (partition.contains(fn.tet().tmIndex())) {
-                return fn.tet();
-            }
-        }
-        return null;
+    /** Axis displacements of 1.5 cell-edges in each direction — far enough to clear the source cell's AABB. */
+    private static float[][] displacements(int edge) {
+        float d = edge * 1.5f;
+        return new float[][] {
+            {d, 0, 0}, {-d, 0, 0}, {0, d, 0}, {0, -d, 0}, {0, 0, d}, {0, 0, -d}
+        };
+    }
+
+    private static boolean containsEntity(EnhancedBubble bubble, String entityId) {
+        return bubble.getAllEntityRecords().stream().anyMatch(r -> r.id().equals(entityId));
     }
 
     private static Point3f centroid(Tet tet) {

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/MultiBubbleSimulationMigrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/MultiBubbleSimulationMigrationTest.java
@@ -104,8 +104,11 @@ class MultiBubbleSimulationMigrationTest {
 
         assertTrue(simulation.getTickCount() >= 2000, "simulation must have advanced the driven ticks");
         assertNotNull(simulation.getMigrationMetrics());
-        // Invariant that holds whether or not a migration commits: the per-tick migration CHECK must never lose
-        // or duplicate an entity. (The old assertTrue(getTotalMigrations() >= 0) was trivially true.)
+        // RDR-015: migration is revived on the live tick() path — entities crossing a bubble face now
+        // route to the real neighbor bubble. This previously committed ZERO migrations (dead path).
+        assertTrue(simulation.getMigrationMetrics().getTotalMigrations() > 0,
+                   "migration must be live: entities crossing bubble faces must commit migrations");
+        // Conservation invariant: the per-tick migration must never lose or duplicate an entity.
         assertConservedAndUnique(initialReal);
     }
 
@@ -114,12 +117,11 @@ class MultiBubbleSimulationMigrationTest {
      * {@code finalEntities >= initialEntities * 0.9}, which tolerated dropping up to 10% of entities every run,
      * and the non-deterministic Thread.sleep). Asserts no loss AND no duplication (Luciferase-j6ybd).
      *
-     * <p><b>Finding (not silent scope reduction):</b> the original AC also asked for a positive-migration
-     * assertion ({@code getTotalMigrations() > 0}). That is NOT asserted here because this simulation commits
-     * ZERO successful migrations through normal {@code tick()} operation — verified across fixtures up to 600
-     * entities in a 15-unit world over 20,000 ticks (all yielded 0). Asserting a migration would be either
-     * impossible or contrived. The likely-dead migration-commit path is filed as a separate defect bead; this
-     * test pins the conservation/uniqueness invariants, which is the load-bearing guarantee regardless.
+     * <p><b>History:</b> this previously could not assert {@code getTotalMigrations() > 0} because the
+     * simulation committed ZERO migrations through normal {@code tick()} (the dead path that motivated
+     * RDR-015). That is now fixed — see {@code testSimulationRunsWithMigration}, which asserts migration is
+     * live. This test pins the conservation/uniqueness invariants that must hold ACROSS those migrations
+     * (RDR-015 AC6): no entity is lost or duplicated when it moves between bubbles.
      */
     @Test
     void testNoEntityLossDuringMigration() {

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/MultiBubbleSimulationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/MultiBubbleSimulationTest.java
@@ -54,7 +54,10 @@ class MultiBubbleSimulationTest {
         );
 
         assertNotNull(simulation);
-        assertEquals(1, simulation.getAllBubbles().size());
+        // RDR-015 Option B: the grid is a single-level partition tiling the world domain, so the bubble
+        // count is determined by the tiling at the chosen partition level, not by the requested count
+        // (which is now a granularity hint). It is never zero and never the L0 root catch-all.
+        assertTrue(simulation.getAllBubbles().size() > 0, "partition must produce at least one bubble");
     }
 
     @Test
@@ -69,9 +72,10 @@ class MultiBubbleSimulationTest {
 
         assertNotNull(simulation);
         var bubbles = simulation.getAllBubbles().size();
-        // Due to tetrahedral key collisions, may create fewer than requested
+        // RDR-015 Option B: count is a granularity hint; the realized count is the number of in-bounds
+        // level-L tets tiling the world domain (may exceed the requested count). The old "<= requested"
+        // bound was a property of the legacy mixed-level grid, not the spatial partition.
         assertTrue(bubbles > 0, "Should create bubbles");
-        assertTrue(bubbles <= 9, "Should not exceed requested count");
     }
 
     @Test

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGridPartitionTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGridPartitionTest.java
@@ -130,6 +130,8 @@ class TetreeBubbleGridPartitionTest {
 
     @Test
     void noBubbleBoundsNestAnother() {
+        // Same-level tets have equal-sized RDG AABBs, so one can never strictly contain another; this guards
+        // against any mixed-level regression (a coarser cell whose AABB swallows a finer one — the legacy bug).
         var grid = partitionGrid();
         var bounds = new ArrayList<BubbleBounds>();
         for (var key : grid.getBubblesWithKeys().keySet()) {
@@ -143,6 +145,32 @@ class TetreeBubbleGridPartitionTest {
                 }
                 assertFalse(strictlyContains(bounds.get(i), bounds.get(j)),
                             "no bubble's bounds may nest/contain another's (mixed-level nesting)");
+            }
+        }
+    }
+
+    @Test
+    void partitionCoversTheWorldDomainIncludingBoundary() {
+        var grid = partitionGrid();
+        byte level = grid.getPartitionLevel();
+        var spatial = grid.getSpatialIndex();
+
+        // Sample a dense grid of in-bounds points (interior, faces, edges, corners). Every entity position
+        // (clamped to the world domain by physics) must fall in a partition cell, else migration routes to
+        // null and the entity is silently stuck. Boundary points are the at-risk case (RDR-015 review).
+        float lo = WORLD.min();
+        float hi = WORLD.max();
+        int steps = 6;
+        for (int i = 0; i <= steps; i++) {
+            for (int j = 0; j <= steps; j++) {
+                for (int k = 0; k <= steps; k++) {
+                    float x = lo + (hi - lo) * i / steps;
+                    float y = lo + (hi - lo) * j / steps;
+                    float z = lo + (hi - lo) * k / steps;
+                    var tet = spatial.locateTetrahedron(new javax.vecmath.Point3f(x, y, z), level);
+                    assertTrue(tet != null && grid.containsBubble(tet.tmIndex()),
+                               "world point (" + x + "," + y + "," + z + ") must fall in a partition bubble");
+                }
             }
         }
     }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGridPartitionTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGridPartitionTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.simulation.bubble;
+
+import com.hellblazer.luciferase.lucien.tetree.Tet;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Well-formed-partition structural test for {@link TetreeBubbleGrid} (RDR-015 AC3).
+ * <p>
+ * Asserts that the bubble grid is a <b>single-level adjacent spatial partition</b>:
+ * <ul>
+ *   <li>every bubble key is at the same level {@code L};</li>
+ *   <li>{@code L > 0} — no bubble is the L0 root catch-all;</li>
+ *   <li>no duplicate keys (every requested bubble materializes at a distinct key);</li>
+ *   <li>the same-level face-neighbor graph is connected (BFS from any key reaches all);</li>
+ *   <li>no bubble's bounds nest/contain another's.</li>
+ * </ul>
+ * <p>
+ * <b>Adjacency is validated by INVOLUTION reciprocity</b>
+ * ({@code faceNeighbor(faceNeighbor(t,f).face()).tet() == t}), NEVER by a shared-vertex
+ * count: the Bey-SFC face neighbor is non-conforming and shares 0–3 vertices (see the
+ * project CLAUDE.md "Face-neighbor testing caveat").
+ * <p>
+ * <b>TDD status (RDR-015 P0): RED against current code.</b> The current
+ * {@link TetreeBubbleGrid#createBubbles} distributes bubbles across MIXED levels
+ * (including the L0 root), so the same-level / no-L0-root / connected-partition
+ * assertions fail. This test goes green when P1 reworks {@code createBubbles} into a
+ * single-level partition tiling the WorldBounds domain (AC2).
+ *
+ * @author hal.hildebrand
+ */
+class TetreeBubbleGridPartitionTest {
+
+    private static final int  BUBBLE_COUNT  = 8;
+    private static final byte MAX_LEVEL     = (byte) 3;
+    private static final long TARGET_FRAME  = 10L;
+
+    private static TetreeBubbleGrid partitionGrid() {
+        var grid = new TetreeBubbleGrid(MAX_LEVEL);
+        grid.createBubbles(BUBBLE_COUNT, MAX_LEVEL, TARGET_FRAME);
+        return grid;
+    }
+
+    @Test
+    void everyBubbleIsAtTheSameLevelAboveRoot() {
+        var grid = partitionGrid();
+        var keys = new ArrayList<>(grid.getBubblesWithKeys().keySet());
+
+        assertEquals(BUBBLE_COUNT, keys.size(),
+                     "every requested bubble must materialize at a distinct key (no dedup loss)");
+
+        byte expectedLevel = keys.get(0).toTet().l();
+        assertTrue(expectedLevel > 0, "partition level L must be > 0 (no L0 root catch-all bubble)");
+
+        for (var key : keys) {
+            assertEquals(expectedLevel, key.toTet().l(),
+                         "all bubbles must share a single partition level L; offending key: " + key);
+        }
+    }
+
+    @Test
+    void noBubbleIsTheRootTetreeKey() {
+        var grid = partitionGrid();
+        var rootKey = new Tet(0, 0, 0, (byte) 0, (byte) 0).tmIndex();
+
+        for (var key : grid.getBubblesWithKeys().keySet()) {
+            assertFalse(key.equals(rootKey), "no bubble may be the all-containing L0 root tet");
+        }
+    }
+
+    @Test
+    void noDuplicateKeys() {
+        var grid = partitionGrid();
+        var keys = new ArrayList<>(grid.getBubblesWithKeys().keySet());
+        assertEquals(keys.size(), new HashSet<>(keys).size(), "bubble keys must be unique");
+    }
+
+    @Test
+    void faceNeighborGraphIsConnected() {
+        var grid = partitionGrid();
+        var keySet = new HashSet<>(grid.getBubblesWithKeys().keySet());
+        assertTrue(keySet.size() > 1, "partition must contain more than one bubble to be meaningfully connected");
+
+        // BFS over same-level face adjacency, validated by involution reciprocity.
+        var start = keySet.iterator().next();
+        var visited = new HashSet<TetreeKey<?>>();
+        var queue = new ArrayDeque<TetreeKey<?>>();
+        queue.add(start);
+        visited.add(start);
+
+        while (!queue.isEmpty()) {
+            var current = queue.poll();
+            for (var neighborKey : sameLevelFaceNeighbors(current, keySet)) {
+                if (visited.add(neighborKey)) {
+                    queue.add(neighborKey);
+                }
+            }
+        }
+
+        assertEquals(keySet.size(), visited.size(),
+                     "the same-level face-neighbor graph must be connected (BFS must reach every bubble)");
+    }
+
+    @Test
+    void noBubbleBoundsNestAnother() {
+        var grid = partitionGrid();
+        var bounds = new ArrayList<BubbleBounds>();
+        for (var key : grid.getBubblesWithKeys().keySet()) {
+            bounds.add(BubbleBounds.fromTetreeKey(key));
+        }
+
+        for (int i = 0; i < bounds.size(); i++) {
+            for (int j = 0; j < bounds.size(); j++) {
+                if (i == j) {
+                    continue;
+                }
+                assertFalse(strictlyContains(bounds.get(i), bounds.get(j)),
+                            "no bubble's bounds may nest/contain another's (mixed-level nesting)");
+            }
+        }
+    }
+
+    /**
+     * Face neighbors of {@code key} that (a) are present in the partition and (b) pass the involution
+     * reciprocity check — {@code faceNeighbor(faceNeighbor(t,f).face()).tet() == t}. The returned
+     * {@link Tet.FaceNeighbor#face()} is the dual face on the neighbor that points back to {@code t}.
+     */
+    private static List<TetreeKey<?>> sameLevelFaceNeighbors(TetreeKey<?> key, Set<TetreeKey<?>> partition) {
+        var t = key.toTet();
+        var result = new ArrayList<TetreeKey<?>>();
+        for (int face = 0; face < 4; face++) {
+            var fn = t.faceNeighbor(face);
+            if (fn == null) {
+                continue;
+            }
+            var back = fn.tet().faceNeighbor(fn.face());
+            if (back == null || !t.equals(back.tet())) {
+                continue; // adjacency not reciprocal — not a true shared-face neighbor
+            }
+            var neighborKey = fn.tet().tmIndex();
+            if (partition.contains(neighborKey)) {
+                result.add(neighborKey);
+            }
+        }
+        return result;
+    }
+
+    /** True iff {@code a}'s RDG AABB strictly contains {@code b}'s (b nested inside a). */
+    private static boolean strictlyContains(BubbleBounds a, BubbleBounds b) {
+        var aMin = a.rdgMin();
+        var aMax = a.rdgMax();
+        var bMin = b.rdgMin();
+        var bMax = b.rdgMax();
+        boolean encloses = aMin.x <= bMin.x && aMin.y <= bMin.y && aMin.z <= bMin.z
+                           && aMax.x >= bMax.x && aMax.y >= bMax.y && aMax.z >= bMax.z;
+        boolean strictlyLarger = aMin.x < bMin.x || aMin.y < bMin.y || aMin.z < bMin.z
+                                 || aMax.x > bMax.x || aMax.y > bMax.y || aMax.z > bMax.z;
+        return encloses && strictlyLarger;
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGridPartitionTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGridPartitionTest.java
@@ -18,6 +18,7 @@ package com.hellblazer.luciferase.simulation.bubble;
 
 import com.hellblazer.luciferase.lucien.tetree.Tet;
 import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+import com.hellblazer.luciferase.simulation.config.WorldBounds;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayDeque;
@@ -57,13 +58,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class TetreeBubbleGridPartitionTest {
 
-    private static final int  BUBBLE_COUNT  = 8;
-    private static final byte MAX_LEVEL     = (byte) 3;
-    private static final long TARGET_FRAME  = 10L;
+    private static final int        BUBBLE_COUNT = 8;
+    private static final long       TARGET_FRAME = 10L;
+    private static final WorldBounds WORLD       = new WorldBounds(0.0f, 100.0f);
 
     private static TetreeBubbleGrid partitionGrid() {
-        var grid = new TetreeBubbleGrid(MAX_LEVEL);
-        grid.createBubbles(BUBBLE_COUNT, MAX_LEVEL, TARGET_FRAME);
+        var grid = new TetreeBubbleGrid((byte) 21);
+        grid.createBubbles(BUBBLE_COUNT, WORLD, TARGET_FRAME);
         return grid;
     }
 
@@ -72,8 +73,8 @@ class TetreeBubbleGridPartitionTest {
         var grid = partitionGrid();
         var keys = new ArrayList<>(grid.getBubblesWithKeys().keySet());
 
-        assertEquals(BUBBLE_COUNT, keys.size(),
-                     "every requested bubble must materialize at a distinct key (no dedup loss)");
+        assertTrue(keys.size() > 1,
+                   "a world-tiling partition must produce more than one bubble; got " + keys.size());
 
         byte expectedLevel = keys.get(0).toTet().l();
         assertTrue(expectedLevel > 0, "partition level L must be > 0 (no L0 root catch-all bubble)");


### PR DESCRIPTION
Implements RDR-015 (Option B). Closes the dead bubble-to-bubble migration path in `MultiBubbleSimulation`: `tick()` previously committed **zero** migrations; it now commits migrations end-to-end (~1982 over 3000 ticks at 200 entities, **0 failures, exact entity conservation**).

## Root causes fixed (three, independent)

1. **Coordinate-space mismatch** — entities are WorldBounds-scale Cartesian, placed directly into the Tetree absolute coordinate space without rescaling (no world↔RDGCS transform). `EntitySpec.position` javadoc corrected (AC1).
2. **Mixed-level non-partition grid** — new `TetreeBubbleGrid.createBubbles(int, WorldBounds, long)` builds a single-level adjacent partition tiling the world domain: level `L` = coarsest with `lengthAtLevel(L) <= size/cbrt(N)` (never L0), seed at world centre, BFS over **involution-reciprocal** same-level face neighbors (never shared-vertex count — Bey-SFC neighbors are non-conforming), cell-AABB-overlap inclusion for boundary coverage. Router queries the partition level directly instead of a level-0-first scan (AC2/AC3/AC4).
3. **Adaptive-bounds escape gate (finding F6, discovered during P3)** — escape was tested against the adaptive entity-derived AABB, which re-wraps the entities every tick, so an escape was never detected even after fixes 1–2. Now `checkMigrations` (and the hysteresis gate) test against each bubble's **fixed registration cell** (`EnhancedBubble.spatialKey`) (AC5/AC6).

## Tests

- `TetreeBubbleGridPartitionTest` (AC3): same-level, no L0 root, no duplicate keys, face-neighbor BFS connected, no nesting, full world-domain coverage.
- `DirectedMigrationRegressionTest` (AC5): end-to-end through the migration subsystem — an escaped entity migrates to the specific cell containing its position (non-vacuous, anti-catch-all).
- `MultiBubbleSimulationMigrationTest` (AC6): asserts `getTotalMigrations() > 0` on the live path plus exact conservation/uniqueness.
- bubble + ghost + topology suites green.

## Process

Phases P0–P4 (TDD: RED harness → partition → router+wiring → revival → close-out). Stacked review (code-review-expert + substantive-critic): 0 Critical; Significant items applied or filed. phase-review-gate PASSED. RDR closed (implemented) with post-mortem.

## Deferred follow-ups (filed, not silent)

- `Luciferase-9eyqy` — dynamic topology (split/merge) re-breaks the same-level partition; explicitly out of scope per the RDR Scope decision (AC7).
- `Luciferase-6kod9` — escape uses an RDG-AABB approximation, not exact tetrahedral containment (the reason the directed test asserts containing-cell rather than strict face-adjacency).
- `Luciferase-0941e` — partition over-produces bubbles vs requested count.

Closes Luciferase-0frcy.131. Epic Luciferase-j8p8n.