### PR TITLE
fix(simulation): one coherent mutation-lock protocol for multi-bubble writers (n7io1)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/AdaptiveSplitPolicy.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/AdaptiveSplitPolicy.java
@@ -160,13 +160,17 @@ public class AdaptiveSplitPolicy {
         // the k-means computation and placing entities in spatially wrong
         // children. Population is now part of the split operation and preserves
         // the cluster-entity correspondence.
+        // Snapshot the source under its mutation lock so the split sees a consistent entity set rather
+        // than one racing a concurrent migration/merge writer (Luciferase-n7io1). Only the source is a
+        // shared bubble here — the child bubbles are freshly constructed below and not yet visible to any
+        // other writer, so they need no locking.
         var recordsById = new HashMap<String, EnhancedBubble.EntityRecord>();
-        for (var record : source.getAllEntityRecords()) {
-            recordsById.put(record.id(), record);
+        try (var ignored = MutationLocks.lock(source)) {
+            for (var record : source.getAllEntityRecords()) {
+                recordsById.put(record.id(), record);
+            }
         }
 
-        // LOCK MISSING (Luciferase-n7io1): acquire source+target getMutationLock() in UUID order;
-        // races concurrent migration/merge
         var childBubbles = new ArrayList<EnhancedBubble>();
         for (var cluster : analysis.clusters()) {
             var childId = UUID.randomUUID();

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/BubbleLifecycle.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/BubbleLifecycle.java
@@ -171,19 +171,22 @@ public class BubbleLifecycle {
             return;
         }
 
-        // Get all entities from source
-        var entities = source.getAllEntityRecords();
+        // Hold both bubbles' mutation locks (UUID order, deadlock-free) for the whole move so the
+        // snapshot, the target adds, and the source removes are atomic w.r.t. concurrent
+        // migration/merge/split writers (Luciferase-n7io1). The snapshot is taken under the lock so it
+        // cannot be stale relative to a racing writer.
+        try (var ignored = MutationLocks.lock(source, target)) {
+            var entities = source.getAllEntityRecords();
 
-        // LOCK MISSING (Luciferase-n7io1): acquire source+target getMutationLock() in UUID order;
-        // races concurrent migration/merge
-        // Transfer each entity to target
-        for (var entity : entities) {
-            target.addEntity(entity.id(), entity.position(), entity.content());
-        }
+            // Transfer each entity to target
+            for (var entity : entities) {
+                target.addEntity(entity.id(), entity.position(), entity.content());
+            }
 
-        // Remove all entities from source
-        for (var entity : entities) {
-            source.removeEntity(entity.id());
+            // Remove all entities from source
+            for (var entity : entities) {
+                source.removeEntity(entity.id());
+            }
         }
     }
 }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/MutationLocks.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/MutationLocks.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.bubble;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * One coherent mutation-lock protocol for multi-bubble entity moves (Luciferase-n7io1).
+ * <p>
+ * Any code path that mutates the entity sets of two or more {@link EnhancedBubble}s as a unit (migration,
+ * merge, split, cross-process commit, duplicate reconciliation) must hold each involved bubble's
+ * {@link EnhancedBubble#getMutationLock() mutation lock} for the duration of the move. A lock that only
+ * some paths honor is not a protocol — it still races the paths that skip it. This helper makes the
+ * protocol uniform and deadlock-free:
+ * <ul>
+ *   <li><b>Global order:</b> locks are always acquired in ascending {@link EnhancedBubble#id()} order, so
+ *       no two concurrent acquisitions involving the same set can form a lock-ordering cycle.</li>
+ *   <li><b>Dedup:</b> repeated/identical bubbles collapse to one acquisition (and the locks are
+ *       reentrant regardless, so nesting inside an already-held lock is safe).</li>
+ *   <li><b>Reverse release:</b> {@link #close()} unlocks in the reverse of acquisition order.</li>
+ *   <li><b>Acquisition failure safety:</b> if a {@code lock()} throws mid-acquisition, locks already taken
+ *       are released before propagating.</li>
+ * </ul>
+ * Intended for try-with-resources:
+ * <pre>{@code
+ * try (var ignored = MutationLocks.lock(source, target)) {
+ *     // mutate source and target atomically w.r.t. other multi-bubble writers
+ * }
+ * }</pre>
+ *
+ * @author hal.hildebrand
+ */
+public final class MutationLocks implements AutoCloseable {
+
+    private final List<ReentrantLock> held;
+
+    private MutationLocks(List<ReentrantLock> held) {
+        this.held = held;
+    }
+
+    /**
+     * Acquire the mutation locks of all given bubbles in ascending UUID order. {@code null} entries are
+     * ignored; duplicate bubbles are acquired once.
+     *
+     * @param bubbles the bubbles whose mutation locks to hold
+     * @return an {@link AutoCloseable} handle that releases the locks (reverse order) on {@link #close()}
+     */
+    public static MutationLocks lock(EnhancedBubble... bubbles) {
+        var ordered = Arrays.stream(bubbles)
+                            .filter(Objects::nonNull)
+                            .distinct()
+                            .sorted(Comparator.comparing(EnhancedBubble::id))
+                            .toList();
+        var acquired = new ArrayList<ReentrantLock>(ordered.size());
+        try {
+            for (var bubble : ordered) {
+                var lock = bubble.getMutationLock();
+                lock.lock();
+                acquired.add(lock);
+            }
+        } catch (RuntimeException | Error e) {
+            for (int i = acquired.size() - 1; i >= 0; i--) {
+                acquired.get(i).unlock();
+            }
+            throw e;
+        }
+        return new MutationLocks(acquired);
+    }
+
+    /** Acquire the mutation locks of all given bubbles (collection overload). */
+    public static MutationLocks lock(List<EnhancedBubble> bubbles) {
+        return lock(bubbles.toArray(EnhancedBubble[]::new));
+    }
+
+    @Override
+    public void close() {
+        for (int i = held.size() - 1; i >= 0; i--) {
+            held.get(i).unlock();
+        }
+    }
+}

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetrahedralMigration.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetrahedralMigration.java
@@ -292,61 +292,50 @@ public class TetrahedralMigration {
             return false;
         }
 
-        // Acquire BOTH bubble mutation locks in consistent UUID order to prevent deadlock.
-        // Any two concurrent migrations involving the same pair always acquire in the same order,
-        // so no lock-ordering cycle is possible.
-        int cmp = srcBubble.id().compareTo(dstBubble.id());
-        ReentrantLock firstLock  = cmp <= 0 ? srcBubble.getMutationLock() : dstBubble.getMutationLock();
-        ReentrantLock secondLock = cmp <= 0 ? dstBubble.getMutationLock() : srcBubble.getMutationLock();
+        // Hold BOTH bubble mutation locks via the shared MutationLocks protocol (ascending UUID order,
+        // deadlock-free) — the one coherent protocol shared by every multi-bubble writer
+        // (Luciferase-n7io1), so no two concurrent migrations/merges/splits on the same pair can form a
+        // lock-ordering cycle.
+        try (var ignored = MutationLocks.lock(srcBubble, dstBubble)) {
+            // PHASE 1: Get entity from source under lock (latest snapshot, not stale)
+            var entityRecords = srcBubble.getAllEntityRecords();
+            var entityRecord = entityRecords.stream()
+                                           .filter(e -> e.id().equals(entityId))
+                                           .findFirst()
+                                           .orElse(null);
 
-        firstLock.lock();
-        try {
-            secondLock.lock();
-            try {
-                // PHASE 1: Get entity from source under lock (latest snapshot, not stale)
-                var entityRecords = srcBubble.getAllEntityRecords();
-                var entityRecord = entityRecords.stream()
-                                               .filter(e -> e.id().equals(entityId))
-                                               .findFirst()
-                                               .orElse(null);
-
-                if (entityRecord == null) {
-                    return false;  // Entity not found (already migrated or removed)
-                }
-
-                // PHASE 2: Add to destination (atomic, still under both locks)
-                dstBubble.addEntity(entityId, entityRecord.position(), entityRecord.content());
-
-                // PHASE 3: Remove from source (may fail)
-                try {
-                    srcBubble.removeEntity(entityId);
-                } catch (Exception e) {
-                    // ROLLBACK: Remove from destination if source remove fails
-                    try {
-                        dstBubble.removeEntity(entityId);
-                    } catch (Exception rollbackEx) {
-                        // Rollback failed: the entity now exists in BOTH source and destination
-                        // bubbles (duplicate-entity state). This is unrecoverable here and must be
-                        // observable for downstream reconciliation, so log at ERROR.
-                        log.error("Rollback failed for entity {} migrating {}->{}: entity now exists in "
-                                  + "both source and destination (duplicate state)",
-                                  entityId, srcBubble.id(), dstBubble.id(), rollbackEx);
-                    }
-                    return false;
-                }
-
-                // Success: Record cooldown
-                migrationCooldowns.put(entityId, currentTick);
-
-                return true;
-
-            } finally {
-                secondLock.unlock();
+            if (entityRecord == null) {
+                return false;  // Entity not found (already migrated or removed)
             }
+
+            // PHASE 2: Add to destination (atomic, still under both locks)
+            dstBubble.addEntity(entityId, entityRecord.position(), entityRecord.content());
+
+            // PHASE 3: Remove from source (may fail)
+            try {
+                srcBubble.removeEntity(entityId);
+            } catch (Exception e) {
+                // ROLLBACK: Remove from destination if source remove fails
+                try {
+                    dstBubble.removeEntity(entityId);
+                } catch (Exception rollbackEx) {
+                    // Rollback failed: the entity now exists in BOTH source and destination
+                    // bubbles (duplicate-entity state). This is unrecoverable here and must be
+                    // observable for downstream reconciliation, so log at ERROR.
+                    log.error("Rollback failed for entity {} migrating {}->{}: entity now exists in "
+                              + "both source and destination (duplicate state)",
+                              entityId, srcBubble.id(), dstBubble.id(), rollbackEx);
+                }
+                return false;
+            }
+
+            // Success: Record cooldown
+            migrationCooldowns.put(entityId, currentTick);
+
+            return true;
+
         } catch (Exception e) {
             return false;
-        } finally {
-            firstLock.unlock();
         }
     }
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/grid/MultiDirectionalMigration.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/grid/MultiDirectionalMigration.java
@@ -9,6 +9,7 @@
 package com.hellblazer.luciferase.simulation.distributed.grid;
 
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
+import com.hellblazer.luciferase.simulation.bubble.MutationLocks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -260,8 +261,17 @@ public class MultiDirectionalMigration {
         // Hold both bubbles' mutation locks (UUID order, deadlock-free) for the whole add-then-remove
         // commit so it is atomic w.r.t. concurrent migration/merge/split writers on the same pair
         // (Luciferase-n7io1). Rollback (below) also runs under the locks.
-        try (var ignored = com.hellblazer.luciferase.simulation.bubble.MutationLocks.lock(
-                sourceBubble, targetBubble)) {
+        try (var ignored = MutationLocks.lock(sourceBubble, targetBubble)) {
+            // Re-validate under the lock: the prepare phase checked source/target membership WITHOUT a
+            // lock, so a concurrent migration may have moved the entity out of source in between. Adding
+            // to target now would inject an entity the source no longer owns — duplication. Bail if the
+            // source no longer holds it (n7io1 / stale-intent guard).
+            if (!sourceBubble.getEntities().contains(entityId)) {
+                metrics.recordFailure();
+                return MigrationResult.failure(
+                    entityId, intent.direction(),
+                    "Source no longer holds entity at commit (concurrent migration); intent stale");
+            }
             try {
                 // Step 1: Add entity to target bubble (target now owns entity)
                 targetBubble.addEntity(entityId, intent.position(), intent.content());

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/grid/MultiDirectionalMigration.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/grid/MultiDirectionalMigration.java
@@ -257,51 +257,55 @@ public class MultiDirectionalMigration {
         var sourceBubble = bubbleGrid.getBubble(intent.sourceCoord());
         var targetBubble = bubbleGrid.getBubble(intent.targetCoord());
 
-        // LOCK MISSING (Luciferase-n7io1): acquire source+target getMutationLock() in UUID order;
-        // races concurrent migration/merge
-        try {
-            // Step 1: Add entity to target bubble (target now owns entity)
-            targetBubble.addEntity(entityId, intent.position(), intent.content());
-        } catch (Exception e) {
-            // Add failed - no rollback needed, entity stays in source
-            metrics.recordFailure();
-            return MigrationResult.failure(
-                entityId,
-                intent.direction(),
-                "Failed to add to target: " + e.getMessage()
-            );
-        }
-
-        try {
-            // Step 2: Add velocity to target (but don't remove from source yet)
-            if (intent.velocity() != null) {
-                velocities.put(entityId, intent.velocity());
+        // Hold both bubbles' mutation locks (UUID order, deadlock-free) for the whole add-then-remove
+        // commit so it is atomic w.r.t. concurrent migration/merge/split writers on the same pair
+        // (Luciferase-n7io1). Rollback (below) also runs under the locks.
+        try (var ignored = com.hellblazer.luciferase.simulation.bubble.MutationLocks.lock(
+                sourceBubble, targetBubble)) {
+            try {
+                // Step 1: Add entity to target bubble (target now owns entity)
+                targetBubble.addEntity(entityId, intent.position(), intent.content());
+            } catch (Exception e) {
+                // Add failed - no rollback needed, entity stays in source
+                metrics.recordFailure();
+                return MigrationResult.failure(
+                    entityId,
+                    intent.direction(),
+                    "Failed to add to target: " + e.getMessage()
+                );
             }
 
-            // Step 3: Remove entity from source bubble
-            sourceBubble.removeEntity(entityId);
+            try {
+                // Step 2: Add velocity to target (but don't remove from source yet)
+                if (intent.velocity() != null) {
+                    velocities.put(entityId, intent.velocity());
+                }
 
-            // Step 4: Now safe to remove velocity from source (source removal succeeded)
-            // Note: velocity is already in target from step 2, so this just cleans up
+                // Step 3: Remove entity from source bubble
+                sourceBubble.removeEntity(entityId);
 
-            // Step 5: Update metrics and cooldown
-            metrics.recordMigration(intent.direction());
-            migrationCooldowns.put(entityId, currentTick + MIGRATION_COOLDOWN_TICKS);
+                // Step 4: Now safe to remove velocity from source (source removal succeeded)
+                // Note: velocity is already in target from step 2, so this just cleans up
 
-            log.debug("Migrated {} from {} to {} ({})",
-                      entityId, intent.sourceCoord(), intent.targetCoord(), intent.direction());
-            return MigrationResult.success(entityId, intent.direction());
+                // Step 5: Update metrics and cooldown
+                metrics.recordMigration(intent.direction());
+                migrationCooldowns.put(entityId, currentTick + MIGRATION_COOLDOWN_TICKS);
 
-        } catch (Exception e) {
-            // Rollback: remove from target since it was added but migration failed
-            // Note: velocity was NOT removed from source, so it's still there
-            rollbackMigration(intent, e);
-            metrics.recordFailure();
-            return MigrationResult.failure(
-                entityId,
-                intent.direction(),
-                "Rollback after failure: " + e.getMessage()
-            );
+                log.debug("Migrated {} from {} to {} ({})",
+                          entityId, intent.sourceCoord(), intent.targetCoord(), intent.direction());
+                return MigrationResult.success(entityId, intent.direction());
+
+            } catch (Exception e) {
+                // Rollback: remove from target since it was added but migration failed
+                // Note: velocity was NOT removed from source, so it's still there
+                rollbackMigration(intent, e);
+                metrics.recordFailure();
+                return MigrationResult.failure(
+                    entityId,
+                    intent.direction(),
+                    "Rollback after failure: " + e.getMessage()
+                );
+            }
         }
     }
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/ghost/DuplicateEntityDetector.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/ghost/DuplicateEntityDetector.java
@@ -17,6 +17,7 @@
 package com.hellblazer.luciferase.simulation.ghost;
 
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
+import com.hellblazer.luciferase.simulation.bubble.MutationLocks;
 import com.hellblazer.luciferase.simulation.bubble.TetreeBubbleGrid;
 import com.hellblazer.luciferase.simulation.entity.StringEntityID;
 import org.slf4j.Logger;
@@ -190,27 +191,29 @@ public class DuplicateEntityDetector {
 
         var sourceBubbleInstance = findBubbleById(sourceBubble);
 
-        // Hold the mutation locks of EVERY involved bubble (the authoritative source plus every
-        // non-source location) in UUID order for the whole verify-then-prune so it is atomic w.r.t.
-        // concurrent migration/merge/split writers (Luciferase-n7io1). Without this, the
-        // "source still holds the entity" check below races a concurrent migration and the prune could
-        // erase the live copy. The locks are gathered before acquisition so the global UUID ordering is
-        // deadlock-free across all writer paths.
-        var involved = new java.util.ArrayList<EnhancedBubble>();
+        // Resolve every involved bubble instance ONCE (the authoritative source plus every non-source
+        // location) and hold each one's mutation lock, in ascending UUID order, for the whole
+        // verify-then-prune so it is atomic w.r.t. concurrent migration/merge/split writers
+        // (Luciferase-n7io1). The same resolved instances are used for both locking and removal — no
+        // second findBubbleById inside the lock — so we mutate exactly the bubbles whose locks we hold.
+        // Guarantee scope: bubbles that exit the grid between this resolution and lock acquisition are
+        // simply absent from the set (resolved to null and skipped); reconciliation for them is deferred
+        // to the next cycle. The source-still-holds-entity check below remains the safety guard.
+        var involvedById = new LinkedHashMap<UUID, EnhancedBubble>();
         if (sourceBubbleInstance != null) {
-            involved.add(sourceBubbleInstance);
+            involvedById.put(sourceBubble, sourceBubbleInstance);
         }
         for (var bubbleId : locations) {
             if (!bubbleId.equals(sourceBubble)) {
                 var b = findBubbleById(bubbleId);
                 if (b != null) {
-                    involved.add(b);
+                    involvedById.put(bubbleId, b);
                 }
             }
         }
 
         var removedCount = 0;
-        try (var ignored = com.hellblazer.luciferase.simulation.bubble.MutationLocks.lock(involved)) {
+        try (var ignored = MutationLocks.lock(new ArrayList<>(involvedById.values()))) {
             // Verify (now race-free, under lock) that the authoritative source still holds the entity
             // before pruning the others. If it has already left the expected source (a migration that
             // committed before we acquired the locks), deleting from the other locations risks erasing
@@ -223,11 +226,10 @@ public class DuplicateEntityDetector {
                 return 0;  // No removal — re-resolve on the next cycle
             }
 
-            // Remove from all non-source bubbles
+            // Remove from all non-source bubbles (using the same instances whose locks we hold)
             for (var bubbleId : locations) {
                 if (!bubbleId.equals(sourceBubble)) {
-                    // Find bubble by ID and remove entity
-                    var bubble = findBubbleById(bubbleId);
+                    var bubble = involvedById.get(bubbleId);
                     if (bubble != null) {
                         try {
                             bubble.removeEntity(entityId);

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/ghost/DuplicateEntityDetector.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/ghost/DuplicateEntityDetector.java
@@ -188,41 +188,61 @@ public class DuplicateEntityDetector {
 
         var sourceBubble = sourceBubbleOpt.get();
 
-        // Verify the authoritative source still holds the entity before pruning the others. If the
-        // entity has already left the expected source (another concurrent migration), deleting from
-        // the other locations risks erasing the live copy — abort and let the next cycle re-resolve.
         var sourceBubbleInstance = findBubbleById(sourceBubble);
-        if (sourceBubbleInstance == null || !sourceBubbleInstance.getEntities().contains(entityId)) {
-            if (config.logLevel() != DuplicateDetectionConfig.LogLevel.ERROR) {
-                log.warn("Reconciliation deferred: entity={} expected source={} no longer holds the entity "
-                         + "(concurrent migration); skipping to avoid entity loss", entityId, sourceBubble);
+
+        // Hold the mutation locks of EVERY involved bubble (the authoritative source plus every
+        // non-source location) in UUID order for the whole verify-then-prune so it is atomic w.r.t.
+        // concurrent migration/merge/split writers (Luciferase-n7io1). Without this, the
+        // "source still holds the entity" check below races a concurrent migration and the prune could
+        // erase the live copy. The locks are gathered before acquisition so the global UUID ordering is
+        // deadlock-free across all writer paths.
+        var involved = new java.util.ArrayList<EnhancedBubble>();
+        if (sourceBubbleInstance != null) {
+            involved.add(sourceBubbleInstance);
+        }
+        for (var bubbleId : locations) {
+            if (!bubbleId.equals(sourceBubble)) {
+                var b = findBubbleById(bubbleId);
+                if (b != null) {
+                    involved.add(b);
+                }
             }
-            return 0;  // No removal — re-resolve on the next cycle
         }
 
         var removedCount = 0;
+        try (var ignored = com.hellblazer.luciferase.simulation.bubble.MutationLocks.lock(involved)) {
+            // Verify (now race-free, under lock) that the authoritative source still holds the entity
+            // before pruning the others. If it has already left the expected source (a migration that
+            // committed before we acquired the locks), deleting from the other locations risks erasing
+            // the live copy — abort and let the next cycle re-resolve.
+            if (sourceBubbleInstance == null || !sourceBubbleInstance.getEntities().contains(entityId)) {
+                if (config.logLevel() != DuplicateDetectionConfig.LogLevel.ERROR) {
+                    log.warn("Reconciliation deferred: entity={} expected source={} no longer holds the entity "
+                             + "(concurrent migration); skipping to avoid entity loss", entityId, sourceBubble);
+                }
+                return 0;  // No removal — re-resolve on the next cycle
+            }
 
-        // LOCK MISSING (Luciferase-n7io1): acquire source+target getMutationLock() in UUID order;
-        // races concurrent migration/merge
-        // Remove from all non-source bubbles
-        for (var bubbleId : locations) {
-            if (!bubbleId.equals(sourceBubble)) {
-                // Find bubble by ID and remove entity
-                var bubble = findBubbleById(bubbleId);
-                if (bubble != null) {
-                    try {
-                        bubble.removeEntity(entityId);
-                        removedCount++;
+            // Remove from all non-source bubbles
+            for (var bubbleId : locations) {
+                if (!bubbleId.equals(sourceBubble)) {
+                    // Find bubble by ID and remove entity
+                    var bubble = findBubbleById(bubbleId);
+                    if (bubble != null) {
+                        try {
+                            bubble.removeEntity(entityId);
+                            removedCount++;
 
-                        if (config.logLevel() != DuplicateDetectionConfig.LogLevel.ERROR) {
-                            log.info("Reconciled duplicate: entity={} source={} removed_from={}",
-                                    entityId, sourceBubble, bubbleId);
+                            if (config.logLevel() != DuplicateDetectionConfig.LogLevel.ERROR) {
+                                log.info("Reconciled duplicate: entity={} source={} removed_from={}",
+                                        entityId, sourceBubble, bubbleId);
+                            }
+                        } catch (Exception e) {
+                            log.error("Failed to remove duplicate: entity={} bubble={}", entityId, bubbleId, e);
                         }
-                    } catch (Exception e) {
-                        log.error("Failed to remove duplicate: entity={} bubble={}", entityId, bubbleId, e);
+                    } else {
+                        log.error("Bubble not found during reconciliation: entity={} bubble={}", entityId, bubbleId);
                     }
-                } else {
-                    log.error("Bubble not found during reconciliation: entity={} bubble={}", entityId, bubbleId);
                 }
             }
         }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/topology/BubbleMerger.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/topology/BubbleMerger.java
@@ -17,6 +17,7 @@
 package com.hellblazer.luciferase.simulation.topology;
 
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
+import com.hellblazer.luciferase.simulation.bubble.MutationLocks;
 import com.hellblazer.luciferase.simulation.bubble.TetreeBubbleGrid;
 import com.hellblazer.luciferase.simulation.distributed.integration.EntityAccountant;
 import com.hellblazer.luciferase.simulation.distributed.integration.EntityValidationResult;
@@ -129,23 +130,12 @@ public class BubbleMerger {
             return new MergeExecutionResult(false, "Bubble2 not found: " + bubble2Id, 0, 0, 0);
         }
 
-        // Acquire BOTH bubble mutation locks in UUID.compareTo() order (consistent total order)
-        // before ANY snapshot or mutation.  This shares the same global lock order as
-        // TetrahedralMigration.executeMigration, making concurrent merge+migration deadlock-free.
-        int cmp = bubble1Id.compareTo(bubble2Id);
-        ReentrantLock firstLock  = cmp <= 0 ? bubble1.getMutationLock() : bubble2.getMutationLock();
-        ReentrantLock secondLock = cmp <= 0 ? bubble2.getMutationLock() : bubble1.getMutationLock();
-
-        firstLock.lock();
-        try {
-            secondLock.lock();
-            try {
-                return executeUnderLocks(correlationId, bubble1Id, bubble2Id, bubble1, bubble2);
-            } finally {
-                secondLock.unlock();
-            }
-        } finally {
-            firstLock.unlock();
+        // Hold BOTH bubble mutation locks via the shared MutationLocks protocol (ascending UUID order,
+        // deadlock-free) before ANY snapshot or mutation. This is the one coherent mutation-lock protocol
+        // shared by every multi-bubble writer (Luciferase-n7io1), so concurrent merge + migration + split
+        // on overlapping pairs cannot form a lock-ordering cycle.
+        try (var ignored = MutationLocks.lock(bubble1, bubble2)) {
+            return executeUnderLocks(correlationId, bubble1Id, bubble2Id, bubble1, bubble2);
         }
     }
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/topology/BubbleSplitter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/topology/BubbleSplitter.java
@@ -17,6 +17,7 @@
 package com.hellblazer.luciferase.simulation.topology;
 
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
+import com.hellblazer.luciferase.simulation.bubble.MutationLocks;
 import com.hellblazer.luciferase.simulation.bubble.TetreeBubbleGrid;
 import com.hellblazer.luciferase.simulation.distributed.integration.EntityAccountant;
 import com.hellblazer.luciferase.simulation.distributed.integration.EntityValidationResult;
@@ -268,6 +269,11 @@ public class BubbleSplitter {
         // and return failure.  The caller (TopologyExecutor) is responsible for
         // any higher-level rollback via OperationTracker.
         var movedRecords = new ArrayList<EnhancedBubble.EntityRecord>(entitiesToMove.size());
+        // Hold source + new-bubble mutation locks (UUID order, deadlock-free) for the whole move loop —
+        // including the rollback branch — so the cross-bubble add/remove is atomic w.r.t. concurrent
+        // migration/merge writers (Luciferase-n7io1). newBubble was registered in the grid above, so it
+        // is reachable by concurrent readers/writers by the time the move starts.
+        try (var ignored = MutationLocks.lock(sourceBubble, newBubble)) {
         for (var entityRecord : entitiesToMove) {
             var entityId = UUID.fromString(entityRecord.id());
 
@@ -308,6 +314,7 @@ public class BubbleSplitter {
             // Remove from source bubble only after accountant confirms the move
             sourceBubble.removeEntity(entityRecord.id());
             movedRecords.add(entityRecord);
+        }
         }
 
         int entitiesMoved = movedRecords.size();

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/topology/BubbleSplitter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/topology/BubbleSplitter.java
@@ -274,47 +274,47 @@ public class BubbleSplitter {
         // migration/merge writers (Luciferase-n7io1). newBubble was registered in the grid above, so it
         // is reachable by concurrent readers/writers by the time the move starts.
         try (var ignored = MutationLocks.lock(sourceBubble, newBubble)) {
-        for (var entityRecord : entitiesToMove) {
-            var entityId = UUID.fromString(entityRecord.id());
+            for (var entityRecord : entitiesToMove) {
+                var entityId = UUID.fromString(entityRecord.id());
 
-            // Add entity to new bubble first
-            newBubble.addEntity(entityRecord.id(), entityRecord.position(), entityRecord.content());
+                // Add entity to new bubble first
+                newBubble.addEntity(entityRecord.id(), entityRecord.position(), entityRecord.content());
 
-            // Move in accountant (atomic under its internal lock)
-            boolean moved = accountant.moveBetweenBubbles(entityId, sourceBubbleId, newBubbleId);
-            if (!moved) {
-                // FAIL FAST: undo all in-progress moves and abort the split.
-                log.error("[{}] Failed to move entity {} from {} to {} — aborting split, rolling back {} partial moves",
-                          correlationId, entityId, sourceBubbleId, newBubbleId, movedRecords.size());
-                // Undo: move already-moved entities back to source.
-                // Rollback is best-effort: if a rollback move itself fails, the entity is
-                // logged as an orphan but we continue reversing the rest.  Full 2PC
-                // (rollback-of-rollback) is out of scope; the log.error below makes
-                // any orphan diagnosable.
-                newBubble.removeEntity(entityRecord.id()); // undo bubble-side add for this entity
-                for (var done : movedRecords) {
-                    var doneId = UUID.fromString(done.id());
-                    boolean rolledBack = accountant.moveBetweenBubbles(doneId, newBubbleId, sourceBubbleId);
-                    if (!rolledBack) {
-                        log.error("[{}] Rollback move FAILED for entity {} (from newBubble {} back to source {}) — entity may be orphaned",
-                                  correlationId, doneId, newBubbleId, sourceBubbleId);
+                // Move in accountant (atomic under its internal lock)
+                boolean moved = accountant.moveBetweenBubbles(entityId, sourceBubbleId, newBubbleId);
+                if (!moved) {
+                    // FAIL FAST: undo all in-progress moves and abort the split.
+                    log.error("[{}] Failed to move entity {} from {} to {} — aborting split, rolling back {} partial moves",
+                              correlationId, entityId, sourceBubbleId, newBubbleId, movedRecords.size());
+                    // Undo: move already-moved entities back to source.
+                    // Rollback is best-effort: if a rollback move itself fails, the entity is
+                    // logged as an orphan but we continue reversing the rest.  Full 2PC
+                    // (rollback-of-rollback) is out of scope; the log.error below makes
+                    // any orphan diagnosable.
+                    newBubble.removeEntity(entityRecord.id()); // undo bubble-side add for this entity
+                    for (var done : movedRecords) {
+                        var doneId = UUID.fromString(done.id());
+                        boolean rolledBack = accountant.moveBetweenBubbles(doneId, newBubbleId, sourceBubbleId);
+                        if (!rolledBack) {
+                            log.error("[{}] Rollback move FAILED for entity {} (from newBubble {} back to source {}) — entity may be orphaned",
+                                      correlationId, doneId, newBubbleId, sourceBubbleId);
+                        }
+                        sourceBubble.addEntity(done.id(), done.position(), done.content());
+                        newBubble.removeEntity(done.id());
                     }
-                    sourceBubble.addEntity(done.id(), done.position(), done.content());
-                    newBubble.removeEntity(done.id());
+                    // Remove the pre-registered empty/reverted new bubble from the grid.
+                    bubbleGrid.removeBubble(newBubbleId);
+                    metrics.recordSplitFailure("MOVE_FAILED");
+                    return new SplitExecutionResult(false,
+                                                   "moveBetweenBubbles failed for entity " + entityId
+                                                   + "; split aborted and rolled back",
+                                                   null, entitiesBeforeSplit, entitiesBeforeSplit);
                 }
-                // Remove the pre-registered empty/reverted new bubble from the grid.
-                bubbleGrid.removeBubble(newBubbleId);
-                metrics.recordSplitFailure("MOVE_FAILED");
-                return new SplitExecutionResult(false,
-                                               "moveBetweenBubbles failed for entity " + entityId
-                                               + "; split aborted and rolled back",
-                                               null, entitiesBeforeSplit, entitiesBeforeSplit);
-            }
 
-            // Remove from source bubble only after accountant confirms the move
-            sourceBubble.removeEntity(entityRecord.id());
-            movedRecords.add(entityRecord);
-        }
+                // Remove from source bubble only after accountant confirms the move
+                sourceBubble.removeEntity(entityRecord.id());
+                movedRecords.add(entityRecord);
+            }
         }
 
         int entitiesMoved = movedRecords.size();

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/BubbleMutationLockConcurrencyTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/BubbleMutationLockConcurrencyTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.bubble;
+
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3f;
+import java.util.HashSet;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Concurrency regression for the one coherent mutation-lock protocol (Luciferase-n7io1).
+ * <p>
+ * Two <b>different</b> multi-bubble entity-writer paths hammer the SAME bubble pair concurrently:
+ * <ul>
+ *   <li>{@link BubbleLifecycle#transferEntities} — a production writer now guarded by
+ *       {@link MutationLocks};</li>
+ *   <li>an independent writer that follows the same {@link MutationLocks} protocol directly (the shape
+ *       used by {@code TetrahedralMigration}/{@code MultiDirectionalMigration}/{@code BubbleMerger}:
+ *       lock the pair in UUID order, then add-to-target / remove-from-source).</li>
+ * </ul>
+ * Because every multi-bubble writer acquires the involved bubbles' locks in a single global UUID order,
+ * (1) the run cannot deadlock (it completes within the timeout) and (2) entities are exactly conserved —
+ * no entity is lost, duplicated, or created. Before n7io1, {@code transferEntities} skipped the lock, so
+ * its read-snapshot / add / remove interleaved with the other writer and could lose or duplicate entities.
+ *
+ * @author hal.hildebrand
+ */
+class BubbleMutationLockConcurrencyTest {
+
+    @Test
+    void concurrentDistinctWriterPaths_conserveEntitiesAndDoNotDeadlock() throws Exception {
+        var lifecycle = new BubbleLifecycle(e -> { });
+        var a = new EnhancedBubble(UUID.randomUUID(), (byte) 10, 10);
+        var b = new EnhancedBubble(UUID.randomUUID(), (byte) 10, 10);
+
+        int entityCount = 50;
+        var originalIds = new HashSet<String>();
+        for (int i = 0; i < entityCount; i++) {
+            var id = "e" + i;
+            originalIds.add(id);
+            a.addEntity(id, new Point3f(i, 0f, 0f), "content-" + i);
+        }
+
+        int iterations = 300;
+        var pool = Executors.newFixedThreadPool(2);
+        var start = new CountDownLatch(1);
+
+        // Path 1: production BubbleLifecycle.transferEntities, ping-ponging the pair.
+        Callable<Void> path1 = () -> {
+            start.await();
+            for (int i = 0; i < iterations; i++) {
+                lifecycle.transferEntities(a, b);
+                lifecycle.transferEntities(b, a);
+            }
+            return null;
+        };
+
+        // Path 2: an independent protocol-honoring writer (same MutationLocks discipline as the
+        // migration/merge paths), moving in the opposite phase.
+        Callable<Void> path2 = () -> {
+            start.await();
+            for (int i = 0; i < iterations; i++) {
+                moveAllUnderLock(b, a);
+                moveAllUnderLock(a, b);
+            }
+            return null;
+        };
+
+        var f1 = pool.submit(path1);
+        var f2 = pool.submit(path2);
+        start.countDown();
+
+        // Completion within the timeout proves no lock-ordering deadlock (UUID-ordered acquisition).
+        f1.get(30, TimeUnit.SECONDS);
+        f2.get(30, TimeUnit.SECONDS);
+        pool.shutdownNow();
+
+        var inA = new HashSet<>(a.getEntities());
+        var inB = new HashSet<>(b.getEntities());
+        var union = new HashSet<String>();
+        union.addAll(inA);
+        union.addAll(inB);
+
+        assertThat(union)
+            .as("entities must be exactly conserved across concurrent multi-bubble writers (no loss/creation)")
+            .isEqualTo(originalIds);
+        assertThat(java.util.Collections.disjoint(inA, inB))
+            .as("no entity may reside in both bubbles (no duplication)")
+            .isTrue();
+    }
+
+    /**
+     * Move every entity from {@code src} to {@code dst} atomically under the shared mutation-lock
+     * protocol — the same add-to-target / remove-from-source shape the production migration/merge paths
+     * use, lifted out so the test exercises a writer path distinct from {@code transferEntities}.
+     */
+    private static void moveAllUnderLock(EnhancedBubble src, EnhancedBubble dst) {
+        try (var ignored = MutationLocks.lock(src, dst)) {
+            var records = src.getAllEntityRecords();
+            for (var record : records) {
+                dst.addEntity(record.id(), record.position(), record.content());
+            }
+            for (var record : records) {
+                src.removeEntity(record.id());
+            }
+        }
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/BubbleMutationLockConcurrencyTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/BubbleMutationLockConcurrencyTest.java
@@ -17,24 +17,30 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Concurrency regression for the one coherent mutation-lock protocol (Luciferase-n7io1).
  * <p>
- * Two <b>different</b> multi-bubble entity-writer paths hammer the SAME bubble pair concurrently:
+ * Two <b>genuinely different</b> multi-bubble entity-writer paths hammer the SAME bubble pair concurrently:
  * <ul>
- *   <li>{@link BubbleLifecycle#transferEntities} — a production writer now guarded by
- *       {@link MutationLocks};</li>
- *   <li>an independent writer that follows the same {@link MutationLocks} protocol directly (the shape
- *       used by {@code TetrahedralMigration}/{@code MultiDirectionalMigration}/{@code BubbleMerger}:
- *       lock the pair in UUID order, then add-to-target / remove-from-source).</li>
+ *   <li><b>Path 1 — {@link BubbleLifecycle#transferEntities}</b>: a production writer that acquires the
+ *       pair via the {@link MutationLocks} utility.</li>
+ *   <li><b>Path 2 — an inline manual locker</b>: acquires {@code getMutationLock()} directly in ascending
+ *       UUID order WITHOUT the utility (the documented contract that {@code TetrahedralMigration} /
+ *       {@code BubbleMerger} historically used). This proves a caller following the ordering by hand
+ *       composes deadlock-free with a {@code MutationLocks} caller — the cross-implementation case.</li>
  * </ul>
- * Because every multi-bubble writer acquires the involved bubbles' locks in a single global UUID order,
- * (1) the run cannot deadlock (it completes within the timeout) and (2) entities are exactly conserved —
- * no entity is lost, duplicated, or created. Before n7io1, {@code transferEntities} skipped the lock, so
- * its read-snapshot / add / remove interleaved with the other writer and could lose or duplicate entities.
+ * Assertions are sensitive to the ACTUAL corruption class, not just the id set: {@code entityCount()} reads
+ * the Tetree spatial index while {@code getAllEntityRecords()} reads the id mapping, so a raced
+ * add/remove that leaves them inconsistent (a spatial-index "zombie" or a lost mapping) is caught — a plain
+ * id-set check would miss it because {@code idMapping.put} overwrites on a duplicate key.
+ * <p>
+ * Before n7io1, {@code transferEntities} skipped the lock, so its snapshot/add/remove interleaved with the
+ * other writer and corrupted the pair. With the shared protocol the run (1) cannot deadlock — it completes
+ * within the timeout — and (2) conserves entities exactly across both the spatial index and the id mapping.
  *
  * @author hal.hildebrand
  */
@@ -54,11 +60,11 @@ class BubbleMutationLockConcurrencyTest {
             a.addEntity(id, new Point3f(i, 0f, 0f), "content-" + i);
         }
 
-        int iterations = 300;
+        int iterations = 400;
         var pool = Executors.newFixedThreadPool(2);
         var start = new CountDownLatch(1);
 
-        // Path 1: production BubbleLifecycle.transferEntities, ping-ponging the pair.
+        // Path 1: production BubbleLifecycle.transferEntities (acquires via MutationLocks), ping-ponging.
         Callable<Void> path1 = () -> {
             start.await();
             for (int i = 0; i < iterations; i++) {
@@ -68,13 +74,12 @@ class BubbleMutationLockConcurrencyTest {
             return null;
         };
 
-        // Path 2: an independent protocol-honoring writer (same MutationLocks discipline as the
-        // migration/merge paths), moving in the opposite phase.
+        // Path 2: an INLINE manual locker (UUID order, not via MutationLocks), opposite phase.
         Callable<Void> path2 = () -> {
             start.await();
             for (int i = 0; i < iterations; i++) {
-                moveAllUnderLock(b, a);
-                moveAllUnderLock(a, b);
+                inlineOrderedMove(b, a);
+                inlineOrderedMove(a, b);
             }
             return null;
         };
@@ -83,19 +88,33 @@ class BubbleMutationLockConcurrencyTest {
         var f2 = pool.submit(path2);
         start.countDown();
 
-        // Completion within the timeout proves no lock-ordering deadlock (UUID-ordered acquisition).
+        // Completion within the timeout proves no lock-ordering deadlock between the utility path and the
+        // inline-manual-lock path (both acquire in ascending UUID order).
         f1.get(30, TimeUnit.SECONDS);
         f2.get(30, TimeUnit.SECONDS);
         pool.shutdownNow();
 
+        // Spatial-index conservation (catches zombies / lost inserts that an id-set check would hide).
+        assertThat(a.entityCount() + b.entityCount())
+            .as("total spatial-index entity count must be exactly conserved across the pair")
+            .isEqualTo(entityCount);
+
+        // Per-bubble internal consistency: spatial index count == id-mapping record count.
+        assertThat(a.entityCount())
+            .as("bubble A: spatial-index count must match id-mapping record count (no divergence)")
+            .isEqualTo(a.getAllEntityRecords().size());
+        assertThat(b.entityCount())
+            .as("bubble B: spatial-index count must match id-mapping record count (no divergence)")
+            .isEqualTo(b.getAllEntityRecords().size());
+
+        // Id-level conservation + uniqueness.
         var inA = new HashSet<>(a.getEntities());
         var inB = new HashSet<>(b.getEntities());
         var union = new HashSet<String>();
         union.addAll(inA);
         union.addAll(inB);
-
         assertThat(union)
-            .as("entities must be exactly conserved across concurrent multi-bubble writers (no loss/creation)")
+            .as("entity ids must be exactly conserved (no loss/creation)")
             .isEqualTo(originalIds);
         assertThat(java.util.Collections.disjoint(inA, inB))
             .as("no entity may reside in both bubbles (no duplication)")
@@ -103,19 +122,30 @@ class BubbleMutationLockConcurrencyTest {
     }
 
     /**
-     * Move every entity from {@code src} to {@code dst} atomically under the shared mutation-lock
-     * protocol — the same add-to-target / remove-from-source shape the production migration/merge paths
-     * use, lifted out so the test exercises a writer path distinct from {@code transferEntities}.
+     * Move every entity {@code src -> dst} atomically by acquiring both mutation locks BY HAND in
+     * ascending UUID order — the documented inline contract, deliberately NOT routed through
+     * {@link MutationLocks}, so the test exercises a writer path distinct from {@code transferEntities}.
      */
-    private static void moveAllUnderLock(EnhancedBubble src, EnhancedBubble dst) {
-        try (var ignored = MutationLocks.lock(src, dst)) {
-            var records = src.getAllEntityRecords();
-            for (var record : records) {
-                dst.addEntity(record.id(), record.position(), record.content());
+    private static void inlineOrderedMove(EnhancedBubble src, EnhancedBubble dst) {
+        int cmp = src.id().compareTo(dst.id());
+        ReentrantLock first = cmp <= 0 ? src.getMutationLock() : dst.getMutationLock();
+        ReentrantLock second = cmp <= 0 ? dst.getMutationLock() : src.getMutationLock();
+        first.lock();
+        try {
+            second.lock();
+            try {
+                var records = src.getAllEntityRecords();
+                for (var record : records) {
+                    dst.addEntity(record.id(), record.position(), record.content());
+                }
+                for (var record : records) {
+                    src.removeEntity(record.id());
+                }
+            } finally {
+                second.unlock();
             }
-            for (var record : records) {
-                src.removeEntity(record.id());
-            }
+        } finally {
+            first.unlock();
         }
     }
 }


### PR DESCRIPTION
Closes Luciferase-n7io1.

## Problem
Multi-bubble entity writers bypassed the `getMutationLock()` protocol, so cross-bubble add/remove sequences could interleave with concurrent migration/merge/split writers and corrupt the pair (lost entities, spatial-index/id-mapping divergence, duplicates).

## Change
Introduces `MutationLocks` — a single coherent, deadlock-free protocol (per-bubble `ReentrantLock`s acquired in ascending-UUID order, try-with-resources, partial-acquisition rollback, reverse-order release, null/duplicate filtering). All six multi-bubble writers now route through it:

- `BubbleLifecycle.transferEntities`
- `BubbleSplitter.execute` (the LIVE split path)
- `BubbleMerger.execute`
- `TetrahedralMigration.executeMigration`
- `MultiDirectionalMigration.commitMigration` (+ re-validate entity presence under lock)
- `DuplicateEntityDetector.reconcile` (single `involvedById` resolution)

`AdaptiveSplitPolicy.performSplit` is dead code (no prod callers); kept defensively.

## Test
`BubbleMutationLockConcurrencyTest` hammers the same bubble pair from two genuinely distinct writer paths — `transferEntities` (via the utility) and an inline manual UUID-ordered locker (NOT via the utility) — proving cross-implementation deadlock-freedom. Assertions are corruption-sensitive: spatial-index conservation, `entityCount() == getAllEntityRecords().size()` (spatial-vs-mapping consistency), id conservation, and disjointness. These fail on the pre-n7io1 unlocked code.

## Review
Stacked review (both reviewers, two rounds):
- Round 1 found 2 Criticals (lock was on dead code; test near-vacuous) + 3 Significants — all fixed in round 2.
- Round 2: code-review-expert 0 Critical; substantive-critic JUSTIFIED / high confidence / 0 Critical.
- Residual non-blocking findings (BubbleSplitter pre-lock snapshot TOCTOU, rollback-protected; no direct split concurrency test) tracked in Luciferase-hvjdj.

Tests green: concurrency 1/1, BubbleSplitterTest 12/12, BubbleMergerTest 14 (1 skip), TetrahedralMigrationTest 23/23.