### PR TITLE
RDR-016: Fence WAL persistence scaffolding + fail-loud migration WAL bracket (R2); scope RDR-017

### DIFF
--- a/docs/rdr/RDR-016-persistence-productionization.md
+++ b/docs/rdr/RDR-016-persistence-productionization.md
@@ -1,0 +1,158 @@
+---
+id: RDR-016
+title: Productionize WAL Persistence and Recovery in the Simulation Node Lifecycle
+status: closed
+date: 2026-06-06
+accepted_date: 2026-06-06
+closed_date: 2026-06-06
+close_reason: implemented
+reviewed-by: self
+supersedes: []
+related: [RDR-004, RDR-017]
+beads: [Luciferase-hwqjk]
+---
+
+# RDR-016: Productionize WAL Persistence and Recovery in the Simulation Node Lifecycle
+
+## Status
+
+Draft (2026-06-06). Created from `Luciferase-hwqjk` after investigation revealed the bead's premise was
+understated: the gap is not merely that `PersistenceManager.recover()` has no production caller — the
+**entire WAL persistence subsystem is never instantiated in production**. This RDR scopes whether and how
+to wire write-ahead-log persistence + crash recovery into the simulation node lifecycle.
+
+## Context
+
+The `simulation/persistence` package implements a complete write-ahead-log subsystem:
+- `PersistenceManager` (nodeId, logDirectory, RecoveryStateSink) — append-only event logging
+  (`logElectionStart`, vote, migration commit, …), batch flush, checkpointing, and `recover()`.
+- `WriteAheadLog` — the on-disk log.
+- `EventRecovery` / `RecoveredState` — replays logged events into a `RecoveryStateSink` on `recover()`.
+- `MigrationRecoveryStateSink` — applies recovered migration events to `EntityMigrationStateMachine`
+  (via a caller-guarded `recoverEntityState`).
+- `PersistenceManagerAdapter` (lifecycle) — wraps `PersistenceManager` as a `LifecycleComponent`;
+  `doStart()` is a documented no-op, `doStop()` calls `close()`.
+
+Wave-14 (2026-06-04) made `recover()` correct and **fail-loud** on mid-file WAL corruption
+(throw `IOException` when `skippedCorrupt > 0`; `validateRecoveryIntegrity`).
+
+## Problem Statement
+
+**Nothing in production constructs or starts the persistence subsystem.** Evidence (2026-06-06):
+
+1. `new PersistenceManager(...)` appears **only in test code** (`PersistenceTest`,
+   `PersistenceManagerAdapterTest`, `MigrationRecoveryStateSinkTest`) and one javadoc comment. Zero
+   production construction sites.
+2. The production node orchestrator `von/Manager` builds a `LifecycleCoordinator` and registers only
+   `EnhancedBubbleAdapter`s (`Manager.java:132,183,222`). It never constructs a `PersistenceManager`,
+   never registers `PersistenceManagerAdapter`.
+3. `BubbleMigrator.setPersistenceManager(...)` (`BubbleMigrator.java:147`) is an optional injection with
+   **no production caller** — migration commits are never WAL-bracketed in production.
+4. `PersistenceManagerAdapter.doStart()` is a no-op, so even if an adapter were registered, recovery
+   would not run.
+
+Consequences:
+- **No durability:** node events (elections, votes, migration commits) are never persisted in
+  production, so there is nothing to recover.
+- **Dead fail-loud guard:** Wave-14's mid-file-corruption `IOException` (the RDR-004-class silent-data-
+  loss defense) can never fire, because `recover()` is never called on a populated log.
+- A node restart after a crash silently starts fresh with no state replay and no integrity check.
+
+## Decision (candidate options — NOT yet locked; pending research + gate)
+
+- **(A) Fence / document as non-production.** Mark the persistence subsystem explicitly test-only /
+  experimental; remove or `@Deprecated`-document `PersistenceManagerAdapter`'s lifecycle pretense. Cheapest;
+  abandons durability as a feature. Must confirm no consumer assumes durability.
+- **(B) Wire persistence into the node lifecycle (productionize).** `von/Manager` constructs a
+  `PersistenceManager` (with a resolved log directory + the `MigrationRecoveryStateSink` bound to the
+  node's `EntityMigrationStateMachine`), registers a `PersistenceManagerAdapter` with the
+  `LifecycleCoordinator` at the correct dependency layer, and `doStart()` calls `recover()` letting
+  `IOException` abort startup. Also inject the `PersistenceManager` into `BubbleMigrator` so migration
+  commits are WAL-bracketed. Restores durability + crash recovery + fail-loud.
+- **(C) Minimal seam-only.** Implement `recover()` in `PersistenceManagerAdapter.doStart()` + fail-loud
+  integration test, but do not assemble persistence in `Manager`. Makes the designed seam correct but
+  leaves production with no persistence (recover() still never runs live). Half-measure.
+
+## Approach (proposed, pending acceptance)
+
+1. **Research:** confirm the intended durability model — is WAL persistence meant to be a production
+   feature? Determine the correct log-directory ownership (per-node vs per-bubble), the authoritative
+   `RecoveryStateSink` wiring (node `EntityMigrationStateMachine`), the dependency-layer ordering for the
+   `PersistenceManagerAdapter` in the `LifecycleCoordinator`, and what state besides migrations must be
+   recovered (consensus/election events are logged but have no sink). Audit IOException
+   swallowing on any path above `PersistenceManager`.
+2. **Decide A vs B vs C** at the gate.
+3. **Implement** the chosen path: lifecycle wiring in `von/Manager`, `doStart()` recovery, BubbleMigrator
+   injection, fail-loud on corruption.
+4. **Integration test:** corrupt WAL → node refuses to start (not degraded-start); clean WAL → events
+   replay into the sink; happy-path durability round-trip (log → restart → recover → state restored).
+
+## Consequences / Risks
+
+- **Blast radius:** `von/Manager` startup/shutdown, `LifecycleCoordinator` dependency graph,
+  `BubbleMigrator`, `EntityMigrationStateMachine` recovery seam, and many bubble-construction tests that
+  do not expect recovery to run/throw.
+- **Startup semantics change:** a corrupt WAL will now abort node startup (intended fail-loud), which
+  tests and operators must expect.
+- **Design unknowns:** log-dir lifecycle (creation, per-node isolation, cleanup), recovery of
+  consensus/election events (currently logged, no sink), interaction with the distributed membership view.
+- **Doing nothing** keeps a complete-but-dead subsystem and a non-functional durability guarantee.
+
+## Research Findings (2026-06-06, code-verified)
+
+Investigation (codebase-deep-analyzer + direct verification) **reframed the problem**: the gap is not
+"persistence is unwired" but "**there is no production node assembly at all**". Full detail in T2
+`Luciferase_rdr/016-research-1`.
+
+- **F1 — `RecoveredState` has zero production consumers.** All `recover()` callers are tests.
+- **F2 — No node bootstrap exists.** There is no `main()` in `simulation/src/main`; `von/Manager` (the
+  orchestrator) has no nodeId, no log directory, no restart path, and is itself never constructed in
+  production. It builds an empty `LifecycleCoordinator` and registers only `EnhancedBubbleAdapter`s.
+- **F3 — `BubbleMigrator.setPersistenceManager()` has no production caller** (WAL bracket skipped).
+- **F4 — `PersistenceManagerAdapter.doStart()` is a no-op;** `recover()` never runs in the lifecycle.
+- **Q1 → aspirational scaffolding.** The WAL subsystem is well-built and internally consistent but 100%
+  disconnected from any running node.
+- **Q2 → per-node WAL**, natural directory `.luciferase/wal/<nodeId>/` (mirrors `MigrationLogPersistence`);
+  no configuration path exists; nodeId would come from the Fireflies member UUID.
+- **Q3 → migration state is the only recoverable state.** Consensus/election events are logged but
+  silently dropped in `EventRecovery.replayEvents` (default `WARN`); no consensus sink is needed.
+- **Q4 → lifecycle dependency ordering is broken three ways** (bubbles register at Layer 0 and start
+  before persistence; `doStart()` no-op; `PersistenceManagerAdapter.dependencies()` references an
+  unregistered `SocketConnectionManager`, which would crash `computeLayers()`).
+- **Three uncoordinated, all-dead durability/recovery subsystems** exist: `PersistenceManager`/WAL,
+  `MigrationLogPersistence`/`CrossProcessMigration` (RDR-`0frcy.30`), and `RecoveryIntegration` — each
+  constructed only in tests/javadoc.
+- **R2 (real latent bug, fixed here):** `BubbleMigrator` swallowed a `MIGRATION_COMMIT` WAL-write failure
+  (`BubbleMigrator.java:322–330`); on a live WAL this causes split-brain entity ownership after a restart.
+
+## Decision (updated post-research — LOCKED: Option A, fence + scope a bootstrap RDR)
+
+**Option B (full wiring) is out of proportion to this bead:** it would require authoring an entire
+production node bootstrap that composes `Manager` + a chosen WAL (of three) + recovery + corrected
+lifecycle ordering, and it is unclear whether the node `main` belongs in this repo or an external embedder.
+That is a separate, larger architecture decision.
+
+**This RDR therefore (A) fences the persistence subsystem as library scaffolding** that is intentionally
+not composed into a production node, documents that fact at the code seam, and **fixes the one standalone
+latent correctness bug (R2)** that is independent of the wiring question. The full productionization —
+including whether a node bootstrap lives here, which of the three durability subsystems survives, and the
+Q4 lifecycle-ordering fixes — is **deferred to RDR-017 (Production Node Bootstrap)**. Options B and C are
+explicitly deferred to RDR-017, not rejected.
+
+## Scope decision — what this RDR does and does not do
+
+- **Does:** fix R2 (fail-loud on WAL bracket-write failure in `BubbleMigrator`, with a regression test);
+  document the persistence/recovery subsystems as uncomposed library scaffolding; scope RDR-017.
+- **Does NOT:** construct a `PersistenceManager` in production; author a node bootstrap; choose among the
+  three durability subsystems; fix the Q4 lifecycle-ordering defects (those are RDR-017's, since they only
+  matter once a node assembles persistence).
+
+## Acceptance Criteria
+
+1. R2 fixed: `BubbleMigrator` aborts the migration (rolls back staging, leaves source authoritative) when
+   a WAL `ENTITY_DEPARTURE`/`MIGRATION_COMMIT` write fails with persistence enabled; regression test proves
+   no split-brain. **(done — `BubbleMigratorTest.migrationCommitWalFailure_abortsMigration_noSplitBrain`)**
+2. The persistence/recovery scaffolding is documented at the code seam as not-composed-in-production.
+3. RDR-017 (Production Node Bootstrap) is created, capturing F2/F4/Q1–Q4 + R3 (three dead subsystems) and
+   the open question of where the node `main` lives.
+4. `Luciferase-hwqjk` is closed against this decision (fenced; real wiring → RDR-017).

--- a/docs/rdr/RDR-017-production-node-bootstrap.md
+++ b/docs/rdr/RDR-017-production-node-bootstrap.md
@@ -1,0 +1,69 @@
+---
+id: RDR-017
+title: Production Node Bootstrap — Compose the Distributed Simulation Node (Lifecycle, WAL, Recovery, Migration)
+status: draft
+date: 2026-06-06
+reviewed-by: self
+supersedes: []
+related: [RDR-016, RDR-004]
+beads: [Luciferase-hwqjk]
+---
+
+# RDR-017: Production Node Bootstrap — Compose the Distributed Simulation Node
+
+## Status
+
+Draft (2026-06-06). Spun out of RDR-016 after research found that the simulation module has **no production
+node assembly at all** — multiple complete subsystems (lifecycle, WAL persistence, crash recovery, cross-
+process migration) exist as library components but nothing composes them into a running node.
+
+## Context / Problem Statement
+
+There is no `main()` / bootstrap in `simulation/src/main`. `von/Manager` (the orchestrator) is never
+constructed in production; it builds an empty `LifecycleCoordinator` and registers only
+`EnhancedBubbleAdapter`s. Three independent durability/recovery subsystems are each dead in production
+(constructed only in tests/javadoc):
+
+1. `PersistenceManager` / `WriteAheadLog` (+ `MigrationRecoveryStateSink`, `EventRecovery`).
+2. `MigrationLogPersistence` / `CrossProcessMigration` (RDR-`0frcy.30`).
+3. `RecoveryIntegration` (`von/RecoveryIntegration`).
+
+The lifecycle dependency graph is also broken for the persistence case (RDR-016 Q4): bubbles register at
+Layer 0 and would start before persistence; `PersistenceManagerAdapter.doStart()` is a no-op; and
+`PersistenceManagerAdapter.dependencies()` references an unregistered `SocketConnectionManager` that would
+crash `LifecycleCoordinator.computeLayers()`.
+
+## Decision (candidate options — NOT yet locked)
+
+- **Q0 — Does the node `main` belong in this repo?** Or is `simulation` a library composed by an external
+  embedder/application that owns the bootstrap? This is the gating question.
+- **Which durability subsystem survives?** Consolidate to one of the three (or define their division of
+  responsibility) — running multiple uncoordinated WALs is a latent inconsistency hazard.
+- **If composed here:** define the node bootstrap (nodeId resolution from the Fireflies member UUID,
+  `.luciferase/wal/<nodeId>/` log dir), register `SocketConnectionManagerAdapter` →
+  `PersistenceManagerAdapter` (with `recover()` fail-loud in `doStart()`) → `EnhancedBubbleAdapter`s
+  (Layer 2, depending on `PersistenceManager`), inject the WAL into `BubbleMigrator`, and wire the
+  `MigrationRecoveryStateSink` to the node's `EntityMigrationStateMachine`.
+
+## Approach (proposed)
+
+1. **Research / decide Q0** with the user — is this repo the node host?
+2. If yes: design the bootstrap + lifecycle ordering; pick the surviving durability subsystem; phase the
+   implementation (bootstrap skeleton → persistence wiring + recover() fail-loud → migration WAL bracket →
+   integration tests: corrupt WAL aborts startup, clean WAL replays, durability round-trip).
+3. If no: document the embedder contract (what a host must construct/register) and fence accordingly.
+
+## Consequences / Risks
+
+- Large blast radius: node startup/shutdown semantics, lifecycle dependency graph, `BubbleMigrator`,
+  `EntityMigrationStateMachine` recovery seam, many bubble-construction tests.
+- Picking among three durability subsystems may mean deprecating/removing two.
+- RDR-016 already fixed the standalone R2 split-brain bug; this RDR makes the WAL that R2 protects actually
+  live.
+
+## Open Questions
+
+- Q0: node `main` here vs external embedder (gating).
+- Which of the three durability/recovery subsystems is authoritative; what happens to the other two.
+- Per-node WAL directory ownership/lifecycle/cleanup; nodeId source of truth.
+- Lifecycle ordering fixes (RDR-016 Q4) — apply as part of the bootstrap.

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapter.java
@@ -25,6 +25,17 @@ import java.util.Objects;
  * The start() method is effectively a no-op but maintains lifecycle state consistency.
  * <p>
  * Extends {@link AbstractLifecycleAdapter} for common state management logic.
+ * <p>
+ * <b>Scaffolding — NOT composed in production (RDR-016).</b> This adapter, and the WAL persistence /
+ * crash-recovery subsystem it wraps, are currently library scaffolding: no production node bootstrap
+ * constructs a {@link PersistenceManager} or registers this adapter with a
+ * {@code LifecycleCoordinator}. Consequences while uncomposed: {@link #doStart()} is a deliberate no-op
+ * (recovery never runs in any live node), and {@code dependencies()} declares
+ * {@code "SocketConnectionManager"} which is itself never registered — so registering this adapter as-is
+ * would fail {@code LifecycleCoordinator.computeLayers()}. Productionizing persistence (constructing it
+ * in a node bootstrap, calling {@code recover()} fail-loud from {@code doStart()}, choosing among the
+ * three independent durability subsystems, and fixing the lifecycle dependency ordering) is deferred to
+ * <b>RDR-017 (Production Node Bootstrap)</b>. Do not wire this adapter into a coordinator until RDR-017.
  *
  * @author hal.hildebrand
  */

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/tumbler/BubbleMigrator.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/tumbler/BubbleMigrator.java
@@ -275,8 +275,13 @@ public class BubbleMigrator {
                         persistenceManager.logEntityDeparture(
                             UUID.fromString(entity.id()), bubbleId, targetBubble.id());
                     } catch (java.io.IOException | IllegalArgumentException walEx) {
-                        log.warn("WAL ENTITY_DEPARTURE log failed for entity {} in bubble {}: {}",
-                                 entity.id(), bubbleId, walEx.getMessage());
+                        // Fail loud: when persistence is enabled the WAL bracket MUST be durable. A
+                        // swallowed open-bracket failure leaves an in-flight migration unrecoverable on
+                        // restart. Re-throw so the outer catch rolls back staging and leaves the source
+                        // authoritative (RDR-016 R2). This is pre-staging, so rollback is a no-op here.
+                        throw new RuntimeException(
+                            "WAL ENTITY_DEPARTURE log failed for entity " + entity.id() + " in bubble "
+                            + bubbleId + ": " + walEx.getMessage(), walEx);
                     }
                 }
             }
@@ -316,20 +321,27 @@ public class BubbleMigrator {
             }
             // ackDeadline used only for the elapsed-time log message above; no raw sleep.
 
-            // COMMIT POINT — no rollback after this line.
-            // WAL bracket close: MIGRATION_COMMIT logged per entity before source is deactivated.
+            // WAL bracket close: MIGRATION_COMMIT logged per entity. This runs BEFORE the true point of
+            // no return (sourceBubble.close() below), so a WAL failure here MUST abort the migration —
+            // re-throw to the outer catch, which rolls back staging and leaves the source authoritative.
+            // Swallowing it would let the source close with no durable commit record; on restart, recovery
+            // would replay ENTITY_DEPARTURE (MIGRATING_OUT) with no MIGRATION_COMMIT and force the entity
+            // back onto the source while the target also owns it — split-brain ownership (RDR-016 R2).
             if (persistenceManager != null) {
                 for (var entity : entities) {
                     try {
                         persistenceManager.logMigrationCommit(
                             UUID.fromString(entity.id()));
                     } catch (java.io.IOException | IllegalArgumentException walEx) {
-                        log.warn("WAL MIGRATION_COMMIT log failed for entity {} in bubble {}: {}",
-                                 entity.id(), bubbleId, walEx.getMessage());
+                        throw new RuntimeException(
+                            "WAL MIGRATION_COMMIT log failed for entity " + entity.id() + " in bubble "
+                            + bubbleId + " — aborting migration before source close: " + walEx.getMessage(),
+                            walEx);
                     }
                 }
             }
 
+            // COMMIT POINT — no rollback after this line.
             // Step 5: Deactivate source bubble — target is now the sole authoritative copy.
             sourceBubble.close();
 

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/tumbler/BubbleMigratorTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/tumbler/BubbleMigratorTest.java
@@ -14,7 +14,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.hellblazer.luciferase.common.time.Clock;
+import com.hellblazer.luciferase.simulation.persistence.PersistenceManager;
 import javax.vecmath.Point3f;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -48,6 +52,48 @@ class BubbleMigratorTest {
 
         tumbler.registerServer(sourceServerId);
         tumbler.registerServer(targetServerId);
+    }
+
+    /**
+     * RDR-016 R2: when persistence is enabled, a MIGRATION_COMMIT WAL-write failure must ABORT the
+     * migration (roll back staging, leave the source authoritative) — not warn-and-proceed. A swallowed
+     * commit-log failure would let the source close with no durable commit record, so a post-crash
+     * recovery replays ENTITY_DEPARTURE (MIGRATING_OUT) with no MIGRATION_COMMIT and forces the entity
+     * back onto the source while the target also owns it — split-brain ownership.
+     */
+    @Test
+    void migrationCommitWalFailure_abortsMigration_noSplitBrain() throws Exception {
+        var walDir = Files.createTempDirectory("rdr016-r2-wal");
+        try (var pm = new PersistenceManager(UUID.randomUUID(), walDir) {
+            @Override
+            public void logMigrationCommit(UUID entityId) throws IOException {
+                throw new IOException("simulated WAL commit-log failure");
+            }
+        }) {
+            migrator.setPersistenceManager(pm);
+
+            var sourceBubble = new Bubble(UUID.randomUUID(), (byte) 5, 16L, mock(Transport.class));
+            sourceBubble.addEntity("e1", new Point3f(1f, 0f, 0f), "content1");
+            var targetBubble = new Bubble(UUID.randomUUID(), (byte) 5, 16L, mock(Transport.class));
+            migrator.setBubbleTransferFactory((tgtServerId, src) -> targetBubble);
+
+            var result = migrator.migrate(sourceBubble, sourceServerId, targetServerId)
+                                 .get(5, TimeUnit.SECONDS);
+
+            assertThat(result.success())
+                .as("MIGRATION_COMMIT WAL failure must abort the migration (RDR-016 R2)")
+                .isFalse();
+            assertThat(sourceBubble.entityCount())
+                .as("source must remain authoritative (not closed) when commit logging fails")
+                .isEqualTo(1);
+            assertThat(targetBubble.entityCount())
+                .as("target staging must be rolled back on WAL-commit abort (no split-brain)")
+                .isEqualTo(0);
+        } finally {
+            try (var paths = Files.walk(walDir)) {
+                paths.sorted(Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
Resolves `Luciferase-hwqjk`. Investigation reframed the bead: not just `PersistenceManager.recover()` lacks a caller — the **entire WAL persistence subsystem** (and two sibling recovery subsystems: `MigrationLogPersistence`/`CrossProcessMigration`, `RecoveryIntegration`) is uninstantiated in production, and there is **no node bootstrap/`main`** at all (`von/Manager` is never constructed in prod). Full productionization is out of proportion to the bead and gated on an architecture decision (does the node `main` live in this repo or an external embedder?), so RDR-016 takes **Decision A (fence)** and defers wiring to **RDR-017**.

## Changes

- **R2 fix (standalone latent bug, BubbleMigrator):** the `MIGRATION_COMMIT` WAL log runs before the point of no return (`sourceBubble.close()`); the old code swallowed a write failure and proceeded, so a post-crash recovery would replay `MIGRATING_OUT` with no commit and force the entity back onto the source while the target also owns it — **split-brain**. Now a WAL bracket-write failure (when persistence is enabled) re-throws and aborts the migration: staging rolled back, source left authoritative. Same fail-loud treatment for the `ENTITY_DEPARTURE` open-bracket.
  - Regression test: `BubbleMigratorTest.migrationCommitWalFailure_abortsMigration_noSplitBrain`.
- **Fence documentation** at the `PersistenceManagerAdapter` seam: the subsystem is library scaffolding, not composed in any production node; do not register it until RDR-017.
- **RDR-016** records the research (F1–F4, Q1–Q4, R2, three dead subsystems) and the locked Decision A.
- **RDR-017 (Production Node Bootstrap)** drafted to capture the real gap + the gating question, tracked by `Luciferase-n6jrh`.

## Tests

210 green across `tumbler` + `distributed/migration` + `persistence` packages.

Closes Luciferase-hwqjk.