### PR TITLE
RDR-019: WAL checkpoint/recovery durability — acceptance + Phase 1 correctness floor

### DIFF
--- a/docs/rdr/RDR-019-wal-checkpoint-recovery-durability.md
+++ b/docs/rdr/RDR-019-wal-checkpoint-recovery-durability.md
@@ -1,0 +1,367 @@
+---
+title: "WAL Checkpoint/Recovery Durability — Bound Replay Safely (Snapshot or Compaction)"
+id: RDR-019
+type: Bug Fix
+status: accepted
+priority: high
+author: self
+reviewed-by: self
+created: 2026-06-07
+accepted_date: 2026-06-07
+related_issues: [Luciferase-n6jrh.3, Luciferase-n6jrh]
+---
+
+# RDR-019: WAL Checkpoint/Recovery Durability — Bound Replay Safely (Snapshot or Compaction)
+
+> Revise during planning; lock at implementation.
+
+## Problem Statement
+
+The simulation WAL recovery (`EventRecovery.recover`) bounds replay at the last checkpoint
+(`readEventsSinceResult(checkpoint.sequenceNumber())`, `EventRecovery.java:106-123`), but a checkpoint is a
+**bare sequence marker with no durable snapshot** of the applied state it claims is captured. The applied
+state — the `EntityMigrationStateMachine` (FSM) migration-state map — lives only in memory and is lost on
+crash. So any event whose only application was into the now-lost FSM is silently skipped on the next
+recovery. This is an RDR-004-class silent data loss (`Luciferase-n6jrh.3`, CRITICAL).
+
+It is **pre-existing** (the post-checkpoint replay bound was introduced by `0frcy.37`) and **not reachable in
+production yet** (`NodeBootstrap.main()` throws). It is a hard precondition for wiring a live node that relies
+on crash recovery. RDR-017 surfaced it; this RDR decides the durable fix.
+
+### Enumerated gaps to close
+
+#### Gap 1: Recovery silently drops checkpointed-but-not-snapshotted events
+
+`recover()` replays only `seq > checkpoint.sequenceNumber`. The 5s periodic checkpoint scheduler
+(`PersistenceManager.startCheckpointScheduler`, `:469-476`) advances that boundary mid-run with no snapshot.
+A node that recovers, runs, takes a periodic checkpoint, then crashes loses every pre-checkpoint
+`MIGRATING_OUT`/`DEPARTED` reconstruction on the next restart — no error, no WARN. Reproduced: log a
+departure → `checkpoint()` → close → recover into a fresh FSM yields `getState == null` (expected
+`MIGRATING_OUT`).
+
+#### Gap 2: No durable snapshot, and recover() never re-checkpoints
+
+The checkpoint contract assumed by `readEventsSince` ("state ≤ seq is durable, skip it") is never
+established: there is no FSM snapshot, and `recover()` does not re-checkpoint after applying the tail. The
+only checkpoint that is safe today is `closeClean()`'s, and only because it is immediately followed by
+`truncate()` (nothing precedes the boundary).
+
+#### Gap 3: Bound WAL growth without reintroducing the data loss
+
+The naive correctness fix (remove mid-run checkpoints, replay the full retained log) eliminates Gap 1 but
+lets the WAL grow unbounded between clean shutdowns and makes crash recovery O(total events). The fix must
+bound replay/WAL **and** stay correct.
+
+#### Gap 4: `eventCounter` resets on restart, diverging from the restored WAL sequence
+
+`PersistenceManager.eventCounter` is `new AtomicLong(0)` and never restored, while
+`WriteAheadLog.sequenceCounter` is restored from `max(log, checkpoint)`. `checkpoint()` records
+`eventCounter`, so after any restart the recorded checkpoint sequence is wrong relative to the WAL sequence
+space `readEventsSince` filters on.
+
+## Context
+
+### Background
+
+Discovered in RDR-017 P3 stacked review (code-review C1). The WAL persists `ENTITY_DEPARTURE`,
+`MIGRATION_COMMIT`, `VIEW_SYNC_ACK`, `DEFERRED_UPDATE`, plus four consensus event types. Only the migration
+FSM is reconstructed on recovery (`MigrationRecoveryStateSink`: `ENTITY_DEPARTURE → MIGRATING_OUT`,
+`MIGRATION_COMMIT → DEPARTED`). Consensus-event recovery is intentionally out of scope (RDR-017 §5a). DSOC,
+deferred updates, and view-sync acks are logged but no sink reconstructs them today.
+
+### Technical Environment
+
+`simulation` module. `PersistenceManager` (`persistence/`), `WriteAheadLog`, `EventRecovery`,
+`MigrationRecoveryStateSink`, `EntityMigrationStateMachine` (`causality/`). Recovery wired through
+`PersistenceManagerAdapter.doStart()` → `recover()` (RDR-017 P1). Clean shutdown compacts via
+`closeClean()` → checkpoint + `WriteAheadLog.truncate()` (RDR-017 P3).
+
+## Research Findings
+
+### Investigation
+
+- **Reproduced the data loss** deterministically (characterization test, not committed): one
+  `logEntityDeparture` + `checkpoint()` + close, then a fresh-FSM `recover()` returns `null` instead of
+  `MIGRATING_OUT`.
+- **Checkpoint callers (production):** only `startCheckpointScheduler` (periodic, the hazard) and
+  `closeClean()` (clean shutdown — safe, truncates). `CausalRollback.checkpoint()` and
+  `EventRecovery.getLastCheckpoint()` are unrelated.
+- **Recovery boundary:** `EventRecovery.recover` uses `getLastCheckpoint` → `readEventsSinceResult(seq)` when
+  a checkpoint exists, else `readAllEventsResult()`. No checkpoint ⇒ full replay (correct).
+- **The only recovery-relevant state is the migration FSM.** Whether *terminal* (`DEPARTED`) state must be
+  reconstructed on restart is the load-bearing open question for the compaction approach (Gap 3) — a
+  `DEPARTED` entity has left this node; if nothing on restart depends on knowing it was `DEPARTED`, committed
+  migration event-pairs are prunable.
+
+### Key Discoveries
+
+- **Verified** — the silent skip is real and triggered by a checkpoint preceding a crash (reproduction:
+  log departure → `checkpoint()` → close → fresh-FSM `recover()` yields `null`, not `MIGRATING_OUT`).
+- **Verified (source search, 2026-06-07)** — **`DEPARTED` reconstruction is NOT load-bearing.** No consumer
+  reads back a recovered `DEPARTED` entry. `GhostStateListener.reconcileGhostState`
+  (`GhostStateListener.java:207-214`) treats `fsm.getState(id) == null` (untracked) identically to any
+  non-`GHOST` state, so a `DEPARTED` entity's *absence* from the recovered FSM is functionally equivalent to
+  its presence. `recoverEntityState` mutates the map directly without firing listeners, so a recovered
+  `DEPARTED` never drives a `DEPARTED→GHOST` transition. No idempotency guard depends on seeing a prior
+  `DEPARTED`. → committed migration pairs may be pruned.
+- **Verified (source search, 2026-06-07)** — replay is **idempotent** (`EventRecovery` `seenMigrations`
+  dedup `:145-150` + `recoverEntityState` `put`), but **order-dependent**: `ENTITY_DEPARTURE` must precede
+  `MIGRATION_COMMIT` for an entity (`recoverEntityState` overwrites; out-of-order `COMMIT,DEPARTURE` would
+  wrongly leave `MIGRATING_OUT`). The append-only WAL write path guarantees this order. **Constraint for
+  compaction:** prune the *whole* `DEPARTURE`+`COMMIT` pair for a committed migration — never a partial pair
+  — and preserve the relative order of retained (in-flight) events.
+- **Documented** — `MigrationRecoveryStateSink.java:83-98` is the sole reconstruction sink;
+  `EntityMigrationStateMachine.recoverEntityState` bypasses the view-stability guard for pre-view recovery.
+
+### Critical Assumptions
+
+- [x] Crash recovery only needs to reconstruct **in-flight** (`MIGRATING_OUT`) migrations; terminal
+  `DEPARTED` reconstruction is not load-bearing across a restart — **Status**: **Verified (scoped)** —
+  **Method**: Source Search. Verified for the recovery/reconcile path (no consumer reads recovered
+  `DEPARTED`; `GhostStateListener.reconcileGhostState:207-214` treats `null` == non-`GHOST`). **Scope caveat
+  (gate S1):** the *forward live* path `GhostStateListener.onEntityStateTransition:164` accepts a
+  `DEPARTED→GHOST` transition, and `EntityMigrationStateMachine.isValidTransition:687-689` has
+  `DEPARTED→GHOST` but routes `null→GHOST` to `default → false`. After restart with committed migrations
+  pruned, `getState(id)` is `null`, so a *subsequent* `DEPARTED→GHOST` ghost notification for a
+  recently-departed, still-spatially-adjacent entity would be silently rejected — a ghost-tracking gap on the
+  source node (not an ownership-invariant violation; the entity is owned at the target). **Phase 2 must
+  resolve this**: either add `null→GHOST` as a valid transition (accept a ghost for an untracked, already-
+  departed entity) or document it as an accepted gap with a tracked bead. Until resolved, the assumption holds
+  for recovery correctness but the forward-path behavior is an explicit open item, not silently assumed away.
+- [x] Replaying the retained migration log into a fresh FSM is idempotent; order-dependence
+  (`DEPARTURE` before `COMMIT`) is guaranteed by the append-only write path and preserved by pair-wise
+  compaction — **Status**: **Verified** — **Method**: Source Search (`EventRecovery.java:143-161,361-368`).
+
+## Proposed Solution
+
+### Approach
+
+Two layers:
+
+1. **Correctness floor (always):** a recovery checkpoint may bound replay **only** when the state it covers
+   is durable independent of the in-memory FSM. Remove the unsafe mid-run periodic checkpoint as a
+   replay-bounding operation. With no safe mid-run checkpoint, crash recovery replays the full retained log
+   (correct, idempotent). Fix Gap 4 by sourcing the checkpoint sequence from the WAL global sequence.
+2. **Bound WAL/replay — DECISION LOCKED: log compaction keyed on migration completion.** Both Critical
+   Assumptions are **verified** (terminal `DEPARTED` is not load-bearing; replay is idempotent with
+   write-path-guaranteed order), so compaction is the chosen design (not the snapshot fallback). A
+   `MIGRATION_COMMIT` makes a migration terminal; compaction prunes its **complete**
+   `ENTITY_DEPARTURE`+`COMMIT` pair (never a partial pair), retaining only in-flight (`MIGRATING_OUT`)
+   departures and other not-yet-terminal events, preserving their relative order. Recovery replays the
+   compacted (small) log in full — no boundary-skip, bounded WAL. Durable in-flight snapshot
+   (Alternative 1) is retained only as the documented fallback had the assumption been false.
+
+### Technical Design
+
+- `EventRecovery.recover`: a checkpoint bounds replay only if backed by truncation (clean shutdown) or
+  compaction metadata; otherwise full replay. Interface unchanged externally
+  (`recover() → RecoveredState`).
+- Compaction (primary): rewrite the retained log dropping completed migration pairs (the whole
+  `DEPARTURE`+`COMMIT` pair, never a partial pair — Q2 order constraint), advancing a compaction watermark.
+  Runs on a bounded trigger (size/age) and on `closeClean`. Crash-safe via write-new-then-rename.
+  **Concurrent-write safety (gate S2):** the batch-flush scheduler keeps writing the *active* segment during
+  compaction, so compaction MUST NOT cover the active segment — otherwise a concurrently-written in-flight
+  `ENTITY_DEPARTURE` would be lost under the rename (the exact RDR-004 class this RDR closes). Design:
+  **seal the active segment** (roll to a new one) before the compaction scan, and compact only *sealed*
+  segments older than the watermark; the live segment is never rewritten. (Alternatives — a write-exclusion
+  lock spanning scan→rename, or per-segment compaction — are inferior for an append-only log.)
+- **DEFERRED_UPDATE / VIEW_SYNC_ACK / consensus events** have no reconstruction consumer today
+  (`MigrationRecoveryStateSink.onDeferredUpdate` is a stub; consensus recovery is out of scope per
+  RDR-017 §5a). Compaction retains them conservatively (does not assume them prunable) unless a follow-up
+  establishes they are safe to drop. Entity-position recovery via `DEFERRED_UPDATE` is **out of scope**
+  (gate O3) — pre-existing gap, separate work if ever needed.
+- Remove `startCheckpointScheduler` / `CHECKPOINT_INTERVAL_MS` as a recovery-bounding scheduler. Keep the
+  batch-flush scheduler (durability).
+- `checkpoint()` sequence ← `WriteAheadLog.getSequence()` (new getter), not `eventCounter` (Gap 4).
+
+```text
+// Illustrative — verify during implementation
+// recover(nodeId): if (compactionWatermark or truncated) replay tail else replay all → into RecoveryStateSink
+// compact(): retain events where migrationKey not in committedSet; atomic rename; bump watermark
+```
+
+### Existing Infrastructure Audit
+
+| Proposed Component | Existing Module | Decision |
+| --- | --- | --- |
+| Compaction / safe replay bound | `WriteAheadLog.truncate()` (clean-shutdown only) | Extend: generalize to mid-run compaction keyed on terminal migrations |
+| Checkpoint sequence source | `PersistenceManager.eventCounter` | Replace with `WriteAheadLog.getSequence()` |
+| Periodic checkpoint scheduler | `PersistenceManager.startCheckpointScheduler` | Remove (unsafe as a replay bound) |
+
+### Decision Rationale
+
+Compaction bounds the WAL without a new serialization surface and matches the domain: the only
+recovery-relevant state is in-flight migrations, which a `MIGRATION_COMMIT` retires. It keeps recovery a
+pure log replay (no snapshot/replay consistency seam). The durable-snapshot alternative is more general but
+adds FSM serialization, snapshot atomicity, and a snapshot-source abstraction `PersistenceManager` lacks.
+
+## Alternatives Considered
+
+### Alternative 1: Durable in-flight FSM snapshot at checkpoint
+
+**Description**: Serialize the in-flight migration-state map at each checkpoint; `recover()` loads the
+snapshot then replays the tail.
+
+**Pros**: General (works even if terminal state must survive); fast recovery; bounded WAL.
+
+**Cons**: New FSM serialization + snapshot atomicity; a snapshot-source abstraction PM does not have;
+snapshot/tail consistency seam.
+
+**Reason for rejection (provisional)**: Heavier than compaction for the same outcome, *if* the
+terminal-state assumption holds. Promoted to primary if that assumption is false.
+
+### Briefly Rejected
+
+- **Full-replay only, no bound (correctness floor alone)**: fixes the data loss but leaves Gap 3 (unbounded
+  WAL, O(total) recovery) — acceptable only as the floor beneath compaction, not the end state.
+- **Checkpoint at WAL global sequence without removing mid-run checkpoints**: still skips un-snapshotted
+  events; changes which events are dropped and can drop the whole prefix. Rejected (does not fix Gap 1).
+
+## Trade-offs
+
+### Consequences
+
+- Eliminates the silent data loss (positive, the point).
+- Recovery becomes a full replay of the *compacted* log — bounded by concurrent in-flight migrations
+  (positive).
+- Compaction adds log-rewrite machinery with crash-safety requirements (negative — must be carefully tested).
+
+### Risks and Mitigations
+
+- **Risk**: compaction drops an event still needed for recovery. **Mitigation**: prune only migration pairs
+  with a durable `MIGRATION_COMMIT`; verify the terminal-state assumption first; crash-safe write-then-rename;
+  regression that an in-flight departure across a compaction survives recovery.
+- **Risk**: removing the periodic checkpoint regresses recovery latency on a long-running node.
+  **Mitigation**: compaction caps retained-log size; measure replay on a representative log.
+
+### Failure Modes
+
+- **Visible**: corrupt WAL still aborts startup (RDR-017 P1 fail-loud, unchanged).
+- **Silently** (the class this RDR closes): an event needed for recovery is skipped/pruned. Closed by:
+  full replay of retained log + compaction that only prunes durably-terminal migrations + a multi-session
+  regression.
+
+## Implementation Plan
+
+### Prerequisites
+
+- [ ] Critical Assumptions verified (esp. terminal-`DEPARTED` necessity).
+
+### Minimum Viable Validation
+
+Two proofs (gate O2 — Phase 1 and Phase 2 prove different things):
+
+- **Phase 1 MVV:** the reproduced scenario — log an in-flight departure, take a checkpoint, crash, recover
+  into a fresh FSM → the departure reconstructs as `MIGRATING_OUT` (today: `null`). Plus: a committed
+  migration replays to `DEPARTED` (harmless, not pruned in Phase 1). Must fail on current code, pass after
+  Phase 1.
+- **Phase 2 MVV:** multi-session through the assembled node — session 1 logs an in-flight departure + a
+  completed (committed) migration, crash; session 2 recovers (in-flight → `MIGRATING_OUT`), runs, compaction
+  fires (committed pair pruned, active segment sealed first), crash; session 3 recovers and **all in-flight
+  migrations are reconstructed, none silently dropped, and the WAL is bounded**.
+
+### Phase 1: Correctness floor
+
+Remove the periodic checkpoint as a replay bound (its removal makes the only writable checkpoint
+`closeClean`'s, which is structurally always truncation-backed — gate O1: no metadata flag needed; do NOT
+re-add a periodic checkpoint without re-establishing the snapshot/truncation invariant); recovery
+full-replays the retained log when no truncation applies; `checkpoint()` uses the WAL global sequence
+(`WriteAheadLog.getSequence()`, Gap 4). Regression: the reproduced data-loss scenario recovers correctly.
+
+### Phase 2: Bounded WAL (compaction)
+
+Implement crash-safe, **active-segment-sealed** compaction keyed on terminal migrations + watermark (gate
+S2); wire a bounded trigger and `closeClean`. Resolve the `null→GHOST` forward-path item (gate S1) — add the
+valid transition or document + track the accepted gap. Regression: in-flight departure survives a compaction
+(including one concurrent with live writes); WAL stays bounded under churn.
+
+### Day 2 Operations
+
+| Resource | List | Info | Delete | Verify | Backup |
+| --- | --- | --- | --- | --- | --- |
+| Per-node WAL dir `.luciferase/wal/<nodeId>/` | N/A (single dir) | N/A | closeClean truncate / compaction | recover() integrity gate | N/A |
+
+## Test Plan
+
+- **Scenario**: log departure → checkpoint → crash → recover — **Verify**: `MIGRATING_OUT` reconstructed
+  (today: `null`).
+- **Scenario**: recover → run → (compaction) → crash → recover — **Verify**: all in-flight migrations
+  survive; committed ones handled per the verified terminal-state contract.
+- **Scenario**: in-flight departure present when compaction runs — **Verify**: it is retained and recovered.
+- **Scenario**: corrupt WAL — **Verify**: startup still aborts (fail-loud unchanged).
+- **Scenario**: WAL size under sustained migration churn — **Verify**: bounded (compaction effective).
+
+## Validation
+
+### Testing Strategy
+
+TDD: the reproduction becomes the Phase 1 regression; the multi-session MVV is the Phase 2 gate. Deterministic
+(TestClock; no reliance on the 5s wall-clock scheduler). Stacked review (code-review-expert +
+substantive-critic) at each phase boundary, with the critic specifically pressure-testing that compaction
+cannot prune an event needed for recovery.
+
+## Finalization Gate
+
+### Contradiction Check
+
+No contradictions between Research Findings and the Proposed Solution. Cross-RDR (gate Layer 3, P7):
+consistent with RDR-017 §Operational notes (gate O1) — RDR-019 removes mid-run checkpoints, leaving
+`closeClean`'s checkpoint as the only one, which is structurally truncation-backed, so the "checkpoint bounds
+replay only when state is durable" invariant holds across both RDRs. Orthogonal to RDR-016 R2 (the
+`BubbleMigrator` fail-loud WAL bracket) — unchanged. Corrupt-WAL fail-loud abort (RDR-017 P1) is preserved.
+
+### Assumption Verification
+
+Both Critical Assumptions verified by source search (`019-research-1`). Assumption (a) is **scoped**: verified
+for the recovery/reconcile path; the forward `DEPARTED→GHOST` live path is an explicit Phase 2 open item
+(gate S1), not an unverified load-bearing assumption — Phase 2 resolves it before compaction ships.
+
+#### API Verification
+
+| API Call | Library | Verification |
+| --- | --- | --- |
+| `EntityMigrationStateMachine.recoverEntityState` / `getState` / `isValidTransition` | in-repo | Source Search |
+| `GhostStateListener.reconcileGhostState` / `onEntityStateTransition` | in-repo | Source Search |
+| `EventRecovery.replayEvents` / `extractMigrationKey` / `readEventsSinceResult` | in-repo | Source Search |
+| `WriteAheadLog.truncate` / `getSequence` (new) | in-repo | Source Search |
+
+### Scope Verification
+
+Phase 1 MVV (reproduced no-loss recovery) and Phase 2 MVV (multi-session bounded no-loss) are both in scope,
+not deferred. Out of scope, explicit: consensus-event recovery (RDR-017 §5a), entity-position recovery via
+`DEFERRED_UPDATE` (gate O3, pre-existing), Subsystem B/C.
+
+### Cross-Cutting Concerns
+
+- **Versioning**: WAL/compaction on-disk change — not in prod (no live node; `main()` throws). Phase 2 stamps
+  a format note in the compaction watermark metadata.
+- **Memory management**: compaction streams sealed segments (no full in-memory rewrite).
+- **Incremental adoption**: Phase 1 (correctness floor) is independently shippable and fully closes the data
+  loss; Phase 2 (compaction) restores bounded WAL/fast recovery.
+- Others: N/A.
+
+### Proportionality
+
+Right-sized: a CRITICAL data-loss correctness fix (Phase 1) plus a bounded-WAL design (Phase 2), two phases.
+
+## References
+
+- `Luciferase-n6jrh.3` (bead), RDR-017 §Operational notes (gate O1), T2 `Luciferase/skaui-p3-stacked-review`.
+- `EventRecovery.java:106-123` (replay bound), `PersistenceManager.java:274-283,469-476` (checkpoint +
+  scheduler), `WriteAheadLog.java` (truncate, restoreSequenceCounter), `MigrationRecoveryStateSink.java:83-98`.
+- `0frcy.37` (introduced post-checkpoint replay).
+
+## Revision History
+
+- 2026-06-07: created (draft) from `Luciferase-n6jrh.3` after brainstorming-gate selected the RDR path
+  (B/C bounded-WAL design).
+- 2026-06-07: research recorded (`019-research-1`) — both Critical Assumptions verified; design locked to
+  compaction. **Gate PASSED** (Layer 1 structural ✓, Layer 2 assumptions ✓, Layer 3 substantive-critic: 0
+  Critical, 2 Significant, 3 Observations). The 2 Significant + 3 Observations folded into the design:
+  - **S1** — `DEPARTED→GHOST` forward-path coverage hole → assumption (a) scoped; Phase 2 resolves
+    `null→GHOST` (add transition or document+track accepted gap).
+  - **S2** — compaction concurrent-write race with the batch-flush scheduler → seal the active segment and
+    compact only sealed segments older than the watermark.
+  - **O1** — Phase 1 "checkpoint only via truncation" is structural (no metadata flag); documented.
+  - **O2** — MVV split into distinct Phase 1 and Phase 2 proofs.
+  - **O3** — `DEFERRED_UPDATE` entity-position recovery explicitly out of scope.

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -29,6 +29,7 @@ See the [RDR process documentation](https://github.com/cwensel/rdr) for the full
 | [RDR-016](RDR-016-persistence-productionization.md) | Productionize WAL Persistence and Recovery in the Simulation Node Lifecycle | closed | Architecture | medium |
 | [RDR-017](RDR-017-production-node-bootstrap.md) | Production Node Bootstrap — Compose the Distributed Simulation Node (Lifecycle, WAL, Recovery, Migration) | implemented | Architecture | medium |
 | [RDR-018](RDR-018-dynamic-topology-vs-single-level-partition.md) | Dynamic Topology (Split/Merge) vs the RDR-015 Single-Level Migration Partition | implemented | Architecture | medium |
+| [RDR-019](RDR-019-wal-checkpoint-recovery-durability.md) | WAL Checkpoint/Recovery Durability — Bound Replay Safely (Snapshot or Compaction) | accepted | Bug Fix | high |
 
 ## Post-Mortems
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapter.java
@@ -28,8 +28,9 @@ import java.util.Objects;
  * {@link com.hellblazer.luciferase.simulation.von.NodeBootstrap} registers it alongside
  * {@code SocketConnectionManagerAdapter}. P1 (Luciferase-pf1iu) makes {@link #doStart()} call
  * {@link PersistenceManager#recover()} fail-loud (a corrupt WAL aborts startup) and then
- * {@link PersistenceManager#startSchedulers()} — the batch-flush and checkpoint schedulers are no longer
- * started in the {@link PersistenceManager} constructor, so neither can run before recovery completes.
+ * {@link PersistenceManager#startSchedulers()} — the batch-flush scheduler is no longer started in the
+ * {@link PersistenceManager} constructor, so it cannot run before recovery completes. (RDR-019 removed
+ * the periodic checkpoint scheduler entirely — gate O1.)
  *
  * @author hal.hildebrand
  */

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/EventRecovery.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/EventRecovery.java
@@ -102,25 +102,33 @@ public class EventRecovery {
     public RecoveredState recover(UUID nodeId) throws IOException {
         Objects.requireNonNull(nodeId, "nodeId must not be null");
 
-        // Load last checkpoint
+        // Load last checkpoint (retained for reporting in RecoveredState only — NOT used to bound replay).
         var checkpoint = getLastCheckpoint(nodeId);
 
-        // Luciferase-0frcy.37: replay only events AFTER the last checkpoint. Previously this read
-        // ALL events unconditionally, making the checkpoint mechanism a no-op for recovery (a crash
-        // at seq=15000 after a checkpoint at seq=10000 would re-replay all 15000 events). When no
-        // checkpoint exists, fall back to the full log.
+        // RDR-019 (Luciferase-punhr, gate O1): FULL replay of the retained log. The checkpoint NO LONGER
+        // bounds replay.
+        //
+        // History: Luciferase-0frcy.37 made recovery replay only events AFTER the last checkpoint, to
+        // avoid re-replaying a long history. But with no durable snapshot behind the checkpoint, that
+        // bound silently DROPPED durably-logged in-flight migrations: a periodic checkpoint at the live
+        // sequence meant recover() skipped events at/below it, reconstructing null instead of
+        // MIGRATING_OUT (the RDR-019 data-loss regression, driving bug Luciferase-n6jrh.3).
+        //
+        // RDR-019 removes the periodic checkpoint (PersistenceManager): the ONLY checkpoint is
+        // closeClean()'s, which is structurally always followed by WriteAheadLog.truncate(). So after a
+        // clean shutdown the log segments are gone and a full replay reads nothing; after a crash the
+        // full log is retained and a full replay reconstructs every in-flight migration. Either way,
+        // full replay is correct — the checkpoint is "truncation-backed" by construction, so there is
+        // never a need to bound. Bounded-WAL size is handled by Phase-2 compaction, not by skipping
+        // durably-logged events on replay.
+        //
         // Luciferase-sc6pl: use a READ-ONLY reader, never a full WriteAheadLog. Constructing a
         // WriteAheadLog here opens the same JSONL log file with a second writable append-mode
         // FileOutputStream while the owning WAL is still being written by the batch-flush scheduler,
         // interleaving partial JSON lines and corrupting the log. WalLogReader opens files for
         // reading only.
         var reader = new WalLogReader(nodeId, logDirectory);
-        WalReadResult readResult;
-        if (checkpoint != null) {
-            readResult = reader.readEventsSinceResult(checkpoint.sequenceNumber());
-        } else {
-            readResult = reader.readAllEventsResult();
-        }
+        WalReadResult readResult = reader.readAllEventsResult();
         List<Map<String, Object>> allEvents = readResult.events();
         int skippedCorrupt = readResult.skippedCorrupt();
         if (skippedCorrupt > 0) {
@@ -163,27 +171,29 @@ public class EventRecovery {
         // Replay valid events — capture per-event exception-skip count (M3)
         skippedCount += replayEvents(validEvents);
 
-        // Luciferase-0frcy.37 fix: a checkpoint at seq=N means the first N events are already
-        // durably captured BY the checkpoint; recovery only re-reads the post-checkpoint tail
-        // (readEventsSince, exclusive). The total number of events represented in the recovered
-        // state is therefore the checkpointed prefix PLUS the freshly-replayed tail. Counting only
-        // validEvents.size() (the tail) dropped the checkpointed prefix and reported 0 whenever the
-        // checkpoint sat at the final sequence (the common "checkpoint everything then recover" case).
-        var checkpointedPrefix = checkpoint != null ? checkpoint.sequenceNumber() : 0L;
-        // Keep the running total as a long end-to-end: checkpointedPrefix is a long sequence number
-        // and on a long-lived log the prefix + tail can exceed Integer.MAX_VALUE. Narrowing to int
-        // here (the prior behavior) would silently overflow to a negative/wrong count.
-        var totalReplayed = checkpointedPrefix + validEvents.size();
+        // RDR-019 (Luciferase-punhr): replay is now FULL (no checkpoint bound), so every replayed
+        // event is counted directly. The previous "checkpointedPrefix + tail" arithmetic existed only
+        // because recovery skipped the checkpointed prefix; with full replay there is no skipped prefix
+        // to add back. Kept as a long for headroom on long-lived logs.
+        long totalReplayed = (long) validEvents.size();
 
         var recovered = new RecoveredState(checkpoint, validEvents, totalReplayed, skippedCount, skippedCorrupt);
 
-        // M1 — wire the integrity gate: non-monotonic sequences or a replay that overlaps the
-        // checkpoint indicate a corrupt or double-opened WAL.  Fail loud; same rationale as C1.
-        // (Luciferase-7wzml.209)
-        if (!validateRecoveryIntegrity(recovered)) {
+        // M1 — wire the integrity gate: a non-monotonic replayed sequence indicates a corrupt or
+        // double-opened WAL. Fail loud; same rationale as C1 (Luciferase-7wzml.209).
+        //
+        // RDR-019: replay is full, so the "first replayed seq must be > checkpoint seq" overlap check
+        // (meaningful only for bounded/post-checkpoint replay) no longer applies — replaying from seq 1
+        // past a checkpoint is now CORRECT, not corruption. Validate with a zero checkpoint so only the
+        // monotonicity invariant is enforced here; the returned RecoveredState still carries the real
+        // checkpoint metadata for reporting. The checkpoint-overlap branch of
+        // validateRecoveryIntegrity(RecoveredState) remains exercised by its direct unit tests.
+        var monotonicityState = new RecoveredState(
+            CheckpointMetadata.now(0, clock), validEvents, totalReplayed, skippedCount, skippedCorrupt);
+        if (!validateRecoveryIntegrity(monotonicityState)) {
             throw new IOException(
                 "WAL recovery integrity failure for node " + nodeId
-                + ": non-monotonic sequence or checkpoint overlap detected — "
+                + ": non-monotonic sequence detected — "
                 + "manual inspection required before recovery can proceed");
         }
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/EventRecovery.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/EventRecovery.java
@@ -150,7 +150,13 @@ public class EventRecovery {
 
         for (var event : allEvents) {
             if (isValidEvent(event)) {
-                // Check for duplicate migrations
+                // Check for duplicate migrations — guards against literally repeated lines (e.g. a
+                // malformed/duplicated log entry). Dedup is keyed per migration CYCLE, not for all time:
+                // a MIGRATION_COMMIT closes the entity's cycle, so a subsequent legitimate re-migration
+                // (the entity departs again later in the same retained log) is replayed, not dropped.
+                // RDR-019 (substantive-critic): without the cycle reset, the second ENTITY_DEPARTURE
+                // collided with the first and was skipped, leaving the entity reconstructed as DEPARTED
+                // when it was actually MIGRATING_OUT again — a silent wrong-state recovery.
                 var migrationKey = extractMigrationKey(event);
                 if (migrationKey != null && seenMigrations.contains(migrationKey)) {
                     log.debug("Skipping duplicate migration: {}", migrationKey);
@@ -161,6 +167,18 @@ public class EventRecovery {
                 validEvents.add(event);
                 if (migrationKey != null) {
                     seenMigrations.add(migrationKey);
+                }
+
+                // Cycle reset: a commit completes the migration cycle. Clear both this entity's
+                // departure and commit keys so a later re-migration (DEPARTURE→COMMIT for the same
+                // entity) is treated as a fresh cycle and fully replayed. The append-only write path
+                // guarantees DEPARTURE precedes COMMIT within a cycle (RDR-019 §Research Findings).
+                if ("MIGRATION_COMMIT".equals(event.get("type"))) {
+                    var entityId = event.get("entityId");
+                    if (entityId != null) {
+                        seenMigrations.remove("ENTITY_DEPARTURE:" + entityId);
+                        seenMigrations.remove("MIGRATION_COMMIT:" + entityId);
+                    }
                 }
             } else {
                 log.warn("Skipping invalid event: {}", event);
@@ -268,7 +286,13 @@ public class EventRecovery {
      *       increasing across the replayed tail (a regression / reordering indicates
      *       a corrupt or double-opened WAL);</li>
      *   <li>the first replayed sequence number, when present, is strictly greater than
-     *       the checkpoint sequence (recovery must not re-replay checkpointed events).</li>
+     *       the checkpoint sequence. <b>RDR-019 note:</b> this overlap check is meaningful
+     *       only for <em>bounded</em> (post-checkpoint) replay. The Phase 1 full-replay path
+     *       deliberately replays from seq 1 past any checkpoint (correct, since the checkpoint
+     *       has no durable snapshot behind it), so {@code recover()} validates with a synthetic
+     *       zero checkpoint to enforce monotonicity ONLY. A future Phase 2 compaction-backed
+     *       bounded replay would re-enable this check against the compaction watermark (not the
+     *       bare checkpoint sequence). This branch remains exercised by direct unit tests.</li>
      * </ul>
      *
      * @param state the recovered state to validate (must not be null)

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManager.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManager.java
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * to provide durable state management with crash recovery.
  *
  * FEATURES:
- * - Automatic checkpoint creation (periodic)
+ * - Clean-shutdown checkpoint + truncate compaction (closeClean; no periodic checkpoint — RDR-019 gate O1)
  * - Batch fsync for non-critical events (every 100ms)
  * - Immediate fsync for critical events (migration commit)
  * - Recovery from crash with integrity validation
@@ -56,7 +56,6 @@ public class PersistenceManager implements AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(PersistenceManager.class);
     private static final long BATCH_FLUSH_INTERVAL_MS = 100;
-    private static final long CHECKPOINT_INTERVAL_MS = 5000; // 5 seconds
 
     private final UUID nodeId;
     private final WriteAheadLog writeAheadLog;
@@ -66,7 +65,6 @@ public class PersistenceManager implements AutoCloseable {
     private final AtomicBoolean schedulersStarted = new AtomicBoolean(false);
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private final AtomicLong lastCheckpointSeq;
-    private final AtomicLong eventCounter;
 
     private volatile Instant lastCheckpoint;
     private volatile Clock clock = Clock.system();
@@ -117,29 +115,35 @@ public class PersistenceManager implements AutoCloseable {
         });
         this.recoveryInProgress = new AtomicBoolean(false);
         this.lastCheckpointSeq = new AtomicLong(0);
-        this.eventCounter = new AtomicLong(0);
         this.lastCheckpoint = Instant.ofEpochMilli(clock.currentTimeMillis());
 
-        // RDR-017 P1 (Luciferase-pf1iu): the batch-flush and checkpoint schedulers are NO LONGER
-        // started here. Starting them in the constructor let a checkpoint (every 5s) or batch flush
-        // (every 100ms) fire before recover() ran — overwriting/truncating an unrecovered WAL. They
-        // are now started by PersistenceManagerAdapter.doStart() via startSchedulers(), strictly AFTER
-        // recover() completes.
+        // RDR-017 P1 (Luciferase-pf1iu): the batch-flush scheduler is NO LONGER started here.
+        // Starting it in the constructor let a batch flush (every 100ms) fire before recover() ran —
+        // overwriting an unrecovered WAL. It is now started by PersistenceManagerAdapter.doStart() via
+        // startSchedulers(), strictly AFTER recover() completes.
+        // RDR-019 (Luciferase-punhr, gate O1): there is NO periodic checkpoint scheduler. A periodic
+        // checkpoint at the live sequence with no durable snapshot behind it silently bounded recovery
+        // replay (recover() skipped events at/below the checkpoint), dropping in-flight migrations on
+        // restart. The ONLY checkpoint is closeClean()'s, which is structurally always followed by
+        // truncate() — so every checkpoint is truncation-backed and recovery can safely full-replay
+        // the retained log. Do NOT re-introduce a periodic/mid-run checkpoint without first
+        // re-establishing a durable snapshot to back it (otherwise the data-loss regression returns).
         log.info("PersistenceManager constructed for node {} at {} (schedulers idle until startSchedulers())",
                  nodeId, logDirectory);
     }
 
     /**
-     * Start the batch-flush and checkpoint background schedulers.
+     * Start the batch-flush background scheduler.
      * <p>
      * RDR-017 P1: called by {@link com.hellblazer.luciferase.simulation.lifecycle.PersistenceManagerAdapter}
-     * ({@code doStart()}) <b>after</b> {@link #recover()} completes, so neither scheduler can run against an
-     * unrecovered WAL. Idempotent: repeated calls are a no-op.
+     * ({@code doStart()}) <b>after</b> {@link #recover()} completes, so the scheduler cannot run against an
+     * unrecovered WAL. RDR-019 (gate O1): there is no periodic checkpoint scheduler. Idempotent: repeated
+     * calls are a no-op.
      */
     public void startSchedulers() {
         if (schedulersStarted.compareAndSet(false, true)) {
             startBatchFlushScheduler();
-            startCheckpointScheduler();
+            // RDR-019 (gate O1): no periodic checkpoint scheduler — see constructor note.
             log.info("PersistenceManager schedulers started for node {}", nodeId);
         }
     }
@@ -153,9 +157,10 @@ public class PersistenceManager implements AutoCloseable {
 
     /**
      * @return the number of tasks currently queued on the scheduler executor. Zero before
-     *         {@link #startSchedulers()} runs; two once both schedulers are scheduled. Package-private
+     *         {@link #startSchedulers()} runs; one once the batch-flush scheduler is scheduled
+     *         (RDR-019 removed the periodic checkpoint scheduler — gate O1). Package-private
      *         test-support: the scheduler-relocation regression (RDR-017 P1) uses it to prove no
-     *         scheduler is queued in the constructor — catching a re-introduction of either scheduler.
+     *         scheduler is queued in the constructor — catching a re-introduction of any scheduler.
      */
     int scheduledTaskCount() {
         if (executor instanceof java.util.concurrent.ScheduledThreadPoolExecutor stpe) {
@@ -184,7 +189,6 @@ public class PersistenceManager implements AutoCloseable {
         event.put("state", "MIGRATING_OUT");
 
         writeAheadLog.append(event);
-        eventCounter.incrementAndGet();
 
         log.debug("Logged ENTITY_DEPARTURE: entity={}, source={}, target={}",
                  entityId, sourceBubble, targetBubble);
@@ -208,7 +212,6 @@ public class PersistenceManager implements AutoCloseable {
         event.put("success", success);
 
         writeAheadLog.append(event);
-        eventCounter.incrementAndGet();
 
         log.debug("Logged VIEW_SYNC_ACK: entity={}, success={}", entityId, success);
     }
@@ -239,7 +242,6 @@ public class PersistenceManager implements AutoCloseable {
         event.put("velocity", new float[]{velocity[0], velocity[1], velocity[2]});
 
         writeAheadLog.append(event);
-        eventCounter.incrementAndGet();
 
         log.debug("Logged DEFERRED_UPDATE: entity={}, pos=[{}, {}, {}]",
                  entityId, position[0], position[1], position[2]);
@@ -258,7 +260,6 @@ public class PersistenceManager implements AutoCloseable {
         event.put("entityId", entityId.toString());
 
         writeAheadLog.append(event);
-        eventCounter.incrementAndGet();
 
         // Critical event - fsync immediately
         writeAheadLog.flush();
@@ -272,7 +273,11 @@ public class PersistenceManager implements AutoCloseable {
      * @throws IOException if checkpoint creation fails
      */
     public void checkpoint() throws IOException {
-        var seq = eventCounter.get();
+        // RDR-019 Gap 4 (Luciferase-punhr): source the checkpoint sequence from the WAL's restored
+        // global high-water mark, NOT a session-local counter that resets to 0 on each restart. A
+        // reset counter checkpoints below the true high-water, silently bounding recovery replay and
+        // dropping durably-logged events.
+        var seq = writeAheadLog.getSequence();
         var timestamp = Instant.ofEpochMilli(clock.currentTimeMillis());
 
         writeAheadLog.checkpoint(seq, timestamp);
@@ -323,7 +328,6 @@ public class PersistenceManager implements AutoCloseable {
         event.put("term", term);
 
         writeAheadLog.append(event);
-        eventCounter.incrementAndGet();
 
         log.debug("Election start logged: candidate={}, term={}", candidateId, term);
     }
@@ -348,7 +352,6 @@ public class PersistenceManager implements AutoCloseable {
         event.put("vote", vote);
 
         writeAheadLog.append(event);
-        eventCounter.incrementAndGet();
 
         log.debug("Vote cast logged: voter={}, candidate={}, term={}, vote={}", voterId, candidateId, term, vote);
     }
@@ -368,7 +371,6 @@ public class PersistenceManager implements AutoCloseable {
         event.put("term", term);
 
         writeAheadLog.append(event);
-        eventCounter.incrementAndGet();
 
         log.info("Leader elected logged: leader={}, term={}", leaderId, term);
     }
@@ -384,7 +386,6 @@ public class PersistenceManager implements AutoCloseable {
         event.put("term", term);
 
         writeAheadLog.append(event);
-        eventCounter.incrementAndGet();
 
         log.debug("Term increment logged: term={}", term);
     }
@@ -466,13 +467,4 @@ public class PersistenceManager implements AutoCloseable {
         }, BATCH_FLUSH_INTERVAL_MS, BATCH_FLUSH_INTERVAL_MS, TimeUnit.MILLISECONDS);
     }
 
-    private void startCheckpointScheduler() {
-        executor.scheduleAtFixedRate(() -> {
-            try {
-                checkpoint();
-            } catch (IOException e) {
-                log.error("Periodic checkpoint failed", e);
-            }
-        }, CHECKPOINT_INTERVAL_MS, CHECKPOINT_INTERVAL_MS, TimeUnit.MILLISECONDS);
-    }
 }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManager.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManager.java
@@ -32,7 +32,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * PersistenceManager - Checkpoint and recovery orchestration (Phase 7G Day 2)
@@ -64,9 +63,6 @@ public class PersistenceManager implements AutoCloseable {
     private final AtomicBoolean recoveryInProgress;
     private final AtomicBoolean schedulersStarted = new AtomicBoolean(false);
     private final AtomicBoolean closed = new AtomicBoolean(false);
-    private final AtomicLong lastCheckpointSeq;
-
-    private volatile Instant lastCheckpoint;
     private volatile Clock clock = Clock.system();
 
     /**
@@ -114,8 +110,6 @@ public class PersistenceManager implements AutoCloseable {
             return thread;
         });
         this.recoveryInProgress = new AtomicBoolean(false);
-        this.lastCheckpointSeq = new AtomicLong(0);
-        this.lastCheckpoint = Instant.ofEpochMilli(clock.currentTimeMillis());
 
         // RDR-017 P1 (Luciferase-pf1iu): the batch-flush scheduler is NO LONGER started here.
         // Starting it in the constructor let a batch flush (every 100ms) fire before recover() ran —
@@ -126,8 +120,16 @@ public class PersistenceManager implements AutoCloseable {
         // replay (recover() skipped events at/below the checkpoint), dropping in-flight migrations on
         // restart. The ONLY checkpoint is closeClean()'s, which is structurally always followed by
         // truncate() — so every checkpoint is truncation-backed and recovery can safely full-replay
-        // the retained log. Do NOT re-introduce a periodic/mid-run checkpoint without first
-        // re-establishing a durable snapshot to back it (otherwise the data-loss regression returns).
+        // the retained log.
+        //
+        // Precise hazard (Phase 1 vs Phase 2): under Phase 1 full-replay, a mid-run checkpoint() call is
+        // harmless on its own — it only updates the metadata sequence and does NOT bound replay
+        // (EventRecovery.recover always reads the full log). The data-loss regression returns only if a
+        // mid-run/periodic checkpoint AND a checkpoint-bounded replay are present together. Phase 2
+        // (compaction) re-introduces a bounded replay for compaction-backed logs; at that point any
+        // checkpoint() that is NOT backed by truncate() (clean shutdown) or a compaction watermark will
+        // again silently drop events. Do NOT re-introduce a periodic/mid-run checkpoint, and when Phase 2
+        // lands, audit every checkpoint() call to ensure it is compaction- or truncation-backed.
         log.info("PersistenceManager constructed for node {} at {} (schedulers idle until startSchedulers())",
                  nodeId, logDirectory);
     }
@@ -281,8 +283,6 @@ public class PersistenceManager implements AutoCloseable {
         var timestamp = Instant.ofEpochMilli(clock.currentTimeMillis());
 
         writeAheadLog.checkpoint(seq, timestamp);
-        lastCheckpointSeq.set(seq);
-        lastCheckpoint = timestamp;
 
         log.info("Checkpoint created: seq={}, timestamp={}", seq, timestamp);
     }
@@ -392,8 +392,14 @@ public class PersistenceManager implements AutoCloseable {
 
     /**
      * Clean-shutdown close (RDR-017 P3, gate O1): checkpoint at the current sequence, truncate the WAL
-     * segments (compaction — recovery replays only post-checkpoint events, of which a head checkpoint
-     * leaves none), then close.
+     * segments, then close.
+     * <p>
+     * <b>Why this is safe under RDR-019 full-replay.</b> Recovery always FULL-replays the retained log
+     * (it does NOT skip pre-checkpoint events). Truncation after the checkpoint is safe not because
+     * recovery skips events, but because the truncated log is <em>empty</em> — so a full replay reads
+     * zero events. The checkpoint metadata survives truncate() to carry the high-water sequence forward
+     * (see {@link WriteAheadLog#truncate()} / {@code restoreSequenceCounter}). This is the only
+     * truncation-backed checkpoint in the system (gate O1).
      * <p>
      * <b>Retention semantics.</b> A clean shutdown leaves a pristine WAL: the next start recovers nothing
      * (a cleanly-stopped node has no in-flight migrations — the caller is expected to have drained the

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/WriteAheadLog.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/WriteAheadLog.java
@@ -390,11 +390,13 @@ public class WriteAheadLog implements AutoCloseable {
 
     /**
      * Truncate the write-ahead log: delete all log segment files and start an empty base log, retaining
-     * the checkpoint metadata. RDR-017 P3 (gate O1) clean-shutdown compaction — after a checkpoint at
-     * the head sequence, the entire log is superseded (recovery replays only post-checkpoint events, of
-     * which there are none), so the segments are safe to discard to reclaim space. The high-water
-     * sequence survives in the checkpoint metadata (see {@link #readCheckpointSequence()}), so a later
-     * restart continues the monotonic sequence rather than colliding below the checkpoint.
+     * the checkpoint metadata. RDR-017 P3 (gate O1) clean-shutdown compaction — called by
+     * {@code PersistenceManager.closeClean()} after a head-sequence checkpoint. Under RDR-019 full-replay
+     * semantics, recovery replays the ENTIRE retained log (it does not skip pre-checkpoint events);
+     * discarding the segments here is safe because it leaves the log <em>empty</em>, so the next start's
+     * full replay reads zero events — not because recovery would skip them. The high-water sequence
+     * survives in the checkpoint metadata (see {@link #readCheckpointSequence()}), so a later restart
+     * continues the monotonic sequence rather than restarting at 1 and colliding below the checkpoint.
      *
      * @throws IOException if segment deletion or base-log recreation fails
      */

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/WriteAheadLog.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/WriteAheadLog.java
@@ -176,6 +176,22 @@ public class WriteAheadLog implements AutoCloseable {
     }
 
     /**
+     * The current global event sequence (high-water mark).
+     * <p>
+     * This is the authoritative sequence counter, restored from the persisted log (and checkpoint
+     * metadata) on construction via {@link #restoreSequenceCounter()} so it remains monotonic across
+     * process restarts. RDR-019 Gap 4: {@link PersistenceManager#checkpoint()} must source the
+     * checkpoint sequence from this value, NOT from a session-local counter that resets to 0 on each
+     * restart (a reset counter checkpoints below the true high-water, silently bounding recovery
+     * replay and dropping durably-logged events).
+     *
+     * @return the highest sequence number assigned so far (0 if no events have ever been appended)
+     */
+    public long getSequence() {
+        return sequenceCounter.get();
+    }
+
+    /**
      * Mark recovery checkpoint in metadata file.
      *
      * @param sequenceNumber Sequence number for checkpoint

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/EventRecoveryCheckpointTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/EventRecoveryCheckpointTest.java
@@ -33,12 +33,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * Checkpoint-filtering regression for {@link EventRecovery} (Luciferase-0frcy.37).
+ * Recovery-replay contract for {@link EventRecovery}.
  *
- * <p>Pre-fix, recover() loaded the checkpoint (and its sequenceNumber) but then called
- * {@code wal.readAllEvents()} unconditionally — replaying the full event history regardless of the
- * checkpoint, making the checkpoint a no-op for recovery. This test writes events, checkpoints, then
- * writes more, and asserts recovery replays only the post-checkpoint events.
+ * <p><b>RDR-019 (Luciferase-punhr) reverses the Luciferase-0frcy.37 checkpoint-bounded replay.</b>
+ * 0frcy.37 made recovery replay only events AFTER the last checkpoint, to avoid re-replaying long
+ * history. But with no durable snapshot behind the checkpoint, that bound silently dropped
+ * durably-logged in-flight migrations (driving bug Luciferase-n6jrh.3). RDR-019 removes the periodic
+ * checkpoint (the only checkpoint is {@code closeClean()}'s, always truncation-backed) and makes
+ * recovery FULL-replay the retained log. So a checkpoint that is NOT truncation-backed (an event
+ * still present in the log) no longer bounds replay — those events are replayed.
  *
  * @author hal.hildebrand
  */
@@ -54,7 +57,10 @@ class EventRecoveryCheckpointTest {
     }
 
     @Test
-    void recoveryReplaysOnlyEventsAfterTheCheckpoint(@TempDir Path logDir) throws IOException {
+    void recoveryFullReplaysWhenCheckpointIsNotTruncationBacked(@TempDir Path logDir) throws IOException {
+        // RDR-019: a checkpoint that is NOT followed by truncate() leaves all events in the log.
+        // Recovery now FULL-replays them (the checkpoint does not bound replay) — pre-RDR-019 this
+        // dropped the 10 pre-checkpoint events, which is the silent data loss RDR-019 fixes.
         var nodeId = UUID.randomUUID();
 
         try (var wal = new WriteAheadLog(nodeId, logDir)) {
@@ -62,7 +68,7 @@ class EventRecoveryCheckpointTest {
             for (int i = 0; i < 10; i++) {
                 wal.append(departureEvent("pre-" + i));
             }
-            // Checkpoint at sequence 10.
+            // Checkpoint at sequence 10, but DO NOT truncate — events remain durably on disk.
             wal.checkpoint(10, Instant.now());
             // 5 post-checkpoint events (sequences 11..15).
             for (int i = 0; i < 5; i++) {
@@ -74,11 +80,14 @@ class EventRecoveryCheckpointTest {
         var state = recovery.recover(nodeId);
 
         assertThat(state.events())
-            .as("Recovery must replay only the 5 events AFTER the checkpoint at seq=10, "
-                + "not all 15 — pre-fix readAllEvents() replayed the full history")
-            .hasSize(5);
+            .as("RDR-019: recovery FULL-replays all 15 durably-logged events — a non-truncation-backed "
+                + "checkpoint no longer bounds replay (pre-RDR-019 only the 5 post-checkpoint events "
+                + "replayed, silently dropping the 10 pre-checkpoint in-flight migrations)")
+            .hasSize(15);
         assertThat(state.events())
-            .allSatisfy(e -> assertThat((String) e.get("entityId")).startsWith("post-"));
+            .as("Both pre- and post-checkpoint events must be present")
+            .anySatisfy(e -> assertThat((String) e.get("entityId")).startsWith("pre-"))
+            .anySatisfy(e -> assertThat((String) e.get("entityId")).startsWith("post-"));
     }
 
     @Test

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/EventRecoveryDataLossRegressionTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/EventRecoveryDataLossRegressionTest.java
@@ -126,4 +126,38 @@ class EventRecoveryDataLossRegressionTest {
                 "A committed migration (DEPARTURE+COMMIT) durably logged before a checkpoint must "
                 + "reconstruct as DEPARTED on recovery — pre-fix the checkpoint-bounded replay drops both events");
     }
+
+    /**
+     * Re-migration in the same retained log: DEPARTURE → COMMIT (cycle 1 completes) → DEPARTURE again
+     * (cycle 2 in flight) → crash → recover. The entity must reconstruct as MIGRATING_OUT (cycle 2's
+     * state), not DEPARTED (cycle 1). Pre-fix the migration-key dedup skipped the second ENTITY_DEPARTURE
+     * (same {@code ENTITY_DEPARTURE:id} key as the first), silently reconstructing the wrong state.
+     * (RDR-019 P1.3 substantive-critic finding.)
+     */
+    @Test
+    void reMigrationAfterCommitReconstructsLatestCycle(@TempDir Path logDir) throws IOException {
+        var nodeId = UUID.randomUUID();
+        var entityA = UUID.randomUUID();
+        var src = UUID.randomUUID();
+        var tgt = UUID.randomUUID();
+        var clock = new TestClock(1_000L);
+
+        try (var mgr = new PersistenceManager(nodeId, logDir, RecoveryStateSink.NOOP)) {
+            mgr.setClock(clock);
+            mgr.logEntityDeparture(entityA, src, tgt);   // cycle 1 begins
+            mgr.logMigrationCommit(entityA);             // cycle 1 completes (entity later returns)
+            mgr.logEntityDeparture(entityA, src, tgt);   // cycle 2 begins, in flight
+            // crash before cycle 2 commits
+        }
+
+        var fsm = freshFsm();
+        try (var mgr = new PersistenceManager(nodeId, logDir, new MigrationRecoveryStateSink(fsm))) {
+            mgr.setClock(clock);
+            mgr.recover();
+        }
+
+        assertEquals(EntityMigrationState.MIGRATING_OUT, fsm.getState(entityA.toString()),
+                "Re-migration: the second (in-flight) ENTITY_DEPARTURE must reconstruct as MIGRATING_OUT, "
+                + "not be dropped by cycle-blind dedup leaving the stale DEPARTED from cycle 1");
+    }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/EventRecoveryDataLossRegressionTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/EventRecoveryDataLossRegressionTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase Simulation Framework.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.persistence;
+
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationState;
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationStateMachine;
+import com.hellblazer.luciferase.simulation.causality.FirefliesViewMonitor;
+import com.hellblazer.luciferase.simulation.delos.mock.MockFirefliesView;
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * RDR-019 P1.1 — TDD failing-first regression reproducing the WAL checkpoint/recovery silent
+ * data-loss (driving bug {@code Luciferase-n6jrh.3}).
+ *
+ * <p><b>The bug.</b> {@link PersistenceManager#checkpoint()} records the checkpoint at the CURRENT
+ * {@code eventCounter} sequence. On recovery, {@link EventRecovery#recover} replays only events
+ * AFTER the last checkpoint. So an in-flight migration that was written and then checkpointed (but
+ * whose state never made it into a durable snapshot — there is none) is silently skipped on the
+ * next start: a fresh FSM recovers nothing for that entity. The departure event is durably on disk,
+ * yet recovery treats it as already-captured and drops it.
+ *
+ * <p>This differs from {@link MigrationRecoveryStateSinkTest#endToEndViaManagerReconstructsFsmState}
+ * (which passes today) only by the explicit {@code checkpoint()} call between the writes and the
+ * crash — that single call is what triggers the loss.
+ *
+ * <p>Crash is simulated with {@link PersistenceManager#close()} (crash-safe: flush + close, NO
+ * truncate), NOT {@link PersistenceManager#closeClean()} (which truncates the WAL).
+ *
+ * <p>EXPECTED: RED on current code (recovered state is {@code null}); GREEN after RDR-019 P1.2
+ * removes the periodic checkpoint as a replay bound and recovery full-replays the retained log.
+ *
+ * @author hal.hildebrand
+ */
+class EventRecoveryDataLossRegressionTest {
+
+    private static EntityMigrationStateMachine freshFsm() {
+        var view = new MockFirefliesView<>();
+        var monitor = new FirefliesViewMonitor(view, 3);
+        return new EntityMigrationStateMachine(monitor);
+    }
+
+    /**
+     * In-flight (uncommitted) departure: DEPARTURE → checkpoint() → crash → recover.
+     * Today recovery skips the post-checkpoint tail (empty), so the entity is lost (null).
+     */
+    @Test
+    void inFlightDepartureSurvivesCheckpointThenCrash(@TempDir Path logDir) throws IOException {
+        var nodeId = UUID.randomUUID();
+        var entityA = UUID.randomUUID();
+        var src = UUID.randomUUID();
+        var tgt = UUID.randomUUID();
+        var clock = new TestClock(1_000L);
+
+        // Write phase: one in-flight departure, then an EXPLICIT checkpoint (mirrors the periodic
+        // 5s checkpoint firing mid-migration), then a crash (no clean shutdown, no truncate).
+        try (var mgr = new PersistenceManager(nodeId, logDir, RecoveryStateSink.NOOP)) {
+            mgr.setClock(clock);
+            mgr.logEntityDeparture(entityA, src, tgt);
+            mgr.checkpoint();
+            // crash: close() flushes + closes but does NOT truncate, retaining the WAL tail
+        }
+
+        // Recovery phase: fresh manager + real FSM sink.
+        var fsm = freshFsm();
+        try (var mgr = new PersistenceManager(nodeId, logDir, new MigrationRecoveryStateSink(fsm))) {
+            mgr.setClock(clock);
+            mgr.recover();
+        }
+
+        assertEquals(EntityMigrationState.MIGRATING_OUT, fsm.getState(entityA.toString()),
+                "An in-flight ENTITY_DEPARTURE that was checkpointed (no durable snapshot exists) must "
+                + "still reconstruct as MIGRATING_OUT on recovery — pre-fix it is silently dropped (null)");
+    }
+
+    /**
+     * Committed migration: DEPARTURE → COMMIT → checkpoint() → crash → recover.
+     * Both events are durably logged; recovery must reconstruct DEPARTED (harmless in Phase 1 — the
+     * pair is not pruned until Phase 2 compaction). Pre-fix the checkpoint-bounded replay drops both.
+     */
+    @Test
+    void committedMigrationSurvivesCheckpointThenCrash(@TempDir Path logDir) throws IOException {
+        var nodeId = UUID.randomUUID();
+        var entityA = UUID.randomUUID();
+        var src = UUID.randomUUID();
+        var tgt = UUID.randomUUID();
+        var clock = new TestClock(1_000L);
+
+        try (var mgr = new PersistenceManager(nodeId, logDir, RecoveryStateSink.NOOP)) {
+            mgr.setClock(clock);
+            mgr.logEntityDeparture(entityA, src, tgt);
+            mgr.logMigrationCommit(entityA);
+            mgr.checkpoint();
+            // crash
+        }
+
+        var fsm = freshFsm();
+        try (var mgr = new PersistenceManager(nodeId, logDir, new MigrationRecoveryStateSink(fsm))) {
+            mgr.setClock(clock);
+            mgr.recover();
+        }
+
+        assertEquals(EntityMigrationState.DEPARTED, fsm.getState(entityA.toString()),
+                "A committed migration (DEPARTURE+COMMIT) durably logged before a checkpoint must "
+                + "reconstruct as DEPARTED on recovery — pre-fix the checkpoint-bounded replay drops both events");
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManagerSchedulerRelocationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManagerSchedulerRelocationTest.java
@@ -22,26 +22,31 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * RDR-017 P1 (Luciferase-pf1iu) — scheduler-relocation regression.
  * <p>
- * Proves NEITHER the batch-flush scheduler NOR the checkpoint scheduler is started in the
- * {@link PersistenceManager} constructor. Both are now started only by {@link
- * PersistenceManager#startSchedulers()} (which {@code PersistenceManagerAdapter.doStart()} invokes
- * after {@code recover()}). The assertion is non-vacuous: re-introducing either scheduler into the
- * constructor would make {@code scheduledTaskCount()} non-zero immediately after construction.
+ * Proves the batch-flush scheduler is NOT started in the {@link PersistenceManager} constructor; it is
+ * started only by {@link PersistenceManager#startSchedulers()} (which {@code
+ * PersistenceManagerAdapter.doStart()} invokes after {@code recover()}). The assertion is non-vacuous:
+ * re-introducing the scheduler into the constructor would make {@code scheduledTaskCount()} non-zero
+ * immediately after construction.
+ * <p>
+ * RDR-019 (gate O1): there is no longer a periodic checkpoint scheduler — {@code startSchedulers()}
+ * queues exactly ONE task (batch-flush). Re-adding a periodic checkpoint would make the post-start
+ * count 2 and trip this regression.
  */
 class PersistenceManagerSchedulerRelocationTest {
 
     @Test
-    void neitherSchedulerIsQueuedInConstructor(@TempDir Path walDir) throws IOException {
+    void schedulerIsNotQueuedInConstructor(@TempDir Path walDir) throws IOException {
         try (var pm = new PersistenceManager(UUID.randomUUID(), walDir)) {
             assertFalse(pm.isSchedulersStarted(), "schedulers must not be started by the constructor");
             assertEquals(0, pm.scheduledTaskCount(),
-                         "no scheduler task may be queued before startSchedulers() — re-adding either "
-                         + "the batch-flush or checkpoint scheduler to the ctor would make this non-zero");
+                         "no scheduler task may be queued before startSchedulers() — re-adding the "
+                         + "batch-flush (or a periodic checkpoint) scheduler to the ctor would make this non-zero");
 
             pm.startSchedulers();
             assertTrue(pm.isSchedulersStarted(), "startSchedulers() must mark schedulers started");
-            assertEquals(2, pm.scheduledTaskCount(),
-                         "startSchedulers() must start BOTH the batch-flush and checkpoint schedulers");
+            assertEquals(1, pm.scheduledTaskCount(),
+                         "startSchedulers() must start exactly the batch-flush scheduler — RDR-019 gate O1 "
+                         + "removed the periodic checkpoint scheduler (a count of 2 means it was re-added)");
         }
     }
 
@@ -50,7 +55,7 @@ class PersistenceManagerSchedulerRelocationTest {
         try (var pm = new PersistenceManager(UUID.randomUUID(), walDir)) {
             pm.startSchedulers();
             pm.startSchedulers();
-            assertEquals(2, pm.scheduledTaskCount(), "repeated startSchedulers() must not double-schedule");
+            assertEquals(1, pm.scheduledTaskCount(), "repeated startSchedulers() must not double-schedule");
         }
     }
 }


### PR DESCRIPTION
## RDR-019 — WAL Checkpoint/Recovery Durability (acceptance + Phase 1)

Fixes the silent WAL checkpoint/recovery data loss (driving bug **Luciferase-n6jrh.3**, epic **Luciferase-anmk0**).

### Doc
- Accept RDR-019 (`docs/rdr/RDR-019-wal-checkpoint-recovery-durability.md`), README index.

### Phase 1 — correctness floor (closes the data loss)
The periodic 5s checkpoint recorded the live WAL sequence with **no durable snapshot** behind it, and recovery replayed only post-checkpoint events — so in-flight migrations durably on disk were silently dropped on restart (reconstructed `null` instead of `MIGRATING_OUT`).

- **P1.1** (`Luciferase-qfqlx`): failing-first regression reproducing the loss (`EventRecoveryDataLossRegressionTest`).
- **P1.2** (`Luciferase-punhr`): remove the periodic checkpoint scheduler; `checkpoint()` sources `WriteAheadLog.getSequence()` (Gap 4); recovery FULL-replays the retained log. **Gate O1:** the only checkpoint is `closeClean()`'s, structurally always followed by `truncate()` — every checkpoint is truncation-backed, so full replay is safe. Bounded-WAL size is deferred to Phase 2 compaction, not checkpoint-skipping.
- **P1.3** (`Luciferase-z6dzr`): stacked review (code-review-expert + substantive-critic, **0 Critical**). Fixed: a pre-existing re-migration dedup bug (second `ENTITY_DEPARTURE` after a `COMMIT` was dropped → wrong reconstructed state; now cycle-keyed), stale docstrings that would mislead Phase 2, danger-comment precision, and dead fields.

### Tests
67 persistence/lifecycle tests green. Regression is RED on pre-fix, GREEN on HEAD.

### Scope
Phase 1 closes the `MIGRATING_OUT`/`DEPARTED` reconstruction loss. Phase 2 (separate) adds bounded-WAL compaction and the `null→GHOST` forward path (gate S1).
