### PR TITLE
RDR-017 P2: migration WAL bracket live + durability round-trip (Luciferase-1693b)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
@@ -156,6 +156,15 @@ public final class NodeBootstrap {
      * {@code setPersistenceManager} is called <b>after</b> the persistence adapter has been registered
      * and started (the coordinator started in the {@link Manager} constructor starts components on
      * registration), so the migrator never logs against an unrecovered/unstarted WAL.
+     * <p>
+     * <b>Shutdown ordering contract.</b> The migrator is wired to the persistence manager but is NOT
+     * registered as a lifecycle component, so {@code Manager.close()} does not stop it. The caller MUST
+     * call {@code migrator.shutdown()} (draining in-flight migrations) <b>before</b> {@code Manager.close()}
+     * closes the WAL — otherwise an in-flight migration can call {@code logMigrationCommit()} after the
+     * WAL is closed, failing the commit and leaving an {@code ENTITY_DEPARTURE}-without-{@code COMMIT}
+     * split-brain precondition (the exact hazard RDR-016 R2 guards). Lifecycle-integrating the migrator
+     * (a {@code BubbleMigratorAdapter} stopped ahead of the persistence layer) is tracked for the live
+     * {@link #main} wiring — until then {@code main} throws, so the race is unreachable in production.
      *
      * @param manager    the VON manager owning the lifecycle coordinator
      * @param scmAdapter the connection-manager adapter (Layer 0)

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
@@ -15,6 +15,7 @@ import com.hellblazer.luciferase.simulation.lifecycle.PersistenceManagerAdapter;
 import com.hellblazer.luciferase.simulation.lifecycle.SocketConnectionManagerAdapter;
 import com.hellblazer.luciferase.simulation.persistence.MigrationRecoveryStateSink;
 import com.hellblazer.luciferase.simulation.persistence.PersistenceManager;
+import com.hellblazer.luciferase.simulation.tumbler.BubbleMigrator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,6 +145,31 @@ public final class NodeBootstrap {
         manager.setBubbleDependencies(List.of(pmAdapter.name()));
         log.info("Node lifecycle assembled: {} and {} at Layer 0; bubbles depend on {}",
                  scmAdapter.name(), pmAdapter.name(), pmAdapter.name());
+    }
+
+    /**
+     * Wire the node lifecycle graph (see {@link #assemble(Manager, SocketConnectionManagerAdapter,
+     * PersistenceManagerAdapter)}) and inject the live {@link PersistenceManager} into the migration
+     * subsystem so the RDR-016 R2 {@code ENTITY_DEPARTURE}/{@code MIGRATION_COMMIT} WAL bracket fires
+     * in the assembled node (RDR-017 P2, §Approach.3).
+     * <p>
+     * {@code setPersistenceManager} is called <b>after</b> the persistence adapter has been registered
+     * and started (the coordinator started in the {@link Manager} constructor starts components on
+     * registration), so the migrator never logs against an unrecovered/unstarted WAL.
+     *
+     * @param manager    the VON manager owning the lifecycle coordinator
+     * @param scmAdapter the connection-manager adapter (Layer 0)
+     * @param pmAdapter  the persistence adapter (Layer 0)
+     * @param migrator   the bubble migrator whose WAL bracket is wired to the started persistence manager
+     */
+    public static void assemble(Manager manager, SocketConnectionManagerAdapter scmAdapter,
+                                PersistenceManagerAdapter pmAdapter, BubbleMigrator migrator) {
+        Objects.requireNonNull(migrator, "migrator cannot be null");
+        assemble(manager, scmAdapter, pmAdapter);
+        // After coordinator.start()/registration: the persistence adapter is RUNNING (recovered,
+        // schedulers up), so the migration WAL bracket can durably log against it.
+        migrator.setPersistenceManager(pmAdapter.getPersistenceManager());
+        log.info("Migration durability wired: BubbleMigrator → {}", pmAdapter.name());
     }
 
     /**

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapDurabilityRoundTripTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapDurabilityRoundTripTest.java
@@ -54,9 +54,10 @@ class NodeBootstrapDurabilityRoundTripTest {
     }
 
     @Test
-    void migrateThenReopenSameWalDir_recoversDepartedFsmState(@TempDir Path base) throws Exception {
+    void migrateThenReopenSameWalDir_recoversFsmState(@TempDir Path base) throws Exception {
         var memberId = DigestAlgorithm.DEFAULT.random();   // stable member identity across "restarts"
-        var entityId = UUID.randomUUID();
+        var committedEntity = UUID.randomUUID();   // full migration → DEPARTED on recovery
+        var inFlightEntity = UUID.randomUUID();    // departure only, no commit → MIGRATING_OUT on recovery
 
         // ───────── node #1: assemble, wire migration durability, migrate one entity ─────────
         var nodeId1 = NodeBootstrap.resolveNodeId(memberId);
@@ -64,26 +65,36 @@ class NodeBootstrapDurabilityRoundTripTest {
 
         var fsm1 = freshFsm();
         var pmAdapter1 = NodeBootstrap.persistenceAdapter(nodeId1, walDir1, fsm1);
+        // 1-arg SocketConnectionManagerAdapter has no bind address → doStart() does not listen on a
+        // socket. Intentional: this is a durability test, not a network test; the SCM only needs to
+        // occupy Layer 0 so the lifecycle graph matches production.
         var scm1 = new SocketConnectionManager(ProcessAddress.localhost("p2-node1", 0), msg -> {});
         var mgr1 = manager();
         var tumbler = new SpatialTumbler((byte) 5, 16L);
         var migrator = new BubbleMigrator(tumbler, Duration.ofSeconds(1), Duration.ofMillis(100), 5);
+        var target = new Bubble(UUID.randomUUID(), (byte) 5, 16L, mock(Transport.class));
         try {
             NodeBootstrap.assemble(mgr1, new SocketConnectionManagerAdapter(scm1), pmAdapter1, migrator);
 
-            // Drive a real, successful WAL-bracketed migration (no neighbors → MOVE ACK completes
+            // (a) Drive a real, successful WAL-bracketed migration (no neighbors → MOVE ACK completes
             // immediately). The entity id MUST be a UUID so the bracket's UUID.fromString succeeds.
             var source = new Bubble(UUID.randomUUID(), (byte) 5, 16L, mock(Transport.class));
-            source.addEntity(entityId.toString(), new Point3f(1f, 0f, 0f), "payload");
-            var target = new Bubble(UUID.randomUUID(), (byte) 5, 16L, mock(Transport.class));
+            source.addEntity(committedEntity.toString(), new Point3f(1f, 0f, 0f), "payload");
             migrator.setBubbleTransferFactory((tgtServer, src) -> target);
 
             var result = migrator.migrate(source, UUID.randomUUID(), UUID.randomUUID())
                                  .get(5, TimeUnit.SECONDS);
             assertTrue(result.success(),
                        "live WAL-bracketed migration must commit: " + result.message());
+
+            // (b) Simulate a crash mid-migration: ENTITY_DEPARTURE durable, MIGRATION_COMMIT never
+            // written (the half the RDR-016 R2 bracket protects). Recovery must reconstruct MIGRATING_OUT.
+            pmAdapter1.getPersistenceManager()
+                      .logEntityDeparture(inFlightEntity, UUID.randomUUID(), UUID.randomUUID());
         } finally {
-            mgr1.close();          // stops the PM adapter → flushes + closes the WAL durably
+            target.close();        // releases the target Bubble's retry-scheduler daemon thread
+            migrator.shutdown();    // releases the migration executor pool
+            mgr1.close();           // stops the PM adapter → flushes + closes the WAL durably
         }
 
         // ───────── WAL-identity pinning (gate C1): the reopened node derives the SAME dir ─────────
@@ -100,9 +111,12 @@ class NodeBootstrapDurabilityRoundTripTest {
         try {
             NodeBootstrap.assemble(mgr2, new SocketConnectionManagerAdapter(scm2), pmAdapter2);
 
-            // The committed migration (ENTITY_DEPARTURE + MIGRATION_COMMIT) must reconstruct as DEPARTED.
-            assertEquals(EntityMigrationState.DEPARTED, fsm2.getState(entityId.toString()),
+            // The committed migration (ENTITY_DEPARTURE + MIGRATION_COMMIT) must reconstruct as DEPARTED;
+            // the in-flight departure (ENTITY_DEPARTURE only) must reconstruct as MIGRATING_OUT (gate S2).
+            assertEquals(EntityMigrationState.DEPARTED, fsm2.getState(committedEntity.toString()),
                          "a committed migration must recover to DEPARTED on the reopened node");
+            assertEquals(EntityMigrationState.MIGRATING_OUT, fsm2.getState(inFlightEntity.toString()),
+                         "an uncommitted departure must recover to MIGRATING_OUT on the reopened node");
         } finally {
             mgr2.close();
         }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapDurabilityRoundTripTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapDurabilityRoundTripTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.von;
+
+import com.hellblazer.delos.cryptography.Digest;
+import com.hellblazer.delos.cryptography.DigestAlgorithm;
+import com.hellblazer.luciferase.simulation.bubble.SpatialLevelHeuristic;
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationState;
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationStateMachine;
+import com.hellblazer.luciferase.simulation.causality.FirefliesViewMonitor;
+import com.hellblazer.luciferase.simulation.delos.mock.MockFirefliesView;
+import com.hellblazer.luciferase.simulation.lifecycle.SocketConnectionManagerAdapter;
+import com.hellblazer.luciferase.simulation.tumbler.BubbleMigrator;
+import com.hellblazer.luciferase.simulation.tumbler.SpatialTumbler;
+import com.hellblazer.luciferase.simulation.von.transport.ProcessAddress;
+import com.hellblazer.luciferase.simulation.von.transport.SocketConnectionManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.vecmath.Point3f;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * RDR-017 P2 (Luciferase-1693b) — assembled-node durability round-trip with WAL-identity pinning
+ * (gate S2). Distinct from and strengthens the in-process
+ * {@code MigrationRecoveryStateSinkTest.endToEndViaManagerReconstructsFsmState()}: this drives a live
+ * migration through the WAL bracket wired by {@link NodeBootstrap#assemble(Manager,
+ * SocketConnectionManagerAdapter, com.hellblazer.luciferase.simulation.lifecycle.PersistenceManagerAdapter,
+ * BubbleMigrator)}, closes the node, and recovers a FRESH node on the SAME digest-derived WAL directory.
+ */
+class NodeBootstrapDurabilityRoundTripTest {
+
+    private static EntityMigrationStateMachine freshFsm() {
+        return new EntityMigrationStateMachine(new FirefliesViewMonitor(new MockFirefliesView<>(), 3));
+    }
+
+    private static Manager manager() {
+        return new Manager(LocalServerTransport.Registry.create(),
+                           SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL, 16L,
+                           SpatialLevelHeuristic.DEFAULT_AOI_RADIUS);
+    }
+
+    @Test
+    void migrateThenReopenSameWalDir_recoversDepartedFsmState(@TempDir Path base) throws Exception {
+        var memberId = DigestAlgorithm.DEFAULT.random();   // stable member identity across "restarts"
+        var entityId = UUID.randomUUID();
+
+        // ───────── node #1: assemble, wire migration durability, migrate one entity ─────────
+        var nodeId1 = NodeBootstrap.resolveNodeId(memberId);
+        var walDir1 = NodeBootstrap.walDir(base, nodeId1);
+
+        var fsm1 = freshFsm();
+        var pmAdapter1 = NodeBootstrap.persistenceAdapter(nodeId1, walDir1, fsm1);
+        var scm1 = new SocketConnectionManager(ProcessAddress.localhost("p2-node1", 0), msg -> {});
+        var mgr1 = manager();
+        var tumbler = new SpatialTumbler((byte) 5, 16L);
+        var migrator = new BubbleMigrator(tumbler, Duration.ofSeconds(1), Duration.ofMillis(100), 5);
+        try {
+            NodeBootstrap.assemble(mgr1, new SocketConnectionManagerAdapter(scm1), pmAdapter1, migrator);
+
+            // Drive a real, successful WAL-bracketed migration (no neighbors → MOVE ACK completes
+            // immediately). The entity id MUST be a UUID so the bracket's UUID.fromString succeeds.
+            var source = new Bubble(UUID.randomUUID(), (byte) 5, 16L, mock(Transport.class));
+            source.addEntity(entityId.toString(), new Point3f(1f, 0f, 0f), "payload");
+            var target = new Bubble(UUID.randomUUID(), (byte) 5, 16L, mock(Transport.class));
+            migrator.setBubbleTransferFactory((tgtServer, src) -> target);
+
+            var result = migrator.migrate(source, UUID.randomUUID(), UUID.randomUUID())
+                                 .get(5, TimeUnit.SECONDS);
+            assertTrue(result.success(),
+                       "live WAL-bracketed migration must commit: " + result.message());
+        } finally {
+            mgr1.close();          // stops the PM adapter → flushes + closes the WAL durably
+        }
+
+        // ───────── WAL-identity pinning (gate C1): the reopened node derives the SAME dir ─────────
+        var nodeId2 = NodeBootstrap.resolveNodeId(memberId);
+        var walDir2 = NodeBootstrap.walDir(base, nodeId2);
+        assertEquals(nodeId1, nodeId2, "nodeId must be deterministic across restarts (same member id)");
+        assertEquals(walDir1, walDir2, "reopened node must resolve the SAME WAL directory");
+
+        // ───────── node #2: reopen on the same WAL dir, recover the FSM ─────────
+        var fsm2 = freshFsm();
+        var pmAdapter2 = NodeBootstrap.persistenceAdapter(nodeId2, walDir2, fsm2);
+        var scm2 = new SocketConnectionManager(ProcessAddress.localhost("p2-node2", 0), msg -> {});
+        var mgr2 = manager();
+        try {
+            NodeBootstrap.assemble(mgr2, new SocketConnectionManagerAdapter(scm2), pmAdapter2);
+
+            // The committed migration (ENTITY_DEPARTURE + MIGRATION_COMMIT) must reconstruct as DEPARTED.
+            assertEquals(EntityMigrationState.DEPARTED, fsm2.getState(entityId.toString()),
+                         "a committed migration must recover to DEPARTED on the reopened node");
+        } finally {
+            mgr2.close();
+        }
+    }
+}


### PR DESCRIPTION
Implements RDR-017 Phase 2 (bead Luciferase-1693b), building on P0 (#209) + P1 (#210). Makes the RDR-016 R2 migration WAL bracket actually fire in the assembled node and proves durability via a close/reopen round-trip with WAL-identity pinning (gate S2).

## What

- **`NodeBootstrap.assemble(manager, scm, pm, migrator)`** — 4-arg overload that, after the persistence adapter is registered and started (RUNNING: recovered, schedulers up), calls `bubbleMigrator.setPersistenceManager(pm)`. The `ENTITY_DEPARTURE`/`MIGRATION_COMMIT` WAL bracket now fires in the composed node.

## Test (TDD, gate S2 — non-vacuous, WAL-identity pinned)

`NodeBootstrapDurabilityRoundTripTest`:
- Drives a **real, successful WAL-bracketed migration** through the assembled node (the live bracket, not a hand-written WAL), plus an **in-flight departure** (ENTITY_DEPARTURE, no COMMIT).
- Closes the node, then reopens a **fresh** node on the **same `digestToUuid`-derived WAL directory**.
- Asserts `nodeId`/`walDir` equality across restart (gate C1 WAL-identity pinning) and FSM recovery: committed entity → **DEPARTED**, in-flight entity → **MIGRATING_OUT**.
- Explicitly distinct from the in-process `MigrationRecoveryStateSinkTest` — goes through the bootstrap + relocated scheduler. Process-level fork/exec restart remains manual QA (RDR §Approach.3), not a CI gate.

## Stacked review (0 Critical from both)

- gate S2 MIGRATING_OUT coverage added (was DEPARTED-only).
- Test resource leaks fixed (`target.close()`, `migrator.shutdown()`).
- Migrator shutdown-ordering contract documented on `assemble()` javadoc — an in-flight migration committing after WAL close would recreate the RDR-016 R2 split-brain precondition; lifecycle-integrating the migrator (`BubbleMigratorAdapter`) is tracked as a `main()`-precondition bead (latent today — `main()` still throws).

39 bootstrap/migrator/persistence tests green locally. Detail in T2 `Luciferase/1693b-p2-stacked-review`.

## Scope

P3 (`Luciferase-skaui`): consensus no-op recovery, WAL lifecycle/cleanup policy, Subsystem B/C disposition docs.