### PR TITLE
RDR-017 P3 (final): consensus no-op recovery, WAL lifecycle policy, B/C disposition (Luciferase-skaui)

### DIFF
--- a/docs/rdr/RDR-017-production-node-bootstrap.md
+++ b/docs/rdr/RDR-017-production-node-bootstrap.md
@@ -124,6 +124,35 @@ crash `LifecycleCoordinator.computeLayers()`.
    recovery is opt-in, off in the default node. Any further deferral gets a tracked bead (phase-review-gate
    discipline).
 
+## Operational notes (P3 — gate O1 + Subsystem B/C disposition)
+
+**WAL directory lifecycle / cleanup (gate O1).** Per-node WAL lives at `.luciferase/wal/<nodeId>/`
+(`nodeId` from `digestToUuid`, stable across restarts — gate C1).
+
+- *Clean shutdown* (lifecycle stop → `PersistenceManagerAdapter.doStop()` → `PersistenceManager.closeClean()`):
+  write a checkpoint at the head sequence, then **truncate** the log segments (compaction). A cleanly-stopped
+  node has no in-flight migrations (the caller drains the migrator first — P2), so there is nothing to
+  recover; the next start replays nothing. The checkpoint `.meta` is retained and carries the high-water
+  sequence, so post-restart appends continue the monotonic sequence rather than colliding below the
+  checkpoint (`WriteAheadLog.restoreSequenceCounter` seeds from `max(log, checkpoint)`).
+- *Crash* (no clean stop; abrupt exit or the `doStart` recover-abort path → `PersistenceManager.close()`):
+  the WAL is flushed and retained in full. Recovery replays the post-(last-checkpoint) tail. This is the
+  durability path the round-trip test exercises.
+- *Retention across restarts*: a clean shutdown leaves a pristine WAL (empty segments + checkpoint); a crash
+  leaves the full segment set until the next clean shutdown compacts it.
+
+**Subsystem B (`MigrationLogPersistence` / `CrossProcessMigration` 2PC) — opt-in, OFF by default.**
+`CrossProcessMigration.walPersistence` is a nullable ctor arg, null in the default node. To opt in, construct
+`CrossProcessMigration` with a `MigrationLogPersistence` (its own dir `.luciferase/migration-wal/<processId>/`).
+**Consequence with B off (gate S3):** a crash between `recordPrepare()` and `recordCommit()` leaves an orphaned
+PREPARE with **no automatic rollback and no operator signal** — the shipped node's durability promise covers
+entity migration-FSM state (Subsystem A), not 2PC transaction recovery. B is defense-in-depth, NOT an
+alternative authoritative WAL.
+
+**Subsystem C (`von/RecoveryIntegration`) — orthogonal, not a WAL.** Zero disk I/O; it is a live VON-topology
+repair bridge (`onNeighborLeave()` → `faultHandler.reportSyncFailure()`). Out of scope for this RDR.
+Productionizing it (partition-fault self-healing) is tracked in **`Luciferase-s23eu`** — not duplicated here.
+
 ## Consequences / Risks
 
 - Large blast radius: node startup/shutdown semantics, lifecycle dependency graph, `BubbleMigrator`,

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapter.java
@@ -81,7 +81,10 @@ public class PersistenceManagerAdapter extends AbstractLifecycleAdapter {
 
     @Override
     protected void doStop() throws Exception {
-        persistenceManager.close();
+        // RDR-017 P3 (gate O1): a lifecycle stop is a CLEAN shutdown — checkpoint + truncate the WAL
+        // (compaction) so the next start recovers nothing. The crash path (abort in doStart) calls
+        // close() directly, retaining the WAL for recovery.
+        persistenceManager.closeClean();
     }
 
     @Override

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/EventRecovery.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/EventRecovery.java
@@ -211,6 +211,15 @@ public class EventRecovery {
                     case "VIEW_SYNC_ACK" -> replayViewSynchronyAck(event);
                     case "DEFERRED_UPDATE" -> replayDeferredUpdate(event);
                     case "MIGRATION_COMMIT" -> replayMigrationCommit(event);
+                    // RDR-017 P3 (§Approach.5a): the four consensus event types are WRITTEN by
+                    // PersistenceManager but no FSM consumes them on recovery — consensus-event RECOVERY
+                    // is explicitly out of scope (not a data-loss risk; no state depends on it). These
+                    // are recognized as deliberate no-ops so a WAL containing them does not emit a
+                    // spurious "Unknown event type" WARN on every restart. Productionizing a consensus
+                    // recovery sink would replace these no-ops.
+                    case "ELECTION_START", "VOTE_CAST", "LEADER_ELECTED", "TERM_INCREMENT" -> {
+                        // no-op: consensus event recovery deliberately not implemented (RDR-017 §5a)
+                    }
                     default -> log.warn("Unknown event type: {}", type);
                 }
             } catch (Exception e) {

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManager.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManager.java
@@ -390,7 +390,32 @@ public class PersistenceManager implements AutoCloseable {
     }
 
     /**
-     * Close persistence manager and release resources.
+     * Clean-shutdown close (RDR-017 P3, gate O1): checkpoint at the current sequence, truncate the WAL
+     * segments (compaction — recovery replays only post-checkpoint events, of which a head checkpoint
+     * leaves none), then close.
+     * <p>
+     * <b>Retention semantics.</b> A clean shutdown leaves a pristine WAL: the next start recovers nothing
+     * (a cleanly-stopped node has no in-flight migrations — the caller is expected to have drained the
+     * migrator first, RDR-017 P2). This is distinct from {@link #close()} (the crash-safe path), which
+     * flushes and closes WITHOUT checkpoint/truncate so a crash retains the full WAL tail for recovery.
+     * Use this from the lifecycle stop path; use {@link #close()} on abort/error paths.
+     * <p>
+     * Idempotent: a no-op if the manager is already closed.
+     *
+     * @throws IOException if checkpoint, truncate, or close fails
+     */
+    public void closeClean() throws IOException {
+        if (closed.get()) {
+            return;
+        }
+        checkpoint();
+        writeAheadLog.truncate();
+        close();
+    }
+
+    /**
+     * Crash-safe close: flush and close WITHOUT checkpoint/truncate, so a crash retains the full WAL for
+     * recovery. For clean lifecycle shutdown use {@link #closeClean()} (checkpoint + truncate compaction).
      *
      * @throws IOException if close fails
      */

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/WriteAheadLog.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/WriteAheadLog.java
@@ -342,10 +342,71 @@ public class WriteAheadLog implements AutoCloseable {
             log.warn("Failed to scan existing log for sequence restoration on node {}; starting at 0", nodeId, e);
             return;
         }
+        // RDR-017 P3 (gate O1): a clean shutdown checkpoints then truncates the log files, so after a
+        // clean restart the logs are empty but the checkpoint .meta still records the high-water
+        // sequence. Seed from max(log max, checkpoint seq) so newly-appended events continue PAST the
+        // checkpoint rather than restarting at 1 and colliding below it (which readEventsSince would
+        // then silently filter out on the next recovery).
+        maxSequence = Math.max(maxSequence, readCheckpointSequence());
         sequenceCounter.set(maxSequence);
         if (maxSequence > 0) {
             log.debug("Restored WAL sequence counter to {} for node {}", maxSequence, nodeId);
         }
+    }
+
+    /**
+     * Read the checkpoint sequence number from the metadata file, or 0 if none exists / unreadable.
+     */
+    private long readCheckpointSequence() {
+        if (!Files.exists(metadataFile)) {
+            return 0L;
+        }
+        try {
+            var json = Files.readString(metadataFile);
+            var meta = MAPPER.readValue(json, new com.fasterxml.jackson.core.type.TypeReference<Map<String, Object>>() {});
+            var seq = meta.get("sequenceNumber");
+            return seq instanceof Number n ? n.longValue() : 0L;
+        } catch (IOException e) {
+            log.warn("Failed to read checkpoint metadata for node {}; sequence seed from log only", nodeId, e);
+            return 0L;
+        }
+    }
+
+    /**
+     * Truncate the write-ahead log: delete all log segment files and start an empty base log, retaining
+     * the checkpoint metadata. RDR-017 P3 (gate O1) clean-shutdown compaction — after a checkpoint at
+     * the head sequence, the entire log is superseded (recovery replays only post-checkpoint events, of
+     * which there are none), so the segments are safe to discard to reclaim space. The high-water
+     * sequence survives in the checkpoint metadata (see {@link #readCheckpointSequence()}), so a later
+     * restart continues the monotonic sequence rather than colliding below the checkpoint.
+     *
+     * @throws IOException if segment deletion or base-log recreation fails
+     */
+    public synchronized void truncate() throws IOException {
+        checkNotClosed();
+
+        if (writer != null) {
+            writer.flush();
+            writer.close();
+            writer = null;
+        }
+        if (fileChannel != null) {
+            fileChannel.close();
+            fileChannel = null;
+        }
+
+        for (var logFile : findLogFiles()) {
+            Files.deleteIfExists(logFile);
+        }
+
+        rotationCount = 0;
+        currentLogFile = logDirectory.resolve("node-" + nodeId + ".log");
+        var fos = new FileOutputStream(currentLogFile.toFile(), true);
+        this.fileChannel = fos.getChannel();
+        this.writer = new BufferedWriter(new OutputStreamWriter(fos, java.nio.charset.StandardCharsets.UTF_8));
+        currentSize.set(0);
+
+        log.info("WriteAheadLog truncated for node {} (clean-shutdown compaction)", nodeId);
     }
 
     private List<Path> findLogFiles() throws IOException {

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/ConsensusEventRecoveryNoopTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/ConsensusEventRecoveryNoopTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.persistence;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RDR-017 P3 (Luciferase-skaui, §Approach.5a) — the four consensus event types are recognized as
+ * deliberate no-ops in {@link EventRecovery#replayEvents}, so a WAL containing only consensus events does
+ * NOT emit a spurious {@code "Unknown event type"} WARN on every restart. This is WARN-silencing only:
+ * consensus-event recovery (a real FSM sink) remains out of scope.
+ */
+class ConsensusEventRecoveryNoopTest {
+
+    private Logger recoveryLogger;
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void attachAppender() {
+        var ctx = (LoggerContext) LoggerFactory.getILoggerFactory();
+        recoveryLogger = ctx.getLogger(EventRecovery.class);
+        appender = new ListAppender<>();
+        appender.start();
+        recoveryLogger.addAppender(appender);
+        recoveryLogger.setLevel(Level.DEBUG);
+    }
+
+    @AfterEach
+    void detachAppender() {
+        recoveryLogger.detachAppender(appender);
+    }
+
+    private boolean warnedUnknownType() {
+        return appender.list.stream()
+                            .anyMatch(e -> e.getLevel() == Level.WARN
+                                           && e.getFormattedMessage().contains("Unknown event type"));
+    }
+
+    @Test
+    void consensusOnlyWalReplaysWithoutUnknownTypeWarn(@TempDir Path walDir) throws IOException {
+        var nodeId = UUID.randomUUID();
+        try (var pm = new PersistenceManager(nodeId, walDir)) {
+            pm.logElectionStart(UUID.randomUUID(), 1L);
+            pm.logVoteCast(UUID.randomUUID(), UUID.randomUUID(), 1L, true);
+            pm.logLeaderElected(UUID.randomUUID(), 1L);
+            pm.logTermIncrement(2L);
+        }
+
+        try (var pm2 = new PersistenceManager(nodeId, walDir)) {
+            pm2.recover();
+        }
+
+        assertFalse(warnedUnknownType(),
+                    "consensus events must be recognized no-ops — no 'Unknown event type' WARN on restart");
+    }
+
+    @Test
+    void trulyUnknownTypeStillWarns(@TempDir Path walDir) throws IOException {
+        // Control: proves the appender + assertion actually observe the WARN arm (non-vacuous).
+        var nodeId = UUID.randomUUID();
+        try (var wal = new WriteAheadLog(nodeId, walDir)) {
+            var event = new java.util.HashMap<String, Object>();
+            event.put("version", 1);
+            event.put("type", "DEFINITELY_NOT_A_REAL_TYPE");
+            event.put("timestamp", java.time.Instant.EPOCH.toString());
+            wal.append(event);
+            wal.flush();
+        }
+
+        new EventRecovery(walDir).recover(nodeId);
+
+        assertTrue(warnedUnknownType(),
+                   "a genuinely unknown event type must still emit the 'Unknown event type' WARN");
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/WalCleanShutdownPolicyTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/WalCleanShutdownPolicyTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.persistence;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RDR-017 P3 (Luciferase-skaui, gate O1) — WAL clean-shutdown lifecycle policy: {@code closeClean()}
+ * checkpoints then truncates the log segments (compaction), and a later restart continues the monotonic
+ * sequence past the checkpoint rather than colliding below it.
+ */
+class WalCleanShutdownPolicyTest {
+
+    private static int logLineCount(Path walDir, UUID nodeId) throws IOException {
+        var logFile = walDir.resolve("node-" + nodeId + ".log");
+        return Files.exists(logFile) ? Files.readAllLines(logFile, StandardCharsets.UTF_8).size() : 0;
+    }
+
+    @Test
+    void cleanCloseCheckpointsAndTruncates_restartReplaysNothing(@TempDir Path walDir) throws IOException {
+        var nodeId = UUID.randomUUID();
+        var pm = new PersistenceManager(nodeId, walDir);
+        // MIGRATION_COMMIT fsyncs (so the segment has flushed content on disk); the departures are
+        // buffered. Either way closeClean must leave an empty segment afterward.
+        pm.logEntityDeparture(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+        pm.logMigrationCommit(UUID.randomUUID());
+        pm.logMigrationCommit(UUID.randomUUID());
+        assertTrue(logLineCount(walDir, nodeId) > 0, "fsynced commits must be on disk before shutdown");
+
+        pm.closeClean();   // checkpoint + truncate
+
+        assertTrue(Files.exists(walDir.resolve("node-" + nodeId + ".meta")),
+                   "clean shutdown must leave a checkpoint");
+        assertEquals(0, logLineCount(walDir, nodeId),
+                     "clean shutdown must truncate the log segments (compaction) — checkpoint-only would "
+                     + "leave the flushed lines on disk");
+
+        // Reopen: recovery replays nothing (the head checkpoint supersedes the truncated prefix).
+        try (var pm2 = new PersistenceManager(nodeId, walDir)) {
+            var recovered = pm2.recover();
+            assertEquals(0, recovered.events().size(),
+                         "a clean-shutdown restart must replay no events");
+        }
+    }
+
+    @Test
+    void postTruncateAppendsContinueSequencePastCheckpoint_noCollision(@TempDir Path walDir) throws IOException {
+        var nodeId = UUID.randomUUID();
+        var pm = new PersistenceManager(nodeId, walDir);
+        pm.logEntityDeparture(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+        pm.logEntityDeparture(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+        pm.logEntityDeparture(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+        pm.closeClean();   // checkpoint at seq=3, logs truncated
+
+        // A fresh manager appends a NEW event, then "crashes" (crash-safe close retains the WAL).
+        var newEntity = UUID.randomUUID();
+        var pm2 = new PersistenceManager(nodeId, walDir);
+        pm2.logEntityDeparture(newEntity, UUID.randomUUID(), UUID.randomUUID());
+        pm2.close();       // crash: flush + retain, no new checkpoint
+
+        // Recovery filters events with sequence > checkpoint(3). The new event must have sequence 4
+        // (continued past the checkpoint), NOT 1 — otherwise readEventsSince(3) would silently drop it.
+        try (var pm3 = new PersistenceManager(nodeId, walDir)) {
+            var recovered = pm3.recover();
+            assertEquals(1, recovered.events().size(),
+                         "the post-truncate append must survive recovery (sequence continued past checkpoint)");
+            assertEquals(newEntity.toString(), recovered.events().get(0).get("entityId"),
+                         "the recovered event must be the post-truncate departure");
+        }
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapDurabilityRoundTripTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapDurabilityRoundTripTest.java
@@ -91,10 +91,16 @@ class NodeBootstrapDurabilityRoundTripTest {
             // written (the half the RDR-016 R2 bracket protects). Recovery must reconstruct MIGRATING_OUT.
             pmAdapter1.getPersistenceManager()
                       .logEntityDeparture(inFlightEntity, UUID.randomUUID(), UUID.randomUUID());
+
+            // Simulate a CRASH, not a clean shutdown: crash-safe close() flushes and retains the full WAL
+            // for recovery. A clean lifecycle stop (doStop → closeClean) would checkpoint + truncate the
+            // WAL (RDR-017 P3 gate O1 compaction) — correct production behavior, but then there would be
+            // nothing to recover. The WAL exists for crash recovery, which is what this round-trip exercises.
+            pmAdapter1.getPersistenceManager().close();
         } finally {
             target.close();        // releases the target Bubble's retry-scheduler daemon thread
             migrator.shutdown();    // releases the migration executor pool
-            mgr1.close();           // stops the PM adapter → flushes + closes the WAL durably
+            mgr1.close();           // doStop → closeClean is a no-op (PM already closed); stops the SCM
         }
 
         // ───────── WAL-identity pinning (gate C1): the reopened node derives the SAME dir ─────────

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapPersistenceWiringTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapPersistenceWiringTest.java
@@ -74,6 +74,50 @@ class NodeBootstrapPersistenceWiringTest {
     }
 
     @Test
+    void assembledCleanShutdownCompactsWal_reopenReplaysNothing(@TempDir Path walDir) throws Exception {
+        // RDR-017 P3 (gate O1): a clean lifecycle stop (mgr.close() → coordinator stop → doStop →
+        // closeClean) must checkpoint + truncate the WAL. Guards the doStop→closeClean wiring against a
+        // regression to plain close() (which would leave the segments on disk).
+        var nodeId = UUID.randomUUID();
+        try (var writer = new PersistenceManager(nodeId, walDir, RecoveryStateSink.NOOP)) {
+            writer.logMigrationCommit(UUID.randomUUID());   // fsynced → segment has flushed content
+        }
+        assertTrue(Files.readAllLines(walDir.resolve("node-" + nodeId + ".log")).size() > 0,
+                   "precondition: WAL segment has content before clean shutdown");
+
+        var fsm1 = freshFsm();
+        var adapter1 = NodeBootstrap.persistenceAdapter(nodeId, walDir, fsm1);
+        var scm1 = new SocketConnectionManager(ProcessAddress.localhost("p3-clean1", 0), msg -> {});
+        var mgr1 = new Manager(LocalServerTransport.Registry.create(),
+                               SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL, 16L,
+                               SpatialLevelHeuristic.DEFAULT_AOI_RADIUS);
+        NodeBootstrap.assemble(mgr1, new SocketConnectionManagerAdapter(scm1), adapter1);
+        mgr1.close();   // clean lifecycle stop → doStop → closeClean (checkpoint + truncate)
+
+        assertEquals(0, Files.readAllLines(walDir.resolve("node-" + nodeId + ".log")).size(),
+                     "clean lifecycle stop must truncate the WAL segment (doStop → closeClean)");
+        assertTrue(Files.exists(walDir.resolve("node-" + nodeId + ".meta")),
+                   "clean lifecycle stop must leave a checkpoint");
+
+        // Reopen the assembled node: recovery replays nothing.
+        var fsm2 = freshFsm();
+        var adapter2 = NodeBootstrap.persistenceAdapter(nodeId, walDir, fsm2);
+        var pm2 = adapter2.getPersistenceManager();
+        var scm2 = new SocketConnectionManager(ProcessAddress.localhost("p3-clean2", 0), msg -> {});
+        var mgr2 = new Manager(LocalServerTransport.Registry.create(),
+                               SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL, 16L,
+                               SpatialLevelHeuristic.DEFAULT_AOI_RADIUS);
+        try {
+            NodeBootstrap.assemble(mgr2, new SocketConnectionManagerAdapter(scm2), adapter2);
+            assertEquals(LifecycleState.RUNNING, mgr2.coordinator().getState("PersistenceManager"),
+                         "reopen on a compacted WAL must start cleanly");
+            assertTrue(pm2.isSchedulersStarted(), "reopen must complete recovery and start schedulers");
+        } finally {
+            mgr2.close();
+        }
+    }
+
+    @Test
     void assembleAbortsOnCorruptWal(@TempDir Path walDir) throws Exception {
         var nodeId = UUID.randomUUID();
         try (var writer = new PersistenceManager(nodeId, walDir, RecoveryStateSink.NOOP)) {


### PR DESCRIPTION
Implements RDR-017 Phase 3 — the final phase (bead Luciferase-skaui), after P0 (#209), P1 (#210), P2 (#211).

## What (all four §Approach.4 sub-items)

1. **Consensus no-op recovery** — `EventRecovery.replayEvents()` has explicit no-op cases for the four consensus event types (`ELECTION_START`, `VOTE_CAST`, `LEADER_ELECTED`, `TERM_INCREMENT`), so a consensus-only WAL no longer emits a spurious `"Unknown event type"` WARN on every restart. WARN-silencing only — consensus-event *recovery* (a real sink) stays out of scope (§5a).
2. **WAL lifecycle / cleanup policy (gate O1, implemented)** — `PersistenceManager.closeClean()` checkpoints then truncates the log segments (compaction); `PersistenceManagerAdapter.doStop()` (clean lifecycle stop) calls it. `close()` remains the crash-safe path (flush + retain, no truncate). `WriteAheadLog.truncate()` discards segments keeping the checkpoint; `restoreSequenceCounter()` seeds from `max(log, checkpoint)` so post-truncate appends continue the monotonic sequence past the checkpoint.
3. **Subsystem B** opt-in path + off-by-default 2PC rollback gap (gate S3) documented in the RDR.
4. **Subsystem C** disposition documented (orthogonal topology bridge; tracked `Luciferase-s23eu`, not duplicated).

## Tests (TDD)

- `ConsensusEventRecoveryNoopTest` — consensus-only WAL replays with no `"Unknown event type"` WARN; non-vacuous control asserts a genuinely-unknown type still WARNs.
- `WalCleanShutdownPolicyTest` — clean close checkpoints + truncates (empty segments, restart replays nothing); post-truncate append continues sequence past the checkpoint (collision guard).
- `NodeBootstrapPersistenceWiringTest#assembledCleanShutdownCompactsWal_reopenReplaysNothing` — the `doStop`→`closeClean` wiring through the real assembled node.
- P2 durability round-trip updated to crash-close node #1 (clean shutdown now compacts the WAL — the round-trip tests crash recovery).

## Stacked review

substantive-critic: justified; its one Significant (missing assembled clean-shutdown integration test) is fixed here. code-review flagged a checkpoint/recovery silent-data-loss (C1): verified **pre-existing** (predates RDR-017), **not** introduced or triggered by P3, and **not reachable** until `main()` is wired (it throws). Filed as CRITICAL `main()`-precondition **`Luciferase-n6jrh.3`** with full analysis — the naive fix worsens the crash case, so it is deliberately not half-fixed here. Detail in T2 `Luciferase/skaui-p3-stacked-review`.

## RDR status

All §Approach phases (P0–P3) delivered. RDR-017 is ready to close (implemented). Remaining `main()`-preconditions (do not block close, block wiring the live entry point): `n6jrh.1` (assemble-before-createBubble guard), BubbleMigratorAdapter lifecycle integration, `n6jrh.3` (WAL checkpoint/recovery data-loss).