### PR TITLE
RDR-017 P1: persistence wiring + recover() fail-loud + scheduler relocation (Luciferase-pf1iu)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapter.java
@@ -21,18 +21,15 @@ import java.util.Objects;
  * <p>
  * Dependency Layer: 0 (no dependencies — RDR-017 gate C2; persistence has zero network surface)
  * <p>
- * Note: PersistenceManager auto-starts background tasks (batch flush, checkpoints) on construction.
- * The start() method is effectively a no-op but maintains lifecycle state consistency.
- * <p>
  * Extends {@link AbstractLifecycleAdapter} for common state management logic.
  * <p>
- * <b>Composition status (RDR-017).</b> P0 (Production Node Bootstrap) fixes the lifecycle dependency
- * ordering: {@code dependencies()} is now {@code List.of()} so this adapter sits at Layer 0, and
+ * <b>Composition status (RDR-017).</b> P0 fixed the lifecycle dependency ordering: {@code dependencies()}
+ * is {@code List.of()} so this adapter sits at Layer 0, and
  * {@link com.hellblazer.luciferase.simulation.von.NodeBootstrap} registers it alongside
- * {@code SocketConnectionManagerAdapter}. {@link #doStart()} remains a deliberate no-op: making it call
- * {@code recover()} fail-loud and relocating the batch-flush/checkpoint schedulers out of the
- * {@link PersistenceManager} constructor into {@code doStart()} (so a checkpoint cannot overwrite an
- * unrecovered log) is <b>RDR-017 P1</b> (Luciferase-pf1iu).
+ * {@code SocketConnectionManagerAdapter}. P1 (Luciferase-pf1iu) makes {@link #doStart()} call
+ * {@link PersistenceManager#recover()} fail-loud (a corrupt WAL aborts startup) and then
+ * {@link PersistenceManager#startSchedulers()} — the batch-flush and checkpoint schedulers are no longer
+ * started in the {@link PersistenceManager} constructor, so neither can run before recovery completes.
  *
  * @author hal.hildebrand
  */
@@ -55,8 +52,14 @@ public class PersistenceManagerAdapter extends AbstractLifecycleAdapter {
     }
 
     @Override
-    protected void doStart() {
-        // No-op: PersistenceManager auto-starts background tasks on construction
+    protected void doStart() throws Exception {
+        // RDR-017 P1 (Luciferase-pf1iu): recover the WAL BEFORE starting the background schedulers.
+        // recover() rethrows IOException on a corrupt WAL — letting it propagate aborts startup
+        // (fail-loud, RDR-004-class silent-data-loss closure) rather than degrading into a node that
+        // runs on partially-recovered state. Schedulers start only after a clean recover(), so a
+        // checkpoint/batch-flush can never overwrite an unrecovered log.
+        persistenceManager.recover();
+        persistenceManager.startSchedulers();
     }
 
     @Override

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapter.java
@@ -53,12 +53,29 @@ public class PersistenceManagerAdapter extends AbstractLifecycleAdapter {
 
     @Override
     protected void doStart() throws Exception {
+        // Idempotent across restart-from-FAILED: if a prior doStart() already recovered and started the
+        // schedulers, do not re-run recover() (which would replay WAL events into the FSM a second time).
+        if (persistenceManager.isSchedulersStarted()) {
+            return;
+        }
         // RDR-017 P1 (Luciferase-pf1iu): recover the WAL BEFORE starting the background schedulers.
         // recover() rethrows IOException on a corrupt WAL — letting it propagate aborts startup
         // (fail-loud, RDR-004-class silent-data-loss closure) rather than degrading into a node that
         // runs on partially-recovered state. Schedulers start only after a clean recover(), so a
         // checkpoint/batch-flush can never overwrite an unrecovered log.
-        persistenceManager.recover();
+        try {
+            persistenceManager.recover();
+        } catch (Exception e) {
+            // Startup is refused. Release the resources this PM owns (scheduler executor + WAL file
+            // handles) — the FAILED adapter is never RUNNING, so the coordinator's stop() will not call
+            // doStop()/close() for us, and leaving them open leaks a thread + descriptors per restart.
+            try {
+                persistenceManager.close();
+            } catch (Exception closeEx) {
+                e.addSuppressed(closeEx);
+            }
+            throw e;
+        }
         persistenceManager.startSchedulers();
     }
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManager.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManager.java
@@ -64,6 +64,7 @@ public class PersistenceManager implements AutoCloseable {
     private final ScheduledExecutorService executor;
     private final AtomicBoolean recoveryInProgress;
     private final AtomicBoolean schedulersStarted = new AtomicBoolean(false);
+    private final AtomicBoolean closed = new AtomicBoolean(false);
     private final AtomicLong lastCheckpointSeq;
     private final AtomicLong eventCounter;
 
@@ -152,11 +153,11 @@ public class PersistenceManager implements AutoCloseable {
 
     /**
      * @return the number of tasks currently queued on the scheduler executor. Zero before
-     *         {@link #startSchedulers()} runs; two once both schedulers are scheduled. Exposed so the
-     *         scheduler-relocation regression (RDR-017 P1) can prove no scheduler is queued in the
-     *         constructor — catching a re-introduction of either scheduler into the ctor.
+     *         {@link #startSchedulers()} runs; two once both schedulers are scheduled. Package-private
+     *         test-support: the scheduler-relocation regression (RDR-017 P1) uses it to prove no
+     *         scheduler is queued in the constructor — catching a re-introduction of either scheduler.
      */
-    public int scheduledTaskCount() {
+    int scheduledTaskCount() {
         if (executor instanceof java.util.concurrent.ScheduledThreadPoolExecutor stpe) {
             return stpe.getQueue().size();
         }
@@ -395,6 +396,11 @@ public class PersistenceManager implements AutoCloseable {
      */
     @Override
     public void close() throws IOException {
+        // Idempotent (RDR-017 P1): the corrupt-WAL abort path closes the PM from doStart(), and a
+        // caller's finally block may close again — a second close must not throw "WAL is closed".
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
         log.info("Shutting down PersistenceManager for node {}", nodeId);
 
         // Shutdown executor

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManager.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManager.java
@@ -63,6 +63,7 @@ public class PersistenceManager implements AutoCloseable {
     private final RecoveryStateSink recoverySink;
     private final ScheduledExecutorService executor;
     private final AtomicBoolean recoveryInProgress;
+    private final AtomicBoolean schedulersStarted = new AtomicBoolean(false);
     private final AtomicLong lastCheckpointSeq;
     private final AtomicLong eventCounter;
 
@@ -118,13 +119,48 @@ public class PersistenceManager implements AutoCloseable {
         this.eventCounter = new AtomicLong(0);
         this.lastCheckpoint = Instant.ofEpochMilli(clock.currentTimeMillis());
 
-        // Start batch flush scheduler
-        startBatchFlushScheduler();
+        // RDR-017 P1 (Luciferase-pf1iu): the batch-flush and checkpoint schedulers are NO LONGER
+        // started here. Starting them in the constructor let a checkpoint (every 5s) or batch flush
+        // (every 100ms) fire before recover() ran — overwriting/truncating an unrecovered WAL. They
+        // are now started by PersistenceManagerAdapter.doStart() via startSchedulers(), strictly AFTER
+        // recover() completes.
+        log.info("PersistenceManager constructed for node {} at {} (schedulers idle until startSchedulers())",
+                 nodeId, logDirectory);
+    }
 
-        // Start periodic checkpoint scheduler
-        startCheckpointScheduler();
+    /**
+     * Start the batch-flush and checkpoint background schedulers.
+     * <p>
+     * RDR-017 P1: called by {@link com.hellblazer.luciferase.simulation.lifecycle.PersistenceManagerAdapter}
+     * ({@code doStart()}) <b>after</b> {@link #recover()} completes, so neither scheduler can run against an
+     * unrecovered WAL. Idempotent: repeated calls are a no-op.
+     */
+    public void startSchedulers() {
+        if (schedulersStarted.compareAndSet(false, true)) {
+            startBatchFlushScheduler();
+            startCheckpointScheduler();
+            log.info("PersistenceManager schedulers started for node {}", nodeId);
+        }
+    }
 
-        log.info("PersistenceManager started for node {} at {}", nodeId, logDirectory);
+    /**
+     * @return whether the background schedulers have been started (RDR-017 P1)
+     */
+    public boolean isSchedulersStarted() {
+        return schedulersStarted.get();
+    }
+
+    /**
+     * @return the number of tasks currently queued on the scheduler executor. Zero before
+     *         {@link #startSchedulers()} runs; two once both schedulers are scheduled. Exposed so the
+     *         scheduler-relocation regression (RDR-017 P1) can prove no scheduler is queued in the
+     *         constructor — catching a re-introduction of either scheduler into the ctor.
+     */
+    public int scheduledTaskCount() {
+        if (executor instanceof java.util.concurrent.ScheduledThreadPoolExecutor stpe) {
+            return stpe.getQueue().size();
+        }
+        return -1;
     }
 
     /**

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
@@ -10,11 +10,15 @@ package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.delos.cryptography.Digest;
 import com.hellblazer.delos.membership.Member;
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationStateMachine;
 import com.hellblazer.luciferase.simulation.lifecycle.PersistenceManagerAdapter;
 import com.hellblazer.luciferase.simulation.lifecycle.SocketConnectionManagerAdapter;
+import com.hellblazer.luciferase.simulation.persistence.MigrationRecoveryStateSink;
+import com.hellblazer.luciferase.simulation.persistence.PersistenceManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
@@ -89,6 +93,33 @@ public final class NodeBootstrap {
         Objects.requireNonNull(base, "base cannot be null");
         Objects.requireNonNull(nodeId, "nodeId cannot be null");
         return base.resolve(".luciferase").resolve("wal").resolve(nodeId.toString());
+    }
+
+    /**
+     * Build the persistence adapter for the node, wiring the WAL recovery sink to the node's migration
+     * FSM (RDR-017 P1, §F5).
+     * <p>
+     * Constructs {@code MigrationRecoveryStateSink(fsm) → PersistenceManager(nodeId, walDir, sink) →
+     * PersistenceManagerAdapter}, so that on startup {@code PersistenceManagerAdapter.doStart()} calls
+     * {@code recover()} and replays {@code ENTITY_DEPARTURE}/{@code MIGRATION_COMMIT} events into the
+     * FSM (reconstructing {@code MIGRATING_OUT}/{@code DEPARTED}) before the schedulers start. Using the
+     * real sink rather than {@code RecoveryStateSink.NOOP} is what makes recovery reconstruct state
+     * instead of silently discarding replayed events.
+     *
+     * @param nodeId the resolved node identity (see {@link #resolveNodeId(Digest)})
+     * @param walDir the per-node WAL directory (see {@link #walDir(Path, UUID)})
+     * @param fsm    the node's entity-migration state machine to reconstruct on recovery
+     * @return a persistence adapter ready to register via {@link #assemble}
+     * @throws IOException if WAL initialization fails
+     */
+    public static PersistenceManagerAdapter persistenceAdapter(UUID nodeId, Path walDir,
+                                                               EntityMigrationStateMachine fsm) throws IOException {
+        Objects.requireNonNull(nodeId, "nodeId cannot be null");
+        Objects.requireNonNull(walDir, "walDir cannot be null");
+        Objects.requireNonNull(fsm, "fsm cannot be null");
+        var sink = new MigrationRecoveryStateSink(fsm);
+        var pm = new PersistenceManager(nodeId, walDir, sink);
+        return new PersistenceManagerAdapter(pm);
     }
 
     /**

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapterRecoveryTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapterRecoveryTest.java
@@ -58,7 +58,7 @@ class PersistenceManagerAdapterRecoveryTest {
         var pm = new PersistenceManager(nodeId, walDir, new MigrationRecoveryStateSink(fsm));
         var adapter = new PersistenceManagerAdapter(pm);
         try {
-            assertEquals(0, pm.scheduledTaskCount(), "schedulers must not run before doStart()");
+            assertFalse(pm.isSchedulersStarted(), "schedulers must not start before doStart()");
 
             adapter.start().get(5, TimeUnit.SECONDS);
 
@@ -66,7 +66,6 @@ class PersistenceManagerAdapterRecoveryTest {
             assertEquals(EntityMigrationState.MIGRATING_OUT, fsm.getState(entityId.toString()),
                          "doStart() must recover() and replay ENTITY_DEPARTURE into the FSM sink");
             assertTrue(pm.isSchedulersStarted(), "schedulers must start after a clean recover()");
-            assertEquals(2, pm.scheduledTaskCount(), "both schedulers must be running after doStart()");
         } finally {
             pm.close();
         }
@@ -98,7 +97,6 @@ class PersistenceManagerAdapterRecoveryTest {
             assertEquals(LifecycleState.FAILED, adapter.getState(), "adapter must be FAILED, not RUNNING");
             // recover-before-schedulers: a failed recover() must NOT have started the schedulers.
             assertFalse(pm.isSchedulersStarted(), "schedulers must not start when recover() fails");
-            assertEquals(0, pm.scheduledTaskCount(), "no scheduler may run when recover() aborts");
         } finally {
             pm.close();
         }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapterRecoveryTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapterRecoveryTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.lifecycle;
+
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationState;
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationStateMachine;
+import com.hellblazer.luciferase.simulation.causality.FirefliesViewMonitor;
+import com.hellblazer.luciferase.simulation.delos.mock.MockFirefliesView;
+import com.hellblazer.luciferase.simulation.persistence.MigrationRecoveryStateSink;
+import com.hellblazer.luciferase.simulation.persistence.PersistenceManager;
+import com.hellblazer.luciferase.simulation.persistence.RecoveryStateSink;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RDR-017 P1 (Luciferase-pf1iu) — {@code PersistenceManagerAdapter.doStart()} fail-loud recovery and
+ * recover-before-schedulers ordering. Closes the P0 gap where {@code doStart()} was a no-op that never
+ * called {@code recover()}.
+ */
+class PersistenceManagerAdapterRecoveryTest {
+
+    private static EntityMigrationStateMachine freshFsm() {
+        return new EntityMigrationStateMachine(new FirefliesViewMonitor(new MockFirefliesView<>(), 3));
+    }
+
+    @Test
+    void doStartRecoversCleanWalToFsmSink_thenStartsSchedulers(@TempDir Path walDir) throws Exception {
+        var nodeId = UUID.randomUUID();
+        var entityId = UUID.randomUUID();
+        var src = UUID.randomUUID();
+        var tgt = UUID.randomUUID();
+
+        // Clean WAL: one departure, no checkpoint (crash). Writer's schedulers stay idle (relocated).
+        try (var writer = new PersistenceManager(nodeId, walDir, RecoveryStateSink.NOOP)) {
+            writer.logEntityDeparture(entityId, src, tgt);
+        }
+
+        var fsm = freshFsm();
+        var pm = new PersistenceManager(nodeId, walDir, new MigrationRecoveryStateSink(fsm));
+        var adapter = new PersistenceManagerAdapter(pm);
+        try {
+            assertEquals(0, pm.scheduledTaskCount(), "schedulers must not run before doStart()");
+
+            adapter.start().get(5, TimeUnit.SECONDS);
+
+            assertEquals(LifecycleState.RUNNING, adapter.getState(), "clean WAL must start cleanly");
+            assertEquals(EntityMigrationState.MIGRATING_OUT, fsm.getState(entityId.toString()),
+                         "doStart() must recover() and replay ENTITY_DEPARTURE into the FSM sink");
+            assertTrue(pm.isSchedulersStarted(), "schedulers must start after a clean recover()");
+            assertEquals(2, pm.scheduledTaskCount(), "both schedulers must be running after doStart()");
+        } finally {
+            pm.close();
+        }
+    }
+
+    @Test
+    void doStartCorruptWalAborts_schedulersNotStarted(@TempDir Path walDir) throws Exception {
+        var nodeId = UUID.randomUUID();
+        // Three events so a corrupt MIDDLE line is a mid-file corruption (fatal), not a trailing
+        // partial line (tolerated). EventRecovery throws IOException when skippedCorrupt > 0.
+        try (var writer = new PersistenceManager(nodeId, walDir, RecoveryStateSink.NOOP)) {
+            writer.logEntityDeparture(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+            writer.logEntityDeparture(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+            writer.logEntityDeparture(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+        }
+        var logFile = walDir.resolve("node-" + nodeId + ".log");
+        var lines = Files.readAllLines(logFile, StandardCharsets.UTF_8);
+        assertTrue(lines.size() >= 3, "expected at least 3 WAL lines");
+        lines.set(1, "{ this is not valid json — mid-file corruption"); // corrupt a non-trailing line
+        Files.write(logFile, String.join("\n", lines).concat("\n").getBytes(StandardCharsets.UTF_8));
+
+        var pm = new PersistenceManager(nodeId, walDir, RecoveryStateSink.NOOP);
+        var adapter = new PersistenceManagerAdapter(pm);
+        try {
+            var ex = assertThrows(ExecutionException.class,
+                                  () -> adapter.start().get(5, TimeUnit.SECONDS),
+                                  "corrupt WAL must abort startup, not degrade");
+            assertTrue(hasIoCause(ex), "abort cause chain must include IOException (fail-loud)");
+            assertEquals(LifecycleState.FAILED, adapter.getState(), "adapter must be FAILED, not RUNNING");
+            // recover-before-schedulers: a failed recover() must NOT have started the schedulers.
+            assertFalse(pm.isSchedulersStarted(), "schedulers must not start when recover() fails");
+            assertEquals(0, pm.scheduledTaskCount(), "no scheduler may run when recover() aborts");
+        } finally {
+            pm.close();
+        }
+    }
+
+    private static boolean hasIoCause(Throwable t) {
+        for (var c = t; c != null; c = c.getCause()) {
+            if (c instanceof IOException) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManagerSchedulerRelocationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManagerSchedulerRelocationTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.persistence;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RDR-017 P1 (Luciferase-pf1iu) — scheduler-relocation regression.
+ * <p>
+ * Proves NEITHER the batch-flush scheduler NOR the checkpoint scheduler is started in the
+ * {@link PersistenceManager} constructor. Both are now started only by {@link
+ * PersistenceManager#startSchedulers()} (which {@code PersistenceManagerAdapter.doStart()} invokes
+ * after {@code recover()}). The assertion is non-vacuous: re-introducing either scheduler into the
+ * constructor would make {@code scheduledTaskCount()} non-zero immediately after construction.
+ */
+class PersistenceManagerSchedulerRelocationTest {
+
+    @Test
+    void neitherSchedulerIsQueuedInConstructor(@TempDir Path walDir) throws IOException {
+        try (var pm = new PersistenceManager(UUID.randomUUID(), walDir)) {
+            assertFalse(pm.isSchedulersStarted(), "schedulers must not be started by the constructor");
+            assertEquals(0, pm.scheduledTaskCount(),
+                         "no scheduler task may be queued before startSchedulers() — re-adding either "
+                         + "the batch-flush or checkpoint scheduler to the ctor would make this non-zero");
+
+            pm.startSchedulers();
+            assertTrue(pm.isSchedulersStarted(), "startSchedulers() must mark schedulers started");
+            assertEquals(2, pm.scheduledTaskCount(),
+                         "startSchedulers() must start BOTH the batch-flush and checkpoint schedulers");
+        }
+    }
+
+    @Test
+    void startSchedulersIsIdempotent(@TempDir Path walDir) throws IOException {
+        try (var pm = new PersistenceManager(UUID.randomUUID(), walDir)) {
+            pm.startSchedulers();
+            pm.startSchedulers();
+            assertEquals(2, pm.scheduledTaskCount(), "repeated startSchedulers() must not double-schedule");
+        }
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapPersistenceWiringTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapPersistenceWiringTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2025, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.von;
+
+import com.hellblazer.luciferase.simulation.bubble.SpatialLevelHeuristic;
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationState;
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationStateMachine;
+import com.hellblazer.luciferase.simulation.causality.FirefliesViewMonitor;
+import com.hellblazer.luciferase.simulation.delos.mock.MockFirefliesView;
+import com.hellblazer.luciferase.simulation.lifecycle.LifecycleException;
+import com.hellblazer.luciferase.simulation.lifecycle.LifecycleState;
+import com.hellblazer.luciferase.simulation.lifecycle.SocketConnectionManagerAdapter;
+import com.hellblazer.luciferase.simulation.persistence.PersistenceManager;
+import com.hellblazer.luciferase.simulation.persistence.RecoveryStateSink;
+import com.hellblazer.luciferase.simulation.von.transport.ProcessAddress;
+import com.hellblazer.luciferase.simulation.von.transport.SocketConnectionManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RDR-017 P1 (Luciferase-pf1iu) — persistence recovery exercised through the REAL
+ * {@link NodeBootstrap#assemble} construction path (not an isolated adapter), per the P0 stacked-review
+ * carry-forward: registering the persistence adapter on the coordinator must drive
+ * {@code doStart() → recover() → FSM replay → startSchedulers()}, and a corrupt WAL must abort assembly.
+ */
+class NodeBootstrapPersistenceWiringTest {
+
+    private static EntityMigrationStateMachine freshFsm() {
+        return new EntityMigrationStateMachine(new FirefliesViewMonitor(new MockFirefliesView<>(), 3));
+    }
+
+    @Test
+    void assembleRecoversFsmViaPersistenceAdapter(@TempDir Path walDir) throws Exception {
+        var nodeId = UUID.randomUUID();
+        var entityId = UUID.randomUUID();
+        try (var writer = new PersistenceManager(nodeId, walDir, RecoveryStateSink.NOOP)) {
+            writer.logEntityDeparture(entityId, UUID.randomUUID(), UUID.randomUUID());
+        }
+
+        var fsm = freshFsm();
+        var adapter = NodeBootstrap.persistenceAdapter(nodeId, walDir, fsm);
+        var pm = adapter.getPersistenceManager();
+        var scm = new SocketConnectionManager(ProcessAddress.localhost("p1-wiring", 0), msg -> {});
+        var registry = LocalServerTransport.Registry.create();
+        var manager = new Manager(registry, SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL, 16L,
+                                  SpatialLevelHeuristic.DEFAULT_AOI_RADIUS);
+        try {
+            NodeBootstrap.assemble(manager, new SocketConnectionManagerAdapter(scm), adapter);
+
+            // Registering the adapter (assemble → registerInfrastructure → registerAndStart) drove doStart().
+            assertEquals(LifecycleState.RUNNING, manager.coordinator().getState("PersistenceManager"));
+            assertEquals(EntityMigrationState.MIGRATING_OUT, fsm.getState(entityId.toString()),
+                         "assemble() must recover the WAL and replay the departure into the FSM");
+            assertTrue(pm.isSchedulersStarted(), "schedulers must start after recovery during assemble()");
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void assembleAbortsOnCorruptWal(@TempDir Path walDir) throws Exception {
+        var nodeId = UUID.randomUUID();
+        try (var writer = new PersistenceManager(nodeId, walDir, RecoveryStateSink.NOOP)) {
+            writer.logEntityDeparture(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+            writer.logEntityDeparture(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+            writer.logEntityDeparture(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+        }
+        var logFile = walDir.resolve("node-" + nodeId + ".log");
+        var lines = Files.readAllLines(logFile, StandardCharsets.UTF_8);
+        lines.set(1, "{ corrupt mid-file line");
+        Files.write(logFile, String.join("\n", lines).concat("\n").getBytes(StandardCharsets.UTF_8));
+
+        var fsm = freshFsm();
+        var adapter = NodeBootstrap.persistenceAdapter(nodeId, walDir, fsm);
+        var pm = adapter.getPersistenceManager();
+        var scm = new SocketConnectionManager(ProcessAddress.localhost("p1-corrupt", 0), msg -> {});
+        var registry = LocalServerTransport.Registry.create();
+        var manager = new Manager(registry, SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL, 16L,
+                                  SpatialLevelHeuristic.DEFAULT_AOI_RADIUS);
+        try {
+            // assemble() registers SCM first (ok), then the persistence adapter whose doStart() recovers
+            // a corrupt WAL — registerInfrastructure must propagate the failure (node refuses to start).
+            assertThrows(LifecycleException.class,
+                         () -> NodeBootstrap.assemble(manager, new SocketConnectionManagerAdapter(scm), adapter),
+                         "corrupt WAL must abort node assembly");
+            assertFalse(pm.isSchedulersStarted(), "schedulers must not start when assembly aborts");
+            assertEquals(0, pm.scheduledTaskCount(), "no scheduler may run when recover() aborts");
+        } finally {
+            // Best-effort: manager.close() stops the RUNNING SCM adapter; the FAILED persistence
+            // adapter is not RUNNING so its PM is closed explicitly here.
+            try {
+                manager.close();
+            } catch (Exception ignored) {
+            }
+            pm.close();
+        }
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapPersistenceWiringTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapPersistenceWiringTest.java
@@ -100,7 +100,6 @@ class NodeBootstrapPersistenceWiringTest {
                          () -> NodeBootstrap.assemble(manager, new SocketConnectionManagerAdapter(scm), adapter),
                          "corrupt WAL must abort node assembly");
             assertFalse(pm.isSchedulersStarted(), "schedulers must not start when assembly aborts");
-            assertEquals(0, pm.scheduledTaskCount(), "no scheduler may run when recover() aborts");
         } finally {
             // Best-effort: manager.close() stops the RUNNING SCM adapter; the FAILED persistence
             // adapter is not RUNNING so its PM is closed explicitly here.


### PR DESCRIPTION
Implements RDR-017 Phase 1 (bead Luciferase-pf1iu), building on the P0 bootstrap seam (#209). Closes the recovery + scheduler-hazard gap so a node refuses to start on a corrupt WAL and no scheduler can run before recovery.

## What

- **`PersistenceManagerAdapter.doStart()`** now calls `recover()` and lets `IOException` propagate (fail-loud) — a corrupt WAL aborts startup (FAILED → `LifecycleException`), it does not degrade. Then `startSchedulers()`. Previously `doStart()` was a no-op that never called `recover()`.
- **Both** the batch-flush and checkpoint schedulers are **relocated out of the `PersistenceManager` constructor** into `startSchedulers()` (idempotent), invoked by `doStart()` strictly after `recover()`. Neither can run against an unrecovered WAL.
- **`NodeBootstrap.persistenceAdapter(nodeId, walDir, fsm)`** builds `MigrationRecoveryStateSink(fsm) → PersistenceManager(nodeId, walDir, sink) → adapter` (§F5 FSM recovery seam, real sink — not NOOP).

## Review fixes (stacked review, 0 Critical from both)

- Corrupt-WAL abort no longer leaks the PM executor/WAL handles: `doStart()` closes the PM on `recover()` failure; `PersistenceManager.close()` is now idempotent.
- `doStart()` is idempotent across restart-from-FAILED (skips re-`recover()` when schedulers already started) — no FSM double-replay.
- Racy `scheduledTaskCount()==2` assertions removed from cross-package tests (use `isSchedulersStarted()`); `scheduledTaskCount()` made package-private.
- P0 HIGH-2 carry-forward (assemble-before-createBubble guard) tracked as `Luciferase-n6jrh.1`, a precondition for wiring `NodeBootstrap.main()`.

## Tests (TDD)

- `PersistenceManagerSchedulerRelocationTest` — non-vacuous: neither scheduler queued in the ctor (`scheduledTaskCount()==0`); both after `startSchedulers()`; idempotent.
- `PersistenceManagerAdapterRecoveryTest` — clean WAL replays `ENTITY_DEPARTURE` into the FSM sink then starts schedulers; corrupt WAL aborts with an `IOException` cause and schedulers NOT started.
- `NodeBootstrapPersistenceWiringTest` — same through the **real `NodeBootstrap.assemble()` path** (recovers FSM; corrupt aborts assembly), per the P0 review carry-forward.
- 60 persistence/lifecycle/von + 23 migrator tests green locally.

## Scope

Consensus-event *recovery* remains P3 (events are written but no FSM consumes them; §Approach.5). Migration WAL bracket live + durability round-trip is **P2 (Luciferase-1693b)**. Detail in T2 `Luciferase/pf1iu-p1-stacked-review`.