### PR TITLE
fix(lucien-distributed): bound ghost gRPC response amplification (onzvy)

### DIFF
--- a/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostExchangeServiceImpl.java
+++ b/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostExchangeServiceImpl.java
@@ -67,7 +67,22 @@ public class GhostExchangeServiceImpl<Key extends SpatialKey<Key>, ID extends En
     // but does not limit the NUMBER of open StreamGhostUpdates streams — many cheap streams would otherwise pin
     // unbounded virtual-thread tasks + activeStreams entries (connection-level DoS).
     private static final int MAX_ACTIVE_STREAMS = 1024;
-    
+
+    // Luciferase-onzvy: SyncGhosts is unary — a small SyncRequest listing many tree_ids makes the server build a
+    // correspondingly large SyncResponse before sending. The inbound message bound caps the REQUEST, not the
+    // OUTBOUND response, so an unbounded tree_id list is a response-amplification DoS vector. Cap the count and
+    // reject an oversized request with INVALID_ARGUMENT before doing any work.
+    private static final int MAX_SYNC_TREE_IDS = 4096;
+
+    // Luciferase-onzvy: capping the tree_id COUNT bounds fan-out but NOT per-tree size — a single tree_id whose
+    // ghost layer holds millions of elements still makes the server allocate a multi-GB response before the
+    // client's inbound bound ever drops it (server-side heap/CPU amplification). Bound the OUTBOUND response by
+    // total element count, checked against GhostLayer.getNumGhostElements() (O(1)) BEFORE building each batch, so
+    // the server never allocates an over-cap response. Applies to both unary all-ghosts paths (syncGhosts and the
+    // no-boundary-keys requestGhosts path). Rejected with RESOURCE_EXHAUSTED (transient/size, not a static
+    // argument violation). 1M elements ≈ a generous ghost working set; tune if a real workload needs more.
+    private static final long MAX_RESPONSE_GHOST_ELEMENTS = 1_000_000L;
+
     // Virtual thread executor for concurrent operations
     private final ExecutorService virtualExecutor;
     
@@ -146,6 +161,23 @@ public class GhostExchangeServiceImpl<Key extends SpatialKey<Key>, ID extends En
                     return;
                 }
                 
+                // Luciferase-onzvy: the no-boundary-keys path of createGhostBatch dumps the ENTIRE ghost layer into one
+                // GhostBatch — the same server-side amplification as syncGhosts. Bound it before building (O(1) count
+                // check). The boundary-keys path is client-bounded (the client enumerates exactly which keys it wants,
+                // capped by the inbound request size), so only the all-ghosts path needs this guard.
+                if (request.getBoundaryKeysCount() == 0
+                    && ghostLayer.getNumGhostElements() > MAX_RESPONSE_GHOST_ELEMENTS) {
+                    log.warn("Rejecting ghost request from rank {} for tree {}: {} ghost elements exceeds cap {}",
+                             request.getRequesterRank(), request.getRequesterTreeId(),
+                             ghostLayer.getNumGhostElements(), MAX_RESPONSE_GHOST_ELEMENTS);
+                    responseObserver.onError(Status.RESOURCE_EXHAUSTED
+                                                 .withDescription("ghost batch would exceed element cap: "
+                                                                  + ghostLayer.getNumGhostElements() + " > "
+                                                                  + MAX_RESPONSE_GHOST_ELEMENTS)
+                                                 .asRuntimeException());
+                    return;
+                }
+
                 // Create response batch with relevant ghosts
                 var batch = createGhostBatch(request, ghostLayer);
                 responseObserver.onNext(batch);
@@ -233,7 +265,20 @@ public class GhostExchangeServiceImpl<Key extends SpatialKey<Key>, ID extends En
     @Override
     public void syncGhosts(SyncRequest request, StreamObserver<SyncResponse> responseObserver) {
         syncRequestCount.incrementAndGet();
-        
+
+        // Luciferase-onzvy: reject an oversized tree_id list synchronously, BEFORE spawning a task or building any
+        // response — bounding outbound response amplification (the inbound limit only caps the request).
+        int treeIdCount = request.getTreeIdsCount();
+        if (treeIdCount > MAX_SYNC_TREE_IDS) {
+            log.warn("Rejecting sync request from rank {}: {} tree_ids exceeds cap {}",
+                     request.getRequesterRank(), treeIdCount, MAX_SYNC_TREE_IDS);
+            responseObserver.onError(Status.INVALID_ARGUMENT
+                                         .withDescription("too many tree_ids in sync request: " + treeIdCount
+                                                          + " > " + MAX_SYNC_TREE_IDS)
+                                         .asRuntimeException());
+            return;
+        }
+
         virtualExecutor.submit(() -> {
             try {
                 log.debug("Processing sync request from rank {} for {} trees", 
@@ -245,9 +290,24 @@ public class GhostExchangeServiceImpl<Key extends SpatialKey<Key>, ID extends En
                 long now = clock.currentTimeMillis();
 
                 // Process each requested tree
+                long projectedElements = 0;
                 for (var treeId : request.getTreeIdsList()) {
                     var ghostLayer = ghostLayerProvider.getGhostLayer(treeId);
                     if (ghostLayer != null) {
+                        // Luciferase-onzvy: bound the OUTBOUND response before allocating this batch. getNumGhostElements
+                        // is O(1); if servicing this tree would push the response past the cap, reject the whole request
+                        // with RESOURCE_EXHAUSTED so the server never builds an over-cap response.
+                        projectedElements += ghostLayer.getNumGhostElements();
+                        if (projectedElements > MAX_RESPONSE_GHOST_ELEMENTS) {
+                            log.warn("Rejecting sync request from rank {}: projected {} ghost elements exceeds cap {}",
+                                     request.getRequesterRank(), projectedElements, MAX_RESPONSE_GHOST_ELEMENTS);
+                            responseObserver.onError(Status.RESOURCE_EXHAUSTED
+                                                         .withDescription("sync response would exceed element cap: "
+                                                                          + projectedElements + " > "
+                                                                          + MAX_RESPONSE_GHOST_ELEMENTS)
+                                                         .asRuntimeException());
+                            return;
+                        }
                         var batch = ProtobufConverters.ghostLayerToProtobufBatch(
                             ghostLayer,
                             ghostLayerProvider.getCurrentRank(),

--- a/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostServiceClient.java
+++ b/lucien-distributed/src/main/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostServiceClient.java
@@ -18,6 +18,7 @@
 package com.hellblazer.luciferase.lucien.forest.ghost.grpc;
 
 import com.hellblazer.luciferase.common.grpc.GrpcCredentialFactory;
+import com.hellblazer.luciferase.common.grpc.GrpcServerHardening;
 import com.hellblazer.luciferase.lucien.SpatialKey;
 import com.hellblazer.luciferase.lucien.entity.EntityID;
 import com.hellblazer.luciferase.lucien.forest.ghost.ContentSerializer;
@@ -465,10 +466,14 @@ public class GhostServiceClient<Key extends SpatialKey<Key>, ID extends EntityID
             // RDR-005: credentials default to insecure (plaintext); mTLS is injected by the caller.
             // endpoint is a host:port target — Grpc.newChannelBuilder resolves it as
             // ManagedChannelBuilder.forTarget did (default name resolver).
+            // Luciferase-onzvy: bound the inbound (response) size on the client. Without this the receiving side has
+            // no cap on a SyncResponse, leaving it exposed to a response-amplification DoS from a compromised/buggy
+            // peer. Mirrors the server inbound bound (GrpcServerHardening.DEFAULT_MAX_INBOUND_MESSAGE_BYTES).
             return Grpc.newChannelBuilder(endpoint, channelCredentials)
                 .keepAliveTime(30, TimeUnit.SECONDS)
                 .keepAliveTimeout(5, TimeUnit.SECONDS)
                 .keepAliveWithoutCalls(true)
+                .maxInboundMessageSize(GrpcServerHardening.DEFAULT_MAX_INBOUND_MESSAGE_BYTES)
                 .build();
         });
     }

--- a/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostSyncTreeIdCapTest.java
+++ b/lucien-distributed/src/test/java/com/hellblazer/luciferase/lucien/forest/ghost/grpc/GhostSyncTreeIdCapTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+package com.hellblazer.luciferase.lucien.forest.ghost.grpc;
+
+import com.hellblazer.luciferase.lucien.entity.LongEntityID;
+import com.hellblazer.luciferase.lucien.forest.ghost.ContentSerializer;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostElement;
+import com.hellblazer.luciferase.lucien.forest.ghost.GhostLayer;
+import com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostExchangeGrpc;
+import com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostRequest;
+import com.hellblazer.luciferase.lucien.forest.ghost.proto.GhostType;
+import com.hellblazer.luciferase.lucien.forest.ghost.proto.StatsResponse;
+import com.hellblazer.luciferase.lucien.forest.ghost.proto.SyncRequest;
+import com.hellblazer.luciferase.lucien.octree.MortonKey;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Luciferase-onzvy: {@code syncGhosts} is a unary RPC — a small {@link SyncRequest} listing an arbitrarily large
+ * number of {@code tree_ids} makes the server build a correspondingly large {@code SyncResponse} before sending.
+ * The server INBOUND message bound caps the request, not the outbound response, so an unbounded tree_id list is a
+ * response-amplification DoS vector. The fix caps the tree_id count and rejects an oversized request with
+ * {@code INVALID_ARGUMENT} BEFORE doing any work.
+ *
+ * @author hal.hildebrand
+ */
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+class GhostSyncTreeIdCapTest {
+
+    private static final ContentSerializer<String> SERIALIZER = new ContentSerializer<>() {
+        @Override public byte[] serialize(String content) { return content.getBytes(StandardCharsets.UTF_8); }
+        @Override public String deserialize(byte[] bytes) { return new String(bytes, StandardCharsets.UTF_8); }
+        @Override public String getContentType() { return "string"; }
+    };
+
+    private Server server;
+    private ManagedChannel channel;
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (channel != null) {
+            channel.shutdownNow();
+            channel.awaitTermination(5, TimeUnit.SECONDS);
+        }
+        if (server != null) {
+            server.shutdownNow();
+            server.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+
+    /** Provider returning a fixed (possibly null) ghost layer for any tree id. */
+    private static final class FixedLayerProvider
+            implements GhostExchangeServiceImpl.GhostLayerProvider<MortonKey, LongEntityID, String> {
+        private final GhostLayer<MortonKey, LongEntityID, String> layer;
+        FixedLayerProvider(GhostLayer<MortonKey, LongEntityID, String> layer) { this.layer = layer; }
+        @Override public GhostLayer<MortonKey, LongEntityID, String> getGhostLayer(long treeId) { return layer; }
+        @Override public int getCurrentRank() { return 0; }
+        @Override public void addGhostElement(GhostElement<MortonKey, LongEntityID, String> e) { }
+        @Override public void updateGhostElement(GhostElement<MortonKey, LongEntityID, String> e) { }
+        @Override public boolean removeGhostElement(String entityId, long treeId) { return false; }
+        @Override public StatsResponse getGlobalStats() { return StatsResponse.getDefaultInstance(); }
+    }
+
+    /** A ghost layer reporting an arbitrary element count without actually holding that many elements. */
+    private static GhostLayer<MortonKey, LongEntityID, String> layerReporting(long count) {
+        return new GhostLayer<>(com.hellblazer.luciferase.lucien.forest.ghost.GhostType.FACES) {
+            @Override public long getNumGhostElements() { return count; }
+        };
+    }
+
+    private GhostExchangeGrpc.GhostExchangeBlockingStub startAndConnect(
+            GhostExchangeServiceImpl.GhostLayerProvider<MortonKey, LongEntityID, String> provider) throws Exception {
+        var serviceImpl = new GhostExchangeServiceImpl<>(provider, SERIALIZER, LongEntityID.class);
+        var name = "ghost-sync-cap-" + System.nanoTime();
+        server = InProcessServerBuilder.forName(name).directExecutor().addService(serviceImpl).build().start();
+        channel = InProcessChannelBuilder.forName(name).directExecutor().build();
+        return GhostExchangeGrpc.newBlockingStub(channel);
+    }
+
+    private GhostExchangeGrpc.GhostExchangeBlockingStub startAndConnect() throws Exception {
+        return startAndConnect(new FixedLayerProvider(null));
+    }
+
+    private static int syncCap() throws Exception {
+        Field f = GhostExchangeServiceImpl.class.getDeclaredField("MAX_SYNC_TREE_IDS");
+        f.setAccessible(true);
+        return (int) f.get(null);
+    }
+
+    private static long responseElementCap() throws Exception {
+        Field f = GhostExchangeServiceImpl.class.getDeclaredField("MAX_RESPONSE_GHOST_ELEMENTS");
+        f.setAccessible(true);
+        return (long) f.get(null);
+    }
+
+    @Test
+    void syncGhosts_rejectsOversizedTreeIdList_withInvalidArgument() throws Exception {
+        var stub = startAndConnect();
+        int cap = syncCap();
+
+        var oversized = SyncRequest.newBuilder().setRequesterRank(1).setGhostType(GhostType.FACES);
+        for (int i = 0; i <= cap; i++) {     // cap + 1 tree ids
+            oversized.addTreeIds(i);
+        }
+
+        var ex = assertThrows(StatusRuntimeException.class, () -> stub.syncGhosts(oversized.build()),
+                              "an over-cap tree_id list must be rejected, not serviced");
+        assertEquals(Status.Code.INVALID_ARGUMENT, ex.getStatus().getCode(),
+                     "oversized sync request must be rejected with INVALID_ARGUMENT");
+    }
+
+    @Test
+    void syncGhosts_acceptsRequestAtCap() throws Exception {
+        var stub = startAndConnect();
+        int cap = syncCap();
+
+        var atCap = SyncRequest.newBuilder().setRequesterRank(1).setGhostType(GhostType.FACES);
+        for (int i = 0; i < cap; i++) {      // exactly cap tree ids — must be serviced
+            atCap.addTreeIds(i);
+        }
+
+        var response = stub.syncGhosts(atCap.build());
+        assertNotNull(response, "a request at the cap must be serviced normally");
+        assertEquals(0, response.getTotalElements(), "no ghost layers registered → empty but valid response");
+    }
+
+    @Test
+    void syncGhosts_rejectsOversizedResponse_withResourceExhausted() throws Exception {
+        long cap = responseElementCap();
+        // A single tree whose ghost layer reports more than the cap — the count cap alone (one tree) would let this
+        // through, but the OUTBOUND element bound must reject it before the server builds the response.
+        var stub = startAndConnect(new FixedLayerProvider(layerReporting(cap + 1)));
+
+        var request = SyncRequest.newBuilder().setRequesterRank(1).setGhostType(GhostType.FACES).addTreeIds(1L).build();
+
+        var ex = assertThrows(StatusRuntimeException.class, () -> stub.syncGhosts(request),
+                              "a single huge tree must be rejected by the outbound element bound");
+        assertEquals(Status.Code.RESOURCE_EXHAUSTED, ex.getStatus().getCode(),
+                     "an over-cap response must be rejected with RESOURCE_EXHAUSTED");
+    }
+
+    @Test
+    void requestGhosts_rejectsOversizedAllGhostsResponse_withResourceExhausted() throws Exception {
+        long cap = responseElementCap();
+        var stub = startAndConnect(new FixedLayerProvider(layerReporting(cap + 1)));
+
+        // No boundary keys → the all-ghosts path, which dumps the entire layer; must be bounded like syncGhosts.
+        var request = GhostRequest.newBuilder().setRequesterRank(1).setRequesterTreeId(1L)
+                                  .setGhostType(GhostType.FACES).build();
+
+        var ex = assertThrows(StatusRuntimeException.class, () -> stub.requestGhosts(request),
+                              "the no-boundary-keys all-ghosts path must be bounded too");
+        assertEquals(Status.Code.RESOURCE_EXHAUSTED, ex.getStatus().getCode(),
+                     "an over-cap all-ghosts batch must be rejected with RESOURCE_EXHAUSTED");
+    }
+}


### PR DESCRIPTION
Closes Luciferase-onzvy.

## Problem
`SyncGhosts` (and the no-boundary-keys `requestGhosts` path) are unary RPCs that built unbounded responses from small requests — an amplification DoS. The gRPC inbound bound caps requests, not outbound responses, and `GhostServiceClient` set no inbound cap at all.

## Fix
**Server (`GhostExchangeServiceImpl`)**
- `MAX_SYNC_TREE_IDS = 4096`: reject oversized tree_id lists with `INVALID_ARGUMENT` synchronously, before spawning a task or building any response (fan-out cap).
- `MAX_RESPONSE_GHOST_ELEMENTS = 1M`: bound the **outbound** response by element count, checked via `GhostLayer.getNumGhostElements()` (O(1)) **before** building each batch, so the server never allocates an over-cap response. Applied to both `syncGhosts` (per-tree projection accumulation) and the all-ghosts `requestGhosts` path. Rejected with `RESOURCE_EXHAUSTED`.

**Client (`GhostServiceClient`)**
- `.maxInboundMessageSize(GrpcServerHardening.DEFAULT_MAX_INBOUND_MESSAGE_BYTES)` (4 MiB) on the channel — caps responses the client accepts from a peer.

## Test
`GhostSyncTreeIdCapTest`: tree_id cap (`INVALID_ARGUMENT`), at-cap accepted, and the response element cap on **both** `syncGhosts` and `requestGhosts` (`RESOURCE_EXHAUSTED`, via a `GhostLayer` reporting `cap+1`).

## Review
Stacked review, two rounds:
- Round 1 substantive-critic **NOT-JUSTIFIED** (2 Criticals: capping tree_id *count* left per-tree server-side amplification open, and `requestGhosts` was uncapped) — this drove the outbound element bound.
- Round 2: code-review-expert clean; substantive-critic **JUSTIFIED / high / 0 Critical / 0 Significant**.

Minor residual noted by the critic (acceptable): the boundary-keys `requestGhosts` path bounds per-key fan-out only via the client inbound cap, not a server-side element count.

Tests green: GhostSyncTreeIdCapTest (4), plus GhostMessageSizeLimitTest, GhostStreamCapConcurrencyTest, GhostExchangeClockInjectionTest, GhostCommunicationIntegrationTest.