### PR TITLE
RDR-019 Phase 2: bounded-WAL compaction (gate S2)

### DIFF
--- a/docs/rdr/RDR-019-wal-checkpoint-recovery-durability.md
+++ b/docs/rdr/RDR-019-wal-checkpoint-recovery-durability.md
@@ -153,12 +153,22 @@ Two layers:
 
 ### Technical Design
 
-- `EventRecovery.recover`: a checkpoint bounds replay only if backed by truncation (clean shutdown) or
-  compaction metadata; otherwise full replay. Interface unchanged externally
-  (`recover() → RecoveredState`).
-- Compaction (primary): rewrite the retained log dropping completed migration pairs (the whole
-  `DEPARTURE`+`COMMIT` pair, never a partial pair — Q2 order constraint), advancing a compaction watermark.
-  Runs on a bounded trigger (size/age) and on `closeClean`. Crash-safe via write-new-then-rename.
+- `EventRecovery.recover`: **always full replay** of the retained log; the interface is unchanged
+  (`recover() → RecoveredState`). **As-built note (P2.3):** Phase 2 chose **physical compaction + full
+  replay** over watermark-filtered (logical-bounded) replay. Pruned events are physically removed from
+  disk, so full replay is *already* bounded — without re-introducing any logical replay filter, which is
+  the exact RDR-019 data-loss class. The compaction watermark is recorded in `*.compaction.meta` for
+  **diagnostics/versioning only** and must never gate replay without a full RDR-019-class audit. (This
+  supersedes the earlier "checkpoint bounds replay if backed by compaction metadata" sketch.)
+- Compaction (primary): rewrite the retained log dropping completed migration cycles **per entity** (the
+  whole `DEPARTURE`+`COMMIT` pair, never a partial pair, and **never a trailing in-flight departure of a
+  re-migrating entity** — cycle-aware: prune the first `min(departures, commits)` departures per entity and
+  every commit, retain trailing in-flight departures — Q2 order constraint), advancing a compaction
+  watermark. Runs on a bounded size trigger (`maybeCompact`, default 16 MB, with a churn guard so a
+  non-prunable log does not re-seal every tick); `closeClean`'s checkpoint+truncate remains the
+  clean-shutdown compaction. Crash-safe via write-new-then-rename. **Gate S1 (`gg28h`):** completed pairs
+  are pruned regardless of recency (accepted gap, decision B — benign: entity owned at target, ghost
+  adjacency re-derivable); the seal boundary buffers the most-recent events.
   **Concurrent-write safety (gate S2):** the batch-flush scheduler keeps writing the *active* segment during
   compaction, so compaction MUST NOT cover the active segment — otherwise a concurrently-written in-flight
   `ENTITY_DEPARTURE` would be lost under the rename (the exact RDR-004 class this RDR closes). Design:

--- a/docs/rdr/RDR-019-wal-checkpoint-recovery-durability.md
+++ b/docs/rdr/RDR-019-wal-checkpoint-recovery-durability.md
@@ -365,3 +365,17 @@ Right-sized: a CRITICAL data-loss correctness fix (Phase 1) plus a bounded-WAL d
   - **O1** — Phase 1 "checkpoint only via truncation" is structural (no metadata flag); documented.
   - **O2** — MVV split into distinct Phase 1 and Phase 2 proofs.
   - **O3** — `DEFERRED_UPDATE` entity-position recovery explicitly out of scope.
+- 2026-06-07: **Phase 1 implemented and merged** (PR #214). `qfqlx` (RED regression), `punhr` (remove
+  periodic checkpoint as replay bound, `checkpoint()` sources `WriteAheadLog.getSequence()`, full-replay
+  recovery — gate O1), `z6dzr` (stacked review, 0 Critical; also fixed a pre-existing re-migration dedup
+  bug). Closes the `MIGRATING_OUT`/`DEPARTED` reconstruction loss (`n6jrh.3`).
+- 2026-06-07: **Gate S1 resolved (Phase 2 P2.1 / `ybipo`) — decision B (accepted gap + tracked bead).**
+  No `null→GHOST` FSM transition is added: `transition()` short-circuits to `notFound` for an untracked
+  (null) entity by the single-owner invariant, so adding `null→GHOST` to `isValidTransition` would be inert
+  unless that invariant were weakened — which would let any `GHOST` notification for an unknown entity
+  silently create a ghost. The gap is benign: after compaction prunes a committed pair, the entity is owned
+  at the **target** (no ownership violation); only source-side ghost *adjacency* tracking is lost, and that
+  is re-derivable by the neighbor layer, not load-bearing on FSM `DEPARTED` bookkeeping. Documented at
+  `EntityMigrationStateMachine.isValidTransition` (DEPARTED case); tracked as **`Luciferase-gg28h`**.
+  **Constraint imposed on P2.3 (`0ejd2`) compaction:** the prune watermark must be conservative enough that
+  recently-departed, still-adjacent entities are not pruned.

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/causality/EntityMigrationStateMachine.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/causality/EntityMigrationStateMachine.java
@@ -690,6 +690,17 @@ public class EntityMigrationStateMachine {
                                                                  // the entity that never committed at
                                                                  // the target (MigrationCoordinator
                                                                  // compensation path).
+            // RDR-019 gate S1 (Luciferase-ybipo) — ACCEPTED GAP, decision B: there is deliberately NO
+            // null->GHOST transition. The DEPARTED->GHOST forward path requires the entity to be tracked
+            // as DEPARTED; transition() short-circuits to notFound for an untracked (null) entity, by the
+            // single-owner invariant (this node must not transition an entity it does not track). After
+            // Phase 2 compaction prunes a committed DEPARTURE+COMMIT pair, getState(id)==null on restart,
+            // so a post-restart DEPARTED->GHOST for that entity is not reconstructible via the FSM. This is
+            // benign: the entity is owned at the TARGET (no ownership violation) — only source-side ghost
+            // adjacency tracking is lost, and that is re-derivable by the neighbor layer, not load-bearing
+            // on FSM bookkeeping. CONSTRAINT for P2.3 compaction: the prune watermark MUST be conservative
+            // enough that recently-departed, still-adjacent entities (which may still ghost) are not pruned.
+            // Tracked follow-up: Luciferase-gg28h.
 
             case GHOST ->
                 newState == EntityMigrationState.MIGRATING_IN;   // Start incoming migration

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/EventRecovery.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/EventRecovery.java
@@ -290,9 +290,11 @@ public class EventRecovery {
      *       only for <em>bounded</em> (post-checkpoint) replay. The Phase 1 full-replay path
      *       deliberately replays from seq 1 past any checkpoint (correct, since the checkpoint
      *       has no durable snapshot behind it), so {@code recover()} validates with a synthetic
-     *       zero checkpoint to enforce monotonicity ONLY. A future Phase 2 compaction-backed
-     *       bounded replay would re-enable this check against the compaction watermark (not the
-     *       bare checkpoint sequence). This branch remains exercised by direct unit tests.</li>
+     *       zero checkpoint to enforce monotonicity ONLY. <b>RDR-019 Phase 2 chose physical
+     *       compaction + full replay</b> (pruned events are removed from disk, bounding replay) rather
+     *       than watermark-filtered replay, so this overlap branch is NOT used by {@code recover()}; the
+     *       compaction watermark metadata is diagnostics/versioning only and must never gate replay
+     *       without a full RDR-019-class audit. This branch remains exercised by direct unit tests.</li>
      * </ul>
      *
      * @param state the recovered state to validate (must not be null)

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManager.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManager.java
@@ -67,6 +67,9 @@ public class PersistenceManager implements AutoCloseable {
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private volatile Clock clock = Clock.system();
     private volatile long compactionThresholdBytes = DEFAULT_COMPACTION_THRESHOLD_BYTES;
+    // Churn guard for the size trigger: once a compaction prunes nothing, suppress further auto-compaction
+    // until retainedLogBytes() exceeds this mark (set to the log size at the no-op). 0 = not suppressed.
+    private volatile long suppressCompactionUntilBytes = 0;
 
     /**
      * Set the clock source for deterministic testing.
@@ -324,12 +327,17 @@ public class PersistenceManager implements AutoCloseable {
      *   <li><b>Seal the active segment first</b> (roll to a fresh segment) and then compact ONLY sealed
      *       segments — never rewrite the live segment the batch-flush scheduler is appending to
      *       (concurrent-write data loss).</li>
-     *   <li>Prune only WHOLE committed {@code DEPARTURE}+{@code COMMIT} pairs — never a partial pair, and
-     *       never an in-flight {@code DEPARTURE} with no matching {@code COMMIT}.</li>
-     *   <li>Apply a conservative watermark so recently-departed, still-adjacent entities are not pruned
-     *       (RDR-019 gate S1 / {@code Luciferase-gg28h}).</li>
+     *   <li>Prune only WHOLE completed migration cycles per entity ({@code DEPARTURE}+{@code COMMIT}) —
+     *       never a partial pair, and never a trailing in-flight {@code DEPARTURE} with no matching
+     *       {@code COMMIT} (cycle-aware: an entity that re-migrates keeps its in-flight cycle).</li>
      *   <li>Retain non-migration event types ({@code DEFERRED_UPDATE}, {@code VIEW_SYNC_ACK}, consensus)
      *       conservatively (gate O3).</li>
+     *   <li><b>Gate S1 (Luciferase-gg28h) — ACCEPTED GAP, no recency watermark.</b> Completed pairs are
+     *       pruned regardless of recency. Per RDR-019 gate S1 decision B this is benign: a pruned entity
+     *       is owned at the target (no ownership violation); only source-side ghost adjacency tracking is
+     *       lost, and that is re-derivable by the neighbor layer. The seal boundary provides a natural
+     *       buffer (the active segment, holding the most recent events, is never compacted). If a workload
+     *       ever needs recently-departed pairs retained, add an age/sequence watermark here (gg28h).</li>
      *   <li>Be crash-safe via write-new-then-rename.</li>
      * </ul>
      *
@@ -516,14 +524,26 @@ public class PersistenceManager implements AutoCloseable {
         if (threshold <= 0) {
             return;
         }
-        if (writeAheadLog.retainedLogBytes() < threshold) {
+        var retained = writeAheadLog.retainedLogBytes();
+        if (retained < threshold) {
+            return;
+        }
+        // Churn guard: if the previous attempt found nothing prunable (e.g. the log is all in-flight
+        // migrations) and the log has not grown since, do NOT compact again — each compact() seals
+        // (rotates) the active segment, so a repeating no-op trigger would create an empty segment every
+        // batch-flush tick, exhausting inodes. Re-arm only once new events grow the log past that mark.
+        if (suppressCompactionUntilBytes > 0 && retained <= suppressCompactionUntilBytes) {
             return;
         }
         try {
             var stats = writeAheadLog.compactCompletedMigrations();
             if (stats.prunedEvents() > 0) {
+                suppressCompactionUntilBytes = 0;
                 log.info("Auto-compaction (size trigger) for node {}: pruned {} events, retained {}",
                          nodeId, stats.prunedEvents(), stats.retainedEvents());
+            } else {
+                // Nothing prunable now; suppress until the log grows beyond its current size.
+                suppressCompactionUntilBytes = writeAheadLog.retainedLogBytes();
             }
         } catch (IOException e) {
             log.error("Auto-compaction failed for node {}", nodeId, e);

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManager.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManager.java
@@ -311,6 +311,35 @@ public class PersistenceManager implements AutoCloseable {
         }
     }
 
+    /**
+     * Compact the write-ahead log: bound replay cost by pruning whole, completed migration cycles
+     * (a {@code ENTITY_DEPARTURE}+{@code MIGRATION_COMMIT} pair) from the retained log, while
+     * guaranteeing no in-flight (uncommitted) migration is ever dropped.
+     * <p>
+     * <b>RDR-019 Phase 2 (gate S2) crash-safety contract</b> — the implementation (Luciferase-0ejd2) MUST:
+     * <ul>
+     *   <li><b>Seal the active segment first</b> (roll to a fresh segment) and then compact ONLY sealed
+     *       segments — never rewrite the live segment the batch-flush scheduler is appending to
+     *       (concurrent-write data loss).</li>
+     *   <li>Prune only WHOLE committed {@code DEPARTURE}+{@code COMMIT} pairs — never a partial pair, and
+     *       never an in-flight {@code DEPARTURE} with no matching {@code COMMIT}.</li>
+     *   <li>Apply a conservative watermark so recently-departed, still-adjacent entities are not pruned
+     *       (RDR-019 gate S1 / {@code Luciferase-gg28h}).</li>
+     *   <li>Retain non-migration event types ({@code DEFERRED_UPDATE}, {@code VIEW_SYNC_ACK}, consensus)
+     *       conservatively (gate O3).</li>
+     *   <li>Be crash-safe via write-new-then-rename.</li>
+     * </ul>
+     *
+     * @throws IOException if compaction I/O fails
+     * @throws UnsupportedOperationException until RDR-019 Phase 2 P2.3 (Luciferase-0ejd2) implements it.
+     *         This stub exists so the Phase 2 failing-first tests (Luciferase-rx1qo) compile and fail for
+     *         the documented reason (compaction not yet implemented / WAL unbounded).
+     */
+    public void compact() throws IOException {
+        throw new UnsupportedOperationException(
+            "RDR-019 Phase 2 P2.3 (Luciferase-0ejd2): WAL compaction not yet implemented");
+    }
+
     // ========== Consensus Event Logging (Phase 7G Day 3.2) ==========
 
     /**

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManager.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/PersistenceManager.java
@@ -55,6 +55,8 @@ public class PersistenceManager implements AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(PersistenceManager.class);
     private static final long BATCH_FLUSH_INTERVAL_MS = 100;
+    /** Default retained-log size that triggers automatic compaction (RDR-019 Phase 2). 16 MB. */
+    private static final long DEFAULT_COMPACTION_THRESHOLD_BYTES = 16L * 1024 * 1024;
 
     private final UUID nodeId;
     private final WriteAheadLog writeAheadLog;
@@ -64,6 +66,7 @@ public class PersistenceManager implements AutoCloseable {
     private final AtomicBoolean schedulersStarted = new AtomicBoolean(false);
     private final AtomicBoolean closed = new AtomicBoolean(false);
     private volatile Clock clock = Clock.system();
+    private volatile long compactionThresholdBytes = DEFAULT_COMPACTION_THRESHOLD_BYTES;
 
     /**
      * Set the clock source for deterministic testing.
@@ -330,14 +333,11 @@ public class PersistenceManager implements AutoCloseable {
      *   <li>Be crash-safe via write-new-then-rename.</li>
      * </ul>
      *
+     * @return statistics describing the compaction
      * @throws IOException if compaction I/O fails
-     * @throws UnsupportedOperationException until RDR-019 Phase 2 P2.3 (Luciferase-0ejd2) implements it.
-     *         This stub exists so the Phase 2 failing-first tests (Luciferase-rx1qo) compile and fail for
-     *         the documented reason (compaction not yet implemented / WAL unbounded).
      */
-    public void compact() throws IOException {
-        throw new UnsupportedOperationException(
-            "RDR-019 Phase 2 P2.3 (Luciferase-0ejd2): WAL compaction not yet implemented");
+    public WriteAheadLog.CompactionStats compact() throws IOException {
+        return writeAheadLog.compactCompletedMigrations();
     }
 
     // ========== Consensus Event Logging (Phase 7G Day 3.2) ==========
@@ -496,10 +496,48 @@ public class PersistenceManager implements AutoCloseable {
         executor.scheduleAtFixedRate(() -> {
             try {
                 writeAheadLog.flush();
+                maybeCompact();
             } catch (IOException e) {
                 log.error("Batch flush failed", e);
             }
         }, BATCH_FLUSH_INTERVAL_MS, BATCH_FLUSH_INTERVAL_MS, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Size-based compaction trigger (RDR-019 Phase 2, item 4). When the retained log grows beyond
+     * {@link #compactionThresholdBytes}, run {@link #compact()} to prune completed migration cycles and
+     * bound replay. Disabled when the threshold is {@code <= 0}. Invoked from the batch-flush scheduler,
+     * so it runs on the same single scheduler thread (never concurrently with itself); {@code compact()}
+     * seals the active segment and is synchronized on the WAL, so it is safe against in-flight appends
+     * (gate S2). A clean shutdown compacts maximally via {@code closeClean()}'s checkpoint+truncate.
+     */
+    private void maybeCompact() {
+        var threshold = compactionThresholdBytes;
+        if (threshold <= 0) {
+            return;
+        }
+        if (writeAheadLog.retainedLogBytes() < threshold) {
+            return;
+        }
+        try {
+            var stats = writeAheadLog.compactCompletedMigrations();
+            if (stats.prunedEvents() > 0) {
+                log.info("Auto-compaction (size trigger) for node {}: pruned {} events, retained {}",
+                         nodeId, stats.prunedEvents(), stats.retainedEvents());
+            }
+        } catch (IOException e) {
+            log.error("Auto-compaction failed for node {}", nodeId, e);
+        }
+    }
+
+    /**
+     * Set the retained-log byte threshold that triggers automatic compaction from the batch-flush
+     * scheduler. {@code <= 0} disables the size trigger (explicit {@link #compact()} still works).
+     *
+     * @param bytes threshold in bytes (default {@value #DEFAULT_COMPACTION_THRESHOLD_BYTES})
+     */
+    public void setCompactionThresholdBytes(long bytes) {
+        this.compactionThresholdBytes = bytes;
     }
 
 }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/WriteAheadLog.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/WriteAheadLog.java
@@ -514,10 +514,22 @@ public class WriteAheadLog implements AutoCloseable {
             return new CompactionStats(0, 0, 0, 0, false);
         }
 
-        // Pass 1: determine which entities have a COMPLETED migration (both DEPARTURE and COMMIT present
-        // across the sealed segments). Only those entities' DEPARTURE/COMMIT events are prunable.
-        var departed = new HashSet<String>();
-        var committed = new HashSet<String>();
+        // Pass 1: per-entity CYCLE accounting. An entity may migrate more than once within the retained
+        // log (DEPARTURE→COMMIT, then DEPARTURE again, ...). We must prune only events of COMPLETED
+        // cycles and NEVER an in-flight (uncommitted) departure — otherwise a re-migration's trailing
+        // DEPARTURE is dropped and recovery reconstructs null instead of MIGRATING_OUT (the RDR-004-class
+        // data loss this RDR closes; substantive-critic RDR-019 P2.4).
+        //
+        // By the Q2 append-order guarantee, an entity's events are DEPARTURE,COMMIT,DEPARTURE,COMMIT,...
+        // optionally ending in a trailing in-flight DEPARTURE. With d departures and c commits in sealed,
+        // the number of completed cycles is min(d, c); the trailing max(0, d - c) departures are in-flight.
+        // So: prune every COMMIT (each closes a cycle whose DEPARTURE is also pruned, or is an orphan whose
+        // DEPARTURE was pruned by an earlier compaction), and prune the FIRST min(d, c) departures (by
+        // order), retaining the trailing in-flight ones. (A COMMIT can never appear in sealed with its
+        // DEPARTURE in the still-active segment: DEPARTURE precedes COMMIT in time, and the seal is a
+        // single point in time.)
+        var departureCounts = new HashMap<String, Integer>();
+        var commitCounts = new HashMap<String, Integer>();
         for (int i = 0; i < sealed.size(); i++) {
             List<Map<String, Object>> events;
             try {
@@ -534,22 +546,32 @@ public class WriteAheadLog implements AutoCloseable {
                     continue;
                 }
                 if ("ENTITY_DEPARTURE".equals(type)) {
-                    departed.add(entityId.toString());
+                    departureCounts.merge(entityId.toString(), 1, Integer::sum);
                 } else if ("MIGRATION_COMMIT".equals(type)) {
-                    committed.add(entityId.toString());
+                    commitCounts.merge(entityId.toString(), 1, Integer::sum);
                 }
             }
         }
-        var completed = new HashSet<String>(departed);
-        completed.retainAll(committed);
 
-        if (completed.isEmpty()) {
-            // Nothing to prune; the seal already happened (harmless empty active segment).
+        long totalCommits = commitCounts.values().stream().mapToLong(Integer::longValue).sum();
+        if (totalCommits == 0) {
+            // No completed cycle anywhere in sealed → nothing prunable (every departure is in-flight).
+            // The seal already happened (harmless empty active segment).
             return new CompactionStats(sealed.size(), 0, countSealed(sealed), 0, false);
         }
 
+        // Per entity, the number of departures (oldest-first) that belong to completed cycles and are
+        // therefore prunable; the remaining trailing departures are in-flight and retained.
+        var prunableDepartures = new HashMap<String, Integer>();
+        for (var e : departureCounts.entrySet()) {
+            prunableDepartures.put(e.getKey(), Math.min(e.getValue(), commitCounts.getOrDefault(e.getKey(), 0)));
+        }
+
         // Pass 2: stream retained events to a temp file (no full in-memory rewrite), preserving order.
+        // Prune every COMMIT, and the first min(d,c) DEPARTUREs per entity (the completed-cycle ones),
+        // retaining trailing in-flight departures and all non-migration events.
         var tempFile = logDirectory.resolve("node-" + nodeId + ".compact.tmp");
+        var departuresPrunedSoFar = new HashMap<String, Integer>();
         long pruned = 0;
         long retained = 0;
         long watermark = 0;
@@ -568,10 +590,21 @@ public class WriteAheadLog implements AutoCloseable {
                 for (var event : events) {
                     var type = (String) event.get("type");
                     var entityId = event.get("entityId");
-                    boolean prunable = entityId != null
-                        && completed.contains(entityId.toString())
-                        && ("ENTITY_DEPARTURE".equals(type) || "MIGRATION_COMMIT".equals(type));
-                    if (prunable) {
+                    boolean prune = false;
+                    if (entityId != null) {
+                        var id = entityId.toString();
+                        if ("MIGRATION_COMMIT".equals(type)) {
+                            prune = true;
+                        } else if ("ENTITY_DEPARTURE".equals(type)) {
+                            int budget = prunableDepartures.getOrDefault(id, 0);
+                            int done = departuresPrunedSoFar.getOrDefault(id, 0);
+                            if (done < budget) {
+                                prune = true;
+                                departuresPrunedSoFar.put(id, done + 1);
+                            }
+                        }
+                    }
+                    if (prune) {
                         pruned++;
                         var seqRaw = event.get("sequence");
                         if (seqRaw instanceof Number n) {

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/WriteAheadLog.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/persistence/WriteAheadLog.java
@@ -27,6 +27,7 @@ import java.io.*;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.util.*;
@@ -189,6 +190,25 @@ public class WriteAheadLog implements AutoCloseable {
      */
     public long getSequence() {
         return sequenceCounter.get();
+    }
+
+    /**
+     * Total bytes across all retained log segments for this node (sealed + active). Used by the
+     * size-based compaction trigger (RDR-019 Phase 2). Returns 0 if the directory cannot be listed.
+     *
+     * @return summed size in bytes of all {@code node-<id>*.log} segments
+     */
+    public long retainedLogBytes() {
+        try {
+            long total = 0;
+            for (var seg : findLogFiles()) {
+                total += Files.size(seg);
+            }
+            return total;
+        } catch (IOException e) {
+            log.warn("Failed to measure retained log bytes for node {}", nodeId, e);
+            return 0;
+        }
     }
 
     /**
@@ -425,6 +445,240 @@ public class WriteAheadLog implements AutoCloseable {
         currentSize.set(0);
 
         log.info("WriteAheadLog truncated for node {} (clean-shutdown compaction)", nodeId);
+    }
+
+    /**
+     * Result of a {@link #compactCompletedMigrations()} run.
+     *
+     * @param sealedSegments  number of sealed segments scanned
+     * @param prunedEvents    number of events removed (whole completed DEPARTURE+COMMIT pairs)
+     * @param retainedEvents  number of events kept (in-flight departures + non-migration events)
+     * @param watermark       highest sequence number pruned (0 if nothing pruned)
+     * @param aborted         true if compaction made no changes (e.g. corrupt sealed segment); the log
+     *                        is left intact so recovery can fail loud on the corruption
+     */
+    public record CompactionStats(int sealedSegments, long prunedEvents, long retainedEvents,
+                                  long watermark, boolean aborted) {}
+
+    /**
+     * Mid-run compaction (RDR-019 Phase 2, gate S2): bound the retained log by pruning WHOLE completed
+     * migration cycles — an {@code ENTITY_DEPARTURE} together with its matching {@code MIGRATION_COMMIT} —
+     * while never dropping an in-flight (uncommitted) departure or a non-migration event.
+     *
+     * <p><b>Gate S2 — concurrent-write safety.</b> The active segment is SEALED first (roll to a fresh
+     * segment via {@link #rotate()}); compaction then scans and rewrites ONLY the now-sealed segments.
+     * The live segment that subsequent {@link #append(Map)} calls write to is never rewritten. (This
+     * method is also {@code synchronized} on the WAL monitor, so no append interleaves — belt and
+     * suspenders; the seal-then-compact-sealed design is the load-bearing guarantee.)
+     *
+     * <p><b>Pruning rule (Q2 order constraint).</b> An entity's events are prunable only if BOTH an
+     * {@code ENTITY_DEPARTURE} and a {@code MIGRATION_COMMIT} for it appear among the sealed events. Only
+     * those two event types, for such completed entities, are dropped — never a partial pair, never an
+     * in-flight departure, and never a non-migration event ({@code DEFERRED_UPDATE}, {@code VIEW_SYNC_ACK},
+     * consensus types are retained conservatively — gate O3; no recovery consumer, so never assumed
+     * prunable). Relative order of retained events is preserved.
+     *
+     * <p><b>Bounded replay without logical filtering.</b> Pruned events are physically removed from disk,
+     * so the next recovery's FULL replay (RDR-019 Phase 1 contract) is naturally bounded — there is no
+     * watermark-filtered replay. This is deliberate: re-introducing a logical replay bound is the exact
+     * RDR-019 data-loss class. The watermark is recorded in metadata for diagnostics/versioning only.
+     *
+     * <p><b>Crash safety.</b> Write-new-then-rename: retained sealed events are streamed to a temp file,
+     * fsync'd, then atomically renamed over the base segment; the other sealed segments are deleted only
+     * afterwards. A crash at any point leaves a fully recoverable (possibly un- or partially-compacted)
+     * log with no event loss — replay is idempotent (duplicate migrations are deduped on recovery).
+     *
+     * <p><b>Corruption.</b> If a sealed segment contains a mid-file corrupt line, compaction ABORTS
+     * (returns {@code aborted=true}, no changes) so the corruption survives for the recovery fail-loud
+     * gate rather than being silently rewritten away. A torn final line of the last sealed segment
+     * (crash-flush) is tolerated and dropped, mirroring recovery.
+     *
+     * @return statistics describing the compaction
+     * @throws IOException if compaction I/O fails
+     */
+    public synchronized CompactionStats compactCompletedMigrations() throws IOException {
+        checkNotClosed();
+
+        // Seal the active segment: everything that exists before this roll becomes sealed (read-only);
+        // appends after this point land in the fresh active segment, which compaction never touches.
+        rotate();
+        var activeSegment = currentLogFile;
+
+        var sealed = new ArrayList<Path>();
+        for (var f : findLogFiles()) {
+            if (!f.equals(activeSegment)) {
+                sealed.add(f);
+            }
+        }
+        if (sealed.isEmpty()) {
+            return new CompactionStats(0, 0, 0, 0, false);
+        }
+
+        // Pass 1: determine which entities have a COMPLETED migration (both DEPARTURE and COMMIT present
+        // across the sealed segments). Only those entities' DEPARTURE/COMMIT events are prunable.
+        var departed = new HashSet<String>();
+        var committed = new HashSet<String>();
+        for (int i = 0; i < sealed.size(); i++) {
+            List<Map<String, Object>> events;
+            try {
+                events = parseSegmentForCompaction(sealed.get(i), i == sealed.size() - 1);
+            } catch (CompactionAbortException e) {
+                log.warn("Compaction aborted for node {}: {} — leaving log intact for fail-loud recovery",
+                         nodeId, e.getMessage());
+                return new CompactionStats(sealed.size(), 0, 0, 0, true);
+            }
+            for (var event : events) {
+                var type = (String) event.get("type");
+                var entityId = event.get("entityId");
+                if (entityId == null) {
+                    continue;
+                }
+                if ("ENTITY_DEPARTURE".equals(type)) {
+                    departed.add(entityId.toString());
+                } else if ("MIGRATION_COMMIT".equals(type)) {
+                    committed.add(entityId.toString());
+                }
+            }
+        }
+        var completed = new HashSet<String>(departed);
+        completed.retainAll(committed);
+
+        if (completed.isEmpty()) {
+            // Nothing to prune; the seal already happened (harmless empty active segment).
+            return new CompactionStats(sealed.size(), 0, countSealed(sealed), 0, false);
+        }
+
+        // Pass 2: stream retained events to a temp file (no full in-memory rewrite), preserving order.
+        var tempFile = logDirectory.resolve("node-" + nodeId + ".compact.tmp");
+        long pruned = 0;
+        long retained = 0;
+        long watermark = 0;
+        try (var fos = new FileOutputStream(tempFile.toFile(), false);
+             var ch = fos.getChannel();
+             var out = new BufferedWriter(new OutputStreamWriter(fos, java.nio.charset.StandardCharsets.UTF_8))) {
+            for (int i = 0; i < sealed.size(); i++) {
+                List<Map<String, Object>> events;
+                try {
+                    events = parseSegmentForCompaction(sealed.get(i), i == sealed.size() - 1);
+                } catch (CompactionAbortException e) {
+                    log.warn("Compaction aborted (pass 2) for node {}: {} — leaving log intact", nodeId, e.getMessage());
+                    Files.deleteIfExists(tempFile);
+                    return new CompactionStats(sealed.size(), 0, 0, 0, true);
+                }
+                for (var event : events) {
+                    var type = (String) event.get("type");
+                    var entityId = event.get("entityId");
+                    boolean prunable = entityId != null
+                        && completed.contains(entityId.toString())
+                        && ("ENTITY_DEPARTURE".equals(type) || "MIGRATION_COMMIT".equals(type));
+                    if (prunable) {
+                        pruned++;
+                        var seqRaw = event.get("sequence");
+                        if (seqRaw instanceof Number n) {
+                            watermark = Math.max(watermark, n.longValue());
+                        }
+                        continue;
+                    }
+                    out.write(MAPPER.writeValueAsString(event));
+                    out.write(System.lineSeparator());
+                    retained++;
+                }
+            }
+            out.flush();
+            ch.force(true);
+        }
+
+        // Atomic publish: rename temp over the base segment, then delete the other (now superseded)
+        // sealed segments. Order matters for crash-safety: the rename happens BEFORE deletion so a crash
+        // between the two leaves duplicate (but never missing) events, which recovery dedupes.
+        var baseSegment = logDirectory.resolve("node-" + nodeId + ".log");
+        try {
+            Files.move(tempFile, baseSegment, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (java.nio.file.AtomicMoveNotSupportedException e) {
+            Files.move(tempFile, baseSegment, StandardCopyOption.REPLACE_EXISTING);
+        }
+        for (var seg : sealed) {
+            if (!seg.equals(baseSegment)) {
+                Files.deleteIfExists(seg);
+            }
+        }
+
+        writeCompactionWatermark(watermark);
+        log.info("WriteAheadLog compacted for node {}: {} sealed segment(s), {} pruned, {} retained, watermark={}",
+                 nodeId, sealed.size(), pruned, retained, watermark);
+        return new CompactionStats(sealed.size(), pruned, retained, watermark, false);
+    }
+
+    /** Count events across sealed segments (used only when nothing is pruned, for stats). */
+    private long countSealed(List<Path> sealed) throws IOException {
+        long n = 0;
+        for (int i = 0; i < sealed.size(); i++) {
+            try {
+                n += parseSegmentForCompaction(sealed.get(i), i == sealed.size() - 1).size();
+            } catch (CompactionAbortException e) {
+                return n;
+            }
+        }
+        return n;
+    }
+
+    /** Signals that compaction must abort and leave the log intact (mid-file corruption). */
+    private static final class CompactionAbortException extends Exception {
+        CompactionAbortException(String message) { super(message); }
+    }
+
+    /**
+     * Parse a sealed segment for compaction. A torn final line of the LAST sealed segment (crash-flush)
+     * is tolerated and skipped; any other parse failure is mid-file corruption and aborts compaction
+     * (so it survives for the recovery fail-loud gate rather than being silently rewritten away).
+     */
+    private List<Map<String, Object>> parseSegmentForCompaction(Path segment, boolean isLastSealed)
+            throws IOException, CompactionAbortException {
+        var rawLines = new ArrayList<String>();
+        try (var reader = Files.newBufferedReader(segment)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (!line.isEmpty()) {
+                    rawLines.add(line);
+                }
+            }
+        }
+        var events = new ArrayList<Map<String, Object>>();
+        for (int i = 0; i < rawLines.size(); i++) {
+            boolean isFinalLine = (i == rawLines.size() - 1);
+            try {
+                Map<String, Object> event = MAPPER.readValue(rawLines.get(i), new TypeReference<Map<String, Object>>() {});
+                if (event != null) {
+                    events.add(event);
+                }
+            } catch (Exception e) {
+                if (isLastSealed && isFinalLine) {
+                    log.debug("Compaction tolerating torn tail at {}:{} - {}", segment, i + 1, e.getMessage());
+                } else {
+                    throw new CompactionAbortException(
+                        "mid-file corrupt line at " + segment + ":" + (i + 1) + " - " + e.getMessage());
+                }
+            }
+        }
+        return events;
+    }
+
+    /** Stamp the compaction watermark + format version into metadata (diagnostics/versioning only). */
+    private void writeCompactionWatermark(long watermark) {
+        try {
+            var meta = new HashMap<String, Object>();
+            meta.put("watermark", watermark);
+            meta.put("formatVersion", 1);
+            meta.put("nodeId", nodeId.toString());
+            meta.put("timestamp", Instant.ofEpochMilli(clock.currentTimeMillis()).toString());
+            var file = logDirectory.resolve("node-" + nodeId + ".compaction.meta");
+            Files.writeString(file, MAPPER.writeValueAsString(meta),
+                              StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        } catch (IOException e) {
+            // Watermark metadata is diagnostic only; failure to write it must not fail compaction.
+            log.warn("Failed to write compaction watermark metadata for node {}", nodeId, e);
+        }
     }
 
     private List<Path> findLogFiles() throws IOException {

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/WalCompactionConcurrencyTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/WalCompactionConcurrencyTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * RDR-019 Phase 2 P2.2 — failing-first concurrency regression for compaction (gate S2).
@@ -84,5 +85,9 @@ class WalCompactionConcurrencyTest {
         assertEquals(EntityMigrationState.MIGRATING_OUT, fsm.getState(inFlight.toString()),
                 "an in-flight ENTITY_DEPARTURE in the active segment must survive compaction — compaction "
                 + "must seal-then-compact only sealed segments older than the watermark, never the live tail");
+        // Non-vacuous: prove compaction actually pruned the completed pair (otherwise a no-op compact()
+        // would also pass the assertion above via full replay).
+        assertNull(fsm.getState(older.toString()),
+                "the completed DEPARTURE+COMMIT pair must be pruned — older entity must reconstruct as null");
     }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/WalCompactionConcurrencyTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/WalCompactionConcurrencyTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase Simulation Framework.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.persistence;
+
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationState;
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationStateMachine;
+import com.hellblazer.luciferase.simulation.causality.FirefliesViewMonitor;
+import com.hellblazer.luciferase.simulation.delos.mock.MockFirefliesView;
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * RDR-019 Phase 2 P2.2 — failing-first concurrency regression for compaction (gate S2).
+ *
+ * <p>An in-flight {@code ENTITY_DEPARTURE} written to the <b>active</b> segment must survive a concurrent
+ * compaction. Compaction must seal the active segment and touch only sealed segments older than the
+ * watermark — it must never rewrite the live segment the batch-flush scheduler is appending to. This test
+ * writes an in-flight departure to the active segment, runs compaction, and asserts the departure is still
+ * recovered afterwards.
+ *
+ * <p>EXPECTED: RED until Phase 2 P2.3 implements {@link PersistenceManager#compact()} (stub throws
+ * {@link UnsupportedOperationException}).
+ *
+ * @author hal.hildebrand
+ */
+class WalCompactionConcurrencyTest {
+
+    private static EntityMigrationStateMachine freshFsm() {
+        return new EntityMigrationStateMachine(new FirefliesViewMonitor(new MockFirefliesView<>(), 3));
+    }
+
+    @Test
+    void inFlightDepartureInActiveSegmentSurvivesCompaction(@TempDir Path logDir) throws IOException {
+        var nodeId = UUID.randomUUID();
+        var older = UUID.randomUUID();      // a completed migration eligible for pruning
+        var inFlight = UUID.randomUUID();   // in-flight in the ACTIVE segment when compaction runs
+        var src = UUID.randomUUID();
+        var tgt = UUID.randomUUID();
+        var clock = new TestClock(1_000L);
+
+        try (var mgr = new PersistenceManager(nodeId, logDir, RecoveryStateSink.NOOP)) {
+            mgr.setClock(clock);
+            // An older completed migration (compaction-eligible).
+            mgr.logEntityDeparture(older, src, tgt);
+            mgr.logMigrationCommit(older);
+            // An in-flight departure sitting in the active segment when compaction runs.
+            mgr.logEntityDeparture(inFlight, src, tgt);
+
+            // Compaction must seal the active segment first and compact only prior sealed segments —
+            // the in-flight departure in the (now sealed-but-newer-than-watermark) active segment must
+            // NOT be pruned.
+            mgr.compact();
+            // crash (retain everything compaction left behind)
+        }
+
+        var fsm = freshFsm();
+        try (var mgr = new PersistenceManager(nodeId, logDir, new MigrationRecoveryStateSink(fsm))) {
+            mgr.setClock(clock);
+            mgr.recover();
+        }
+
+        assertEquals(EntityMigrationState.MIGRATING_OUT, fsm.getState(inFlight.toString()),
+                "an in-flight ENTITY_DEPARTURE in the active segment must survive compaction — compaction "
+                + "must seal-then-compact only sealed segments older than the watermark, never the live tail");
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/WalCompactionRecoveryTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/WalCompactionRecoveryTest.java
@@ -113,4 +113,40 @@ class WalCompactionRecoveryTest {
                 + ") must shrink below pre-compaction (" + bytesBeforeCompaction
                 + ") by pruning the committed DEPARTURE+COMMIT pair");
     }
+
+    /**
+     * Re-migration across compaction (RDR-019 P2.4 substantive-critic CRITICAL): an entity with a
+     * completed cycle 1 (DEPARTURE+COMMIT) AND an in-flight cycle 2 (DEPARTURE only), all in sealed
+     * segments at compaction time, must reconstruct as MIGRATING_OUT — compaction must prune ONLY
+     * cycle 1 and retain the cycle-2 in-flight departure. A cycle-blind prune (drop all DEPARTURE/COMMIT
+     * for any entity with a completed pair) would drop cycle 2 and reconstruct null — the RDR-004-class
+     * silent data loss this RDR closes.
+     */
+    @Test
+    void reMigrationAcrossCompactionRetainsInFlightCycle2(@TempDir Path logDir) throws IOException {
+        var nodeId = UUID.randomUUID();
+        var entity = UUID.randomUUID();
+        var src = UUID.randomUUID();
+        var tgt = UUID.randomUUID();
+        var clock = new TestClock(1_000L);
+
+        try (var mgr = new PersistenceManager(nodeId, logDir, RecoveryStateSink.NOOP)) {
+            mgr.setClock(clock);
+            mgr.logEntityDeparture(entity, src, tgt);   // cycle 1 begins
+            mgr.logMigrationCommit(entity);             // cycle 1 completes
+            mgr.logEntityDeparture(entity, src, tgt);   // cycle 2 begins, in-flight
+            mgr.compact();                              // must prune cycle 1 only, retain cycle 2
+            // crash
+        }
+
+        var fsm = freshFsm();
+        try (var mgr = new PersistenceManager(nodeId, logDir, new MigrationRecoveryStateSink(fsm))) {
+            mgr.setClock(clock);
+            mgr.recover();
+        }
+
+        assertEquals(EntityMigrationState.MIGRATING_OUT, fsm.getState(entity.toString()),
+                "the in-flight cycle-2 departure must survive compaction — cycle-blind pruning would "
+                + "drop it and reconstruct null (RDR-004-class data loss)");
+    }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/WalCompactionRecoveryTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/persistence/WalCompactionRecoveryTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase Simulation Framework.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.persistence;
+
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationState;
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationStateMachine;
+import com.hellblazer.luciferase.simulation.causality.FirefliesViewMonitor;
+import com.hellblazer.luciferase.simulation.delos.mock.MockFirefliesView;
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RDR-019 Phase 2 P2.2 — failing-first MVV for bounded-WAL compaction (RDR-019 §MVV Phase 2).
+ *
+ * <p><b>Multi-session bounded no-loss:</b> across crash → recover → compact → crash → recover, every
+ * in-flight (uncommitted) migration must still be reconstructed (none silently dropped), while the
+ * retained WAL is bounded (committed pairs pruned, so total log bytes shrink after compaction).
+ *
+ * <p>EXPECTED: RED until Phase 2 P2.3 (Luciferase-0ejd2) implements {@link PersistenceManager#compact()}
+ * — the stub throws {@link UnsupportedOperationException}. GREEN once compaction seals the active segment
+ * and prunes whole committed DEPARTURE+COMMIT pairs from sealed segments.
+ *
+ * @author hal.hildebrand
+ */
+class WalCompactionRecoveryTest {
+
+    private static EntityMigrationStateMachine freshFsm() {
+        return new EntityMigrationStateMachine(new FirefliesViewMonitor(new MockFirefliesView<>(), 3));
+    }
+
+    /** Sum of all WAL segment (.log) byte sizes in the directory — the "retained log" footprint. */
+    private static long walBytes(Path dir) throws IOException {
+        try (var s = Files.list(dir)) {
+            return s.filter(p -> p.getFileName().toString().endsWith(".log"))
+                    .mapToLong(p -> {
+                        try {
+                            return Files.size(p);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .sum();
+        }
+    }
+
+    @Test
+    void multiSessionCompactionBoundsWalWithoutDroppingInFlight(@TempDir Path logDir) throws IOException {
+        var nodeId = UUID.randomUUID();
+        var inFlight = UUID.randomUUID();   // departs, never commits — must survive ALL sessions
+        var committed = UUID.randomUUID();  // departs + commits — eligible for compaction pruning
+        var src = UUID.randomUUID();
+        var tgt = UUID.randomUUID();
+        var clock = new TestClock(1_000L);
+
+        // session 1: one in-flight departure + one completed migration; crash (no clean shutdown).
+        try (var mgr = new PersistenceManager(nodeId, logDir, RecoveryStateSink.NOOP)) {
+            mgr.setClock(clock);
+            mgr.logEntityDeparture(inFlight, src, tgt);
+            mgr.logEntityDeparture(committed, src, tgt);
+            mgr.logMigrationCommit(committed);
+            // crash
+        }
+        long bytesBeforeCompaction = walBytes(logDir);
+
+        // session 2: recover, then compact (must seal the active segment first, prune the committed
+        // pair, retain the in-flight departure), then crash.
+        var fsm2 = freshFsm();
+        try (var mgr = new PersistenceManager(nodeId, logDir, new MigrationRecoveryStateSink(fsm2))) {
+            mgr.setClock(clock);
+            mgr.recover();
+            assertEquals(EntityMigrationState.MIGRATING_OUT, fsm2.getState(inFlight.toString()),
+                    "session 2: in-flight departure must recover as MIGRATING_OUT");
+            mgr.compact();
+            // crash
+        }
+        long bytesAfterCompaction = walBytes(logDir);
+
+        // session 3: recover from the compacted log — in-flight migration still present, WAL bounded.
+        var fsm3 = freshFsm();
+        try (var mgr = new PersistenceManager(nodeId, logDir, new MigrationRecoveryStateSink(fsm3))) {
+            mgr.setClock(clock);
+            mgr.recover();
+        }
+
+        assertEquals(EntityMigrationState.MIGRATING_OUT, fsm3.getState(inFlight.toString()),
+                "session 3: the in-flight migration must survive compaction+crash — never silently dropped");
+        assertTrue(bytesAfterCompaction < bytesBeforeCompaction,
+                "compaction must bound the WAL: retained log bytes (" + bytesAfterCompaction
+                + ") must shrink below pre-compaction (" + bytesBeforeCompaction
+                + ") by pruning the committed DEPARTURE+COMMIT pair");
+    }
+}


### PR DESCRIPTION
## RDR-019 Phase 2 — Bounded-WAL compaction

Builds on Phase 1 (PR #214, merged). Phase 1 closed the silent data loss by full-replaying the retained WAL; Phase 2 bounds WAL/replay growth via crash-safe compaction — without re-introducing any logical replay bound.

### What ships
- **P2.1** (`ybipo`): gate-S1 `null→GHOST` forward-path decision — **B (accepted gap)**, tracked as `Luciferase-gg28h`. No FSM transition added (would weaken the single-owner invariant); the gap is benign (entity owned at target; ghost adjacency re-derivable).
- **P2.2** (`rx1qo`): failing-first compaction tests (multi-session MVV + active-segment concurrency).
- **P2.3** (`0ejd2`): `WriteAheadLog.compactCompletedMigrations()` — **seal the active segment first**, then two-pass stream over **sealed** segments, prune **whole completed migration cycles per entity** (cycle-aware: never a partial pair, never a trailing in-flight re-migration departure, never a non-migration event), crash-safe **write-new-then-rename**, watermark metadata (diagnostics only), mid-file-corruption abort. `PersistenceManager.compact()` + a size auto-trigger (16 MB) with a churn guard.
- **P2.4** (`iji57`): stacked review (code-review-expert + substantive-critic) — **2 CRITICAL found and fixed**:
  - cycle-blind pruning would drop an in-flight re-migration departure (RDR-004-class loss) → now cycle-aware;
  - non-prunable log above the trigger re-sealed every tick (inode exhaustion) → churn guard added.

### Design note
Bounded replay is achieved by **physical removal + full replay**, not watermark-filtered replay — deliberately avoiding the RDR-019 data-loss class. The compaction watermark is diagnostics/versioning only and never gates replay. `EventRecovery` is unchanged from Phase 1.

### Tests
279 persistence/WAL/migration/FSM/ghost tests green; corrupt-WAL fail-loud preserved. Phase-review-gate (RDR-019 §Approach ↔ closing beads) PASSED.
