### PR TITLE
RDR-017 P0: production node bootstrap skeleton + lifecycle ordering fix (Luciferase-vhhu0)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/LifecycleCoordinator.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/LifecycleCoordinator.java
@@ -706,7 +706,9 @@ public class LifecycleCoordinator {
      * @return list of layers, each layer is a list of component names
      * @throws LifecycleException if circular dependency detected
      */
-    private List<List<String>> computeLayers() {
+    // Package-private (was private) so layering tests can assert the computed dependency
+    // grouping directly without driving a full start() (RDR-017 P0, Luciferase-vhhu0).
+    List<List<String>> computeLayers() {
         var layers = new ArrayList<List<String>>();
 
         // Build in-degree map (count of dependencies for each component)

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapter.java
@@ -19,23 +19,20 @@ import java.util.Objects;
  * Wraps PersistenceManager to provide LifecycleComponent interface without modifying
  * the original class. Uses composition pattern for clean separation.
  * <p>
- * Dependency Layer: 1 (depends on SocketConnectionManager)
+ * Dependency Layer: 0 (no dependencies — RDR-017 gate C2; persistence has zero network surface)
  * <p>
  * Note: PersistenceManager auto-starts background tasks (batch flush, checkpoints) on construction.
  * The start() method is effectively a no-op but maintains lifecycle state consistency.
  * <p>
  * Extends {@link AbstractLifecycleAdapter} for common state management logic.
  * <p>
- * <b>Scaffolding — NOT composed in production (RDR-016).</b> This adapter, and the WAL persistence /
- * crash-recovery subsystem it wraps, are currently library scaffolding: no production node bootstrap
- * constructs a {@link PersistenceManager} or registers this adapter with a
- * {@code LifecycleCoordinator}. Consequences while uncomposed: {@link #doStart()} is a deliberate no-op
- * (recovery never runs in any live node), and {@code dependencies()} declares
- * {@code "SocketConnectionManager"} which is itself never registered — so registering this adapter as-is
- * would fail {@code LifecycleCoordinator.computeLayers()}. Productionizing persistence (constructing it
- * in a node bootstrap, calling {@code recover()} fail-loud from {@code doStart()}, choosing among the
- * three independent durability subsystems, and fixing the lifecycle dependency ordering) is deferred to
- * <b>RDR-017 (Production Node Bootstrap)</b>. Do not wire this adapter into a coordinator until RDR-017.
+ * <b>Composition status (RDR-017).</b> P0 (Production Node Bootstrap) fixes the lifecycle dependency
+ * ordering: {@code dependencies()} is now {@code List.of()} so this adapter sits at Layer 0, and
+ * {@link com.hellblazer.luciferase.simulation.von.NodeBootstrap} registers it alongside
+ * {@code SocketConnectionManagerAdapter}. {@link #doStart()} remains a deliberate no-op: making it call
+ * {@code recover()} fail-loud and relocating the batch-flush/checkpoint schedulers out of the
+ * {@link PersistenceManager} constructor into {@code doStart()} (so a checkpoint cannot overwrite an
+ * unrecovered log) is <b>RDR-017 P1</b> (Luciferase-pf1iu).
  *
  * @author hal.hildebrand
  */
@@ -74,7 +71,12 @@ public class PersistenceManagerAdapter extends AbstractLifecycleAdapter {
 
     @Override
     public List<String> dependencies() {
-        return List.of("SocketConnectionManager"); // Layer 1 - depends on SocketConnectionManager
+        // Layer 0 - no dependencies (RDR-017 gate C2). PersistenceManager imports only
+        // java.io/java.nio.file/java.util.concurrent/Clock — zero network surface — and runs
+        // flush/checkpoint/recover entirely from local WAL files. The former
+        // "SocketConnectionManager" dependency was spurious and crashed computeLayers() when SCM
+        // was not co-registered. Bubbles declare their own network dependency on the bubble adapter.
+        return List.of();
     }
 
     /**

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Manager.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Manager.java
@@ -21,6 +21,7 @@ import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
 import com.hellblazer.luciferase.simulation.bubble.SpatialLevelHeuristic;
 import com.hellblazer.luciferase.common.time.Clock;
 import com.hellblazer.luciferase.simulation.lifecycle.EnhancedBubbleAdapter;
+import com.hellblazer.luciferase.simulation.lifecycle.LifecycleComponent;
 import com.hellblazer.luciferase.simulation.lifecycle.LifecycleCoordinator;
 import javax.vecmath.Point3d;
 import org.slf4j.Logger;
@@ -69,6 +70,11 @@ public class Manager {
     private final float aoiRadius;
     private volatile Clock clock;
     private final LifecycleCoordinator coordinator;
+    // RDR-017 P0 (Luciferase-vhhu0): lifecycle dependencies declared on every bubble adapter created
+    // by this manager. Default empty = bubbles register at Layer 0 (pre-RDR-017 behavior). The node
+    // bootstrap sets this to List.of("PersistenceManager") after registering the persistence adapter,
+    // so bubbles register at Layer 1 and start only after persistence is up.
+    private volatile List<String> bubbleDependencies = List.of();
 
     /**
      * Create a Manager with default configuration.
@@ -156,6 +162,53 @@ public class Manager {
     }
 
     /**
+     * Register an infrastructure lifecycle component (e.g. {@code SocketConnectionManagerAdapter},
+     * {@code PersistenceManagerAdapter}) with this manager's coordinator.
+     * <p>
+     * RDR-017 P0 (Luciferase-vhhu0): the node bootstrap calls this to register Layer-0 infrastructure
+     * <b>before</b> any bubble is created, so that bubble adapters declaring a dependency on those
+     * components (see {@link #setBubbleDependencies(List)}) resolve at registration time.
+     *
+     * @param component the infrastructure component to register and start
+     */
+    public void registerInfrastructure(LifecycleComponent component) {
+        Objects.requireNonNull(component, "component cannot be null");
+        coordinator.registerAndStart(component);
+        log.info("Registered infrastructure component: {}", component.name());
+    }
+
+    /**
+     * Set the lifecycle dependencies declared on every bubble adapter created by this manager.
+     * <p>
+     * RDR-017 P0: the node bootstrap sets this to {@code List.of("PersistenceManager")} after
+     * {@link #registerInfrastructure(LifecycleComponent)} so bubbles register at Layer 1 and start
+     * only after persistence. Each named dependency must already be registered (or be registered
+     * before the next {@code createBubble}) or {@code createBubble} will fail to register the bubble.
+     *
+     * @param dependencies component names new bubbles depend on (defensively copied)
+     */
+    public void setBubbleDependencies(List<String> dependencies) {
+        this.bubbleDependencies = List.copyOf(Objects.requireNonNull(dependencies, "dependencies cannot be null"));
+    }
+
+    /**
+     * @return the lifecycle dependencies declared on bubble adapters created by this manager
+     */
+    public List<String> getBubbleDependencies() {
+        return bubbleDependencies;
+    }
+
+    /**
+     * Package-private accessor to the lifecycle coordinator, for the node bootstrap and tests to
+     * observe component state and layering. Not part of the public API.
+     *
+     * @return this manager's lifecycle coordinator
+     */
+    LifecycleCoordinator coordinator() {
+        return coordinator;
+    }
+
+    /**
      * Create a new Bubble and register it with the manager.
      * <p>
      * The new bubble inherits the manager's clock for deterministic timestamps.
@@ -180,7 +233,8 @@ public class Manager {
         // Non-fatal if registration fails - bubble still works without coordinator
         if (bubble instanceof EnhancedBubble enhanced) {
             try {
-                var adapter = new EnhancedBubbleAdapter(enhanced, enhanced.getRealTimeController());
+                var adapter = new EnhancedBubbleAdapter(enhanced, enhanced.getRealTimeController(),
+                                                        bubbleDependencies);
                 coordinator.registerAndStart(adapter);
                 log.debug("Created and registered bubble: {}", id);
             } catch (Exception e) {
@@ -219,7 +273,8 @@ public class Manager {
         // Non-fatal if registration fails - bubble still works without coordinator
         if (bubble instanceof EnhancedBubble enhanced) {
             try {
-                var adapter = new EnhancedBubbleAdapter(enhanced, enhanced.getRealTimeController());
+                var adapter = new EnhancedBubbleAdapter(enhanced, enhanced.getRealTimeController(),
+                                                        bubbleDependencies);
                 coordinator.registerAndStart(adapter);
                 log.debug("Created and registered bubble with ID: {}", id);
             } catch (Exception e) {

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Manager.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Manager.java
@@ -23,6 +23,7 @@ import com.hellblazer.luciferase.common.time.Clock;
 import com.hellblazer.luciferase.simulation.lifecycle.EnhancedBubbleAdapter;
 import com.hellblazer.luciferase.simulation.lifecycle.LifecycleComponent;
 import com.hellblazer.luciferase.simulation.lifecycle.LifecycleCoordinator;
+import com.hellblazer.luciferase.simulation.lifecycle.LifecycleException;
 import javax.vecmath.Point3d;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -229,22 +230,7 @@ public class Manager {
 
         bubbles.put(id, bubble);
 
-        // Register with lifecycle coordinator for graceful shutdown
-        // Non-fatal if registration fails - bubble still works without coordinator
-        if (bubble instanceof EnhancedBubble enhanced) {
-            try {
-                var adapter = new EnhancedBubbleAdapter(enhanced, enhanced.getRealTimeController(),
-                                                        bubbleDependencies);
-                coordinator.registerAndStart(adapter);
-                log.debug("Created and registered bubble: {}", id);
-            } catch (Exception e) {
-                log.warn("Failed to register bubble {} with lifecycle coordinator: {}", id, e.getMessage());
-                // Continue - bubble still functional without coordinator
-            }
-        } else {
-            log.debug("Created bubble: {}", id);
-        }
-
+        registerBubbleAdapter(id, bubble);
         return bubble;
     }
 
@@ -267,25 +253,46 @@ public class Manager {
         // Forward events to manager listeners
         bubble.addEventListener(this::dispatchEvent);
 
-        bubbles.put(id, bubble);
+        registerBubbleAdapter(id, bubble);
+        return bubble;
+    }
 
-        // Register with lifecycle coordinator for graceful shutdown
-        // Non-fatal if registration fails - bubble still works without coordinator
+    /**
+     * Register a newly created bubble with the lifecycle coordinator.
+     * <p>
+     * RDR-017 P0 (Luciferase-vhhu0): registration failure handling depends on whether bubbles carry
+     * lifecycle dependencies. In the legacy/standalone path ({@code bubbleDependencies} empty) a
+     * registration failure is non-fatal — the bubble still works without coordinator management,
+     * preserving pre-RDR-017 behavior. In the composed-node path ({@code bubbleDependencies} non-empty,
+     * set by {@link com.hellblazer.luciferase.simulation.von.NodeBootstrap#assemble}) a failure means the
+     * declared dependency (e.g. {@code PersistenceManager}) is not registered — an ordering/wiring bug
+     * that must fail loud rather than silently produce a bubble outside the lifecycle graph (it would
+     * start before persistence and skip graceful shutdown/recovery). The half-registered bubble is
+     * removed from the manager before rethrowing.
+     */
+    private void registerBubbleAdapter(UUID id, Bubble bubble) {
         if (bubble instanceof EnhancedBubble enhanced) {
             try {
                 var adapter = new EnhancedBubbleAdapter(enhanced, enhanced.getRealTimeController(),
                                                         bubbleDependencies);
                 coordinator.registerAndStart(adapter);
-                log.debug("Created and registered bubble with ID: {}", id);
+                log.debug("Created and registered bubble: {}", id);
             } catch (Exception e) {
+                if (!bubbleDependencies.isEmpty()) {
+                    // Composed-node path: a dependency is unregistered — fail loud, do not leak an
+                    // unmanaged bubble into the lifecycle graph.
+                    bubbles.remove(id, bubble);
+                    throw new LifecycleException(
+                        "Failed to register bubble " + id + " with declared dependencies "
+                        + bubbleDependencies + " (is the persistence adapter registered via "
+                        + "NodeBootstrap.assemble() before createBubble()?)", e);
+                }
                 log.warn("Failed to register bubble {} with lifecycle coordinator: {}", id, e.getMessage());
-                // Continue - bubble still functional without coordinator
+                // Continue - bubble still functional without coordinator (legacy standalone path)
             }
         } else {
-            log.debug("Created bubble with ID: {}", id);
+            log.debug("Created bubble: {}", id);
         }
-
-        return bubble;
     }
 
     /**

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2025, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.von;
+
+import com.hellblazer.delos.cryptography.Digest;
+import com.hellblazer.delos.membership.Member;
+import com.hellblazer.luciferase.simulation.lifecycle.PersistenceManagerAdapter;
+import com.hellblazer.luciferase.simulation.lifecycle.SocketConnectionManagerAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Production node bootstrap — composes the distributed simulation node (RDR-017).
+ * <p>
+ * RDR-017 Q0 is decided: the node {@code main} lives in this repo and {@code simulation} owns the
+ * production node assembly. This class is the entry point and the assembly seam.
+ * <p>
+ * <b>Phase 0 (Luciferase-vhhu0) — this class:</b>
+ * <ul>
+ *   <li>resolves {@code nodeId} from the Fireflies member via {@link #resolveNodeId(Digest)}
+ *       ({@code FirefliesMemberLookup.digestToUuid} — gate C1, the canonical member&rarr;UUID
+ *       derivation; deterministic across restarts, which WAL recovery depends on);</li>
+ *   <li>derives the per-node WAL directory {@code .luciferase/wal/<nodeId>/} via
+ *       {@link #walDir(Path, UUID)};</li>
+ *   <li>assembles the lifecycle graph via {@link #assemble} — {@code SocketConnectionManagerAdapter}
+ *       and {@code PersistenceManagerAdapter} at Layer 0, bubbles at Layer 1 depending on
+ *       {@code PersistenceManager}.</li>
+ * </ul>
+ * <b>Deferred to later phases:</b> calling {@code PersistenceManager.recover()} fail-loud and relocating
+ * its schedulers ({@code PersistenceManagerAdapter.doStart()}) is P1 (Luciferase-pf1iu); injecting the WAL
+ * into {@code BubbleMigrator} and the durability round-trip is P2 (Luciferase-1693b). Live Fireflies view
+ * construction (and therefore a fully self-starting {@link #main}) lands with the persistence wiring in P1.
+ *
+ * @author hal.hildebrand
+ */
+public final class NodeBootstrap {
+
+    private static final Logger log = LoggerFactory.getLogger(NodeBootstrap.class);
+
+    private NodeBootstrap() {
+    }
+
+    /**
+     * Resolve the node identity from a Fireflies member id.
+     * <p>
+     * Gate C1: this is {@code FirefliesMemberLookup.digestToUuid}, the canonical member&rarr;UUID
+     * derivation across the codebase (first 16 bytes of the {@link Digest}). It is deterministic across
+     * restarts, which is a correctness requirement: the WAL directory identity
+     * ({@code .luciferase/wal/<nodeId>/}) must resolve to the same path on restart or recovery silently
+     * finds no log and starts fresh. Do NOT substitute {@code UUID.nameUUIDFromBytes} — it produces a
+     * different value from the same {@link Digest}.
+     *
+     * @param memberId the Fireflies member id ({@code member.getId()})
+     * @return the deterministic node UUID
+     */
+    public static UUID resolveNodeId(Digest memberId) {
+        return FirefliesMemberLookup.digestToUuid(Objects.requireNonNull(memberId, "memberId cannot be null"));
+    }
+
+    /**
+     * Resolve the node identity from a Fireflies {@link Member}.
+     *
+     * @param member the Fireflies member
+     * @return the deterministic node UUID
+     */
+    public static UUID resolveNodeId(Member member) {
+        return resolveNodeId(Objects.requireNonNull(member, "member cannot be null").getId());
+    }
+
+    /**
+     * Derive the per-node WAL directory: {@code <base>/.luciferase/wal/<nodeId>/}.
+     *
+     * @param base   the base directory (typically the process working directory)
+     * @param nodeId the resolved node identity
+     * @return the WAL directory path
+     */
+    public static Path walDir(Path base, UUID nodeId) {
+        Objects.requireNonNull(base, "base cannot be null");
+        Objects.requireNonNull(nodeId, "nodeId cannot be null");
+        return base.resolve(".luciferase").resolve("wal").resolve(nodeId.toString());
+    }
+
+    /**
+     * Wire the node lifecycle graph: register the connection-manager and persistence adapters at Layer 0
+     * and configure bubbles (created subsequently via {@link Manager#createBubble()}) to depend on
+     * {@code PersistenceManager} (Layer 1).
+     * <p>
+     * Must be called before any {@code createBubble} so the bubble dependency resolves.
+     *
+     * @param manager    the VON manager owning the lifecycle coordinator
+     * @param scmAdapter the connection-manager adapter (Layer 0)
+     * @param pmAdapter  the persistence adapter (Layer 0)
+     */
+    public static void assemble(Manager manager, SocketConnectionManagerAdapter scmAdapter,
+                                PersistenceManagerAdapter pmAdapter) {
+        Objects.requireNonNull(manager, "manager cannot be null");
+        Objects.requireNonNull(scmAdapter, "scmAdapter cannot be null");
+        Objects.requireNonNull(pmAdapter, "pmAdapter cannot be null");
+
+        manager.registerInfrastructure(scmAdapter);
+        manager.registerInfrastructure(pmAdapter);
+        manager.setBubbleDependencies(List.of(pmAdapter.name()));
+        log.info("Node lifecycle assembled: {} and {} at Layer 0; bubbles depend on {}",
+                 scmAdapter.name(), pmAdapter.name(), pmAdapter.name());
+    }
+
+    /**
+     * Production node entry point.
+     * <p>
+     * Phase 0 skeleton: the live startup path constructs the Fireflies view, resolves the local member,
+     * derives {@code nodeId}/{@code walDir}, constructs the {@code PersistenceManager} + adapters, calls
+     * {@link #assemble}, and starts the coordinator. That wiring depends on the persistence
+     * recover()/scheduler work delivered in RDR-017 P1 (Luciferase-pf1iu); until then this entry point
+     * fails loud rather than silently starting an unrecoverable node.
+     *
+     * @param args command-line arguments (unused in P0)
+     */
+    public static void main(String[] args) {
+        throw new UnsupportedOperationException(
+            "Node live-startup wiring (Fireflies view, PersistenceManager.recover() fail-loud, scheduler "
+            + "relocation) is delivered in RDR-017 P1 (Luciferase-pf1iu). P0 provides the assembly seam: "
+            + "NodeBootstrap.resolveNodeId / walDir / assemble.");
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/lifecycle/NodeBootstrapLayeringTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/lifecycle/NodeBootstrapLayeringTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.lifecycle;
+
+import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
+import com.hellblazer.luciferase.simulation.persistence.PersistenceManager;
+import com.hellblazer.luciferase.simulation.von.transport.ProcessAddress;
+import com.hellblazer.luciferase.simulation.von.transport.SocketConnectionManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RDR-017 P0 (Luciferase-vhhu0) — lifecycle layering regression.
+ * <p>
+ * Proves the gate-C2 fix: with {@link PersistenceManagerAdapter#dependencies()} emptied,
+ * the coordinator computes {@code {L0:[SocketConnectionManager, PersistenceManager], L1:[Bubble]}}
+ * without throwing {@link LifecycleException}. The pre-fix graph crashed
+ * {@code computeLayers()} because the spurious {@code "SocketConnectionManager"} dependency on
+ * the persistence adapter referenced a component never registered alongside it.
+ * <p>
+ * Uses real adapters (dynamic-port socket, {@code @TempDir} WAL) so the assertion exercises the
+ * production {@code dependencies()} values, not mock stand-ins.
+ */
+class NodeBootstrapLayeringTest {
+
+    @Test
+    void computeLayersPlacesScmAndPmAtL0_bubbleAtL1_withoutThrowing(@TempDir Path walDir) throws IOException {
+        var nodeId = UUID.randomUUID();
+        var scm = new SocketConnectionManager(ProcessAddress.localhost("p0-layering", 0), msg -> {});
+        var pm = new PersistenceManager(nodeId, walDir);
+        var bubble = new EnhancedBubble(UUID.randomUUID(), (byte) 10, 16L);
+        try {
+            var scmAdapter = new SocketConnectionManagerAdapter(scm);
+            var pmAdapter = new PersistenceManagerAdapter(pm);
+            var bubbleAdapter = new EnhancedBubbleAdapter(bubble, bubble.getRealTimeController(),
+                                                          List.of("PersistenceManager"));
+
+            // gate C2: persistence is Layer 0 (no network dependency).
+            assertTrue(pmAdapter.dependencies().isEmpty(),
+                       "PersistenceManagerAdapter must declare no dependencies (Layer 0)");
+            assertTrue(scmAdapter.dependencies().isEmpty(),
+                       "SocketConnectionManagerAdapter must declare no dependencies (Layer 0)");
+            // AC3: bubble adapter built via the 3-arg ctor depending on PersistenceManager (Layer 1).
+            assertEquals(List.of("PersistenceManager"), bubbleAdapter.dependencies(),
+                         "Bubble adapter must depend on PersistenceManager");
+
+            var coordinator = new LifecycleCoordinator();
+            coordinator.register(scmAdapter);
+            coordinator.register(pmAdapter);
+            coordinator.register(bubbleAdapter);
+
+            var layers = assertDoesNotThrow(coordinator::computeLayers,
+                                            "computeLayers must not throw with PM at Layer 0");
+
+            assertEquals(2, layers.size(), "expected exactly two dependency layers");
+            assertEquals(Set.of("SocketConnectionManager", "PersistenceManager"),
+                         Set.copyOf(layers.get(0)),
+                         "Layer 0 must be {SocketConnectionManager, PersistenceManager}");
+            assertEquals(List.of(bubbleAdapter.name()), layers.get(1),
+                         "Layer 1 must be the bubble");
+        } finally {
+            pm.close();
+            bubble.close();
+            scm.closeAll();
+        }
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapterTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapterTest.java
@@ -86,10 +86,12 @@ class PersistenceManagerAdapterTest {
 
     @Test
     void testDependencies() {
+        // RDR-017 gate C2: PersistenceManager is Layer 0 — it has zero network surface (imports only
+        // java.io/java.nio.file/java.util.concurrent/Clock) and runs entirely from local WAL files.
+        // The former "SocketConnectionManager" dependency was spurious and crashed computeLayers().
         var deps = adapter.dependencies();
         assertNotNull(deps, "Dependencies should not be null");
-        assertEquals(1, deps.size(), "PersistenceManager depends on SocketConnectionManager (Layer 1)");
-        assertEquals("SocketConnectionManager", deps.get(0), "Should depend on SocketConnectionManager");
+        assertTrue(deps.isEmpty(), "PersistenceManager has no dependencies (Layer 0)");
     }
 
     @Test

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.von;
+
+import com.hellblazer.delos.cryptography.DigestAlgorithm;
+import com.hellblazer.luciferase.simulation.bubble.SpatialLevelHeuristic;
+import com.hellblazer.luciferase.simulation.lifecycle.LifecycleState;
+import com.hellblazer.luciferase.simulation.lifecycle.PersistenceManagerAdapter;
+import com.hellblazer.luciferase.simulation.lifecycle.SocketConnectionManagerAdapter;
+import com.hellblazer.luciferase.simulation.persistence.PersistenceManager;
+import com.hellblazer.luciferase.simulation.von.transport.ProcessAddress;
+import com.hellblazer.luciferase.simulation.von.transport.SocketConnectionManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RDR-017 P0 (Luciferase-vhhu0) — node bootstrap nodeId/WAL-dir derivation and lifecycle assembly.
+ */
+class NodeBootstrapTest {
+
+    @Test
+    void nodeIdResolvedViaDigestToUuid() {
+        var memberId = DigestAlgorithm.DEFAULT.random();
+        // gate C1: nodeId is the canonical FirefliesMemberLookup.digestToUuid derivation,
+        // NOT UUID.nameUUIDFromBytes (which yields a different value from the same Digest).
+        assertEquals(FirefliesMemberLookup.digestToUuid(memberId),
+                     NodeBootstrap.resolveNodeId(memberId),
+                     "nodeId must be derived via FirefliesMemberLookup.digestToUuid(member.getId())");
+    }
+
+    @Test
+    void walDirDerivedFromNodeId(@TempDir Path base) {
+        var nodeId = UUID.randomUUID();
+        var expected = base.resolve(".luciferase").resolve("wal").resolve(nodeId.toString());
+        assertEquals(expected, NodeBootstrap.walDir(base, nodeId),
+                     "WAL dir must be <base>/.luciferase/wal/<nodeId>/");
+    }
+
+    @Test
+    void assembleRegistersInfrastructureAtL0_andBubbleStartsAtL1(@TempDir Path walDir) throws IOException {
+        var registry = LocalServerTransport.Registry.create();
+        var manager = new Manager(registry, SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL, 16L,
+                                  SpatialLevelHeuristic.DEFAULT_AOI_RADIUS);
+        var scm = new SocketConnectionManager(ProcessAddress.localhost("p0-bootstrap", 0), msg -> {});
+        var pm = new PersistenceManager(UUID.randomUUID(), walDir);
+        try {
+            NodeBootstrap.assemble(manager, new SocketConnectionManagerAdapter(scm),
+                                   new PersistenceManagerAdapter(pm));
+
+            assertEquals(java.util.List.of("PersistenceManager"), manager.getBubbleDependencies(),
+                         "assemble must configure bubbles to depend on PersistenceManager");
+            assertEquals(LifecycleState.RUNNING, manager.coordinator().getState("SocketConnectionManager"));
+            assertEquals(LifecycleState.RUNNING, manager.coordinator().getState("PersistenceManager"));
+
+            // Bubble created after infra wiring must register at Layer 1 (dep PersistenceManager)
+            // and start without LifecycleException.
+            var bubble = manager.createBubble();
+            assertEquals(LifecycleState.RUNNING, manager.coordinator().getState("EnhancedBubble-" + bubble.id()),
+                         "bubble must register and start under the coordinator (Layer 1)");
+        } finally {
+            // manager.close() stops the coordinator, which stops the SCM/PM adapters and closes
+            // their wrapped components — closing pm/scm again here would double-close the WAL.
+            manager.close();
+        }
+    }
+
+    @Test
+    void createBubbleHasNoPersistenceDependencyByDefault() {
+        // No regression: a Manager not wired for persistence creates bubbles with no
+        // lifecycle dependencies (registers at Layer 0, exactly as before RDR-017).
+        var registry = LocalServerTransport.Registry.create();
+        var manager = new Manager(registry, SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL, 16L,
+                                  SpatialLevelHeuristic.DEFAULT_AOI_RADIUS);
+        try {
+            assertTrue(manager.getBubbleDependencies().isEmpty(),
+                       "default Manager must declare no bubble dependencies");
+            var bubble = manager.createBubble();
+            assertEquals(LifecycleState.RUNNING, manager.coordinator().getState("EnhancedBubble-" + bubble.id()),
+                         "bubble must register and start even with no persistence wired");
+        } finally {
+            manager.close();
+        }
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -73,6 +74,25 @@ class NodeBootstrapTest {
         } finally {
             // manager.close() stops the coordinator, which stops the SCM/PM adapters and closes
             // their wrapped components — closing pm/scm again here would double-close the WAL.
+            manager.close();
+        }
+    }
+
+    @Test
+    void createBubbleFailsLoudWhenDeclaredDependencyMissing() {
+        // Composed-node hardening (RDR-017 P0 review): if bubbleDependencies is configured but the
+        // named dependency was never registered (assemble() skipped / misordered), createBubble must
+        // fail loud rather than silently emit a bubble outside the lifecycle graph.
+        var registry = LocalServerTransport.Registry.create();
+        var manager = new Manager(registry, SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL, 16L,
+                                  SpatialLevelHeuristic.DEFAULT_AOI_RADIUS);
+        try {
+            manager.setBubbleDependencies(java.util.List.of("PersistenceManager")); // PM NOT registered
+            assertThrows(com.hellblazer.luciferase.simulation.lifecycle.LifecycleException.class,
+                         manager::createBubble,
+                         "createBubble must fail loud when a declared dependency is unregistered");
+            assertEquals(0, manager.size(), "the half-registered bubble must not leak into the manager");
+        } finally {
             manager.close();
         }
     }


### PR DESCRIPTION
Implements RDR-017 Phase 0 (bead Luciferase-vhhu0): the production node bootstrap seam and the lifecycle dependency-graph fix. First of a 4-phase arc under epic Luciferase-n6jrh.

## What

- **gate C2** — `PersistenceManagerAdapter.dependencies()` → `List.of()`. PersistenceManager has zero network surface (imports only java.io/java.nio.file/java.util.concurrent/Clock); the spurious `"SocketConnectionManager"` dependency crashed `computeLayers()` whenever SCM was not co-registered. PM now sits at Layer 0 alongside SCM.
- **gate C1** — `NodeBootstrap.resolveNodeId()` derives nodeId via `FirefliesMemberLookup.digestToUuid(member.getId())`, the canonical, deterministic-across-restarts member→UUID derivation (WAL directory identity is a correctness requirement). `walDir()` = `.luciferase/wal/<nodeId>/`.
- **`NodeBootstrap`** (new) — `assemble()` registers SCM + PM adapters at Layer 0 and configures bubbles to depend on PersistenceManager (Layer 1). `main()` fails loud pending P1 live wiring.
- **`Manager`** — configurable `bubbleDependencies` (default empty = pre-RDR-017 Layer-0 behavior, no regression); `createBubble()` uses the 3-arg adapter ctor and **fails loud** (does not silently leak an unmanaged bubble) when a declared dependency is unregistered; `registerInfrastructure()` + package-private `coordinator()` accessor for the bootstrap.
- `LifecycleCoordinator.computeLayers()` made package-private as a test seam.

## Scope boundary (explicit, not silent)

`PersistenceManager.recover()` fail-loud and relocating its schedulers out of the constructor into `doStart()` is **P1 (Luciferase-pf1iu)** — `doStart()` stays a deliberate no-op here. Two stacked-review carry-forwards (scheduler-before-recovery hazard now instantiated since the bootstrap constructs PM; assemble-before-createBubble enforcement) are recorded on pf1iu. **This skeleton must not run a live node until P1 lands.**

## Deviation from literal bead text

The bead said "convert createBubble to unconditional 3-arg dep on PersistenceManager". Unconditional would break every Manager without a registered PM (the swallowed LifecycleException silently drops coordinator registration). Made it configurable instead — bootstrap sets the dep; standalone Managers unchanged. Both reviewers judged this the correct call; all ACs still met.

## Tests (TDD)

- `NodeBootstrapLayeringTest` — asserts `computeLayers()` = {L0:[SCM,PM], L1:[Bubble]} without throwing (non-vacuous: pre-fix graph yields 3 layers).
- `NodeBootstrapTest` — nodeId/walDir derivation, assemble wiring, fail-loud on missing dep, no-persistence default.
- 106 lifecycle + von Manager/bubble tests green locally.

## Review

Stacked review clean: 0 Critical from both code-review-expert and substantive-critic; the shared HIGH/Significant (createBubble silent swallow) fixed in-phase. Detail in T2 `Luciferase/vhhu0-p0-stacked-review`.