### PR TITLE
RDR-020: Bubble→Fireflies member Digest resolution for migration consensus

### DIFF
--- a/docs/rdr/RDR-020-bubble-to-fireflies-member-digest-resolution.md
+++ b/docs/rdr/RDR-020-bubble-to-fireflies-member-digest-resolution.md
@@ -333,6 +333,9 @@ interface BubbleOwnershipResolver {
     Digest resolveOwningMember(UUID bubbleId);   // throws IllegalStateException if no current-view owner
     Digest localMember();                         // this process's own member Digest (source node)
     Digest memberDigestForNode(UUID nodeId);      // canonical node-UUID -> member Digest (B4); throws if unknown
+    boolean isActiveMember(Digest member);        // S5: active-only (RDR-005) membership test; memberDigestForNode
+                                                  // resolves over all-members so the node-UUID hint guard needs
+                                                  // this to reject evicted-but-not-GC'd members
 }
 
 // Deterministic, view-derived ownership — pure function, identical on every node.

--- a/docs/rdr/RDR-020-bubble-to-fireflies-member-digest-resolution.md
+++ b/docs/rdr/RDR-020-bubble-to-fireflies-member-digest-resolution.md
@@ -116,21 +116,46 @@ wrong link.
 
 ### Critical Assumptions
 
-- [ ] **A1**: A bubble's owning node can be resolved to a current-view member `Digest` — either
-  deterministically from the spatial partition (a bubble's SFC range maps to a member) or via a maintained
-  ownership registry. — **Status**: Unverified — **Method**: Source Search (TetreeBubbleGrid ↔ membership
-  partition; does any existing code assign bubbles/SFC ranges to members?)
-- [ ] **A2**: This process can obtain its own Fireflies member `Digest` for the source node of locally-owned
-  migrations (the common case), avoiding a lookup for the source. — **Status**: Unverified — **Method**:
-  Source Search (`FirefliesMembershipView`/local member accessor).
-- [ ] **A3**: The `MigrationProposal` node-id semantics are "owning node of source/target bubble," not
-  "bubble id" — i.e. fixing the resolution requires no change to the proposal record or vote logic. —
-  **Status**: Unverified — **Method**: Source Search (`ViewCommitteeConsensus` vote tally usage of
-  `sourceNodeId`/`targetNodeId`).
+- [x] **A1**: A bubble's owning node can be resolved to a current-view member `Digest` deterministically from
+  the spatial partition or an existing registry. — **Status**: **REFUTED** (2026-06-08, Source Search) —
+  **Finding**: NO bubble→node ownership mapping exists. `TetreeBubbleGrid` indexes bubbles by `TetreeKey`
+  (spatial), not by node (`TetreeBubbleGrid.java:54`); there is no range→member table, ownership registry,
+  or consistent-hash assignment anywhere. `TopologyConsensusCoordinator:258-265` even documents that
+  bubble-UUID digests are rejected as "not in view." **Implication**: the target-ownership backing of the
+  resolver must be *built or supplied by the caller* — it is not a free lookup. This is a scope fork (see
+  Revision History 2026-06-08 and the revised Approach).
+- [x] **A2**: This process can obtain its own Fireflies member `Digest` for the source node. — **Status**:
+  **VERIFIED** (Source Search) — `Delos fireflies/View.getNodeId() → Digest` (`View.java:187-189`);
+  `FirefliesMembershipView` holds the `View` (`:65-72`) and can expose it. Source node is free.
+- [x] **A3**: `MigrationProposal` node-id semantics are "owning node," and redefining them requires no
+  change to the proposal record or vote/quorum logic. — **Status**: **VERIFIED** (Source Search) —
+  `sourceNodeId`/`targetNodeId` are read only for null checks, the self-migration check
+  (`ViewCommitteeConsensus.java:365`), and `isNodeInView` (`:372-376`). Vote tally
+  (`CommitteeBallotBox.java:90-248`) is keyed on `proposalId`; quorum derives from committee size/tolerance,
+  not node identity. Changing the digests to real owning-node identities is safe.
 
 ## Proposed Solution
 
 ### Approach
+
+> **Revised 2026-06-08 after A1 was REFUTED.** No bubble→node ownership map exists, and the spatial
+> partition does not assign bubbles to members — so the resolver's *target* backing is not a free lookup;
+> it requires an ownership source that must be built. This forks the scope (see below). The boundary
+> design and the source-node/fail-loud parts are unchanged; only the **target-resolution backing** is
+> affected.
+>
+> **Scope decision (open — see Decision Rationale / Revision History):**
+> - **Option α (correctness floor, recommended):** RDR-020 ships the resolver interface, `source = local
+>   member` (A2), the **fail-loud** contract, and a resolver that maps a target bubble to an owning member
+>   *only when that owner is independently known* (single-node/degenerate: the local member owns its
+>   bubbles; or the caller supplies the target node). Where ownership is unknown it **throws** — turning
+>   today's *silent* broken consensus into a *loud, correct* unavailability. The distributed bubble→node
+>   ownership registry is split to a **follow-up RDR** (spatial-partition ↔ membership binding; tied to
+>   `s23eu` partition-fault-tolerance and RDR-003/015). This closes the silent-defect class in
+>   `vhbw3`/`l5c8q` without building a distributed subsystem inside a bug-fix RDR.
+> - **Option β (absorb):** RDR-020 also designs and builds the distributed ownership registry
+>   (range→member assignment kept consistent across view changes). Larger; overlaps unsolved
+>   partition-fault-tolerance work.
 
 Introduce a thin **node-identity resolution boundary** and keep the consensus layer `Digest`-native:
 
@@ -315,3 +340,15 @@ Right-sized as a boundary bug-fix RDR; the one genuinely-open question (A1 owner
 - 2026-06-08: created (draft) — scoped from `vhbw3`+`l5c8q` after seam research; recommends a node-identity
   boundary resolver with fail-loud contract; A1 (ownership sourcing) flagged as the load-bearing
   unverified assumption for `/conexus:rdr-research`.
+- 2026-06-08: **research complete** (Source Search; T2 `Luciferase_rdr/rdr-020/...`, `Luciferase/uuid-digest-mapping-research`).
+  - **A2 VERIFIED** — `View.getNodeId() → Digest` (`View.java:187-189`); source node is free.
+  - **A3 VERIFIED** — proposal node digests used only for null/self-migration/`isNodeInView` checks; vote
+    tally keyed on `proposalId` (`CommitteeBallotBox.java:90-248`); redefining them to owning-node identities
+    is safe with no consensus-logic change.
+  - **A1 REFUTED** — no bubble→node ownership map exists; `TetreeBubbleGrid` keys by `TetreeKey` not member;
+    no range→member assignment anywhere. The resolver's target backing must be built or caller-supplied.
+    **Consequence**: scope fork (Option α correctness-floor + split the distributed ownership registry to a
+    follow-up RDR, vs Option β absorb it). **Recommended: Option α** — closes the silent-broken-consensus
+    defect (`vhbw3`/`l5c8q`) via fail-loud + resolver seam, defers the distributed ownership subsystem
+    (which belongs with `s23eu` / spatial-partition work) to its own RDR. Pending owner decision before
+    `/conexus:rdr-gate`.

--- a/docs/rdr/RDR-020-bubble-to-fireflies-member-digest-resolution.md
+++ b/docs/rdr/RDR-020-bubble-to-fireflies-member-digest-resolution.md
@@ -2,12 +2,12 @@
 title: "Bubble→Fireflies Member Digest Resolution for Migration Consensus"
 id: RDR-020
 type: Bug Fix
-status: draft
+status: accepted
 priority: high
 author: self
 reviewed-by: self
 created: 2026-06-08
-accepted_date:
+accepted_date: 2026-06-08
 related_issues: [Luciferase-vhbw3, Luciferase-l5c8q, Luciferase-0frcy, Luciferase-s23eu]
 ---
 
@@ -125,8 +125,12 @@ wrong link.
   resolver must be *built or supplied by the caller* — it is not a free lookup. This is a scope fork (see
   Revision History 2026-06-08 and the revised Approach).
 - [x] **A2**: This process can obtain its own Fireflies member `Digest` for the source node. — **Status**:
-  **VERIFIED** (Source Search) — `Delos fireflies/View.getNodeId() → Digest` (`View.java:187-189`);
-  `FirefliesMembershipView` holds the `View` (`:65-72`) and can expose it. Source node is free.
+  **VERIFIED** (Source Search; re-confirmed at gate 2026-06-08) — an **exposed accessor already exists**:
+  `FirefliesMemberLookup.getLocalMember() → Member` (`von/FirefliesMemberLookup.java:131-133`, returns
+  `view.getNode()`); `view.getNode().getId()` is the local member `Digest`. No new method on the
+  `MembershipView` interface is required — the resolver is backed by `FirefliesMemberLookup`, not by
+  `MembershipView` (gate C1 corrected: the original RDR named `View.getNodeId()` on `FirefliesMembershipView`,
+  which does **not** expose it; the working seam is `FirefliesMemberLookup.getLocalMember()`). Source node is free.
 - [x] **A3**: `MigrationProposal` node-id semantics are "owning node," and redefining them requires no
   change to the proposal record or vote/quorum logic. — **Status**: **VERIFIED** (Source Search) —
   `sourceNodeId`/`targetNodeId` are read only for null checks, the self-migration check
@@ -140,11 +144,27 @@ wrong link.
   migration. — **Status**: **PARTIAL → resolved by decision** (2026-06-08, Source Search) — Nothing binds a
   bubble to a node today (HRW is free to define ownership; bubbles are position-driven,
   `TetreeBubbleGrid.java:54,241`). BUT `DistributedBubbleNode.initiateRemoteMigration(entityId, targetNodeId)`
-  (`:108-126`) takes an **explicit** target node, which a position-derived owner can contradict.
+  (`:108-126`) takes an **explicit** target **node** UUID, which a position-derived owner can contradict.
   **Decision**: the HRW `owner(targetBubbleKey, view)` is **authoritative**; an explicitly-supplied
   `targetNodeId` is **validated against** it and **fails loud on mismatch** (no silent re-route). This keeps
-  the position-driven model (RDR-015) authoritative and the API as a checked hint. The gate should scrutinize
-  this decision.
+  the position-driven model (RDR-015) authoritative and the API as a checked hint. **Implementability of the
+  comparison is established by B4** (the node-UUID↔member-`Digest` mapping the validation needs already
+  exists). Note this hint path is *secondary*: `initiateRemoteMigration` does not itself reach committee
+  consensus (it calls `initiateOptimisticMigration`, not `requestMigrationApproval`); the two live consensus
+  entry points are **bubble-keyed**, so HRW `owner(bubbleKey)` applies to them directly without any
+  node-UUID comparison.
+- [x] **B4** (gate C2): A network node `UUID` can be mapped back to its Fireflies member `Digest`, so the
+  B1 hint comparison is implementable. — **Status**: **VERIFIED** (gate Source Search, 2026-06-08) — node
+  UUIDs are **canonically** `FirefliesMemberLookup.digestToUuid(member.getId())`: `NodeBootstrap.resolveNodeId`
+  (`von/NodeBootstrap.java:62-74`) is documented as "the canonical member→UUID derivation across the codebase…
+  deterministic across restarts" (WAL directory identity depends on it). The reverse —
+  `FirefliesMemberLookup.getMemberByUuid(UUID)` (`:85-90`) — recovers the `Member` (hence `Digest`) by matching
+  `digestToUuid(m.getId()).equals(uuid)`. So `targetNodeId (UUID) → Digest` is a real, existing lookup; the
+  critic's premise that "no UUID→Digest mapping exists" held only for *bubble* UUIDs, not *node* UUIDs.
+  **Caveat folded in**: `getMemberByUuid` is built on `getActiveMembers()`, which in `FirefliesMemberLookup`
+  is **misnamed** — it delegates to `context.allMembers()`, not `active()`. The resolver MUST perform the
+  in-view determination against the active-only set (RDR-005), so it consults `MembershipView.activeMembers()`
+  / `context.active()` for ownership and never trusts the misnamed accessor's all-members backing.
 - [x] **B2**: View-change ownership rebalancing is acceptable. — **Status**: **VERIFIED** (Source Search) —
   `ViewCommitteeConsensus` checks `proposal.viewId() == currentViewId` at submission (`:182`) and before
   execution (`:223`); `onViewChange()` rolls back all pending proposals (`:252-269`). An in-flight proposal
@@ -174,31 +194,80 @@ wrong link.
 > Considered and not chosen: **Option α** (correctness floor only — resolver + fail-loud, splitting the
 > ownership mechanism to a follow-up RDR). Rejected by owner decision in favor of solving ownership here.
 
+**Two distinct node roles (gate C3 — the load-bearing clarification).** A migration proposal carries two
+node digests that mean *different things*, and conflating them is the original bug:
+
+- **`sourceNodeId` = current holder = local member.** The process that initiates a migration **physically
+  holds** the entity/bubble, so the source is authoritative *by possession*, not by HRW. It is always a
+  current-view member (this process is in its own view), so it always passes `isNodeInView`. This is
+  deliberately **not** `owner(sourceKey)` — "who holds it now" is a different question from "who should own
+  the region," and possession is the correct answer for the source.
+- **`targetNodeId` = intended owner of the destination region = `owner(destinationKey, activeMembers)`** (HRW).
+  HRW **defines** which node should host a region; a migration's purpose is to move the entity to that node.
+
+These two roles also explain the **single-process / single-member case**: with one member, source = local =
+HRW owner of every key = target, so `source == target` and `validateProposal` **rejects it as a
+self-migration** (`ViewCommitteeConsensus.java:365-369`). That is correct, not a gap: a single-node "migration"
+is a *local* move with nothing to vote on, and committee consensus is a **cross-node** mechanism by
+construction. The HRW-owner-vs-physical-host invariant is therefore **maintained, not assumed**: migrations
+route entities *to* their HRW owner, and the partition layer must seed initial placement by the same function
+(see the explicit contract below). The production-live path today is single-process (`s23eu`: not yet
+partition-fault-tolerant, VoN↔membership unwired), where every proposal is a self-migration / local move —
+multi-node correctness is gated on placement honoring HRW, stated as a named dependency rather than silently
+assumed.
+
+> **Placement-honors-HRW contract (C3).** This RDR makes HRW `owner(key, view)` *authoritative for target
+> ownership*. For physical hosting to track ownership at steady state, the partition/placement layer must
+> (a) seed each bubble onto `owner(bubbleKey, view)` at construction and (b) re-home on view change. That
+> placement work is **out of scope here** and belongs with the spatial-partition↔membership binding
+> (`s23eu`, RDR-003/RDR-015 follow-on); this RDR depends on it for multi-node steady-state correctness and
+> records the dependency explicitly. Until it lands, the only live path is the single-member/local case
+> above, which is correct under the self-migration semantics.
+
 Introduce a thin **node-identity resolution boundary** and keep the consensus layer `Digest`-native:
 
-1. **Source node = local member.** For both entry points, the source node digest is this process's own
-   Fireflies member `Digest` (the bubble being migrated currently lives here). Obtain it from the membership
-   view; no per-bubble lookup.
+1. **Source node = local member, always (possession).** For both consensus entry points the source digest is
+   this process's own Fireflies member `Digest` via `FirefliesMemberLookup.getLocalMember().getId()` (A2). The
+   source bubble is locally hosted by construction at both call sites (you only propose topology/migration for
+   bubbles you hold), so there is no "non-local source" path — that ambiguity is removed (gate S4).
 2. **Target node via a `BubbleOwnershipResolver` backed by a deterministic, view-derived owner function.**
    The injected interface `Digest resolveOwningMember(UUID bubbleId)` resolves the bubble's spatial key
    (`bubbleId → TetreeKey`, B3) and computes `owner = assign(spatialKey, view.activeMembers())` where
    `assign` is a **deterministic partition of spatial keys over the current active members** (recommended:
    **rendezvous / highest-random-weight hashing** of `(spatialKey, memberDigest)` — minimal reshuffle on
-   membership change, no coordinator, computable identically on every node). Because the view is the single
-   source of truth and every node holds it, no separate replicated registry or gossip is needed, and
-   ownership rebalances deterministically across view changes.
-3. **HRW owner is authoritative; explicit target is a checked hint (B1).** Where a caller supplies an
-   explicit `targetNodeId` (`DistributedBubbleNode.initiateRemoteMigration`), it is **validated against**
-   `owner(targetBubbleKey, view)` and **throws on mismatch** — never silently re-routed. The position-driven
-   owner (RDR-015) is the source of truth; the explicit parameter is a hint the consensus path verifies.
-4. **Fail loud, never silent.** If the resolver cannot map a bubble to a current-view member, both
-   `toMigrationProposal` and `requestMigrationApproval` **throw** (not produce a silently-rejected proposal
-   and not silently approve) — satisfying the `vhbw3` wave-20 requirement and preserving `l5c8q`'s existing
-   fail-loud stance.
-5. **Delete `digestOf(UUID)`** as a node-id source; it remains valid only where a content-addressed hash of
-   a UUID is genuinely wanted (none in the consensus path).
+   membership change, no coordinator, computable identically on every node). The in-view set is the
+   **active-only** members (`MembershipView.activeMembers()` / `context.active()`), per RDR-005 and the B4
+   caveat — never the misnamed all-members accessor. Because the view is the single source of truth and every
+   node holds it, no separate replicated registry or gossip is needed, and ownership rebalances
+   deterministically across view changes.
+3. **HRW owner is authoritative; an explicit node hint is checked, not trusted (B1/B4).** The two live
+   consensus entry points are **bubble-keyed**, so HRW `owner(bubbleKey)` applies directly with no node-UUID
+   comparison. Separately, where a caller supplies an explicit `targetNodeId` *node UUID*
+   (`DistributedBubbleNode.initiateRemoteMigration`), it is mapped to its member `Digest` via the canonical
+   `FirefliesMemberLookup.getMemberByUuid(targetNodeId)` (B4) and **validated against** the HRW owner of the
+   destination region, **throwing on mismatch** — never silently re-routed. (This path does not itself invoke
+   committee consensus; the validation is a consistency guard wherever the node hint meets the ownership
+   function.)
+4. **Fail loud, never silent.** If the resolver cannot map a bubble to a current-view member (empty active
+   set, or a hint that resolves to no member), both `toMigrationProposal` and `requestMigrationApproval`
+   **throw** (not produce a silently-rejected proposal and not silently approve) — satisfying the `vhbw3`
+   wave-20 requirement and preserving `l5c8q`'s existing fail-loud stance.
+5. **Delete `digestOf(UUID)`** as a node-id source. Confirmed scope (gate S3): `digestOf` is a `private
+   static` method (`:286-288`) with **3 invocations, all inside the single method
+   `TopologyConsensusCoordinator.toMigrationProposal`** (`:274-275`) — a project-wide grep finds no other
+   caller. Deleting it as a node-id source is fully contained to that one class.
+6. **Tighten `isNodeInView` to active-only (re-gate finding).** `ViewCommitteeSelector.isNodeInView`
+   (`consensus/committee/ViewCommitteeSelector.java:82-86`) currently matches against `context.allMembers()`,
+   not `context.active()`. The resolver enforces the active-only set (RDR-005 / B4) for *ownership*, but the
+   *validator* that gates the resolved digest still admits evicted-but-not-GC'd members — the invariant would
+   be enforced at the wrong layer. Change `isNodeInView` to `context.active().anyMatch(...)` in tandem with
+   resolver wiring so target/source in-view checks are active-only end-to-end. Implementation note:
+   `FirefliesMemberLookup.getMemberByUuid` is built on the misnamed all-members `getActiveMembers()`, so it is
+   used **only** for the node-UUID→`Digest` hint mapping (B4) — never for the active-membership ownership set,
+   which comes from `MembershipView.activeMembers()` / `context.active()`.
 
-The consensus records, vote tally, and `isNodeInView` gate are unchanged (A3) — this is a boundary fix.
+The consensus records, vote tally, and `isNodeInView` gate are unchanged (A3) — this is a boundary fix at the
+two entry points plus the new ownership function.
 
 ### Technical Design
 
@@ -209,6 +278,7 @@ Interface (signatures, not implementation):
 interface BubbleOwnershipResolver {
     Digest resolveOwningMember(UUID bubbleId);   // throws IllegalStateException if no current-view owner
     Digest localMember();                         // this process's own member Digest (source node)
+    Digest memberDigestForNode(UUID nodeId);      // canonical node-UUID -> member Digest (B4); throws if unknown
 }
 
 // Deterministic, view-derived ownership — pure function, identical on every node.
@@ -218,30 +288,44 @@ interface SpatialOwnershipFunction {
 }
 ```
 
-- `BubbleOwnershipResolver` resolves `bubbleId → TetreeKey` (B3), reads `view.activeMembers()` (RDR-005),
-  and returns `SpatialOwnershipFunction.owner(key, members)`; throws if the result is not a current-view
-  member (e.g. empty view) — fail-loud, never a silently-rejectable digest.
-- `localMember()` returns `View.getNodeId()` (A2).
+- The resolver depends on its **own small port** (the three methods above), not on the `MembershipView`
+  interface — so no contract surgery to `MembershipView`/`MockFirefliesView` is needed (gate C1). It has two
+  implementations: a production one over `FirefliesMemberLookup` (which already exposes `getLocalMember()`,
+  the active-member set, and `getMemberByUuid`), and a test double seeded with known member digests + a
+  fixed key→member map for deterministic HRW-convergence tests.
+- `resolveOwningMember` resolves `bubbleId → TetreeKey` (B3), reads the **active** members (RDR-005 / B4 —
+  the active-only set, not the misnamed `getActiveMembers()` all-members backing), and returns
+  `SpatialOwnershipFunction.owner(key, members)`; throws if the result is not a current-view member (e.g.
+  empty view) — fail-loud, never a silently-rejectable digest.
+- `localMember()` returns `FirefliesMemberLookup.getLocalMember().getId()` (A2) — an existing accessor.
+- `memberDigestForNode(nodeId)` is `getMemberByUuid(nodeId).map(Member::getId)`, throwing if absent (B4);
+  used only to validate an explicit node-UUID hint.
 - **Ownership is not stored.** It is recomputed from the view at proposal time; a view change recomputes it.
   In-flight proposals carrying a now-stale owner are rejected by `isNodeInView` (visible), not mis-routed.
 
-- `TopologyConsensusCoordinator.toMigrationProposal(...)`: `sourceNodeId = resolver.localMember()` (or the
-  owner of the source bubble when not local), `targetNodeId = resolver.resolveOwningMember(targetBubble)`;
-  throw on unresolved.
-- `OptimisticMigratorImpl.requestMigrationApproval(entityId, targetBubble)`: resolve `sourceId`/`targetNodeId`
-  via the resolver, then delegate to `OptimisticMigratorIntegration.requestMigrationApproval(entityId,
-  sourceId, targetNodeId)`. Remove the `UnsupportedOperationException` once the resolver is injected.
-- The resolver must use `activeMembers()` (not `allMembers()`) for the in-view determination (RDR-005).
+- `TopologyConsensusCoordinator.toMigrationProposal(...)`: `sourceNodeId = resolver.localMember()` (the
+  source bubble is locally hosted by construction — no non-local-source path, gate S4),
+  `targetNodeId = resolver.resolveOwningMember(targetBubble)`; throw on unresolved. Delete `digestOf` (S3).
+- `OptimisticMigratorImpl.requestMigrationApproval(entityId, targetBubble)`: note `targetBubble` is a
+  **bubble** UUID, so `targetNodeId = resolver.resolveOwningMember(targetBubble)` (HRW direct — no node-UUID
+  lookup here); `sourceId = resolver.localMember()`. Then delegate to
+  `OptimisticMigratorIntegration.requestMigrationApproval(entityId, sourceId, targetNodeId)` and remove the
+  `UnsupportedOperationException` (`OptimisticMigratorImpl.java:135-141`) once the resolver is injected.
+- **Hot-path index (gate S1).** `resolveOwningMember` calls `TetreeBubbleGrid.getKeyForBubble(UUID)`, which is
+  an **O(N) linear scan** of `bubblesByKey` (`TetreeBubbleGrid.java:641-650`) — run on every proposal.
+  Add an inverse `ConcurrentHashMap<UUID, TetreeKey>` maintained in the grid's add/remove paths so the lookup
+  is O(1); the scan is acceptable only for the single-bubble fixtures, not at cluster scale.
 
 ### Existing Infrastructure Audit
 
 | Proposed Component | Existing Module | Decision |
 | --- | --- | --- |
-| `BubbleOwnershipResolver` | `von/FirefliesMemberLookup` | Extend or wrap: reuse its member-index access; add the forward bubble→member direction (the existing `digestToUuid` is reverse-only and assumes Digest-derived UUIDs). |
-| Source-node = local member | `FirefliesMembershipView` / `View.getNodeId()` | Reuse: expose the local-member accessor (A2). |
+| `BubbleOwnershipResolver` (resolver port) | `von/FirefliesMemberLookup` | Wrap: it already exposes `getLocalMember()`, the member set, and `getMemberByUuid` — the resolver owns a 3-method port over it; no `MembershipView` change (gate C1). |
+| Source-node = local member | `FirefliesMemberLookup.getLocalMember()` (`:131-133`, → `view.getNode()`) | Reuse the **existing** accessor (A2). The original `FirefliesMembershipView`/`View.getNodeId()` path was wrong — corrected. |
+| Node `UUID` → member `Digest` (hint check) | `FirefliesMemberLookup.getMemberByUuid` + `NodeBootstrap.resolveNodeId` | Reuse: node UUIDs are canonically `digestToUuid(memberId)`, so the reverse lookup exists (B4, gate C2). |
 | `SpatialOwnershipFunction` (rendezvous/HRW) | — (none exists; A1 refuted) | New: deterministic view-derived owner; no replicated state. |
-| bubble `UUID` → `TetreeKey` | `TetreeBubbleGrid` | Reuse/extend per B3. |
-| `digestOf(UUID)` node-id | `TopologyConsensusCoordinator` | Replace: delete as a node-id source. |
+| bubble `UUID` → `TetreeKey` | `TetreeBubbleGrid.getKeyForBubble` (`:641-650`) | Reuse per B3; add an O(1) inverse index (gate S1, currently an O(N) scan). |
+| `digestOf(UUID)` node-id | `TopologyConsensusCoordinator` | Replace: delete (2 call sites, `private static`, no other caller — gate S3). |
 
 ### Decision Rationale
 
@@ -301,8 +385,9 @@ independent of position).
 - (+) Fail-loud everywhere — no silent approve (`l5c8q`) and no silently-rejected proposal (`vhbw3`).
 - (−) Introduces a node-identity dependency the single-process fixtures did not need; multi-node tests
   require real/mock membership wiring.
-- (−) Couples migration consensus to the spatial-partition↔membership mapping (A1), which may need its own
-  follow-up if ownership is dynamic.
+- (−) Multi-node *steady-state* correctness depends on the partition layer seeding/re-homing physical
+  placement by the same HRW function (the placement-honors-HRW contract, `s23eu`/RDR-015 follow-on). Named as
+  a dependency; the consensus-record correctness (source = possession, target = HRW owner) does not wait on it.
 
 ### Risks and Mitigations
 
@@ -310,8 +395,13 @@ independent of position).
   **Mitigation**: Resolve against the current view at proposal time; the node-in-view gate rejects
   stale digests; fail-loud surfaces it rather than mis-routing.
 - **Risk**: A1 has no deterministic partition→member map, forcing a gossiped registry (larger scope).
-  **Mitigation**: Verify A1 in research before locking; if a registry is required, scope it explicitly or
-  split it to a follow-up RDR.
+  **Mitigation**: **Resolved** — Option β supplies a deterministic view-derived HRW function, no registry.
+- **Risk** (gate C3): HRW ownership and physical bubble placement diverge, so a resolved digest names a node
+  that does not host the bubble. **Mitigation**: the two node roles are defined to make this benign for the
+  consensus *records* (source = possession, always in-view; target = HRW owner, the migration destination by
+  definition); steady-state physical alignment is a named **placement-honors-HRW contract** owned by the
+  partition layer (`s23eu`/RDR-015 follow-on), not assumed here. The only live path until then is the
+  single-member/local case, which is correct under self-migration semantics.
 
 ### Failure Modes
 
@@ -327,18 +417,28 @@ independent of position).
 
 ### Minimum Viable Validation
 
-An integration test with a real (or mock) multi-member `ViewCommitteeConsensus`: a migration whose target
-bubble is owned by a current-view member produces a proposal that **passes** `validateProposal` and reaches
-quorum; a migration whose target cannot be resolved **throws** (fail-loud) — proving the gap is closed in
-both directions, not mocked away.
+An integration test with a real (or mock) **≥2-member** `ViewCommitteeConsensus`: a migration whose target
+bubble is owned by a *different* current-view member produces a proposal that **passes** `validateProposal`
+and reaches quorum; a migration whose target cannot be resolved **throws** (fail-loud) — proving the gap is
+closed in both directions, not mocked away. The MVV must also assert **HRW convergence** (two resolver
+instances on the same view agree on `owner(K)`); single-member self-migration rejection is a unit-level
+companion check.
 
 ### Phase 1: Code Implementation
 
-#### Step 1: Resolver interface + membership-backed implementation (A1/A2)
+#### Step 1: `SpatialOwnershipFunction` (rendezvous/HRW) + `BubbleOwnershipResolver` port over `FirefliesMemberLookup` (A2/B3/B4), plus the test double
 
-#### Step 2: Wire `toMigrationProposal` and `requestMigrationApproval` to the resolver; delete `digestOf` as a node-id source; fail-loud on unresolved
+#### Step 2: Add the O(1) inverse `UUID → TetreeKey` index to `TetreeBubbleGrid` add/remove paths (gate S1)
 
-#### Step 3: Remove the `UnsupportedOperationException` gate in `OptimisticMigratorImpl` once the resolver is injected
+#### Step 3: Wire `toMigrationProposal` (source = `localMember()`, target = `resolveOwningMember`) and delete `digestOf` (gate S3); fail-loud on unresolved
+
+#### Step 4: Wire `OptimisticMigratorImpl.requestMigrationApproval` to the resolver (target bubble → HRW; source = local) and remove the `UnsupportedOperationException` gate
+
+#### Step 5: Add the explicit node-UUID hint validation in `DistributedBubbleNode.initiateRemoteMigration` via `memberDigestForNode` (B1/B4), throw on mismatch
+
+#### Step 6: Change `ViewCommitteeSelector.isNodeInView` to match `context.active()` (not `allMembers()`) so the active-only invariant is enforced at the validator too (re-gate finding)
+
+#### Step 7: Update the test callers that pass random node UUIDs (see Test Plan / observation) so they use canonical (`digestToUuid`-derived) node identities or assert the fail-loud path
 
 ### New Dependencies
 
@@ -346,14 +446,23 @@ None anticipated (reuses Delos membership already on the classpath).
 
 ## Test Plan
 
-- **Scenario**: Target bubble owned by a current-view member — **Verify**: proposal passes
-  `validateProposal`, reaches quorum (not mocked).
+- **Scenario**: Target bubble owned by a *different* current-view member (≥2-member view) — **Verify**:
+  proposal passes `validateProposal`, reaches quorum (not mocked).
+- **Scenario** (gate S2 — HRW convergence): two `SpatialOwnershipFunction`/resolver instances seeded from the
+  **same** active-member set independently compute `owner(K, members)` for the same key — **Verify**: they
+  return the **identical** member `Digest`. This is the property that makes the view-derived function a valid
+  substitute for a replicated registry; without it Option β is unfounded.
+- **Scenario** (single-member / local move): a one-member view yields `source == target` — **Verify**:
+  `validateProposal` rejects it as a self-migration (`:365`), confirming committee consensus is cross-node
+  only and the single-process live path is correct, not silently broken.
 - **Scenario**: Target bubble unresolvable to any current-view member — **Verify**: `toMigrationProposal` and
   `requestMigrationApproval` throw (fail-loud), no silent approve, no silently-rejected proposal.
-- **Scenario**: Resolver uses `activeMembers()` not `allMembers()` — **Verify**: an evicted member is not a
-  valid owner (RDR-005).
+- **Scenario** (gate C2/B1): explicit `targetNodeId` node hint that disagrees with `owner(destKey)` —
+  **Verify**: `initiateRemoteMigration` throws on mismatch; a hint that *agrees* passes.
+- **Scenario**: Resolver uses the **active-only** set (not the misnamed all-members backing) — **Verify**: an
+  evicted-but-not-GC'd member is not a valid owner (RDR-005 / B4).
 - **Scenario**: Source node defaults to local member for a locally-owned bubble — **Verify**: source digest
-  equals this process's member id.
+  equals this process's member id (`getLocalMember().getId()`).
 
 ## Validation
 
@@ -366,26 +475,47 @@ mock membership view containing known member digests; assert validity, quorum, a
 
 ### Contradiction Check
 
-[To complete at gate.]
+No internal contradiction after the C3 clarification: `sourceNodeId` (possession/local) and `targetNodeId`
+(HRW owner) are defined as distinct notions, so "source = local" and "target = HRW owner" do not compete.
+The B1 explicit-hint path is consistent with HRW authority (hint is *validated against* HRW, never overrides
+it). No contradiction with RDR-015's position-driven model: HRW is the *target-ownership* authority and the
+partition layer is required to seed placement by it (stated as a dependency, not assumed satisfied).
 
 ### Assumption Verification
 
-A1/A2/A3 to be verified by source search during `/conexus:rdr-research` before acceptance.
+A1 (refuted — drives Option β), A2/A3 (verified), B1 (resolved by decision), B2/B3 (verified), B4 (verified at
+gate — the node-UUID↔Digest mapping the B1 hint needs already exists). Each carries an explicit status and
+risk note in §Research Findings.
 
 ### Scope Verification
 
-[To complete at gate — confirm MVV (live-committee pass + fail-loud throw) is in scope, not deferred.]
+In scope and not deferred: resolver + HRW function + both consensus entry points + fail-loud throws + the MVV
+(≥2-member live-committee pass, fail-loud throw, **HRW convergence**, single-member self-migration). Honestly
+**out of scope and named**: the placement-honors-HRW physical re-homing (partition layer, `s23eu`/RDR-015
+follow-on) on which multi-node *steady-state* correctness depends — this is a declared dependency, not a
+silent reduction.
 
 ### Cross-Cutting Concerns
 
 - **Versioning**: N/A (no wire-format change; `MigrationProposal` unchanged).
 - **Secret/credential lifecycle**: N/A (uses existing Fireflies identities).
 - **Incremental adoption**: resolver is injected; fail-loud preserves current behavior until wired.
+- **Test-caller impact (gate observation)**: `PerformanceResilienceValidationTest` (9 `initiateRemoteMigration`
+  call sites passing random `UUID` targets) and similar will hit the new throw-on-mismatch once the hint
+  validation lands, because random UUIDs are not `digestToUuid`-derived and resolve to no member. Step 6
+  updates these callers to canonical node identities or re-points them at the fail-loud assertion — planned,
+  not incidental breakage.
 - Others: N/A.
 
 ### Proportionality
 
-Right-sized as a boundary bug-fix RDR; the one genuinely-open question (A1 ownership sourcing) is isolated.
+Honestly framed as a **boundary fix + a small ownership primitive** (not a pure one-line bug fix): the
+`digestOf` deletion and the two-entry-point rewiring are the boundary fix; the deterministic HRW
+`SpatialOwnershipFunction` is a genuinely new (but self-contained, stateless, ~one-function) mechanism the
+A1 refutation forced. It is *not* a distributed subsystem — no replicated state, no consistency protocol,
+no convergence concern — because ownership is a pure function of state every node already holds. The one
+larger thing it touches (physical placement honoring HRW) is explicitly pushed to the partition layer rather
+than absorbed here.
 
 ## References
 
@@ -418,6 +548,21 @@ Right-sized as a boundary bug-fix RDR; the one genuinely-open question (A1 owner
   bubble placement/migration model), **B2** (view-change rebalancing acceptable), **B3** (bubble→`TetreeKey`
   resolvable) — all Unverified, to be checked in a second `/conexus:rdr-research` pass before the gate.
   Gossiped registry retained as Alternative 2.
+- 2026-06-08: **gate BLOCKED then remediated** (substantive-critic, 3 Critical / 4 Significant). All addressed
+  with code-grounded evidence: **C1** — A2's exposure path corrected (`FirefliesMemberLookup.getLocalMember()`
+  already exists; resolver owns a 3-method port, no `MembershipView` surgery). **C2** — added **B4**: node
+  UUIDs are canonically `digestToUuid(memberId)` (`NodeBootstrap.resolveNodeId`), so `getMemberByUuid` is the
+  UUID→`Digest` mapping the B1 hint needs; critic's "no mapping" held only for *bubble* UUIDs. **C3** — defined
+  the two node roles (source = possession/local, target = HRW owner); self-migration reject (`:365`) makes the
+  single-member live path correct, and physical placement honoring HRW is a *named* partition-layer contract
+  (`s23eu`), not a silent assumption. **S1** O(1) inverse `UUID→TetreeKey` index added to the plan; **S2** HRW
+  convergence test added to MVV; **S3** `digestOf` deletion scope enumerated (2 sites, one class); **S4**
+  non-local-source path removed (source = local, always). Test-caller impact (random-UUID migrations) folded
+  into the plan as Step 7.
+- 2026-06-08: **re-gate PASSED** (substantive-critic; 0 Critical, 2 implementation-scoped Significant). Folded
+  in: `ViewCommitteeSelector.isNodeInView` uses `allMembers()` not `active()` — the active-only RDR-005
+  invariant must also be enforced at the validator (new Step 6 / Approach item 6); and the `digestOf` scope
+  count corrected to "3 invocations in one method." No design changes required.
 - 2026-06-08: **research pass 2** (Source Search; T2 `Luciferase_rdr/020-research-2`). **B2 VERIFIED**
   (`viewId` check at submission `:182` + pre-execution `:223`; `onViewChange` rolls back pending `:252-269`).
   **B3 VERIFIED** (`TetreeBubbleGrid.getKeyForBubble(UUID)` `:641-650`, already used by topology ops).

--- a/docs/rdr/RDR-020-bubble-to-fireflies-member-digest-resolution.md
+++ b/docs/rdr/RDR-020-bubble-to-fireflies-member-digest-resolution.md
@@ -2,12 +2,13 @@
 title: "Bubble→Fireflies Member Digest Resolution for Migration Consensus"
 id: RDR-020
 type: Bug Fix
-status: accepted
+status: implemented
 priority: high
 author: self
 reviewed-by: self
 created: 2026-06-08
 accepted_date: 2026-06-08
+closed_date: 2026-06-09
 related_issues: [Luciferase-vhbw3, Luciferase-l5c8q, Luciferase-0frcy, Luciferase-s23eu]
 ---
 
@@ -662,3 +663,25 @@ than absorbed here.
   target, which a position-derived owner can contradict. **Decision**: HRW `owner(targetBubbleKey, view)` is
   authoritative; an explicit `targetNodeId` is validated against it and **fails loud on mismatch**. All
   assumptions now resolved; ready for `/conexus:rdr-gate` (which should scrutinize the B1 decision).
+- 2026-06-09: **IMPLEMENTED** — full Phase-1 arc shipped on `feature/rdr-020-scope` and validated.
+  Steps: S1 view-derived HRW resolver (`Luciferase-bucvb`), S2 O(1) inverse index (`epihi`), S3 TOPOLOGY
+  `ProposalKind` + coordinator wiring / `digestOf` deleted (`e8gl4`), S4 `OptimisticMigratorImpl` wiring /
+  UOE removed (`jf7u6`), S5 node-UUID hint validation + `isActiveMember` (`kcgj1`), S6 `isNodeInView`
+  active-only (`i4prr`), S7 opt-in-contract pin (`h3lc6`), MVV end-to-end integration (`u911y`), holistic
+  phase-boundary review (`05ms3`). External Gap bugs closed: `vhbw3` (Gap 2), `l5c8q` (Gap 3).
+  Every increment passed stacked review (code-review-expert + substantive-critic); phase-review-gate PASSED
+  (9/9 §Approach items); full simulation suite 3241 tests green.
+  **Key divergences from the original design** (all gated/tracked): (1) the single-region TOPOLOGY
+  node-identity model (S3 amendment) — `source == target == owner(region)`, self-migration reject skipped
+  only for TOPOLOGY. (2) `BubbleOwnershipResolver` gained a 4th method `isActiveMember` (S5) — the spec's
+  3-method sketch understated it; `memberDigestForNode` resolves over all-members (B4) so the hint guard
+  needs a separate active check. (3) S6's active-only invariant covers source/target identity at the
+  validator; the committee-*composition* active-only gap (offline member voting) was closed separately at
+  vote-receipt (`yagnw.1` → `CommitteeVotingProtocol.recordVote` drops inactive votes), the safety-
+  conservative option that fixes the quorum denominator at the original committee size.
+  **Named deferrals (out of scope, tracked):** placement-honors-HRW partition seeding and production
+  resolver wiring → `s23eu` (multi-node bootstrap); cross-region merge → fail-loud guard (two-node merge
+  protocol later); committee-resizing-under-churn liveness → `Luciferase-0frcy.134`; pre-existing
+  `TetreeBubbleGrid` dual-map atomicity → tracked under `0frcy`. The live path is single-process
+  (`s23eu` unwired), where every proposal is a correctly-rejected self-migration — correct today, not by
+  coincidence. Post-mortem: `docs/rdr/post-mortem/020-bubble-to-fireflies-member-digest-resolution.md`.

--- a/docs/rdr/RDR-020-bubble-to-fireflies-member-digest-resolution.md
+++ b/docs/rdr/RDR-020-bubble-to-fireflies-member-digest-resolution.md
@@ -52,6 +52,18 @@ whose node digests are genuine members of the current view — or **fail loud** 
 per the wave-20 review note on `vhbw3` (a membership-enforcing consensus must never be handed a
 silently-rejectable proposal).
 
+**Amendment (2026-06-08, S3 implementation finding) — topology proposals are single-region, not
+entity migrations.** A second collision surfaces once the digests are real: a split/merge/move/collapse
+restructures bubbles the proposing node already hosts, so the HRW owner of the affected region *is* the
+local member (always single-node; and at steady state whenever placement honors HRW). The entity-migration
+mapping (`source = localMember`, `target = owner(affectedBubble)`) then yields `source == target`, which
+`validateProposal` **rejects as a self-migration** (`:365-369`) — so the topology change never executes.
+Unlike an entity staying put (a genuine no-op, correctly rejected, §Approach), a topology change is **not**
+a no-op and must execute even single-node. Topology consensus therefore needs a **topology-aware validity
+path**: the proposal's single owning node must be in-view, but the self-migration check must not apply. The
+original RDR's A3 "no consensus-record change" held for the entity-migration path only; topology requires a
+proposal-kind discriminator (see Technical Design → Topology proposal node-identity model).
+
 #### Gap 3: Migrator consensus delegation is unavailable
 
 `OptimisticMigratorImpl.requestMigrationApproval` (`OptimisticMigratorImpl.java:125-149`) correctly throws
@@ -266,8 +278,50 @@ Introduce a thin **node-identity resolution boundary** and keep the consensus la
    used **only** for the node-UUID→`Digest` hint mapping (B4) — never for the active-membership ownership set,
    which comes from `MembershipView.activeMembers()` / `context.active()`.
 
-The consensus records, vote tally, and `isNodeInView` gate are unchanged (A3) — this is a boundary fix at the
-two entry points plus the new ownership function.
+The vote tally (keyed on `proposalId`, A3) and the `isNodeInView` gate are unchanged. The consensus *record*
+gains one back-compatible discriminator field for the entity-migration-vs-topology distinction (see below);
+the entity-migration path (S4/S5) is otherwise a pure boundary fix.
+
+#### Topology proposal node-identity model (S3 amendment, 2026-06-08)
+
+Topology proposals are single-region structural changes, so they cannot use the two-distinct-node migration
+shape. Model them as **single-owner**:
+
+1. `ownerNode = resolver.resolveOwningMember(primaryAffectedBubble)` — the HRW owner of the region being
+   restructured (primary bubble per `getAffectedBubbles`: split→`sourceBubble`, merge→`bubble1`,
+   move→`sourceBubble`, collapse→`anchorChild`).
+   - **Cross-region merge guard (gate finding).** `MergeProposal` is the one two-bubble case
+     (`bubble1`, `bubble2`); the others are genuinely single-region. A merge whose two bubbles fall in
+     different HRW regions has **two** owners, which the single-owner model cannot represent. `toMigrationProposal`
+     therefore asserts `resolver.resolveOwningMember(bubble1).equals(resolver.resolveOwningMember(bubble2))`
+     for merges and **throws (fail-loud) `IllegalStateException("cross-region merge not yet supported")`**
+     on mismatch — a cross-region merge needs a two-node merge protocol that is **explicitly out of scope**
+     here (named boundary, alongside the placement-honors-HRW contract; `s23eu`/RDR-015 follow-on). Same-owner
+     merges use the single-owner model normally. On the single-process live path both bubbles share the one
+     local owner, so the guard is a no-op there.
+2. **Fail-loud ownership guard**: assert `resolver.localMember().equals(ownerNode)` — a node may only propose
+   topology changes for a region it owns; throw (IllegalStateException) otherwise. This both gives the
+   proposal a meaningful, in-view source identity and prevents a node from restructuring another node's
+   region (a safety property the old `digestOf` hash silently lacked).
+3. Build `MigrationProposal(proposalId, entityId=primaryBubble, sourceNodeId=ownerNode,
+   targetNodeId=ownerNode, viewId, timestamp, kind=TOPOLOGY)`.
+4. **`MigrationProposal` gains `ProposalKind kind` (ENTITY_MIGRATION | TOPOLOGY)** as a trailing field, with
+   a back-compatible secondary constructor defaulting to `ENTITY_MIGRATION` so the ~70 existing construction
+   sites (entity-migration + tests) are untouched. `validateProposal` branches: TOPOLOGY proposals carry a
+   real (non-null) `viewId` exactly like entity migrations — the null-viewId reject and `isNodeInView(ownerNode)`
+   (active-only after S6) gates apply unchanged; the **only** difference is that the self-migration reject
+   (`:365`) is **skipped** for TOPOLOGY. ENTITY_MIGRATION is fully unchanged (self-migration reject retained).
+5. **`kind` on the wire is correctness-critical, not hygiene (gate finding).** `validateProposal` runs on
+   **every committee member that receives the proposal**, not just the proposer: `CommitteeServiceImpl`
+   (remote receipt) calls `fromProto` then `consensus.requestConsensus(...)` → `validateProposal`
+   (`ViewCommitteeConsensus.java:175`). So `kind` must be serialized — one optional `kind` enum field on
+   `CommitteeMigrationProposal` (default `ENTITY_MIGRATION`), `CommitteeProtoConverter` maps both ways. **Mixed-version
+   contract**: a committee member running pre-amendment code has no `kind` field → defaults to ENTITY_MIGRATION
+   → self-migration-rejects any TOPOLOGY proposal. **Therefore TOPOLOGY consensus requires all committee
+   members to run amended code**; until the cluster is fully upgraded a TOPOLOGY proposal cannot reach quorum.
+   This is acceptable because the live path today is single-process (`s23eu` multi-node unwired) where the
+   proposer is the only validator; the upgrade contract is documented as a named multi-node prerequisite. The
+   Test Plan adds a mixed-version scenario (old-default node rejects TOPOLOGY) so the limit is asserted, not implicit.
 
 ### Technical Design
 
@@ -303,9 +357,9 @@ interface SpatialOwnershipFunction {
 - **Ownership is not stored.** It is recomputed from the view at proposal time; a view change recomputes it.
   In-flight proposals carrying a now-stale owner are rejected by `isNodeInView` (visible), not mis-routed.
 
-- `TopologyConsensusCoordinator.toMigrationProposal(...)`: `sourceNodeId = resolver.localMember()` (the
-  source bubble is locally hosted by construction — no non-local-source path, gate S4),
-  `targetNodeId = resolver.resolveOwningMember(targetBubble)`; throw on unresolved. Delete `digestOf` (S3).
+- `TopologyConsensusCoordinator.toMigrationProposal(...)`: builds a **TOPOLOGY-kind** proposal per the
+  Topology proposal node-identity model below (single owning node, `source == target == owner(region)`);
+  throw on unresolved. Delete `digestOf` (S3).
 - `OptimisticMigratorImpl.requestMigrationApproval(entityId, targetBubble)`: note `targetBubble` is a
   **bubble** UUID, so `targetNodeId = resolver.resolveOwningMember(targetBubble)` (HRW direct — no node-UUID
   lookup here); `sourceId = resolver.localMember()`. Then delegate to
@@ -457,6 +511,19 @@ None anticipated (reuses Delos membership already on the classpath).
   only and the single-process live path is correct, not silently broken.
 - **Scenario**: Target bubble unresolvable to any current-view member — **Verify**: `toMigrationProposal` and
   `requestMigrationApproval` throw (fail-loud), no silent approve, no silently-rejected proposal.
+- **Scenario** (S3 topology, single-node): a TOPOLOGY proposal where `source == target == owner(region)` —
+  **Verify**: passes `validateProposal` against a real committee (NOT self-migration-rejected) and reaches
+  agreement; the same proposal as `ENTITY_MIGRATION` kind IS rejected (proves the discriminator is load-bearing).
+- **Scenario** (S3 topology, non-owner proposer): local member ≠ `owner(primaryAffectedBubble)` —
+  **Verify**: `toMigrationProposal` throws (fail-loud ownership guard), no off-region proposal is emitted.
+- **Scenario** (S3 cross-region merge): a `MergeProposal` whose `bubble1`/`bubble2` resolve to **different**
+  owners — **Verify**: `toMigrationProposal` throws `IllegalStateException("cross-region merge not yet supported")`
+  (fail-loud), no proposal emitted; a same-owner merge succeeds.
+- **Scenario** (S3 wire): a TOPOLOGY `MigrationProposal` round-trips through `CommitteeProtoConverter`
+  preserving `kind`; a proto with no `kind` field deserializes as `ENTITY_MIGRATION` (back-compat).
+- **Scenario** (S3 mixed-version): a committee member validating a TOPOLOGY proposal as `ENTITY_MIGRATION`
+  (the old-code/default-kind path) self-migration-rejects it — **Verify**: documents/asserts that TOPOLOGY
+  consensus requires all members on amended code (the upgrade contract), so the limit is explicit not silent.
 - **Scenario** (gate C2/B1): explicit `targetNodeId` node hint that disagrees with `owner(destKey)` —
   **Verify**: `initiateRemoteMigration` throws on mismatch; a hint that *agrees* passes.
 - **Scenario**: Resolver uses the **active-only** set (not the misnamed all-members backing) — **Verify**: an
@@ -497,7 +564,13 @@ silent reduction.
 
 ### Cross-Cutting Concerns
 
-- **Versioning**: N/A (no wire-format change; `MigrationProposal` unchanged).
+- **Versioning**: `MigrationProposal` and `CommitteeMigrationProposal` (proto) gain one **optional** `kind`
+  field defaulting to `ENTITY_MIGRATION` (S3 amendment). Wire-compatible at the encoding level (old peer omits
+  the field; new peer reads the default), but **semantically the field is load-bearing for remote validity**:
+  committee members re-validate received proposals (`CommitteeServiceImpl` → `validateProposal`), so a member
+  on pre-amendment code defaults a TOPOLOGY proposal to ENTITY_MIGRATION and self-migration-rejects it. Hence
+  the documented **upgrade contract**: TOPOLOGY consensus requires all committee members on amended code;
+  ENTITY_MIGRATION is fully back-compatible. Existing construction sites use the back-compat secondary constructor.
 - **Secret/credential lifecycle**: N/A (uses existing Fireflies identities).
 - **Incremental adoption**: resolver is injected; fail-loud preserves current behavior until wired.
 - **Test-caller impact (gate observation)**: `PerformanceResilienceValidationTest` (9 `initiateRemoteMigration`
@@ -559,6 +632,22 @@ than absorbed here.
   convergence test added to MVV; **S3** `digestOf` deletion scope enumerated (2 sites, one class); **S4**
   non-local-source path removed (source = local, always). Test-caller impact (random-UUID migrations) folded
   into the plan as Step 7.
+- 2026-06-08: **S3 amendment — topology proposal node-identity model** (surfaced during S1/S2 implementation,
+  owner chose "amend + topology-aware validity"). Finding: topology proposals (split/merge/move/collapse) are
+  single-region structural changes, so `source == target == owner(region)` and `validateProposal`'s
+  self-migration reject (`:365`) would block every real-committee topology change — the entity-migration
+  mapping does not fit. Resolution: model topology as single-owner (`source == target == owner`), add a
+  fail-loud ownership guard (proposer must own the region), and a `MigrationProposal.kind`
+  (ENTITY_MIGRATION | TOPOLOGY) discriminator — back-compatible (default ENTITY_MIGRATION, ~70 sites
+  untouched; one optional proto field) — with `validateProposal` skipping the self-migration check for
+  TOPOLOGY only. Entity-migration path (S4/S5) unaffected. Bead `Luciferase-e8gl4` scope widened to include
+  `MigrationProposal` + `ViewCommitteeConsensus.validateProposal` + `CommitteeProtoConverter`.
+  **Amendment gate (substantive-critic) BLOCKED v1 (2 critical), fixed:** (C1) `validateProposal` is NOT
+  proposer-local — `CommitteeServiceImpl` re-validates on remote receipt, so `kind` is correctness-critical on
+  the wire and a mixed-version cluster self-migration-rejects TOPOLOGY on old nodes → documented upgrade
+  contract + mixed-version test scenario. (C2) `MergeProposal` is two-bubble; single-owner silently
+  restructures a second region → added fail-loud cross-region merge guard (`owner(bubble1)==owner(bubble2)`,
+  else throw; cross-region merge protocol out of scope). Garbled "null-viewId" wording corrected.
 - 2026-06-08: **re-gate PASSED** (substantive-critic; 0 Critical, 2 implementation-scoped Significant). Folded
   in: `ViewCommitteeSelector.isNodeInView` uses `allMembers()` not `active()` — the active-only RDR-005
   invariant must also be enforced at the validator (new Step 6 / Approach item 6); and the `digestOf` scope

--- a/docs/rdr/RDR-020-bubble-to-fireflies-member-digest-resolution.md
+++ b/docs/rdr/RDR-020-bubble-to-fireflies-member-digest-resolution.md
@@ -136,16 +136,23 @@ wrong link.
 
 **Option β — new assumptions introduced by the deterministic ownership function (verify before accept):**
 
-- [ ] **B1**: A deterministic `owner(spatialKey, activeMembers)` assignment (rendezvous/HRW hashing) is
-  compatible with how bubbles are placed and migrated — nothing else already binds a bubble to a node by a
-  rule this would contradict. — **Status**: Unverified — **Method**: Source Search (`TetreeBubbleGrid`
-  placement; `DistributedBubbleNode` target selection).
-- [ ] **B2**: View-change ownership rebalancing is acceptable for migration semantics — a region's owner
-  changing on membership change does not corrupt an in-flight migration beyond what the `isNodeInView`
-  fail-loud reject already handles. — **Status**: Unverified — **Method**: Source Search / reasoning against
-  the `ViewCommitteeConsensus` proposal lifecycle + view-change handling.
-- [ ] **B3**: A bubble `UUID` resolves to its `TetreeKey` at proposal time. — **Status**: Unverified —
-  **Method**: Source Search (`TetreeBubbleGrid`/`Bubble` → key accessor).
+- [x] **B1**: A deterministic `owner(spatialKey, activeMembers)` is compatible with bubble placement/
+  migration. — **Status**: **PARTIAL → resolved by decision** (2026-06-08, Source Search) — Nothing binds a
+  bubble to a node today (HRW is free to define ownership; bubbles are position-driven,
+  `TetreeBubbleGrid.java:54,241`). BUT `DistributedBubbleNode.initiateRemoteMigration(entityId, targetNodeId)`
+  (`:108-126`) takes an **explicit** target node, which a position-derived owner can contradict.
+  **Decision**: the HRW `owner(targetBubbleKey, view)` is **authoritative**; an explicitly-supplied
+  `targetNodeId` is **validated against** it and **fails loud on mismatch** (no silent re-route). This keeps
+  the position-driven model (RDR-015) authoritative and the API as a checked hint. The gate should scrutinize
+  this decision.
+- [x] **B2**: View-change ownership rebalancing is acceptable. — **Status**: **VERIFIED** (Source Search) —
+  `ViewCommitteeConsensus` checks `proposal.viewId() == currentViewId` at submission (`:182`) and before
+  execution (`:223`); `onViewChange()` rolls back all pending proposals (`:252-269`). An in-flight proposal
+  whose owner changed is invalidated by its own view-binding — recomputed ownership on the new view is
+  consistent; worst case is a visible fail-loud reject, never a mis-route.
+- [x] **B3**: A bubble `UUID` resolves to its `TetreeKey` at proposal time. — **Status**: **VERIFIED**
+  (Source Search) — `TetreeBubbleGrid.getKeyForBubble(UUID)` (`:641-650`) already exists and is used by
+  `BubbleSplitter`/`BubbleMerger`/`TopologyExecutor`. The resolver calls it; no gap.
 
 ## Proposed Solution
 
@@ -180,11 +187,15 @@ Introduce a thin **node-identity resolution boundary** and keep the consensus la
    membership change, no coordinator, computable identically on every node). Because the view is the single
    source of truth and every node holds it, no separate replicated registry or gossip is needed, and
    ownership rebalances deterministically across view changes.
-3. **Fail loud, never silent.** If the resolver cannot map a bubble to a current-view member, both
+3. **HRW owner is authoritative; explicit target is a checked hint (B1).** Where a caller supplies an
+   explicit `targetNodeId` (`DistributedBubbleNode.initiateRemoteMigration`), it is **validated against**
+   `owner(targetBubbleKey, view)` and **throws on mismatch** — never silently re-routed. The position-driven
+   owner (RDR-015) is the source of truth; the explicit parameter is a hint the consensus path verifies.
+4. **Fail loud, never silent.** If the resolver cannot map a bubble to a current-view member, both
    `toMigrationProposal` and `requestMigrationApproval` **throw** (not produce a silently-rejected proposal
    and not silently approve) — satisfying the `vhbw3` wave-20 requirement and preserving `l5c8q`'s existing
    fail-loud stance.
-4. **Delete `digestOf(UUID)`** as a node-id source; it remains valid only where a content-addressed hash of
+5. **Delete `digestOf(UUID)`** as a node-id source; it remains valid only where a content-addressed hash of
    a UUID is genuinely wanted (none in the consensus path).
 
 The consensus records, vote tally, and `isNodeInView` gate are unchanged (A3) — this is a boundary fix.
@@ -407,3 +418,10 @@ Right-sized as a boundary bug-fix RDR; the one genuinely-open question (A1 owner
   bubble placement/migration model), **B2** (view-change rebalancing acceptable), **B3** (bubble→`TetreeKey`
   resolvable) — all Unverified, to be checked in a second `/conexus:rdr-research` pass before the gate.
   Gossiped registry retained as Alternative 2.
+- 2026-06-08: **research pass 2** (Source Search; T2 `Luciferase_rdr/020-research-2`). **B2 VERIFIED**
+  (`viewId` check at submission `:182` + pre-execution `:223`; `onViewChange` rolls back pending `:252-269`).
+  **B3 VERIFIED** (`TetreeBubbleGrid.getKeyForBubble(UUID)` `:641-650`, already used by topology ops).
+  **B1 PARTIAL → resolved**: `initiateRemoteMigration(entityId, targetNodeId)` (`:108-126`) takes an explicit
+  target, which a position-derived owner can contradict. **Decision**: HRW `owner(targetBubbleKey, view)` is
+  authoritative; an explicit `targetNodeId` is validated against it and **fails loud on mismatch**. All
+  assumptions now resolved; ready for `/conexus:rdr-gate` (which should scrutinize the B1 decision).

--- a/docs/rdr/RDR-020-bubble-to-fireflies-member-digest-resolution.md
+++ b/docs/rdr/RDR-020-bubble-to-fireflies-member-digest-resolution.md
@@ -1,0 +1,317 @@
+---
+title: "Bubble→Fireflies Member Digest Resolution for Migration Consensus"
+id: RDR-020
+type: Bug Fix
+status: draft
+priority: high
+author: self
+reviewed-by: self
+created: 2026-06-08
+accepted_date:
+related_issues: [Luciferase-vhbw3, Luciferase-l5c8q, Luciferase-0frcy, Luciferase-s23eu]
+---
+
+# RDR-020: Bubble→Fireflies Member Digest Resolution for Migration Consensus
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+Migration consensus votes on **nodes** (Fireflies cluster members, identified by a Delos `Digest`),
+but the simulation only has **bubble** identities (`UUID`) and has **no node-identity layer** that maps a
+bubble to the cluster member that hosts it. The two consensus entry points paper over this with
+`digestOf(UUID) = DigestAlgorithm.DEFAULT.digest(uuid.toString())` — an arbitrary hash that can never equal
+a real member `Digest`. Against a live, membership-enforcing `ViewCommitteeConsensus` this makes migration
+consensus **non-functional**: every proposal is rejected at the node-in-view validity gate. Unit tests mock
+out `requestConsensus`, so the gap is invisible in CI.
+
+This blocks two corroborated deep-review defects (`Luciferase-vhbw3` topology side, `Luciferase-l5c8q`
+migrator side), both children of epic `Luciferase-0frcy`. They share one missing primitive: a
+bubble/entity-`UUID` → owning-member-`Digest` resolution, plus a fail-loud contract so the gap can never
+again be silently approved or silently rejected.
+
+### Enumerated gaps to close
+
+#### Gap 1: No bubble→node identity mapping exists
+
+A node hosts many bubbles (`TetreeBubbleGrid`), but nothing maps a bubble `UUID` to the `Digest` of the
+Fireflies member that owns it. `digestOf(bubbleUUID)`
+(`TopologyConsensusCoordinator.java:286-287`) produces a hash unrelated to cluster membership;
+`ViewCommitteeSelector.isNodeInView(digest)` (`ViewCommitteeSelector.java:82-86`) compares it against real
+`Member.getId()` digests and always returns false. The fix must establish a real, cluster-consistent
+bubble→owning-member-`Digest` resolution.
+
+#### Gap 2: Topology consensus is non-functional against a live committee
+
+`TopologyConsensusCoordinator.toMigrationProposal` (`TopologyConsensusCoordinator.java:270-278`) builds a
+`MigrationProposal` whose `sourceNodeId`/`targetNodeId` are bubble-UUID hashes, so
+`ViewCommitteeConsensus.validateProposal` (`ViewCommitteeConsensus.java:332-386`, node-in-view gate
+`:371-376`) rejects every real-committee proposal at the validity check. The fix must produce proposals
+whose node digests are genuine members of the current view — or **fail loud** if they cannot be resolved,
+per the wave-20 review note on `vhbw3` (a membership-enforcing consensus must never be handed a
+silently-rejectable proposal).
+
+#### Gap 3: Migrator consensus delegation is unavailable
+
+`OptimisticMigratorImpl.requestMigrationApproval` (`OptimisticMigratorImpl.java:125-149`) correctly throws
+`UnsupportedOperationException` when `consensusIntegration` is wired (no silent approve), but cannot
+delegate to the committee because it has only `(UUID entityId, UUID targetBubble)` and no way to produce the
+`Digest sourceId, Digest targetNodeId` that
+`OptimisticMigratorIntegration.requestMigrationApproval(UUID, Digest, Digest)` (`:108`) requires. The fix
+must supply those digests (resolve them, or take them from the call site) so the quorum gate becomes live.
+
+## Context
+
+### Background
+
+Surfaced by the 24-agent simulation deep review (2026-06-03, `simulation/doc/DEEP_REVIEW_2026-06-03.md`),
+waves 1 (`vhbw3`) and 2 (`l5c8q`). Both were deferred pending a shared identity-mapping decision. The
+defect class is "hollow production stub behind a test mock": the consensus path looks wired but is inert
+against real membership. It is adjacent to RDR-017's shipped-node scope boundary (`s23eu`: the node is not
+yet partition-fault-tolerant; VoN↔membership is only partially wired) and depends on how the spatial
+partition (RDR-003/RDR-015) assigns bubbles to processes.
+
+### Technical Environment
+
+- Delos Fireflies membership: `Member.getId() → Digest`; `DynamicContext<Member>.allMembers()/active()`.
+- `FirefliesMembershipView` (`delos/fireflies/FirefliesMembershipView.java`): `getMembers` (`:86-92`,
+  `allMembers`), `activeMembers` (`:96-102`, `active` — RDR-005 security-critical), `getCurrentViewId`
+  (`:117-119`). `MockFirefliesView` mirrors the interface for tests.
+- Consensus: `MigrationProposal(UUID proposalId, UUID entityId, Digest sourceNodeId, Digest targetNodeId,
+  Digest viewId, long timestamp)` (`consensus/committee/MigrationProposal.java:40-48`);
+  `ViewCommitteeConsensus`, `ViewCommitteeSelector`.
+- Identity util (reverse direction only): `FirefliesMemberLookup.digestToUuid` (`von/FirefliesMemberLookup.java:168-182`,
+  first 16 bytes of a `Digest`) + `getMemberByUuid` (`:92-96`). Assumes the UUID was *derived from* a Digest;
+  bubbles are not, so it is **not** reusable as-is.
+- Bubble identity: `Bubble.id() → UUID` (`bubble/Bubble.java:24,44`). No node-id concept today; fixtures run
+  one process.
+
+## Research Findings
+
+### Investigation
+
+Code seams confirmed by source reading (see T2 `Luciferase/uuid-digest-mapping-research` for the full
+file:line map). The consensus layer is already `Digest`-native and correct; the defect is entirely at the
+**boundary** where bubble UUIDs are translated to node digests. The translation (`digestOf`) is the only
+wrong link.
+
+#### Dependency Source Verification
+
+| Dependency | Source Searched? | Key Findings |
+| --- | --- | --- |
+| Delos Fireflies (`Member`, `DynamicContext`, `Digest`) | Yes | `Member.getId()` is the `Digest` the committee validates against; members enumerated via `context.active()`. |
+| `ViewCommitteeSelector.isNodeInView` | Yes | Compares the proposal digest against `context.allMembers().getId()`; bubble-UUID hash never matches. |
+
+### Key Discoveries
+
+- **Documented** — The consensus principal is the **node**, not the bubble: `MigrationProposal` carries
+  node digests and `validateProposal` checks node-in-view. Picking two bubble UUIDs as source/target
+  (`TopologyConsensusCoordinator:274-275`) conflates "which bubbles move" with "which nodes vote."
+- **Documented** — The source node of a migration is almost always **this process's own member** (the bubble
+  currently lives here). Only the *target* node genuinely needs a lookup.
+- **Documented** — No cluster-consistent bubble→node ownership map exists; how bubbles are assigned to
+  processes (deterministically from the spatial partition vs. a gossiped registry) is **undecided** and is
+  the load-bearing question.
+
+### Critical Assumptions
+
+- [ ] **A1**: A bubble's owning node can be resolved to a current-view member `Digest` — either
+  deterministically from the spatial partition (a bubble's SFC range maps to a member) or via a maintained
+  ownership registry. — **Status**: Unverified — **Method**: Source Search (TetreeBubbleGrid ↔ membership
+  partition; does any existing code assign bubbles/SFC ranges to members?)
+- [ ] **A2**: This process can obtain its own Fireflies member `Digest` for the source node of locally-owned
+  migrations (the common case), avoiding a lookup for the source. — **Status**: Unverified — **Method**:
+  Source Search (`FirefliesMembershipView`/local member accessor).
+- [ ] **A3**: The `MigrationProposal` node-id semantics are "owning node of source/target bubble," not
+  "bubble id" — i.e. fixing the resolution requires no change to the proposal record or vote logic. —
+  **Status**: Unverified — **Method**: Source Search (`ViewCommitteeConsensus` vote tally usage of
+  `sourceNodeId`/`targetNodeId`).
+
+## Proposed Solution
+
+### Approach
+
+Introduce a thin **node-identity resolution boundary** and keep the consensus layer `Digest`-native:
+
+1. **Source node = local member.** For both entry points, the source node digest is this process's own
+   Fireflies member `Digest` (the bubble being migrated currently lives here). Obtain it from the membership
+   view; no per-bubble lookup.
+2. **Target node via a `BubbleOwnershipResolver`.** A small injected interface
+   `Digest resolveOwningMember(UUID bubbleId)` returns the current-view member that owns the target bubble.
+   Its backing is decided in research (A1): preferred is **deterministic from the spatial partition** (the
+   target bubble's SFC range → owning member) if the partition is membership-aware; fallback is a maintained
+   ownership registry synced over the topology/membership layer.
+3. **Fail loud, never silent.** If the resolver cannot map a bubble to a current-view member, both
+   `toMigrationProposal` and `requestMigrationApproval` **throw** (not produce a silently-rejected proposal
+   and not silently approve) — satisfying the `vhbw3` wave-20 requirement and preserving `l5c8q`'s existing
+   fail-loud stance.
+4. **Delete `digestOf(UUID)`** as a node-id source; it remains valid only where a content-addressed hash of
+   a UUID is genuinely wanted (none in the consensus path).
+
+The consensus records, vote tally, and `isNodeInView` gate are unchanged (A3) — this is a boundary fix.
+
+### Technical Design
+
+Interface (signatures, not implementation):
+
+```text
+// Resolves the current-view Fireflies member that owns a bubble. Throws (fail-loud) if unresolvable.
+interface BubbleOwnershipResolver {
+    Digest resolveOwningMember(UUID bubbleId);   // throws IllegalStateException if no current-view owner
+    Digest localMember();                         // this process's own member Digest (source node)
+}
+```
+
+- `TopologyConsensusCoordinator.toMigrationProposal(...)`: `sourceNodeId = resolver.localMember()` (or the
+  owner of the source bubble when not local), `targetNodeId = resolver.resolveOwningMember(targetBubble)`;
+  throw on unresolved.
+- `OptimisticMigratorImpl.requestMigrationApproval(entityId, targetBubble)`: resolve `sourceId`/`targetNodeId`
+  via the resolver, then delegate to `OptimisticMigratorIntegration.requestMigrationApproval(entityId,
+  sourceId, targetNodeId)`. Remove the `UnsupportedOperationException` once the resolver is injected.
+- The resolver must use `activeMembers()` (not `allMembers()`) for the in-view determination (RDR-005).
+
+### Existing Infrastructure Audit
+
+| Proposed Component | Existing Module | Decision |
+| --- | --- | --- |
+| `BubbleOwnershipResolver` | `von/FirefliesMemberLookup` | Extend or wrap: reuse its member-index access; add the forward bubble→member direction (the existing `digestToUuid` is reverse-only and assumes Digest-derived UUIDs). |
+| Source-node = local member | `FirefliesMembershipView` | Reuse: add/confirm a local-member accessor. |
+| `digestOf(UUID)` node-id | `TopologyConsensusCoordinator` | Replace: delete as a node-id source. |
+
+### Decision Rationale
+
+The consensus layer is already correct; the only bug is the bubble→node translation. A boundary resolver
+plus "source = local member" fixes both beads with no change to consensus semantics, keeps the fail-loud
+contract, and localizes the one genuinely-open question (how target ownership is sourced) behind one
+injectable interface that research A1 resolves.
+
+## Alternatives Considered
+
+### Alternative 1: Push `Digest` to the call site (no resolver)
+
+**Description**: Change both entry points to accept `Digest` source/target from callers that already know the
+target node.
+
+**Pros**: No new mapping component; consensus stays Digest-native.
+
+**Cons**: `TopologyConsensusCoordinator` operates on *bubbles* from a topology proposal and does **not** know
+the target node — it would still need a resolver. Only covers `l5c8q`, not `vhbw3`.
+
+**Reason for rejection**: Does not close Gap 2; a resolver is needed regardless, so this is a strict subset.
+
+### Briefly Rejected
+
+- **Topology-native proposal type** (vote on the topology change keyed by view, not node membership): the
+  node-in-view check is the security gate against off-cluster proposals — removing it weakens validity. Out
+  of scope.
+- **Reuse `digestOf(UUID)` but register those synthetic digests as members**: pollutes the membership view
+  with non-cluster identities; defeats the security purpose of `isNodeInView`.
+
+## Trade-offs
+
+### Consequences
+
+- (+) Migration consensus becomes functional against a live `ViewCommitteeConsensus`; two corroborated
+  defects close.
+- (+) Fail-loud everywhere — no silent approve (`l5c8q`) and no silently-rejected proposal (`vhbw3`).
+- (−) Introduces a node-identity dependency the single-process fixtures did not need; multi-node tests
+  require real/mock membership wiring.
+- (−) Couples migration consensus to the spatial-partition↔membership mapping (A1), which may need its own
+  follow-up if ownership is dynamic.
+
+### Risks and Mitigations
+
+- **Risk**: Ownership resolution is stale during a view change (target bubble's owner just changed).
+  **Mitigation**: Resolve against the current view at proposal time; the node-in-view gate rejects
+  stale digests; fail-loud surfaces it rather than mis-routing.
+- **Risk**: A1 has no deterministic partition→member map, forcing a gossiped registry (larger scope).
+  **Mitigation**: Verify A1 in research before locking; if a registry is required, scope it explicitly or
+  split it to a follow-up RDR.
+
+### Failure Modes
+
+- Unresolvable bubble → **throws** (visible) at proposal/approval time; a developer sees the entity/bubble id
+  and the empty resolution.
+- A correctly-resolved-but-evicted member → rejected by `isNodeInView` (visible WARN), not silent.
+
+## Implementation Plan
+
+### Prerequisites
+
+- [ ] A1, A2, A3 verified (esp. A1: how target ownership is sourced).
+
+### Minimum Viable Validation
+
+An integration test with a real (or mock) multi-member `ViewCommitteeConsensus`: a migration whose target
+bubble is owned by a current-view member produces a proposal that **passes** `validateProposal` and reaches
+quorum; a migration whose target cannot be resolved **throws** (fail-loud) — proving the gap is closed in
+both directions, not mocked away.
+
+### Phase 1: Code Implementation
+
+#### Step 1: Resolver interface + membership-backed implementation (A1/A2)
+
+#### Step 2: Wire `toMigrationProposal` and `requestMigrationApproval` to the resolver; delete `digestOf` as a node-id source; fail-loud on unresolved
+
+#### Step 3: Remove the `UnsupportedOperationException` gate in `OptimisticMigratorImpl` once the resolver is injected
+
+### New Dependencies
+
+None anticipated (reuses Delos membership already on the classpath).
+
+## Test Plan
+
+- **Scenario**: Target bubble owned by a current-view member — **Verify**: proposal passes
+  `validateProposal`, reaches quorum (not mocked).
+- **Scenario**: Target bubble unresolvable to any current-view member — **Verify**: `toMigrationProposal` and
+  `requestMigrationApproval` throw (fail-loud), no silent approve, no silently-rejected proposal.
+- **Scenario**: Resolver uses `activeMembers()` not `allMembers()` — **Verify**: an evicted member is not a
+  valid owner (RDR-005).
+- **Scenario**: Source node defaults to local member for a locally-owned bubble — **Verify**: source digest
+  equals this process's member id.
+
+## Validation
+
+### Testing Strategy
+
+Integration over mocks: exercise the real `ViewCommitteeConsensus`/`ViewCommitteeSelector` path with a
+mock membership view containing known member digests; assert validity, quorum, and the fail-loud throws.
+
+## Finalization Gate
+
+### Contradiction Check
+
+[To complete at gate.]
+
+### Assumption Verification
+
+A1/A2/A3 to be verified by source search during `/conexus:rdr-research` before acceptance.
+
+### Scope Verification
+
+[To complete at gate — confirm MVV (live-committee pass + fail-loud throw) is in scope, not deferred.]
+
+### Cross-Cutting Concerns
+
+- **Versioning**: N/A (no wire-format change; `MigrationProposal` unchanged).
+- **Secret/credential lifecycle**: N/A (uses existing Fireflies identities).
+- **Incremental adoption**: resolver is injected; fail-loud preserves current behavior until wired.
+- Others: N/A.
+
+### Proportionality
+
+Right-sized as a boundary bug-fix RDR; the one genuinely-open question (A1 ownership sourcing) is isolated.
+
+## References
+
+- T2 `Luciferase/uuid-digest-mapping-research` (full file:line seam map).
+- Beads `Luciferase-vhbw3`, `Luciferase-l5c8q`, epic `Luciferase-0frcy`; scope-boundary `Luciferase-s23eu`.
+- RDR-005 (Fireflies/KERI identity; `activeMembers()` security), RDR-003/RDR-015 (spatial partition).
+- `simulation/doc/DEEP_REVIEW_2026-06-03.md`.
+
+## Revision History
+
+- 2026-06-08: created (draft) — scoped from `vhbw3`+`l5c8q` after seam research; recommends a node-identity
+  boundary resolver with fail-loud contract; A1 (ownership sourcing) flagged as the load-bearing
+  unverified assumption for `/conexus:rdr-research`.

--- a/docs/rdr/RDR-020-bubble-to-fireflies-member-digest-resolution.md
+++ b/docs/rdr/RDR-020-bubble-to-fireflies-member-digest-resolution.md
@@ -134,6 +134,19 @@ wrong link.
   (`CommitteeBallotBox.java:90-248`) is keyed on `proposalId`; quorum derives from committee size/tolerance,
   not node identity. Changing the digests to real owning-node identities is safe.
 
+**Option β — new assumptions introduced by the deterministic ownership function (verify before accept):**
+
+- [ ] **B1**: A deterministic `owner(spatialKey, activeMembers)` assignment (rendezvous/HRW hashing) is
+  compatible with how bubbles are placed and migrated — nothing else already binds a bubble to a node by a
+  rule this would contradict. — **Status**: Unverified — **Method**: Source Search (`TetreeBubbleGrid`
+  placement; `DistributedBubbleNode` target selection).
+- [ ] **B2**: View-change ownership rebalancing is acceptable for migration semantics — a region's owner
+  changing on membership change does not corrupt an in-flight migration beyond what the `isNodeInView`
+  fail-loud reject already handles. — **Status**: Unverified — **Method**: Source Search / reasoning against
+  the `ViewCommitteeConsensus` proposal lifecycle + view-change handling.
+- [ ] **B3**: A bubble `UUID` resolves to its `TetreeKey` at proposal time. — **Status**: Unverified —
+  **Method**: Source Search (`TetreeBubbleGrid`/`Bubble` → key accessor).
+
 ## Proposed Solution
 
 ### Approach
@@ -144,29 +157,29 @@ wrong link.
 > design and the source-node/fail-loud parts are unchanged; only the **target-resolution backing** is
 > affected.
 >
-> **Scope decision (open — see Decision Rationale / Revision History):**
-> - **Option α (correctness floor, recommended):** RDR-020 ships the resolver interface, `source = local
->   member` (A2), the **fail-loud** contract, and a resolver that maps a target bubble to an owning member
->   *only when that owner is independently known* (single-node/degenerate: the local member owns its
->   bubbles; or the caller supplies the target node). Where ownership is unknown it **throws** — turning
->   today's *silent* broken consensus into a *loud, correct* unavailability. The distributed bubble→node
->   ownership registry is split to a **follow-up RDR** (spatial-partition ↔ membership binding; tied to
->   `s23eu` partition-fault-tolerance and RDR-003/015). This closes the silent-defect class in
->   `vhbw3`/`l5c8q` without building a distributed subsystem inside a bug-fix RDR.
-> - **Option β (absorb):** RDR-020 also designs and builds the distributed ownership registry
->   (range→member assignment kept consistent across view changes). Larger; overlaps unsolved
->   partition-fault-tolerance work.
+> **Scope decision (2026-06-08): Option β chosen — RDR-020 absorbs the ownership mechanism.**
+> The key design move that keeps β tractable is to make ownership a **deterministic function of (bubble
+> spatial key, current Fireflies view)** rather than a separately-replicated, gossiped registry. Any node
+> derives the owner of any region from the view it already holds — no extra replicated state, no bespoke
+> consistency protocol, and ownership **auto-rebalances** when the view changes. (The gossiped-registry
+> form is retained as Alternative 2.)
+>
+> Considered and not chosen: **Option α** (correctness floor only — resolver + fail-loud, splitting the
+> ownership mechanism to a follow-up RDR). Rejected by owner decision in favor of solving ownership here.
 
 Introduce a thin **node-identity resolution boundary** and keep the consensus layer `Digest`-native:
 
 1. **Source node = local member.** For both entry points, the source node digest is this process's own
    Fireflies member `Digest` (the bubble being migrated currently lives here). Obtain it from the membership
    view; no per-bubble lookup.
-2. **Target node via a `BubbleOwnershipResolver`.** A small injected interface
-   `Digest resolveOwningMember(UUID bubbleId)` returns the current-view member that owns the target bubble.
-   Its backing is decided in research (A1): preferred is **deterministic from the spatial partition** (the
-   target bubble's SFC range → owning member) if the partition is membership-aware; fallback is a maintained
-   ownership registry synced over the topology/membership layer.
+2. **Target node via a `BubbleOwnershipResolver` backed by a deterministic, view-derived owner function.**
+   The injected interface `Digest resolveOwningMember(UUID bubbleId)` resolves the bubble's spatial key
+   (`bubbleId → TetreeKey`, B3) and computes `owner = assign(spatialKey, view.activeMembers())` where
+   `assign` is a **deterministic partition of spatial keys over the current active members** (recommended:
+   **rendezvous / highest-random-weight hashing** of `(spatialKey, memberDigest)` — minimal reshuffle on
+   membership change, no coordinator, computable identically on every node). Because the view is the single
+   source of truth and every node holds it, no separate replicated registry or gossip is needed, and
+   ownership rebalances deterministically across view changes.
 3. **Fail loud, never silent.** If the resolver cannot map a bubble to a current-view member, both
    `toMigrationProposal` and `requestMigrationApproval` **throw** (not produce a silently-rejected proposal
    and not silently approve) — satisfying the `vhbw3` wave-20 requirement and preserving `l5c8q`'s existing
@@ -186,7 +199,20 @@ interface BubbleOwnershipResolver {
     Digest resolveOwningMember(UUID bubbleId);   // throws IllegalStateException if no current-view owner
     Digest localMember();                         // this process's own member Digest (source node)
 }
+
+// Deterministic, view-derived ownership — pure function, identical on every node.
+// owner(key) = argmax over m in activeMembers of weight(key, m.getId())   // rendezvous / HRW hashing
+interface SpatialOwnershipFunction {
+    Digest owner(TetreeKey key, List<Digest> activeMembers);  // empty members -> throws (fail-loud)
+}
 ```
+
+- `BubbleOwnershipResolver` resolves `bubbleId → TetreeKey` (B3), reads `view.activeMembers()` (RDR-005),
+  and returns `SpatialOwnershipFunction.owner(key, members)`; throws if the result is not a current-view
+  member (e.g. empty view) — fail-loud, never a silently-rejectable digest.
+- `localMember()` returns `View.getNodeId()` (A2).
+- **Ownership is not stored.** It is recomputed from the view at proposal time; a view change recomputes it.
+  In-flight proposals carrying a now-stale owner are rejected by `isNodeInView` (visible), not mis-routed.
 
 - `TopologyConsensusCoordinator.toMigrationProposal(...)`: `sourceNodeId = resolver.localMember()` (or the
   owner of the source bubble when not local), `targetNodeId = resolver.resolveOwningMember(targetBubble)`;
@@ -201,15 +227,21 @@ interface BubbleOwnershipResolver {
 | Proposed Component | Existing Module | Decision |
 | --- | --- | --- |
 | `BubbleOwnershipResolver` | `von/FirefliesMemberLookup` | Extend or wrap: reuse its member-index access; add the forward bubble→member direction (the existing `digestToUuid` is reverse-only and assumes Digest-derived UUIDs). |
-| Source-node = local member | `FirefliesMembershipView` | Reuse: add/confirm a local-member accessor. |
+| Source-node = local member | `FirefliesMembershipView` / `View.getNodeId()` | Reuse: expose the local-member accessor (A2). |
+| `SpatialOwnershipFunction` (rendezvous/HRW) | — (none exists; A1 refuted) | New: deterministic view-derived owner; no replicated state. |
+| bubble `UUID` → `TetreeKey` | `TetreeBubbleGrid` | Reuse/extend per B3. |
 | `digestOf(UUID)` node-id | `TopologyConsensusCoordinator` | Replace: delete as a node-id source. |
 
 ### Decision Rationale
 
-The consensus layer is already correct; the only bug is the bubble→node translation. A boundary resolver
-plus "source = local member" fixes both beads with no change to consensus semantics, keeps the fail-loud
-contract, and localizes the one genuinely-open question (how target ownership is sourced) behind one
-injectable interface that research A1 resolves.
+The consensus layer is already correct (A3); the only bug is the bubble→node translation. A boundary
+resolver plus "source = local member" (A2) fixes both beads with no change to consensus semantics and keeps
+the fail-loud contract. A1 refuted the existence of any ownership map, so β builds one — but as a
+**deterministic, view-derived function** rather than a replicated registry: ownership becomes a pure
+function of `(spatial key, current view)`, which every node computes identically from state it already
+holds, eliminating the consistency/convergence burden a gossiped registry would add and rebalancing
+automatically on membership change. This is the smallest mechanism that actually makes multi-node consensus
+functional.
 
 ## Alternatives Considered
 
@@ -224,6 +256,22 @@ target node.
 the target node — it would still need a resolver. Only covers `l5c8q`, not `vhbw3`.
 
 **Reason for rejection**: Does not close Gap 2; a resolver is needed regardless, so this is a strict subset.
+
+### Alternative 2: Gossiped / replicated ownership registry
+
+**Description**: Maintain an explicit `bubble/region → member` table, replicated across the cluster and
+updated on placement, migration, and view change.
+
+**Pros**: Ownership can be arbitrary (not tied to a hash of the spatial key); supports explicit hand-off.
+
+**Cons**: Needs its own consistency protocol (who is authoritative, conflict resolution, convergence under
+partition) — a distributed subsystem, larger than the defect it serves; must itself stay consistent with the
+Fireflies view it duplicates.
+
+**Reason for rejection**: The deterministic view-derived function obtains the same result as a *pure function
+of state every node already holds*, with no extra replicated state or convergence concern. Reconsider only
+if B1 shows ownership cannot be a function of the spatial key (e.g. ownership must be explicitly assignable
+independent of position).
 
 ### Briefly Rejected
 
@@ -352,3 +400,10 @@ Right-sized as a boundary bug-fix RDR; the one genuinely-open question (A1 owner
     defect (`vhbw3`/`l5c8q`) via fail-loud + resolver seam, defers the distributed ownership subsystem
     (which belongs with `s23eu` / spatial-partition work) to its own RDR. Pending owner decision before
     `/conexus:rdr-gate`.
+- 2026-06-08: **Owner chose Option β** (absorb the ownership mechanism). Design updated: ownership is a
+  **deterministic, view-derived function** `owner(spatialKey, activeMembers)` (rendezvous/HRW hashing), not
+  a gossiped registry — a pure function of state every node already holds, so no extra replicated state and
+  auto-rebalancing on view change. Adds assumptions **B1** (deterministic assignment compatible with the
+  bubble placement/migration model), **B2** (view-change rebalancing acceptable), **B3** (bubble→`TetreeKey`
+  resolvable) — all Unverified, to be checked in a second `/conexus:rdr-research` pass before the gate.
+  Gossiped registry retained as Alternative 2.

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -30,6 +30,7 @@ See the [RDR process documentation](https://github.com/cwensel/rdr) for the full
 | [RDR-017](RDR-017-production-node-bootstrap.md) | Production Node Bootstrap — Compose the Distributed Simulation Node (Lifecycle, WAL, Recovery, Migration) | implemented | Architecture | medium |
 | [RDR-018](RDR-018-dynamic-topology-vs-single-level-partition.md) | Dynamic Topology (Split/Merge) vs the RDR-015 Single-Level Migration Partition | implemented | Architecture | medium |
 | [RDR-019](RDR-019-wal-checkpoint-recovery-durability.md) | WAL Checkpoint/Recovery Durability — Bound Replay Safely (Snapshot or Compaction) | accepted | Bug Fix | high |
+| [RDR-020](RDR-020-bubble-to-fireflies-member-digest-resolution.md) | Bubble→Fireflies Member Digest Resolution for Migration Consensus | accepted | Bug Fix | high |
 
 ## Post-Mortems
 

--- a/docs/rdr/post-mortem/020-bubble-to-fireflies-member-digest-resolution.md
+++ b/docs/rdr/post-mortem/020-bubble-to-fireflies-member-digest-resolution.md
@@ -1,0 +1,91 @@
+---
+rdr: RDR-020
+title: "Post-mortem — Bubble→Fireflies Member Digest Resolution for Migration Consensus"
+closed_date: 2026-06-09
+outcome: implemented
+---
+
+# RDR-020 Post-Mortem
+
+## What shipped
+
+A node-identity resolution boundary (`BubbleOwnershipResolver`) that makes migration
+consensus functional against a live, membership-enforcing `ViewCommitteeConsensus`,
+replacing the `digestOf(UUID)` hash that the live committee silently rejected.
+
+Phase-1 arc, all on `feature/rdr-020-scope`, each increment stacked-reviewed:
+
+| Step | Bead | Delivered |
+|------|------|-----------|
+| S1 | bucvb | `SpatialOwnershipFunction` (HRW/rendezvous) + `BubbleOwnershipResolver` port (Fireflies + Stub impls) |
+| S2 | epihi | O(1) inverse `UUID→TetreeKey` index in `TetreeBubbleGrid` |
+| S3 | e8gl4 | `ProposalKind` discriminator; TOPOLOGY single-owner model; `digestOf` deleted |
+| S4 | jf7u6 | `OptimisticMigratorImpl` → resolver; `UnsupportedOperationException` gate removed |
+| S5 | kcgj1 | node-UUID hint validation + `isActiveMember` |
+| S6 | i4prr | `isNodeInView` → `context.active()` (active-only at the validator) |
+| S7 | h3lc6 | opt-in-validation contract pinned (premise obviated by S5's resolver-gated design) |
+| MVV | u911y | end-to-end integration over the real wired path (11 scenarios) |
+| review | 05ms3 | holistic phase-boundary stacked review |
+
+External Gap bugs closed: `vhbw3` (Gap 2, topology), `l5c8q` (Gap 3, migrator).
+
+## Divergences from the original design (all gated)
+
+1. **TOPOLOGY node-identity model (S3 amendment).** Implementation revealed that a
+   topology change is single-region: `source == target == owner(region)`, which the
+   entity-migration self-migration reject would kill. Added a `ProposalKind`
+   {ENTITY_MIGRATION, TOPOLOGY} discriminator carried on the wire; the self-migration
+   reject is skipped only for TOPOLOGY. The amendment was itself gate-BLOCKED twice
+   (validateProposal is not proposer-local; cross-region merge) before passing.
+
+2. **`isActiveMember` interface widening (S5).** The spec's 3-method resolver sketch
+   understated the interface. `memberDigestForNode` resolves over the all-members
+   backing (B4), so the node-hint guard needs a *separate* active-only check to reject
+   an evicted-but-not-GC'd member — a 4th method.
+
+3. **Committee-composition active-only via vote-receipt (yagnw.1).** S6 closed the
+   active-only gap for source/target *identity*; the committee *composition* (offline
+   member as a voter) was a separate gap. Fixed at vote-receipt
+   (`CommitteeVotingProtocol.recordVote` drops inactive votes) — the safety-conservative
+   choice that keeps the quorum denominator at the original committee size rather than
+   shrinking it toward `committeeQuorum(2)==1`.
+
+## What worked
+
+- **Stacked review caught load-bearing bugs the green suite hid every single time**:
+  S1 vacuous HRW convergence test; S3 cooldown-orphan on synchronous guard throw; S4
+  non-volatile resolver field; MVV's missing owner≠local (Gap-2-closing) path. None
+  were visible from passing tests.
+- **Verifying review claims against the codebase** rejected three confident false
+  positives (VirtualSynchronyTest "NPE", a stale MVV finding, the Step-6 scope
+  confusion) — each disproven by actually running the test or reading the committed code.
+- **Stopping to amend the RDR when implementation contradicted the design** (S3) rather
+  than winging it; the amendment then re-gated.
+
+## Lessons
+
+- A passing suite that mocks the integration boundary (`requestConsensus`) hides the
+  exact class of defect this RDR fixed. The MVV — integration over the *real* wired path
+  with identity alignment across the consensus context and the resolver view — is what
+  actually proves the gap closed. Mock one level up and the gap stays invisible.
+- "Fail-loud" is a property to test explicitly (unresolvable target throws; no silent
+  approve), not assume — it was the wave-20 requirement and the MVV asserts it directly.
+- Critic rationales can be wrong in instructive ways: the claim that filtering
+  `bftSubset` "preserves BFT quorum sizing" was backwards — it can shrink the committee
+  below the BFT-safe majority. The conservative vote-receipt gate was the right call.
+
+## Named deferrals (tracked, out of scope)
+
+- Production resolver wiring + placement-honors-HRW partition seeding → `s23eu`
+  (multi-node bootstrap). Live path is single-process; every proposal is a correctly
+  rejected self-migration — correct today, not by coincidence.
+- Cross-region merge → fail-loud guard only; a two-node merge protocol is later work.
+- Committee-resizing-under-churn liveness (quorum denominator fixed at full committee
+  size) → `Luciferase-0frcy.134` (needs Delos `bftSubset(Digest, Predicate)` semantics
+  verification).
+- Pre-existing `TetreeBubbleGrid` dual-map atomicity → tracked under `0frcy`.
+
+## Validation
+
+Phase-review-gate PASSED (9/9 §Approach items). Full simulation suite: 3241 tests,
+0 failures, 11 skipped (pre-existing).

--- a/grpc/src/main/proto/lucien/committee.proto
+++ b/grpc/src/main/proto/lucien/committee.proto
@@ -18,6 +18,15 @@ import "google/protobuf/empty.proto";
  * View ID prevents double-commit race conditions across view boundaries.
  */
 
+// Node-identity model for a proposal (RDR-020 S3).
+// ENTITY_MIGRATION (default, ordinal 0) = two-distinct-node migration; TOPOLOGY = single-region
+// structural change where source == target == owner(region) and the self-migration reject is skipped.
+// A pre-amendment peer omits the field, so it defaults to ENTITY_MIGRATION.
+enum ProposalKind {
+    ENTITY_MIGRATION = 0;
+    TOPOLOGY = 1;
+}
+
 // Migration proposal for committee voting
 message CommitteeMigrationProposal {
     string proposal_id = 1;           // UUID as string
@@ -27,6 +36,7 @@ message CommitteeMigrationProposal {
     string proposer_address = 5;      // gRPC address of proposer (for vote replies)
     string view_id = 6;               // Digest as hex string (prevents cross-view double-commit)
     int64 timestamp = 7;              // Proposal creation time (for ordering/debugging)
+    ProposalKind kind = 8;            // RDR-020 S3: node-identity model (default ENTITY_MIGRATION)
 }
 
 // Vote from committee member

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGrid.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGrid.java
@@ -52,6 +52,8 @@ import java.util.concurrent.ConcurrentHashMap;
 public class TetreeBubbleGrid {
 
     private final Map<TetreeKey<?>, EnhancedBubble> bubblesByKey;
+    /** O(1) inverse index: bubble UUID → the TetreeKey it is registered under. Maintained in lock-step with bubblesByKey. */
+    private final Map<UUID, TetreeKey<?>> keyByBubbleId = new ConcurrentHashMap<>();
     private final Tetree<StringEntityID, BubbleLocation> spatialIndex;
     private final TetreeNeighborFinder neighborFinder;
     private final byte maxLevel;
@@ -132,6 +134,7 @@ public class TetreeBubbleGrid {
 
         // Clear existing bubbles. Legacy mixed-level distribution is NOT a single-level partition.
         bubblesByKey.clear();
+        keyByBubbleId.clear();
         partitionLevel = -1;
         maxLeafLevel.set(-1);
 
@@ -190,6 +193,7 @@ public class TetreeBubbleGrid {
 
                 // Register in maps
                 bubblesByKey.put(key, bubble);
+                keyByBubbleId.put(bubble.id(), key);
 
                 // Add to spatial index
                 var coords = tet.coordinates();
@@ -304,6 +308,7 @@ public class TetreeBubbleGrid {
 
         // Materialize the partition.
         bubblesByKey.clear();
+        keyByBubbleId.clear();
         neighborFinder.clearCache();
         for (var entry : partition.entrySet()) {
             var bubble = new EnhancedBubble(UUID.randomUUID(), level, targetFrameMs);
@@ -605,9 +610,9 @@ public class TetreeBubbleGrid {
     /**
      * Get a bubble by its UUID identifier.
      * <p>
-     * Searches through all bubbles to find one with matching UUID.
-     * This is less efficient than getBubble(TetreeKey) but useful
-     * for scenarios where only the UUID is known.
+     * O(1) lookup via the inverse UUID→TetreeKey index. Equivalent to
+     * {@code getBubble(getKeyForBubble(bubbleId))} but returns {@code null} when the id is absent
+     * rather than throwing, for callers that treat absence as a normal case.
      *
      * @param bubbleId UUID to search for
      * @return EnhancedBubble with matching ID, or null if not found
@@ -616,12 +621,8 @@ public class TetreeBubbleGrid {
     public EnhancedBubble getBubbleById(UUID bubbleId) {
         Objects.requireNonNull(bubbleId, "Bubble ID cannot be null");
 
-        for (var bubble : bubblesByKey.values()) {
-            if (bubble.id().equals(bubbleId)) {
-                return bubble;
-            }
-        }
-        return null;
+        var key = keyByBubbleId.get(bubbleId);
+        return key != null ? bubblesByKey.get(key) : null;
     }
 
     /**
@@ -640,20 +641,15 @@ public class TetreeBubbleGrid {
      */
     public TetreeKey<?> getKeyForBubble(UUID bubbleId) {
         Objects.requireNonNull(bubbleId, "Bubble ID cannot be null");
-
-        for (var entry : bubblesByKey.entrySet()) {
-            if (entry.getValue().id().equals(bubbleId)) {
-                return entry.getKey();
-            }
-        }
-        return null;
+        return keyByBubbleId.get(bubbleId);
     }
 
     /**
      * Get topological neighbors of a bubble by its UUID.
      * <p>
-     * Convenience method that first looks up the bubble by UUID,
-     * then returns its neighbors. Returns bubble UUIDs for consistency.
+     * O(1) UUID→key resolution via the inverse index, then delegates to
+     * {@link #getNeighbors(TetreeKey)}. Returns the neighbor UUIDs for consistency with callers
+     * that only hold a UUID (e.g. MergeProposal.validate).
      *
      * @param bubbleId UUID of bubble to find neighbors for
      * @return Set of neighboring bubble UUIDs
@@ -663,15 +659,7 @@ public class TetreeBubbleGrid {
     public Set<UUID> getNeighbors(UUID bubbleId) {
         Objects.requireNonNull(bubbleId, "Bubble ID cannot be null");
 
-        // Find the bubble and its key
-        TetreeKey<?> key = null;
-        for (var entry : bubblesByKey.entrySet()) {
-            if (entry.getValue().id().equals(bubbleId)) {
-                key = entry.getKey();
-                break;
-            }
-        }
-
+        var key = keyByBubbleId.get(bubbleId);
         if (key == null) {
             throw new NoSuchElementException("No bubble found with ID: " + bubbleId);
         }
@@ -821,6 +809,17 @@ public class TetreeBubbleGrid {
             throw new IllegalArgumentException("Bubble already exists at key: " + key);
         }
 
+        // Guard against re-keying an existing bubble id without a prior removeBubble(): if the same
+        // bubble id is already registered under a DIFFERENT key, the two maps would diverge — the old
+        // bubblesByKey entry would become an orphan (forward key → old bubble still present, inverse
+        // id → new key). Callers that need to move a bubble must removeBubble(id) first, then addBubble.
+        var existingKey = keyByBubbleId.get(bubble.id());
+        if (existingKey != null && !existingKey.equals(key)) {
+            throw new IllegalArgumentException(
+                "Bubble id " + bubble.id() + " is already registered under key " + existingKey
+                + ". Call removeBubble(id) before re-adding under a different key.");
+        }
+
         // Record the fixed registration cell on the bubble so migration containment can test against it.
         bubble.setSpatialKey(key);
 
@@ -830,8 +829,9 @@ public class TetreeBubbleGrid {
         int keyLevel = key.getLevel();
         maxLeafLevel.getAndUpdate(cur -> Math.max(cur, keyLevel));
 
-        // Add to key map
+        // Add to key map (forward and inverse)
         bubblesByKey.put(key, bubble);
+        keyByBubbleId.put(bubble.id(), key);
 
         // Add to spatial index
         var tet = key.toTet();
@@ -867,20 +867,14 @@ public class TetreeBubbleGrid {
     public boolean removeBubble(UUID bubbleId) {
         Objects.requireNonNull(bubbleId, "Bubble ID cannot be null");
 
-        // Find the bubble by ID
-        TetreeKey<?> keyToRemove = null;
-        for (var entry : bubblesByKey.entrySet()) {
-            if (entry.getValue().id().equals(bubbleId)) {
-                keyToRemove = entry.getKey();
-                break;
-            }
-        }
+        // O(1) lookup via inverse index — avoids the previous O(N) entrySet scan.
+        var keyToRemove = keyByBubbleId.remove(bubbleId);
 
         if (keyToRemove == null) {
             return false;
         }
 
-        // Remove from key map
+        // Remove from forward key map
         bubblesByKey.remove(keyToRemove);
 
         // Note: Tetree spatial index does not support remove() operation.
@@ -898,8 +892,22 @@ public class TetreeBubbleGrid {
      */
     public void clear() {
         bubblesByKey.clear();
+        keyByBubbleId.clear();
         neighborFinder.clearCache();
         partitionLevel = -1;
         maxLeafLevel.set(-1);
+    }
+
+    /**
+     * Package-private test accessor: the current size of the inverse UUID→TetreeKey index.
+     * <p>
+     * Must equal {@link #getBubbleCount()} at all times. Exposed only for the
+     * {@code TetreeBubbleGridInverseIndexTest} size-parity assertion (OBS-2 hardening).
+     * Production code must not call this method.
+     *
+     * @return the number of entries in the inverse index
+     */
+    int inverseIndexSize() {
+        return keyByBubbleId.size();
     }
 }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeProtoConverter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeProtoConverter.java
@@ -135,7 +135,37 @@ public final class CommitteeProtoConverter {
             .setProposerAddress(proposerAddress)
             .setViewId(digestToHex(proposal.viewId()))
             .setTimestamp(proposal.timestamp())
+            .setKind(toProtoKind(proposal.kind()))
             .build();
+    }
+
+    /**
+     * Map the domain {@link ProposalKind} to its proto counterpart (RDR-020 S3).
+     */
+    private static com.hellblazer.luciferase.simulation.consensus.committee.proto.ProposalKind toProtoKind(
+        ProposalKind kind) {
+        return switch (kind) {
+            case ENTITY_MIGRATION ->
+                com.hellblazer.luciferase.simulation.consensus.committee.proto.ProposalKind.ENTITY_MIGRATION;
+            case TOPOLOGY ->
+                com.hellblazer.luciferase.simulation.consensus.committee.proto.ProposalKind.TOPOLOGY;
+        };
+    }
+
+    /**
+     * Map the proto {@link com.hellblazer.luciferase.simulation.consensus.committee.proto.ProposalKind}
+     * back to the domain {@link ProposalKind} (RDR-020 S3).
+     * <p>
+     * An absent field decodes to the proto default {@code ENTITY_MIGRATION} (ordinal 0). An
+     * {@code UNRECOGNIZED} value from a newer peer is conservatively treated as
+     * {@code ENTITY_MIGRATION} — the safe default that retains the self-migration reject rather
+     * than silently skipping it.
+     */
+    private static ProposalKind fromProtoKind(
+        com.hellblazer.luciferase.simulation.consensus.committee.proto.ProposalKind kind) {
+        return kind == com.hellblazer.luciferase.simulation.consensus.committee.proto.ProposalKind.TOPOLOGY
+               ? ProposalKind.TOPOLOGY
+               : ProposalKind.ENTITY_MIGRATION;
     }
 
     /**
@@ -155,7 +185,8 @@ public final class CommitteeProtoConverter {
             hexToDigest(proto.getSourceNodeId()),
             hexToDigest(proto.getTargetNodeId()),
             hexToDigest(proto.getViewId()),
-            proto.getTimestamp()
+            proto.getTimestamp(),
+            fromProtoKind(proto.getKind())
         );
     }
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeVotingProtocol.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeVotingProtocol.java
@@ -157,6 +157,26 @@ public class CommitteeVotingProtocol {
             return;
         }
 
+        // yagnw.1: Verify the voter is a current-view ACTIVE member. selectCommittee draws the
+        // committee from context.bftSubset, which walks the full ring — an evicted-but-not-GC'd
+        // member can still sit in the committee set. S6 tightened the source/target identity gate
+        // (isNodeInView) to active-only; this gate stops such a member from contributing a vote
+        // toward quorum. Fails closed: an offline committee member's vote is dropped, never counted.
+        //
+        // Liveness tradeoff (known, by design): the quorum denominator is fixed at committee
+        // formation time from committee.size() (which includes offline members); this guard drops
+        // their votes but does NOT shrink the threshold. So if more than floor(n/2) of the selected
+        // committee are simultaneously offline, no set of active votes can reach quorum and the
+        // proposal times out (then retries in the next view). This is the conservative choice: it
+        // preserves a genuine majority-of-the-original-committee requirement (safety) at the cost of
+        // liveness under heavy churn, rather than shrinking the committee toward the unsafe
+        // committeeQuorum(2)==1 floor. Resizing the committee to the active set under churn is tracked
+        // as a follow-up (Luciferase-0frcy.134).
+        if (!context.isActive(vote.voterId())) {
+            // Vote from an inactive (evicted-but-not-GC'd) committee member (ignore)
+            return;
+        }
+
         // Verify view ID matches proposal
         if (!vote.viewId().equals(state.proposal.viewId())) {
             // Vote from different view (ignore)

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/MigrationProposal.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/MigrationProposal.java
@@ -35,6 +35,9 @@ import java.util.UUID;
  * @param targetNodeId Target node for migration
  * @param viewId       View context (prevents cross-view double-commit)
  * @param timestamp    Proposal creation time (optional, for ordering/debugging)
+ * @param kind         Node-identity model (ENTITY_MIGRATION vs TOPOLOGY); governs the
+ *                     self-migration reject in {@code ViewCommitteeConsensus.validateProposal}
+ *                     (RDR-020 S3)
  * @author hal.hildebrand
  */
 public record MigrationProposal(
@@ -43,6 +46,19 @@ public record MigrationProposal(
     Digest sourceNodeId,
     Digest targetNodeId,
     Digest viewId,
-    long timestamp
+    long timestamp,
+    ProposalKind kind
 ) {
+    /**
+     * Back-compatible constructor defaulting {@link #kind()} to
+     * {@link ProposalKind#ENTITY_MIGRATION} (RDR-020 S3).
+     * <p>
+     * Preserves the pre-amendment 6-arg signature so the existing entity-migration
+     * construction sites compile unchanged; only the topology path passes an explicit
+     * {@link ProposalKind#TOPOLOGY}.
+     */
+    public MigrationProposal(UUID proposalId, UUID entityId, Digest sourceNodeId, Digest targetNodeId, Digest viewId,
+                             long timestamp) {
+        this(proposalId, entityId, sourceNodeId, targetNodeId, viewId, timestamp, ProposalKind.ENTITY_MIGRATION);
+    }
 }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/ProposalKind.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/ProposalKind.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase Simulation Framework.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.consensus.committee;
+
+/**
+ * Discriminates the node-identity model a {@link MigrationProposal} carries (RDR-020 S3).
+ * <p>
+ * The two kinds use structurally different source/target node identities, which
+ * {@code ViewCommitteeConsensus.validateProposal} must branch on:
+ * <ul>
+ *   <li>{@link #ENTITY_MIGRATION} — two distinct nodes: {@code source = local holder
+ *       (possession)}, {@code target = HRW owner of the destination region}. The
+ *       self-migration reject ({@code source == target}) is enforced: a cross-node
+ *       migration to oneself is meaningless.</li>
+ *   <li>{@link #TOPOLOGY} — a single-region structural change (split/merge/move/collapse)
+ *       owned by exactly one node, so {@code source == target == owner(region)} by
+ *       construction. The self-migration reject is therefore <em>skipped</em>; all other
+ *       validity gates (null-viewId, in-view membership) apply unchanged.</li>
+ * </ul>
+ * <p>
+ * <b>Wire/upgrade contract.</b> {@code kind} is serialized on
+ * {@code CommitteeMigrationProposal} because every committee member re-validates a
+ * received proposal. The proto field defaults to {@link #ENTITY_MIGRATION} (ordinal 0),
+ * so a member running pre-amendment code reads any TOPOLOGY proposal as ENTITY_MIGRATION
+ * and self-migration-rejects it. TOPOLOGY consensus therefore requires all committee
+ * members on amended code — a documented multi-node prerequisite (RDR-020).
+ */
+public enum ProposalKind {
+    /**
+     * Two-distinct-node entity migration (source = possession, target = HRW owner).
+     * Default kind for back-compatibility; ordinal 0 matches the proto default.
+     */
+    ENTITY_MIGRATION,
+
+    /**
+     * Single-region topology change where {@code source == target == owner(region)}.
+     * The self-migration reject is skipped for this kind.
+     */
+    TOPOLOGY
+}

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeConsensus.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeConsensus.java
@@ -198,21 +198,41 @@ public class ViewCommitteeConsensus {
                  proposal.viewId(),
                  committeeIds.size());
 
+        // Track proposal for view change rollback. Luciferase-0frcy.132: this MUST be written
+        // BEFORE the inFlightByEntity reservation. onViewChange iterates pendingProposals and, for
+        // each stale-view entry, releases the matching inFlightByEntity slot. If the entity slot were
+        // reserved first and a view change fired in the gap before pendingProposals.put, onViewChange
+        // would not see the proposal and would never release the slot — orphaning the entity. With
+        // pendingProposals written first, onViewChange always sees the proposal (and a post-write
+        // view re-check below reconciles the residual interleaving where the scan ran entirely before
+        // the entity reservation).
+        var entityId = proposal.entityId();
+        var tracking = new ProposalTracking(proposal, committeeIds);
+        pendingProposals.put(proposal.proposalId(), tracking);
+
         // Per-entity in-flight guard (Luciferase-0frcy.94): reserve the migration
         // slot for this entity. If another proposal already holds it, reject this
         // one immediately so two concurrent proposals for the same entity cannot
         // both reach quorum and double-register the entity at two targets.
-        var entityId = proposal.entityId();
         var existing = inFlightByEntity.putIfAbsent(entityId, proposal.proposalId());
         if (existing != null) {
             log.debug("Entity {} already has in-flight migration proposal {}, rejecting {}",
                      entityId, existing, proposal.proposalId());
+            pendingProposals.remove(proposal.proposalId());  // undo the tracking entry we just added
             return CompletableFuture.completedFuture(false);
         }
 
-        // Track proposal for view change rollback
-        var tracking = new ProposalTracking(proposal, committeeIds);
-        pendingProposals.put(proposal.proposalId(), tracking);
+        // Luciferase-0frcy.132: reconcile a view change that raced between the early viewId check and
+        // the two writes above. If the view has since changed, onViewChange may have run its scan
+        // before either entry was visible; clean up both ourselves and reject (fail-closed, never an
+        // orphaned slot or a stale-view proposal entering voting).
+        if (!proposal.viewId().equals(getCurrentViewId())) {
+            log.debug("View changed during reservation for proposal {}, releasing slot and aborting",
+                     proposal.proposalId());
+            inFlightByEntity.remove(entityId, proposal.proposalId());
+            pendingProposals.remove(proposal.proposalId());
+            return CompletableFuture.completedFuture(false);
+        }
 
         // Submit to voting protocol
         var votingFuture = votingProtocol.requestConsensus(proposal, committeeIds);

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeConsensus.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeConsensus.java
@@ -361,8 +361,12 @@ public class ViewCommitteeConsensus {
             return false;
         }
 
-        // Prevent self-migration (source == target)
-        if (proposal.sourceNodeId().equals(proposal.targetNodeId())) {
+        // Prevent self-migration (source == target) — ENTITY_MIGRATION only.
+        // RDR-020 S3: TOPOLOGY proposals are single-region structural changes where
+        // source == target == owner(region) by construction, so the self-migration reject does
+        // NOT apply to them; every other validity gate (null-viewId, in-view membership) does.
+        if (proposal.kind() != ProposalKind.TOPOLOGY
+            && proposal.sourceNodeId().equals(proposal.targetNodeId())) {
             log.warn("Rejected proposal {} with source == target (self-migration): {}",
                     proposal.proposalId(), proposal.sourceNodeId());
             return false;

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeSelector.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeSelector.java
@@ -71,17 +71,29 @@ public class ViewCommitteeSelector {
     }
 
     /**
-     * Check if a node exists in the current view.
+     * Check if a node is an <em>active</em> member of the current view.
      * <p>
-     * Used for Byzantine input validation - verify target node exists
-     * before allowing migration proposal.
+     * Used for Byzantine input validation — verify the target/source node is a current-view active
+     * member before admitting a migration proposal.
+     * <p>
+     * RDR-020 S6 (RDR-005 active-only invariant): this matches against {@code context.active()}, NOT
+     * {@code context.allMembers()}. The all-members backing can still contain an evicted member that
+     * has not yet been garbage-collected from the view; admitting it would let a proposal target a node
+     * that is no longer participating. The resolver enforces active-only on the ownership side
+     * ({@code MembershipView.activeMembers()}); this gate enforces the same invariant for the proposal's
+     * <b>source/target node identity</b> at the validator.
+     * <p>
+     * Scope: this gate covers the source/target membership check only. Committee <em>composition</em>
+     * ({@link #selectCommittee} → {@code context.bftSubset}) still draws from the full ring and may
+     * include an offline member as a <em>voter</em> — a distinct, adjacent active-only gap tracked
+     * separately (Luciferase-yagnw.1), not closed here.
      *
      * @param nodeId Node identifier (member ID) to check
-     * @return true if node exists in current view, false otherwise
+     * @return true if the node is a current-view active member, false otherwise
      */
     public boolean isNodeInView(Digest nodeId) {
         Objects.requireNonNull(nodeId, "nodeId must not be null");
-        return context.allMembers()
+        return context.active()
                       .anyMatch(member -> member.getId().equals(nodeId));
     }
 }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/BubbleOwnershipResolver.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/BubbleOwnershipResolver.java
@@ -91,4 +91,19 @@ public interface BubbleOwnershipResolver {
      * @throws IllegalStateException if no member with this node UUID is found
      */
     Digest memberDigestForNode(UUID nodeId);
+
+    /**
+     * Report whether {@code member} is a <em>current-view active</em> member (RDR-020 S5 / RDR-005).
+     * <p>
+     * {@link #memberDigestForNode(UUID)} resolves over the all-members backing
+     * ({@code FirefliesMemberLookup.getMemberByUuid}, built on the misnamed all-members accessor), so it
+     * can return a member that has been evicted but not yet garbage-collected from the view. Node-UUID
+     * hint validation must additionally confirm the resolved member is in the <em>active-only</em> set
+     * ({@code DynamicContext.active()} / {@code MembershipView.activeMembers()}). This method exposes
+     * that determination without leaking the membership backing to callers.
+     *
+     * @param member the member {@link Digest} to test; must not be {@code null}
+     * @return {@code true} iff {@code member} is in the current active-only member set
+     */
+    boolean isActiveMember(Digest member);
 }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/BubbleOwnershipResolver.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/BubbleOwnershipResolver.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.consensus.ownership;
+
+import com.hellblazer.delos.cryptography.Digest;
+
+import java.util.UUID;
+
+/**
+ * Resolves bubble and node identities to Fireflies cluster member {@link Digest}s.
+ * <p>
+ * This is the node-identity boundary layer for migration consensus (RDR-020).
+ * Migration proposals carry two distinct node roles, and both are resolved here:
+ * <ul>
+ *   <li><b>Source node = local member (possession).</b> The process that initiates a migration
+ *       physically holds the entity/bubble, so the source is authoritative by possession.
+ *       Obtained via {@link #localMember()}.</li>
+ *   <li><b>Target node = HRW owner of the destination region.</b> The intended owner of the
+ *       destination bubble's spatial key, computed via a {@link SpatialOwnershipFunction}.
+ *       Obtained via {@link #resolveOwningMember(UUID)}.</li>
+ * </ul>
+ * <p>
+ * All methods fail loud ({@link IllegalStateException}) rather than returning a silently-rejectable
+ * {@link Digest}. The consensus layer ({@code ViewCommitteeConsensus.validateProposal}) expects
+ * real, current-view member digests; returning an unresolvable digest would produce a proposal
+ * that is silently rejected at the validity gate, masking the identity gap (RDR-020 Gap 2).
+ * <p>
+ * <b>Security invariant (RDR-005):</b> implementations must use the <em>active-only</em>
+ * ({@code DynamicContext.active()}) member set for the ownership computation, never the
+ * all-members backing. See {@code MembershipView.activeMembers()} javadoc.
+ */
+public interface BubbleOwnershipResolver {
+
+    /**
+     * Resolve the current-view Fireflies member that owns the bubble identified by
+     * {@code bubbleId}.
+     * <p>
+     * Resolution steps:
+     * <ol>
+     *   <li>Resolve {@code bubbleId} → {@link com.hellblazer.luciferase.lucien.tetree.TetreeKey}
+     *       via the bubble grid (fail loud if not found).</li>
+     *   <li>Read the <em>active-only</em> member set.</li>
+     *   <li>Delegate to {@link SpatialOwnershipFunction#owner(com.hellblazer.luciferase.lucien.tetree.TetreeKey, java.util.List)}.</li>
+     *   <li>Verify the result is a current-view member (fail loud if not).</li>
+     * </ol>
+     *
+     * @param bubbleId the bubble's UUID; must not be {@code null}
+     * @return the owning member's {@link Digest}; never {@code null}
+     * @throws IllegalStateException if the bubble is not in the grid, if the active
+     *                               member set is empty, or if the resolved owner is not
+     *                               a current-view member
+     */
+    Digest resolveOwningMember(UUID bubbleId);
+
+    /**
+     * Return this process's own Fireflies member {@link Digest}.
+     * <p>
+     * Always the source node for any migration this process initiates, because this
+     * process physically holds the source bubble (possession semantics).
+     *
+     * @return this node's member {@link Digest}; never {@code null}
+     */
+    Digest localMember();
+
+    /**
+     * Resolve a canonical node {@link UUID} to its Fireflies member {@link Digest}.
+     * <p>
+     * Node UUIDs are derived canonically from their member digest via
+     * {@code FirefliesMemberLookup.digestToUuid} / {@code NodeBootstrap.resolveNodeId} (B4).
+     * Use this method only for validating an explicit node-UUID hint (e.g. from
+     * {@code DistributedBubbleNode.initiateRemoteMigration}); not for the ownership path
+     * (use {@link #resolveOwningMember(UUID)} for that).
+     *
+     * @param nodeId the canonical node UUID; must not be {@code null}
+     * @return the member's {@link Digest}; never {@code null}
+     * @throws IllegalStateException if no member with this node UUID is found
+     */
+    Digest memberDigestForNode(UUID nodeId);
+}

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/FirefliesBubbleOwnershipResolver.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/FirefliesBubbleOwnershipResolver.java
@@ -137,6 +137,12 @@ public final class FirefliesBubbleOwnershipResolver implements BubbleOwnershipRe
      *   <li>Verify the result is in the active set (defensive; the HRW function guarantees
      *       this invariant, but we fail loud on any violation).</li>
      * </ol>
+     * <p>
+     * Note: the active set is a snapshot read at call time. A view transition between this call and
+     * the moment the resulting proposal reaches {@code validateProposal}/{@code isNodeInView} can make
+     * the returned owner stale — the consensus layer's view-ID binding is the authoritative guard and
+     * rejects such a proposal visibly (never a mis-route). This two-read TOCTOU is a best-effort
+     * boundary, not an atomic guarantee.
      */
     @Override
     public Digest resolveOwningMember(UUID bubbleId) {

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/FirefliesBubbleOwnershipResolver.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/FirefliesBubbleOwnershipResolver.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.consensus.ownership;
+
+import com.hellblazer.delos.cryptography.Digest;
+import com.hellblazer.delos.membership.Member;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+import com.hellblazer.luciferase.simulation.bubble.TetreeBubbleGrid;
+import com.hellblazer.luciferase.simulation.delos.MembershipView;
+import com.hellblazer.luciferase.simulation.von.FirefliesMemberLookup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Production {@link BubbleOwnershipResolver} backed by a live Fireflies cluster.
+ * <p>
+ * Integrates four components via narrow injected seams, following the project's
+ * constructor-injection / interfaces-not-concretes convention:
+ * <ul>
+ *   <li>{@code localMemberSupplier} — returns this node's own {@link Member} for
+ *       {@link #localMember()}.</li>
+ *   <li>{@code nodeResolver} — maps a node {@link UUID} to its optional {@link Member}
+ *       for {@link #memberDigestForNode(UUID)}.</li>
+ *   <li>{@code bubbleKeyResolver} — maps a bubble {@link UUID} to its {@link TetreeKey}
+ *       (or {@code null} if not in grid) for {@link #resolveOwningMember(UUID)}.</li>
+ *   <li>{@link MembershipView}{@code <Member>} — for the <em>active-only</em> member set
+ *       ({@code activeMembers()}). This MUST NOT be substituted with
+ *       {@code FirefliesMemberLookup.getActiveMembers()}, which is misnamed and delegates
+ *       to {@code context.allMembers()} — see RDR-020 B4 / RDR-005.</li>
+ *   <li>{@link SpatialOwnershipFunction} — the HRW ownership computation.</li>
+ * </ul>
+ * <p>
+ * The narrow-seam constructor is the primary constructor for testability.
+ * A convenience constructor adapts a {@link FirefliesMemberLookup} and
+ * {@link TetreeBubbleGrid} to those seams for production use.
+ * <p>
+ * All methods fail loud ({@link IllegalStateException}) on unresolvable inputs so that
+ * callers never receive a silently-rejectable digest (RDR-020 Gap 2 / vhbw3 wave-20 requirement).
+ */
+public final class FirefliesBubbleOwnershipResolver implements BubbleOwnershipResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(FirefliesBubbleOwnershipResolver.class);
+
+    private final Supplier<Member>                 localMemberSupplier;
+    private final Function<UUID, Optional<Member>> nodeResolver;
+    private final Function<UUID, TetreeKey<?>>     bubbleKeyResolver;
+    private final MembershipView<Member>           membershipView;
+    private final SpatialOwnershipFunction         ownershipFunction;
+
+    /**
+     * Primary (narrow-seam) constructor.  Constructor-injects three narrow function seams,
+     * making the class testable without a live Fireflies View or a populated
+     * {@link TetreeBubbleGrid}.
+     *
+     * @param localMemberSupplier  returns this node's {@link Member}; must not be {@code null}
+     * @param nodeResolver         maps a node {@link UUID} to its optional {@link Member};
+     *                             must not be {@code null}
+     * @param bubbleKeyResolver    maps a bubble {@link UUID} to its {@link TetreeKey}, or
+     *                             {@code null} if not present; must not be {@code null}
+     * @param membershipView       the membership view providing the active-only member stream;
+     *                             must not be {@code null}
+     * @param ownershipFunction    the HRW (or other) deterministic ownership function;
+     *                             must not be {@code null}
+     */
+    public FirefliesBubbleOwnershipResolver(Supplier<Member> localMemberSupplier,
+                                            Function<UUID, Optional<Member>> nodeResolver,
+                                            Function<UUID, TetreeKey<?>> bubbleKeyResolver,
+                                            MembershipView<Member> membershipView,
+                                            SpatialOwnershipFunction ownershipFunction) {
+        this.localMemberSupplier = Objects.requireNonNull(localMemberSupplier,
+                                                          "localMemberSupplier must not be null");
+        this.nodeResolver = Objects.requireNonNull(nodeResolver, "nodeResolver must not be null");
+        this.bubbleKeyResolver = Objects.requireNonNull(bubbleKeyResolver, "bubbleKeyResolver must not be null");
+        this.membershipView = Objects.requireNonNull(membershipView, "membershipView must not be null");
+        this.ownershipFunction = Objects.requireNonNull(ownershipFunction, "ownershipFunction must not be null");
+    }
+
+    /**
+     * Convenience constructor that adapts a {@link FirefliesMemberLookup} and a
+     * {@link TetreeBubbleGrid} to the narrow function seams.  Wired as:
+     * <pre>
+     *   localMemberSupplier = memberLookup::getLocalMember
+     *   nodeResolver        = memberLookup::getMemberByUuid
+     *   bubbleKeyResolver   = bubbleGrid::getKeyForBubble
+     * </pre>
+     *
+     * @param memberLookup        the Fireflies member lookup (local member + node UUID mapping)
+     * @param membershipView      the membership view providing the active-only member stream
+     * @param bubbleGrid          the bubble grid for key resolution
+     * @param ownershipFunction   the HRW (or other) deterministic ownership function
+     */
+    public FirefliesBubbleOwnershipResolver(FirefliesMemberLookup memberLookup,
+                                            MembershipView<Member> membershipView,
+                                            TetreeBubbleGrid bubbleGrid,
+                                            SpatialOwnershipFunction ownershipFunction) {
+        this(
+            Objects.requireNonNull(memberLookup, "memberLookup must not be null")::getLocalMember,
+            memberLookup::getMemberByUuid,
+            Objects.requireNonNull(bubbleGrid, "bubbleGrid must not be null")::getKeyForBubble,
+            membershipView,
+            ownershipFunction
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Resolution:
+     * <ol>
+     *   <li>Resolve {@code bubbleId} → {@code TetreeKey} via the bubble-key resolver.</li>
+     *   <li>Collect the <em>active-only</em> member digests via
+     *       {@code membershipView.activeMembers()} (RDR-005 — not the misnamed
+     *       {@code FirefliesMemberLookup.getActiveMembers()}).</li>
+     *   <li>Delegate to {@link SpatialOwnershipFunction#owner}.</li>
+     *   <li>Verify the result is in the active set (defensive; the HRW function guarantees
+     *       this invariant, but we fail loud on any violation).</li>
+     * </ol>
+     */
+    @Override
+    public Digest resolveOwningMember(UUID bubbleId) {
+        Objects.requireNonNull(bubbleId, "bubbleId must not be null");
+
+        var key = bubbleKeyResolver.apply(bubbleId);
+        if (key == null) {
+            throw new IllegalStateException(
+                "Cannot resolve owning member: bubble not in grid: " + bubbleId);
+        }
+
+        // Active-only set per RDR-005 / B4. Never use FirefliesMemberLookup.getActiveMembers()
+        // (misnamed — it returns allMembers()). Map Member → Digest.
+        List<Digest> activeDigests = membershipView.activeMembers()
+                                                   .map(Member::getId)
+                                                   .toList();
+
+        log.debug("Resolving owner for bubble {} (key={}) across {} active members",
+                  bubbleId, key, activeDigests.size());
+
+        // HRW throws IllegalStateException when activeDigests is empty — propagates as-is.
+        var owner = ownershipFunction.owner(key, activeDigests);
+
+        // Defensive: verify the result is in the active set (should always hold by construction)
+        if (!activeDigests.contains(owner)) {
+            throw new IllegalStateException(
+                "HRW returned a digest not in the active member set — " +
+                "ownership function contract violated for bubble " + bubbleId);
+        }
+        return owner;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Returns this node's {@link Member#getId()} via the injected {@code localMemberSupplier}.
+     */
+    @Override
+    public Digest localMember() {
+        return localMemberSupplier.get().getId();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Uses the injected {@code nodeResolver} to map the node UUID to its {@link Member}, then
+     * returns {@link Member#getId()}.  Fail-loud if no member is found.
+     * <p>
+     * Note: when wired to {@link FirefliesMemberLookup#getMemberByUuid}, this is built on the
+     * misnamed {@code getActiveMembers()} (all-members backing) — this is acceptable here
+     * because this method is used only for validating an explicit node-UUID hint, not for
+     * determining ownership; the active-only gate is enforced in
+     * {@link #resolveOwningMember(UUID)}.
+     */
+    @Override
+    public Digest memberDigestForNode(UUID nodeId) {
+        Objects.requireNonNull(nodeId, "nodeId must not be null");
+        return nodeResolver.apply(nodeId)
+                           .map(Member::getId)
+                           .orElseThrow(() -> new IllegalStateException(
+                               "No Fireflies member found for node UUID: " + nodeId));
+    }
+}

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/FirefliesBubbleOwnershipResolver.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/FirefliesBubbleOwnershipResolver.java
@@ -199,4 +199,18 @@ public final class FirefliesBubbleOwnershipResolver implements BubbleOwnershipRe
                            .orElseThrow(() -> new IllegalStateException(
                                "No Fireflies member found for node UUID: " + nodeId));
     }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Tests {@code member} against the <em>active-only</em> set ({@code membershipView.activeMembers()},
+     * RDR-005) — never the misnamed all-members backing.
+     */
+    @Override
+    public boolean isActiveMember(Digest member) {
+        Objects.requireNonNull(member, "member must not be null");
+        return membershipView.activeMembers()
+                             .map(Member::getId)
+                             .anyMatch(member::equals);
+    }
 }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/RendezvousOwnershipFunction.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/RendezvousOwnershipFunction.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.consensus.ownership;
+
+import com.hellblazer.delos.cryptography.Digest;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Rendezvous / highest-random-weight (HRW) implementation of {@link SpatialOwnershipFunction}.
+ * <p>
+ * For each active member {@code m} in {@code activeMembers}, computes a stable 64-bit weight
+ * {@code w(key, m)} using a well-mixed bitwise hash of the spatial key bits combined with
+ * the member digest bytes. Returns the member with the maximum weight; ties broken
+ * deterministically by {@link Digest#compareTo} natural order, ensuring identical results
+ * across all nodes given the same inputs.
+ * <p>
+ * <b>Weight function design:</b> uses a 64-bit finalizer-mix (Murmur3-style) applied to
+ * {@code keyBits XOR memberBits} so that small changes in either input produce large,
+ * uniform changes in the weight. No random seed, no clock dependency — purely deterministic
+ * from inputs.
+ * <p>
+ * <b>Key stable inputs:</b> {@code key.getLevel()}, {@code key.getLowBits()},
+ * {@code key.getHighBits()}. Member stable input: all available {@code long} words from the
+ * member {@link Digest} bytes (big-endian), folded via a chained mix so the full digest
+ * entropy participates (for a 32-byte SHA-256 digest all four 8-byte words are included).
+ */
+public final class RendezvousOwnershipFunction implements SpatialOwnershipFunction {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Digest owner(TetreeKey<?> key, List<Digest> activeMembers) {
+        Objects.requireNonNull(key, "key must not be null");
+        Objects.requireNonNull(activeMembers, "activeMembers must not be null");
+        if (activeMembers.isEmpty()) {
+            throw new IllegalStateException("Cannot determine owner: activeMembers is empty");
+        }
+
+        // Stable key fingerprint: mix level + low bits + high bits
+        long keyFp = fingerprint(key.getLevel(), key.getLowBits(), key.getHighBits());
+
+        Digest maxMember = null;
+        long maxWeight = Long.MIN_VALUE;
+
+        for (var member : activeMembers) {
+            long memberFp = memberFingerprint(member);
+            long weight = mix64(keyFp ^ memberFp);
+            if (weight > maxWeight || (weight == maxWeight && (maxMember == null || member.compareTo(maxMember) > 0))) {
+                maxWeight = weight;
+                maxMember = member;
+            }
+        }
+        return maxMember;
+    }
+
+    /**
+     * Combine key parts into a single stable fingerprint.
+     */
+    private static long fingerprint(byte level, long lowBits, long highBits) {
+        // Spread the level byte into the high word so it participates in the mix
+        long levelSpread = ((long) (level & 0xFF)) * 0x9E3779B97F4A7C15L;
+        return mix64(levelSpread ^ lowBits) ^ mix64(highBits + 1L);
+    }
+
+    /**
+     * Extract a stable 64-bit word from a {@link Digest} by folding all available
+     * 8-byte words (big-endian) into a single value using a chained mix. For a standard
+     * 32-byte SHA-256 digest this folds all four 8-byte words; shorter digests degrade
+     * gracefully because {@link #readLong} zero-pads missing bytes.
+     * <p>
+     * Using all available entropy prevents two members that differ only in bytes 16–31
+     * from mapping to the same fingerprint and degrading to compareTo tie-breaking for
+     * every key.
+     */
+    private static long memberFingerprint(Digest member) {
+        byte[] bytes = member.getBytes();
+        long w0 = readLong(bytes, 0);
+        long w1 = readLong(bytes, 8);
+        long w2 = readLong(bytes, 16);
+        long w3 = readLong(bytes, 24);
+        return w0 ^ mix64(w1 ^ mix64(w2 ^ mix64(w3)));
+    }
+
+    /**
+     * Read up to 8 bytes from {@code bytes} starting at {@code offset} as a big-endian
+     * {@code long}. Missing bytes are treated as zero.
+     */
+    private static long readLong(byte[] bytes, int offset) {
+        long v = 0;
+        int end = Math.min(offset + 8, bytes.length);
+        for (int i = offset; i < end; i++) {
+            v = (v << 8) | (bytes[i] & 0xFF);
+        }
+        return v;
+    }
+
+    /**
+     * 64-bit Murmur3 finalizer mix: avalanche effect so every input bit affects every
+     * output bit. No external state, no randomness.
+     */
+    private static long mix64(long h) {
+        h ^= (h >>> 33);
+        h *= 0xFF51AFD7ED558CCDL;
+        h ^= (h >>> 33);
+        h *= 0xC4CEB9FE1A85EC53L;
+        h ^= (h >>> 33);
+        return h;
+    }
+}

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/SpatialOwnershipFunction.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/SpatialOwnershipFunction.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.consensus.ownership;
+
+import com.hellblazer.delos.cryptography.Digest;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+
+import java.util.List;
+
+/**
+ * Deterministic, view-derived spatial ownership function.
+ * <p>
+ * Maps a spatial key to the cluster member that owns the corresponding region,
+ * given the current set of active Fireflies members. The function is a
+ * <em>pure function</em> of its inputs: identical inputs on any node produce
+ * identical outputs, with no replicated state, no gossip, and no coordinator.
+ * Ownership auto-rebalances when the active member set changes (view change).
+ * <p>
+ * The recommended implementation is <strong>rendezvous / highest-random-weight
+ * (HRW) hashing</strong>: for each active member {@code m}, compute a stable
+ * 64-bit weight {@code w(key, m)} and return the member with the maximum weight,
+ * breaking ties deterministically (e.g. by {@link Digest} natural order) so the
+ * result is identical on every node.
+ * <p>
+ * <b>Security invariant (RDR-005 / B4):</b> {@code activeMembers} must be the
+ * <em>active-only</em> set ({@code DynamicContext.active()} /
+ * {@code MembershipView.activeMembers()}). Never pass the full all-members set.
+ * An evicted-but-not-GC'd member still holds a valid certificate; admitting it
+ * via this function would let a removed node be named as an owner.
+ */
+public interface SpatialOwnershipFunction {
+
+    /**
+     * Return the cluster member that owns the region represented by {@code key},
+     * given the current active member set.
+     * <p>
+     * The result is deterministic: for the same {@code key} and {@code activeMembers}
+     * (same elements, regardless of list order) every call on every node returns the
+     * same {@link Digest}.
+     *
+     * @param key           the spatial key identifying the region; must not be {@code null}
+     * @param activeMembers the current <em>active-only</em> Fireflies member digests;
+     *                      must not be {@code null}
+     * @return the {@link Digest} of the owning member — always a member present in
+     *         {@code activeMembers}
+     * @throws IllegalStateException if {@code activeMembers} is empty (fail-loud: no
+     *                               owner can be determined)
+     * @throws NullPointerException  if {@code key} or {@code activeMembers} is {@code null}
+     */
+    Digest owner(TetreeKey<?> key, List<Digest> activeMembers);
+}

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/StubBubbleOwnershipResolver.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/StubBubbleOwnershipResolver.java
@@ -110,4 +110,16 @@ public final class StubBubbleOwnershipResolver implements BubbleOwnershipResolve
         }
         return digest;
     }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Tests membership against the seeded active member list (this double uses the same set for
+     * active and all members — see the class note).
+     */
+    @Override
+    public boolean isActiveMember(Digest member) {
+        Objects.requireNonNull(member, "member must not be null");
+        return activeMembers.contains(member);
+    }
 }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/StubBubbleOwnershipResolver.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/ownership/StubBubbleOwnershipResolver.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.consensus.ownership;
+
+import com.hellblazer.delos.cryptography.Digest;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Deterministic test double for {@link BubbleOwnershipResolver}.
+ * <p>
+ * Seeded at construction time with:
+ * <ul>
+ *   <li>A fixed {@code bubbleId → TetreeKey} map (simulating the bubble grid)</li>
+ *   <li>A fixed active member {@link Digest} list</li>
+ *   <li>A designated local member {@link Digest}</li>
+ *   <li>A fixed {@code nodeId → Digest} map (for {@link #memberDigestForNode})</li>
+ * </ul>
+ * Drives deterministic unit tests without any real Fireflies infrastructure.
+ * Uses a {@link RendezvousOwnershipFunction} internally so HRW convergence properties
+ * are exercised through the resolver as well.
+ * <p>
+ * <b>Note on active/all distinction:</b> this test double uses the same set for both
+ * active members and all members because tests using it do not exercise that distinction.
+ * This equivalence is intentional and documented per the {@code MembershipView.activeMembers()}
+ * contract.
+ */
+public final class StubBubbleOwnershipResolver implements BubbleOwnershipResolver {
+
+    private static final SpatialOwnershipFunction HRW = new RendezvousOwnershipFunction();
+
+    private final Map<UUID, TetreeKey<?>> bubbleGrid;
+    private final List<Digest> activeMembers;
+    private final Digest localMember;
+    private final Map<UUID, Digest> nodeIdToDigest;
+
+    /**
+     * Construct a seeded test double.
+     *
+     * @param bubbleGrid      fixed {@code bubbleId → TetreeKey} mapping; must not be {@code null}
+     * @param activeMembers   fixed active member digests; must not be {@code null}
+     * @param localMember     this process's own member {@link Digest}; must not be {@code null}
+     * @param nodeIdToDigest  fixed {@code nodeId → Digest} mapping; must not be {@code null}
+     */
+    public StubBubbleOwnershipResolver(Map<UUID, TetreeKey<?>> bubbleGrid,
+                                       List<Digest> activeMembers,
+                                       Digest localMember,
+                                       Map<UUID, Digest> nodeIdToDigest) {
+        this.bubbleGrid = Map.copyOf(Objects.requireNonNull(bubbleGrid, "bubbleGrid must not be null"));
+        this.activeMembers = List.copyOf(Objects.requireNonNull(activeMembers, "activeMembers must not be null"));
+        this.localMember = Objects.requireNonNull(localMember, "localMember must not be null");
+        this.nodeIdToDigest = Map.copyOf(Objects.requireNonNull(nodeIdToDigest, "nodeIdToDigest must not be null"));
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Resolves via the seeded bubble grid then delegates to the HRW function over the
+     * seeded active member set.
+     */
+    @Override
+    public Digest resolveOwningMember(UUID bubbleId) {
+        Objects.requireNonNull(bubbleId, "bubbleId must not be null");
+        var key = bubbleGrid.get(bubbleId);
+        if (key == null) {
+            throw new IllegalStateException(
+                "Bubble not in grid (test double): " + bubbleId);
+        }
+        // activeMembers list may be empty → HRW throws with a clear message
+        return HRW.owner(key, activeMembers);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Digest localMember() {
+        return localMember;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Digest memberDigestForNode(UUID nodeId) {
+        Objects.requireNonNull(nodeId, "nodeId must not be null");
+        var digest = nodeIdToDigest.get(nodeId);
+        if (digest == null) {
+            throw new IllegalStateException(
+                "No member found for node UUID (test double): " + nodeId);
+        }
+        return digest;
+    }
+}

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/OptimisticMigratorImpl.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/OptimisticMigratorImpl.java
@@ -70,8 +70,18 @@ public class OptimisticMigratorImpl implements OptimisticMigrator {
     // Per-entity deferred update queue (bounded, lock-free)
     private final Map<UUID, java.util.concurrent.BlockingDeque<DeferredUpdate>> deferredQueues;
 
-    // Integration with committee consensus (Phase 7G.3)
-    private com.hellblazer.luciferase.simulation.consensus.committee.OptimisticMigratorIntegration consensusIntegration;
+    // Integration with committee consensus (Phase 7G.3).
+    // volatile: requestMigrationApproval is documented as concurrently callable (see the AtomicLong
+    // metrics), and this field is written via a setter; volatile gives the read a happens-before edge
+    // so a concurrent caller never observes a stale null after wiring (RDR-020 S4 review).
+    private volatile com.hellblazer.luciferase.simulation.consensus.committee.OptimisticMigratorIntegration consensusIntegration;
+
+    // Node-identity boundary for entity migration (RDR-020 S4). Resolves the target bubble UUID to
+    // the HRW owning member Digest and supplies the local member Digest as the source. Required when
+    // consensusIntegration is set; without it the bubble-UUID→member-Digest mapping the integration
+    // needs is unavailable and approval fails loud rather than silently bypassing the quorum gate.
+    // volatile for the same concurrent-visibility reason as consensusIntegration.
+    private volatile com.hellblazer.luciferase.simulation.consensus.ownership.BubbleOwnershipResolver ownershipResolver;
 
     // Metrics — AtomicLong because all increments occur from public interface methods that the
     // class documents as concurrently callable; plain long read-add-write triples lose
@@ -104,6 +114,22 @@ public class OptimisticMigratorImpl implements OptimisticMigrator {
         log.debug("Consensus integration set");
     }
 
+    /**
+     * Set the bubble ownership resolver (RDR-020 S4).
+     * <p>
+     * Required alongside {@link #setConsensusIntegration} so {@link #requestMigrationApproval} can map
+     * the target bubble UUID to its HRW owning member {@link com.hellblazer.delos.cryptography.Digest}
+     * (target node) and supply the local member as the source node. Without it, a consensus-gated
+     * approval fails loud rather than silently bypassing the quorum gate.
+     *
+     * @param resolver the ownership resolver
+     */
+    public void setOwnershipResolver(
+        com.hellblazer.luciferase.simulation.consensus.ownership.BubbleOwnershipResolver resolver) {
+        this.ownershipResolver = resolver;
+        log.debug("Ownership resolver set");
+    }
+
     @Override
     public void initiateOptimisticMigration(UUID entityId, UUID targetBubbleId) {
         Objects.requireNonNull(entityId, "entityId must not be null");
@@ -126,19 +152,30 @@ public class OptimisticMigratorImpl implements OptimisticMigrator {
         Objects.requireNonNull(entityId, "entityId must not be null");
         Objects.requireNonNull(targetBubble, "targetBubble must not be null");
 
-        // Phase 7G.3 / Luciferase-0frcy.35: when a consensus integration is wired, the caller
-        // expects the committee-quorum gate to actually run. The integration's
-        // requestMigrationApproval requires Digest source/target node identities, but this impl
-        // only has UUID bubble ids and no UUID→Digest mapping. Previously this branch silently
-        // returned `true`, bypassing the quorum check entirely while logging "Delegating ...".
-        // That is a safety hazard: a caller relying on the gate would skip it without any signal.
-        // Fail loud instead of silently approving until a real UUID→Digest mapping is wired.
+        // Phase 7G.3 / Luciferase-0frcy.35 / RDR-020 S4: when a consensus integration is wired the
+        // caller expects the committee-quorum gate to actually run. The integration needs Digest
+        // source/target node identities; the BubbleOwnershipResolver (S1) supplies them — target is the
+        // HRW owner of the target BUBBLE UUID, source is the local member (possession). This replaces
+        // the old UnsupportedOperationException gate, which existed only because no UUID→Digest mapping
+        // was available. Fail-loud invariants are preserved: a configured integration with no resolver
+        // throws (rather than silently approving), and resolveOwningMember itself throws on an
+        // unresolvable target (never a silent approve).
         if (consensusIntegration != null) {
-            throw new UnsupportedOperationException(
-                "Consensus-gated migration approval is configured but the UUID→Digest mapping "
-                + "required to delegate to committee consensus is not available "
-                + "(entity=" + entityId + ", target=" + targetBubble + "). Refusing to silently "
-                + "approve and bypass the quorum gate.");
+            if (ownershipResolver == null) {
+                throw new IllegalStateException(
+                    "Consensus-gated migration approval is configured but no BubbleOwnershipResolver is "
+                    + "set, so the target bubble cannot be resolved to a member Digest "
+                    + "(entity=" + entityId + ", target=" + targetBubble + "). Refusing to silently "
+                    + "approve and bypass the quorum gate.");
+            }
+            // targetBubble is a BUBBLE UUID → resolve directly to its HRW owner (no node-UUID lookup).
+            // resolveOwningMember fails loud (IllegalStateException) on an unresolvable target;
+            // localMember() always returns this process's own in-view member (possession).
+            var targetNodeId = ownershipResolver.resolveOwningMember(targetBubble);
+            var sourceId = ownershipResolver.localMember();
+            log.debug("Delegating migration approval to committee consensus: entity={}, source={}, target={}",
+                    entityId, sourceId, targetNodeId);
+            return consensusIntegration.requestMigrationApproval(entityId, sourceId, targetNodeId);
         }
 
         // Backward compatibility: default to approved when consensus not configured

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/OptimisticMigratorImpl.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/migration/OptimisticMigratorImpl.java
@@ -124,6 +124,9 @@ public class OptimisticMigratorImpl implements OptimisticMigrator {
      *
      * @param resolver the ownership resolver
      */
+    // Production wiring note (RDR-020 / s23eu): no bootstrap assembly calls this yet — the live path
+    // is single-process and consensus integration is unwired; multi-node wiring lands with bead
+    // Luciferase-s23eu.
     public void setOwnershipResolver(
         com.hellblazer.luciferase.simulation.consensus.ownership.BubbleOwnershipResolver resolver) {
         this.ownershipResolver = resolver;

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/network/DistributedBubbleNode.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/network/DistributedBubbleNode.java
@@ -8,6 +8,7 @@ package com.hellblazer.luciferase.simulation.distributed.network;
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
 import com.hellblazer.luciferase.simulation.bubble.EnhancedBubbleMigrationIntegration;
 import com.hellblazer.luciferase.simulation.causality.*;
+import com.hellblazer.luciferase.simulation.consensus.ownership.BubbleOwnershipResolver;
 import com.hellblazer.luciferase.simulation.distributed.migration.*;
 import com.hellblazer.luciferase.simulation.events.*;
 import java.util.UUID;
@@ -30,6 +31,16 @@ public class DistributedBubbleNode implements BubbleNetworkChannel.EntityDepartu
     private final BubbleNetworkChannel networkChannel;
     private final EnhancedBubbleMigrationIntegration migrationIntegration;
     private final EntityMigrationStateMachine fsm;
+
+    /**
+     * Node-identity resolver for validating an explicit {@code targetNodeId} hint (RDR-020 S5).
+     * <p>
+     * Optional: when set, {@link #initiateRemoteMigration(UUID, UUID)} fails loud if the supplied
+     * {@code targetNodeId} does not resolve to a current-view active member. When unset (the default),
+     * the hint is not validated (backward compatibility). volatile for safe visibility across the
+     * concurrently-callable migration path.
+     */
+    private volatile BubbleOwnershipResolver ownershipResolver;
 
     /**
      * Create a distributed bubble node with network communication.
@@ -102,13 +113,56 @@ public class DistributedBubbleNode implements BubbleNetworkChannel.EntityDepartu
     }
 
     /**
+     * Set the node-identity resolver used to validate an explicit {@code targetNodeId} hint
+     * (RDR-020 S5). When set, {@link #initiateRemoteMigration} fails loud on a node UUID that does
+     * not resolve to a current-view active member; when unset the hint is not validated.
+     *
+     * @param resolver the ownership resolver, or {@code null} to disable hint validation
+     */
+    public void setOwnershipResolver(BubbleOwnershipResolver resolver) {
+        if (resolver == null && this.ownershipResolver != null) {
+            // Surface the downgrade: clearing a previously-wired resolver silently re-opens the
+            // unvalidated-hint path. Make it visible rather than a quiet safety regression.
+            log.warn("Ownership resolver cleared on node {}: targetNodeId hint validation now disabled", nodeId);
+        }
+        this.ownershipResolver = resolver;
+    }
+
+    /**
      * Initiate an optimistic migration to a remote node.
      *
      * @param entityId    UUID of entity to migrate
      * @param targetNodeId UUID of target node
      * @return true if migration successfully initiated
+     * @throws IllegalStateException if an ownership resolver is wired and {@code targetNodeId} does not
+     *                               resolve to a current-view active member (RDR-020 S5 fail-loud hint
+     *                               validation) — a stale/forged/random node UUID is a consistency
+     *                               error, not a transient condition. Note: the resolution and
+     *                               active-membership check are two reads, not one atomic snapshot; a
+     *                               view transition between them may yield a false-pass or false-fail.
+     *                               That is acceptable — an in-flight migration is independently subject
+     *                               to view-change rollback downstream (a false-pass self-heals), and a
+     *                               false-fail is a visible fail-loud, never a mis-route.
      */
     public boolean initiateRemoteMigration(UUID entityId, UUID targetNodeId) {
+        // RDR-020 S5 (B1/B4): when a resolver is wired, validate the explicit node-UUID hint before
+        // anything else. targetNodeId carries no destination region key, so HRW owner(destKey) is not
+        // computable here (that cross-check lives at the bubble-keyed consensus entry points, S3/S4);
+        // the implementable guard is the canonical node-UUID -> member-Digest resolution plus an
+        // active-only membership check. A random/unknown UUID resolves to no member, and an
+        // evicted-but-not-GC'd node resolves but is inactive — both fail loud rather than silently
+        // initiating a migration toward a node that cannot own the entity.
+        var resolver = ownershipResolver;
+        if (resolver != null) {
+            var targetDigest = resolver.memberDigestForNode(targetNodeId); // throws if no such member
+            if (!resolver.isActiveMember(targetDigest)) {
+                throw new IllegalStateException(
+                    "Target node " + targetNodeId + " resolves to member " + targetDigest
+                    + " which is not a current-view active member; refusing to initiate migration of "
+                    + entityId + " toward an inactive node");
+            }
+        }
+
         // Check if target is reachable
         if (!networkChannel.isNodeReachable(targetNodeId)) {
             log.warn("Cannot migrate {}: target node {} unreachable", entityId, targetNodeId);

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/network/DistributedBubbleNode.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/network/DistributedBubbleNode.java
@@ -119,6 +119,8 @@ public class DistributedBubbleNode implements BubbleNetworkChannel.EntityDepartu
      *
      * @param resolver the ownership resolver, or {@code null} to disable hint validation
      */
+    // Production wiring note (RDR-020 / s23eu): no bootstrap assembly calls this yet — the live path
+    // is single-process; multi-node wiring lands with bead Luciferase-s23eu.
     public void setOwnershipResolver(BubbleOwnershipResolver resolver) {
         if (resolver == null && this.ownershipResolver != null) {
             // Surface the downgrade: clearing a previously-wired resolver silently re-opens the

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/topology/TopologyConsensusCoordinator.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/topology/TopologyConsensusCoordinator.java
@@ -107,9 +107,11 @@ public class TopologyConsensusCoordinator {
     /**
      * Underlying consensus protocol for Byzantine fault tolerance.
      * <p>
-     * Set via setConsensusProtocol() for dependency injection.
+     * Set via setConsensusProtocol() for dependency injection. volatile: written by the setter and
+     * read in requestConsensus on a possibly-different thread; volatile gives the read a happens-before
+     * edge so it never observes a stale null after wiring (matches OptimisticMigratorImpl, RDR-020 review).
      */
-    private ViewCommitteeConsensus consensusProtocol;
+    private volatile ViewCommitteeConsensus consensusProtocol;
 
     /**
      * Resolves the HRW owning member of a region for the TOPOLOGY node-identity model (RDR-020 S3).
@@ -119,8 +121,13 @@ public class TopologyConsensusCoordinator {
      * change must carry the real, in-view member identity of the region's owner, not a
      * bubble-UUID-derived digest (the old {@code digestOf} which the live membership-enforcing
      * consensus silently rejected — RDR-020 Gap 2 / Luciferase-vhbw3).
+     * volatile for the same concurrent-visibility reason as consensusProtocol.
+     * <p>
+     * Production wiring note (RDR-020 / s23eu): no bootstrap assembly wires this resolver yet — the
+     * live path is single-process where every proposal is a self-migration, so the resolver is not
+     * needed. Multi-node productionization wires it via the node bootstrap (bead Luciferase-s23eu).
      */
-    private BubbleOwnershipResolver ownershipResolver;
+    private volatile BubbleOwnershipResolver ownershipResolver;
 
     /**
      * Creates a topology consensus coordinator with default 30-second cooldown.

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/topology/TopologyConsensusCoordinator.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/topology/TopologyConsensusCoordinator.java
@@ -16,11 +16,11 @@
  */
 package com.hellblazer.luciferase.simulation.topology;
 
-import com.hellblazer.delos.cryptography.Digest;
-import com.hellblazer.delos.cryptography.DigestAlgorithm;
 import com.hellblazer.luciferase.simulation.bubble.TetreeBubbleGrid;
 import com.hellblazer.luciferase.simulation.consensus.committee.MigrationProposal;
+import com.hellblazer.luciferase.simulation.consensus.committee.ProposalKind;
 import com.hellblazer.luciferase.simulation.consensus.committee.ViewCommitteeConsensus;
+import com.hellblazer.luciferase.simulation.consensus.ownership.BubbleOwnershipResolver;
 import com.hellblazer.luciferase.common.time.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,6 +112,17 @@ public class TopologyConsensusCoordinator {
     private ViewCommitteeConsensus consensusProtocol;
 
     /**
+     * Resolves the HRW owning member of a region for the TOPOLOGY node-identity model (RDR-020 S3).
+     * <p>
+     * Set via {@link #setOwnershipResolver(BubbleOwnershipResolver)} for dependency injection.
+     * Required before {@link #requestConsensus(TopologyProposal)} can build a proposal: a topology
+     * change must carry the real, in-view member identity of the region's owner, not a
+     * bubble-UUID-derived digest (the old {@code digestOf} which the live membership-enforcing
+     * consensus silently rejected — RDR-020 Gap 2 / Luciferase-vhbw3).
+     */
+    private BubbleOwnershipResolver ownershipResolver;
+
+    /**
      * Creates a topology consensus coordinator with default 30-second cooldown.
      *
      * @param bubbleGrid the bubble grid for validation
@@ -164,6 +175,20 @@ public class TopologyConsensusCoordinator {
     }
 
     /**
+     * Sets the bubble ownership resolver (RDR-020 S3).
+     * <p>
+     * Dependency injection for {@link BubbleOwnershipResolver}. Required before
+     * {@link #requestConsensus(TopologyProposal)} can map a topology change to a TOPOLOGY-kind
+     * {@link MigrationProposal} carrying the region owner's real Fireflies member identity.
+     *
+     * @param resolver the ownership resolver
+     * @throws NullPointerException if resolver is null
+     */
+    public void setOwnershipResolver(BubbleOwnershipResolver resolver) {
+        this.ownershipResolver = Objects.requireNonNull(resolver, "ownershipResolver must not be null");
+    }
+
+    /**
      * Requests consensus for a topology change proposal.
      * <p>
      * Performs three-stage validation:
@@ -178,7 +203,11 @@ public class TopologyConsensusCoordinator {
      * @param proposal the topology change proposal
      * @return CompletableFuture<Boolean> - true if approved, false if rejected
      * @throws NullPointerException  if proposal is null
-     * @throws IllegalStateException if consensusProtocol not set
+     * @throws IllegalStateException if {@code consensusProtocol} is not set, if
+     *                               {@code ownershipResolver} is not set, if the local node does not
+     *                               own the region being restructured, or if a merge spans two HRW
+     *                               regions (cross-region merge, out of scope — RDR-020 S3). On any of
+     *                               these the Stage 1 cooldown reservation is restored before the throw.
      */
     public CompletableFuture<Boolean> requestConsensus(TopologyProposal proposal) {
         Objects.requireNonNull(proposal, "proposal must not be null");
@@ -223,7 +252,21 @@ public class TopologyConsensusCoordinator {
                  proposal.viewId(),
                  proposal.timestamp());
 
-        return consensusProtocol.requestConsensus(toMigrationProposal(proposal))
+        // Build the consensus envelope BEFORE entering the future chain. toMigrationProposal can
+        // throw synchronously (resolver unset, ownership guard, cross-region merge); were it evaluated
+        // inline as the requestConsensus(...) argument, the throw would escape before .handle() is
+        // registered, orphaning the Stage 1 cooldown reservation (it would never be restored). Restore
+        // the reservation on the synchronous-throw path so a rejected proposal imposes no spurious
+        // cooldown, then rethrow.
+        final MigrationProposal migrationProposal;
+        try {
+            migrationProposal = toMigrationProposal(proposal);
+        } catch (RuntimeException e) {
+            restoreCooldown(proposal, priorTimestamps);
+            throw e;
+        }
+
+        return consensusProtocol.requestConsensus(migrationProposal)
                                 .handle((approved, ex) -> {
                                     if (ex == null && Boolean.TRUE.equals(approved)) {
                                         // Cooldown was already reserved atomically in Stage 1;
@@ -248,43 +291,61 @@ public class TopologyConsensusCoordinator {
 
     /**
      * Adapts a {@link TopologyProposal} to the consensus layer's
-     * {@link MigrationProposal} envelope for committee voting.
+     * {@link MigrationProposal} envelope for committee voting (RDR-020 S3).
      * <p>
-     * The consensus layer votes on opaque proposal identity (proposalId + viewId +
-     * timestamp); the topology-specific payload is validated locally in Stage 2.
-     * The affected bubble is mapped to source/target node identities so the
-     * proposal is well-formed for the voting protocol.
+     * A topology change is a single-region structural change, so it uses the
+     * <b>TOPOLOGY node-identity model</b>: {@code source == target == owner(region)}, where the
+     * owner is the HRW member of the primary affected bubble resolved through the injected
+     * {@link BubbleOwnershipResolver}. This replaces the old {@code digestOf} hash of bubble UUIDs,
+     * which produced identities the live membership-enforcing {@code ViewCommitteeConsensus} would
+     * silently reject as "node not in view" (RDR-020 Gap 2 / Luciferase-vhbw3).
      * <p>
-     * <b>Known limitation (Luciferase-vhbw3):</b> the source/target node identities
-     * here are {@link #digestOf(UUID) digests derived from bubble UUIDs}, which are
-     * NOT Fireflies member IDs. A live {@code ViewCommitteeConsensus.validateProposal}
-     * gates on {@code isNodeInView(...)} against the actual Fireflies membership view,
-     * so a bubble-UUID-derived digest will be rejected as "node not in view". The
-     * mapping is therefore only sound against a test/mock consensus that does not
-     * enforce membership. Wiring real Fireflies member IDs through this envelope is
-     * tracked by bead Luciferase-vhbw3.
+     * Two fail-loud guards encode safety invariants the old hash silently lacked:
+     * <ul>
+     *   <li><b>Ownership.</b> The local process may only restructure a region it owns:
+     *       {@code resolver.localMember().equals(ownerNode)} or an {@link IllegalStateException}
+     *       is thrown.</li>
+     *   <li><b>Cross-region merge (out of scope).</b> A {@link MergeProposal} whose two bubbles
+     *       resolve to different owners cannot be represented by the single-owner model and throws
+     *       {@code IllegalStateException("cross-region merge not yet supported")} — a two-node merge
+     *       protocol is a named boundary (s23eu / RDR-015 follow-on). On the single-process live
+     *       path both bubbles share the one local owner, so the guard is a no-op there.</li>
+     * </ul>
      *
      * @param proposal the topology proposal to wrap
-     * @return a migration proposal carrying the same identity for committee voting
+     * @return a TOPOLOGY-kind migration proposal carrying the region owner's member identity
+     * @throws IllegalStateException if the resolver is unset, the local process does not own the
+     *                               region, or the merge spans two HRW regions
      */
     private MigrationProposal toMigrationProposal(TopologyProposal proposal) {
+        if (ownershipResolver == null) {
+            throw new IllegalStateException("ownershipResolver not set - call setOwnershipResolver()");
+        }
         var affected = getAffectedBubbles(proposal);
         var primary = affected.get(0);
-        var entityId = primary;
-        var sourceNode = digestOf(primary);
-        var targetNode = affected.size() > 1 ? digestOf(affected.get(1)) : digestOf(proposal.proposalId());
-        return new MigrationProposal(proposal.proposalId(), entityId, sourceNode, targetNode,
-                                     proposal.viewId(), proposal.timestamp());
-    }
+        var ownerNode = ownershipResolver.resolveOwningMember(primary);
 
-    /**
-     * Derives a stable {@link Digest} identity from a UUID for the consensus envelope.
-     *
-     * @param id the source identifier
-     * @return a deterministic digest of the identifier
-     */
-    private static Digest digestOf(UUID id) {
-        return DigestAlgorithm.DEFAULT.digest(id.toString());
+        // Cross-region merge guard: a merge is the one two-bubble case; both bubbles must share one
+        // HRW owner for the single-owner model to hold. Cross-region merge is explicitly out of scope.
+        if (proposal instanceof MergeProposal) {
+            var secondOwner = ownershipResolver.resolveOwningMember(affected.get(1));
+            if (!ownerNode.equals(secondOwner)) {
+                throw new IllegalStateException("cross-region merge not yet supported");
+            }
+        }
+
+        // Ownership guard: a node may only propose topology changes for a region it owns. This gives
+        // the proposal a meaningful in-view source identity AND prevents a node from restructuring
+        // another node's region (a safety property the old digestOf hash silently lacked).
+        var localMember = ownershipResolver.localMember();
+        if (!localMember.equals(ownerNode)) {
+            throw new IllegalStateException(
+                "Local node " + localMember + " may not propose a topology change for region owned by "
+                + ownerNode + " (primary bubble " + primary + ")");
+        }
+
+        return new MigrationProposal(proposal.proposalId(), primary, ownerNode, ownerNode,
+                                     proposal.viewId(), proposal.timestamp(), ProposalKind.TOPOLOGY);
     }
 
     /**

--- a/simulation/src/test/java/com/hellblazer/delos/membership/MockMember.java
+++ b/simulation/src/test/java/com/hellblazer/delos/membership/MockMember.java
@@ -1,0 +1,40 @@
+package com.hellblazer.delos.membership;
+
+import com.hellblazer.delos.cryptography.Digest;
+import com.hellblazer.delos.cryptography.JohnHancock;
+import com.hellblazer.delos.cryptography.SigningThreshold;
+
+import java.io.InputStream;
+
+/**
+ * A stand in for comparison functions
+ *
+ * @author hal.hildebrand
+ **/
+public class MockMember implements Member {
+    private final Digest id;
+
+    public MockMember(Digest id) {
+        this.id = id;
+    }
+
+    @Override
+    public int compareTo(Member o) {
+        return id.compareTo(o.getId());
+    }
+
+    @Override
+    public Digest getId() {
+        return id;
+    }
+
+    @Override
+    public boolean verify(JohnHancock signature, InputStream message) {
+        return false;
+    }
+
+    @Override
+    public boolean verify(SigningThreshold threshold, JohnHancock signature, InputStream message) {
+        return false;
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGridInverseIndexTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/bubble/TetreeBubbleGridInverseIndexTest.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.simulation.bubble;
+
+import com.hellblazer.luciferase.lucien.tetree.Tet;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+import com.hellblazer.luciferase.simulation.config.WorldBounds;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * TDD tests for the O(1) inverse UUID→TetreeKey index in TetreeBubbleGrid (RDR-020 S2).
+ * <p>
+ * Verifies that:
+ * <ul>
+ *   <li>after addBubble, getKeyForBubble(id) returns the exact key it was added under;</li>
+ *   <li>after removeBubble(id), getKeyForBubble(id) returns null (no leak);</li>
+ *   <li>absent id → null;</li>
+ *   <li>the WorldBounds partition path (createBubbles(int,WorldBounds,long)) also populates
+ *       the inverse index;</li>
+ *   <li>the legacy mixed-level path (createBubbles(int,byte,long)) also populates the
+ *       inverse index;</li>
+ *   <li>consistency invariant: for every entry in bubblesByKey, getKeyForBubble(bubble.id())
+ *       equals that key, and the two maps never drift in size after add/remove sequences;</li>
+ *   <li>clear() wipes the inverse index so all ids resolve to null.</li>
+ * </ul>
+ *
+ * @author hal.hildebrand
+ */
+class TetreeBubbleGridInverseIndexTest {
+
+    private TetreeBubbleGrid grid;
+
+    @BeforeEach
+    void setUp() {
+        grid = new TetreeBubbleGrid((byte) 5);
+    }
+
+    // ── addBubble path ────────────────────────────────────────────────────────
+
+    @Test
+    void addBubble_getKeyForBubble_returnsExactKey() {
+        var bubble = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+        var key = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(0).tmIndex();
+
+        grid.addBubble(bubble, key);
+
+        assertThat(grid.getKeyForBubble(bubble.id())).isEqualTo(key);
+    }
+
+    @Test
+    void addBubble_getKeyForBubble_identicalToLinearScanResult() {
+        // Belt-and-suspenders: the new O(1) result must equal what the old O(N) scan returned.
+        var bubble = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+        var key = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(2).tmIndex();
+
+        grid.addBubble(bubble, key);
+
+        // getBubblesWithKeys() lets us independently derive the key via iteration.
+        TetreeKey<?> scanKey = null;
+        for (var entry : grid.getBubblesWithKeys().entrySet()) {
+            if (entry.getValue().id().equals(bubble.id())) {
+                scanKey = entry.getKey();
+                break;
+            }
+        }
+        assertThat(grid.getKeyForBubble(bubble.id())).isEqualTo(scanKey);
+    }
+
+    // ── removeBubble path ─────────────────────────────────────────────────────
+
+    @Test
+    void removeBubble_getKeyForBubble_returnsNull() {
+        var bubble = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+        var key = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(0).tmIndex();
+        grid.addBubble(bubble, key);
+
+        boolean removed = grid.removeBubble(bubble.id());
+
+        assertThat(removed).isTrue();
+        assertThat(grid.getKeyForBubble(bubble.id())).isNull();
+    }
+
+    @Test
+    void removeBubble_inverseIndexNoLeak() {
+        // Add 3 bubbles, remove the middle one: inverse index size must track bubblesByKey size.
+        var key1 = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(0).tmIndex();
+        var key2 = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(1).tmIndex();
+        var key3 = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(2).tmIndex();
+
+        var b1 = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+        var b2 = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+        var b3 = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+
+        grid.addBubble(b1, key1);
+        grid.addBubble(b2, key2);
+        grid.addBubble(b3, key3);
+
+        grid.removeBubble(b2.id());
+
+        // b2 gone; b1 and b3 still resolvable.
+        assertThat(grid.getKeyForBubble(b2.id())).isNull();
+        assertThat(grid.getKeyForBubble(b1.id())).isEqualTo(key1);
+        assertThat(grid.getKeyForBubble(b3.id())).isEqualTo(key3);
+    }
+
+    // ── absent id ─────────────────────────────────────────────────────────────
+
+    @Test
+    void getKeyForBubble_absentId_returnsNull() {
+        assertThat(grid.getKeyForBubble(UUID.randomUUID())).isNull();
+    }
+
+    @Test
+    void getKeyForBubble_nullId_throwsNullPointerException() {
+        assertThatNullPointerException().isThrownBy(() -> grid.getKeyForBubble(null));
+    }
+
+    // ── WorldBounds partition path ────────────────────────────────────────────
+
+    @Test
+    void createBubbles_worldBoundsPath_populatesInverseIndex() {
+        var bounds = new WorldBounds(0f, 1_000_000f);
+        grid.createBubbles(4, bounds, 16L);
+
+        assertThat(grid.getBubbleCount()).isGreaterThan(0);
+        // Every registered bubble must be resolvable via inverse index.
+        for (var entry : grid.getBubblesWithKeys().entrySet()) {
+            assertThat(grid.getKeyForBubble(entry.getValue().id()))
+                .as("WorldBounds partition bubble %s must resolve via inverse index", entry.getValue().id())
+                .isEqualTo(entry.getKey());
+        }
+    }
+
+    // ── Legacy mixed-level path ───────────────────────────────────────────────
+
+    @Test
+    void createBubbles_legacyPath_populatesInverseIndex() {
+        grid.createBubbles(6, (byte) 2, 16L);
+
+        assertThat(grid.getBubbleCount()).isGreaterThan(0);
+        for (var entry : grid.getBubblesWithKeys().entrySet()) {
+            assertThat(grid.getKeyForBubble(entry.getValue().id()))
+                .as("Legacy path bubble %s must resolve via inverse index", entry.getValue().id())
+                .isEqualTo(entry.getKey());
+        }
+    }
+
+    // ── clear() path ──────────────────────────────────────────────────────────
+
+    @Test
+    void clear_wipesInverseIndex() {
+        var key1 = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(0).tmIndex();
+        var b1 = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+        grid.addBubble(b1, key1);
+
+        grid.clear();
+
+        assertThat(grid.getKeyForBubble(b1.id())).isNull();
+        assertThat(grid.getBubbleCount()).isZero();
+    }
+
+    @Test
+    void clear_afterCreateBubbles_wipesInverseIndex() {
+        grid.createBubbles(5, (byte) 2, 16L);
+        var allBefore = grid.getBubblesWithKeys();
+        assertThat(allBefore).isNotEmpty();
+
+        grid.clear();
+
+        for (var bubble : allBefore.values()) {
+            assertThat(grid.getKeyForBubble(bubble.id())).isNull();
+        }
+    }
+
+    // ── consistency invariant ─────────────────────────────────────────────────
+
+    @Test
+    void consistencyInvariant_afterAddRemoveSequence_noMapDrift() {
+        // Add 4 bubbles, remove 2 of them — sizes of bubblesByKey and inverse index must agree.
+        var key1 = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(0).tmIndex();
+        var key2 = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(1).tmIndex();
+        var key3 = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(2).tmIndex();
+        var key4 = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(3).tmIndex();
+
+        var b1 = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+        var b2 = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+        var b3 = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+        var b4 = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+
+        grid.addBubble(b1, key1);
+        grid.addBubble(b2, key2);
+        grid.addBubble(b3, key3);
+        grid.addBubble(b4, key4);
+
+        // Each added bubble must resolve correctly.
+        assertThat(grid.getKeyForBubble(b1.id())).isEqualTo(key1);
+        assertThat(grid.getKeyForBubble(b2.id())).isEqualTo(key2);
+        assertThat(grid.getKeyForBubble(b3.id())).isEqualTo(key3);
+        assertThat(grid.getKeyForBubble(b4.id())).isEqualTo(key4);
+
+        // Remove b1 and b3.
+        grid.removeBubble(b1.id());
+        grid.removeBubble(b3.id());
+
+        // b2 and b4 still present; b1 and b3 gone.
+        assertThat(grid.getKeyForBubble(b1.id())).isNull();
+        assertThat(grid.getKeyForBubble(b2.id())).isEqualTo(key2);
+        assertThat(grid.getKeyForBubble(b3.id())).isNull();
+        assertThat(grid.getKeyForBubble(b4.id())).isEqualTo(key4);
+
+        // Sizes agree: bubblesByKey has 2, inverse index should also cover exactly 2.
+        assertThat(grid.getBubbleCount()).isEqualTo(2);
+        // Forward-check: every key in bubblesByKey maps back via inverse index.
+        for (var entry : grid.getBubblesWithKeys().entrySet()) {
+            assertThat(grid.getKeyForBubble(entry.getValue().id()))
+                .as("Forward consistency for bubble %s", entry.getValue().id())
+                .isEqualTo(entry.getKey());
+        }
+        // Reverse-check: removed ids no longer in inverse index.
+        assertThat(grid.getKeyForBubble(b1.id())).isNull();
+        assertThat(grid.getKeyForBubble(b3.id())).isNull();
+    }
+
+    @Test
+    void consistencyInvariant_createBubblesThenClear_noDrift() {
+        grid.createBubbles(8, (byte) 2, 16L);
+        int beforeCount = grid.getBubbleCount();
+        assertThat(beforeCount).isGreaterThan(0);
+
+        // All must resolve.
+        for (var entry : grid.getBubblesWithKeys().entrySet()) {
+            assertThat(grid.getKeyForBubble(entry.getValue().id()))
+                .isEqualTo(entry.getKey());
+        }
+
+        grid.clear();
+
+        // None must resolve after clear.
+        assertThat(grid.getBubbleCount()).isZero();
+    }
+
+    // ── SIG-1: getNeighbors(UUID) uses inverse index ──────────────────────────
+
+    @Test
+    void getNeighbors_byUuid_presentId_returnsSameSetAsKeyOverload() {
+        // Add two bubbles at adjacent children of the level-1 root: verify UUID overload delegates
+        // to the key overload without an O(N) scan (same result, same exception contract).
+        var key1 = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(0).tmIndex();
+        var key2 = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(1).tmIndex();
+        var b1 = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+        var b2 = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+        grid.addBubble(b1, key1);
+        grid.addBubble(b2, key2);
+
+        var byUuid = grid.getNeighbors(b1.id());
+        var byKey  = grid.getNeighbors(key1);
+
+        // Both overloads must agree on the neighbor UUIDs.
+        var byKeyUuids = new java.util.HashSet<UUID>();
+        for (var nb : byKey) byKeyUuids.add(nb.id());
+        assertThat(byUuid).isEqualTo(byKeyUuids);
+    }
+
+    @Test
+    void getNeighbors_byUuid_absentId_throwsNoSuchElement() {
+        assertThatThrownBy(() -> grid.getNeighbors(UUID.randomUUID()))
+            .isInstanceOf(java.util.NoSuchElementException.class);
+    }
+
+    // ── SIG-2: getBubbleById uses inverse index ───────────────────────────────
+
+    @Test
+    void getBubbleById_presentId_returnsBubble() {
+        var key = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(0).tmIndex();
+        var bubble = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+        grid.addBubble(bubble, key);
+
+        assertThat(grid.getBubbleById(bubble.id())).isSameAs(bubble);
+    }
+
+    @Test
+    void getBubbleById_absentId_returnsNull() {
+        assertThat(grid.getBubbleById(UUID.randomUUID())).isNull();
+    }
+
+    @Test
+    void getBubbleById_afterRemove_returnsNull() {
+        var key = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(0).tmIndex();
+        var bubble = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+        grid.addBubble(bubble, key);
+        grid.removeBubble(bubble.id());
+
+        assertThat(grid.getBubbleById(bubble.id())).isNull();
+    }
+
+    // ── OBS-1: duplicate-id guard in addBubble ────────────────────────────────
+
+    @Test
+    void addBubble_duplicateId_differentKey_throwsIllegalArgument() {
+        // Same bubble re-added under a different key without removeBubble must be rejected fail-loud.
+        var key1 = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(0).tmIndex();
+        var key2 = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(1).tmIndex();
+        var bubble = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+        grid.addBubble(bubble, key1);
+
+        assertThatThrownBy(() -> grid.addBubble(bubble, key2))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(bubble.id().toString());
+
+        // Maps must be consistent after the rejected operation: forward key still points to the original entry.
+        assertThat(grid.getKeyForBubble(bubble.id())).isEqualTo(key1);
+        assertThat(grid.getBubbleCount()).isEqualTo(1);
+        assertThat(grid.inverseIndexSize()).isEqualTo(1);
+    }
+
+    @Test
+    void addBubble_sameIdSameKey_throwsIllegalArgument_existingKeyGuardFires() {
+        // Duplicate key (same id, same key) must be caught by the existing duplicate-key guard.
+        var key = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(0).tmIndex();
+        var bubble = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+        grid.addBubble(bubble, key);
+
+        assertThatThrownBy(() -> grid.addBubble(bubble, key))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ── OBS-2: inverse index size parity ─────────────────────────────────────
+
+    @Test
+    void inverseIndexSize_equalsForwardMapSize_afterAddRemoveSequence() {
+        var key1 = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(0).tmIndex();
+        var key2 = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(1).tmIndex();
+        var key3 = new Tet(0, 0, 0, (byte) 0, (byte) 0).child(2).tmIndex();
+        var b1 = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+        var b2 = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+        var b3 = new EnhancedBubble(UUID.randomUUID(), (byte) 1, 16L);
+
+        // After each add, inverse size == forward size.
+        grid.addBubble(b1, key1);
+        assertThat(grid.inverseIndexSize()).isEqualTo(grid.getBubbleCount());
+
+        grid.addBubble(b2, key2);
+        assertThat(grid.inverseIndexSize()).isEqualTo(grid.getBubbleCount());
+
+        grid.addBubble(b3, key3);
+        assertThat(grid.inverseIndexSize()).isEqualTo(grid.getBubbleCount());
+
+        // After remove, still in sync.
+        grid.removeBubble(b2.id());
+        assertThat(grid.inverseIndexSize()).isEqualTo(grid.getBubbleCount());
+        assertThat(grid.inverseIndexSize()).isEqualTo(2);
+
+        // After clear, both are 0.
+        grid.clear();
+        assertThat(grid.inverseIndexSize()).isEqualTo(0);
+        assertThat(grid.getBubbleCount()).isEqualTo(0);
+    }
+
+    @Test
+    void inverseIndexSize_equalsForwardMapSize_afterCreateBubbles() {
+        grid.createBubbles(6, (byte) 2, 16L);
+        assertThat(grid.inverseIndexSize()).isEqualTo(grid.getBubbleCount());
+        assertThat(grid.inverseIndexSize()).isGreaterThan(0);
+    }
+
+    @Test
+    void inverseIndexSize_equalsForwardMapSize_afterWorldBoundsCreateAndClear() {
+        var bounds = new WorldBounds(0f, 1_000_000f);
+        grid.createBubbles(4, bounds, 16L);
+        assertThat(grid.inverseIndexSize()).isEqualTo(grid.getBubbleCount());
+
+        grid.clear();
+        assertThat(grid.inverseIndexSize()).isEqualTo(0);
+        assertThat(grid.getBubbleCount()).isEqualTo(0);
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeP2PIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeP2PIntegrationTest.java
@@ -274,6 +274,8 @@ public class CommitteeP2PIntegrationTest {
         // Mock allMembers for Byzantine validation (ViewCommitteeSelector.isNodeInView)
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(mockContext.allMembers()).thenAnswer(invocation -> members.stream());
+        when(mockContext.active()).thenAnswer(invocation -> members.stream());
+
 
         return mockContext;
     }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeP2PIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeP2PIntegrationTest.java
@@ -275,6 +275,8 @@ public class CommitteeP2PIntegrationTest {
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(mockContext.allMembers()).thenAnswer(invocation -> members.stream());
         when(mockContext.active()).thenAnswer(invocation -> members.stream());
+        when(mockContext.isActive(org.mockito.Mockito.any(com.hellblazer.delos.cryptography.Digest.class))).thenReturn(true);
+
 
 
         return mockContext;

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeProtoConverterTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeProtoConverterTest.java
@@ -201,4 +201,43 @@ class CommitteeProtoConverterTest {
         assertArrayEquals(viewId.getBytes(), reconstructed.viewId().getBytes(),
                           "View ID bytes must match exactly");
     }
+
+    /**
+     * RDR-020 S3: {@code kind} survives proto conversion in both directions for both values —
+     * it is correctness-critical on the wire because every committee member re-validates a received
+     * proposal and branches on kind.
+     */
+    @Test
+    void kindPreservedAcrossSerialization() {
+        for (var kind : ProposalKind.values()) {
+            var proposal = new MigrationProposal(UUID.randomUUID(), UUID.randomUUID(),
+                                                 DigestAlgorithm.DEFAULT.random(), DigestAlgorithm.DEFAULT.random(),
+                                                 DigestAlgorithm.DEFAULT.random(), 1000L, kind);
+            var reconstructed = CommitteeProtoConverter.fromProto(
+                CommitteeProtoConverter.toProto(proposal, "localhost:12345"));
+            assertEquals(kind, reconstructed.kind(), "kind must round-trip for " + kind);
+        }
+    }
+
+    /**
+     * RDR-020 S3 back-compat: a proto with no {@code kind} field set (the pre-amendment / old-peer
+     * encoding) decodes to the default {@link ProposalKind#ENTITY_MIGRATION}, so old senders are read
+     * as entity migrations and retain the self-migration reject.
+     */
+    @Test
+    void absentKindDecodesToEntityMigration() {
+        // Build a proto WITHOUT setting kind — mirrors an old-peer / default encoding.
+        var proto = com.hellblazer.luciferase.simulation.consensus.committee.proto.CommitteeMigrationProposal
+            .newBuilder()
+            .setProposalId(UUID.randomUUID().toString())
+            .setEntityId(UUID.randomUUID().toString())
+            .setSourceNodeId(CommitteeProtoConverter.digestToHex(DigestAlgorithm.DEFAULT.random()))
+            .setTargetNodeId(CommitteeProtoConverter.digestToHex(DigestAlgorithm.DEFAULT.random()))
+            .setViewId(CommitteeProtoConverter.digestToHex(DigestAlgorithm.DEFAULT.random()))
+            .setTimestamp(1000L)
+            .build();
+        var reconstructed = CommitteeProtoConverter.fromProto(proto);
+        assertEquals(ProposalKind.ENTITY_MIGRATION, reconstructed.kind(),
+                     "absent kind must default to ENTITY_MIGRATION");
+    }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeServiceImplTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeServiceImplTest.java
@@ -76,6 +76,8 @@ public class CommitteeServiceImplTest {
         when(mockContext.bftSubset(Mockito.any())).thenReturn(new java.util.LinkedHashSet<>());
         when(mockContext.allMembers()).thenAnswer(inv -> java.util.stream.Stream.empty());
         when(mockContext.active()).thenAnswer(inv -> java.util.stream.Stream.empty());
+        when(mockContext.isActive(org.mockito.Mockito.any(com.hellblazer.delos.cryptography.Digest.class))).thenReturn(true);
+
 
 
         var executor = Executors.newScheduledThreadPool(1);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeServiceImplTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeServiceImplTest.java
@@ -74,8 +74,8 @@ public class CommitteeServiceImplTest {
         when(mockContext.size()).thenReturn(3);
         when(mockContext.toleranceLevel()).thenReturn(1);
         when(mockContext.bftSubset(Mockito.any())).thenReturn(new java.util.LinkedHashSet<>());
-        when(mockContext.allMembers()).thenReturn(java.util.stream.Stream.empty());
-        when(mockContext.active()).thenReturn(java.util.stream.Stream.empty());
+        when(mockContext.allMembers()).thenAnswer(inv -> java.util.stream.Stream.empty());
+        when(mockContext.active()).thenAnswer(inv -> java.util.stream.Stream.empty());
 
 
         var executor = Executors.newScheduledThreadPool(1);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeServiceImplTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeServiceImplTest.java
@@ -75,6 +75,8 @@ public class CommitteeServiceImplTest {
         when(mockContext.toleranceLevel()).thenReturn(1);
         when(mockContext.bftSubset(Mockito.any())).thenReturn(new java.util.LinkedHashSet<>());
         when(mockContext.allMembers()).thenReturn(java.util.stream.Stream.empty());
+        when(mockContext.active()).thenReturn(java.util.stream.Stream.empty());
+
 
         var executor = Executors.newScheduledThreadPool(1);
         var votingProtocol = new CommitteeVotingProtocol(mockContext, CommitteeConfig.defaultConfig(), executor);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeVotingProtocolTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeVotingProtocolTest.java
@@ -64,6 +64,10 @@ class CommitteeVotingProtocolTest {
         config = CommitteeConfig.defaultConfig();
         scheduler = Executors.newScheduledThreadPool(2);
         viewId = DigestAlgorithm.DEFAULT.getOrigin();
+        // yagnw.1: recordVote now drops votes from inactive members. These tests model a healthy
+        // committee where every voter is active; stub isActive=true so quorum is reachable.
+        when(mockContext.isActive(org.mockito.Mockito.any(com.hellblazer.delos.cryptography.Digest.class)))
+            .thenReturn(true);
     }
 
     @AfterEach
@@ -143,6 +147,37 @@ class CommitteeVotingProtocolTest {
 
         var result = future.get(1, TimeUnit.SECONDS);
         assertTrue(result, "Future should complete with true when quorum reached");
+    }
+
+    /**
+     * yagnw.1: a vote from an inactive (evicted-but-not-GC'd) committee member must NOT count toward
+     * quorum. selectCommittee draws the committee from the full ring, so an offline member can sit in
+     * the committee set; recordVote drops its vote (fails closed).
+     */
+    @Test
+    void testInactiveCommitteeMemberVoteDroppedFromQuorum() throws Exception {
+        // 3-node committee, quorum=2.
+        when(mockContext.size()).thenReturn(3);
+        when(mockContext.toleranceLevel()).thenReturn(1);
+        // member-1 is in the committee but inactive (evicted-not-GC'd); override the blanket stub.
+        var inactiveDigest = DigestAlgorithm.DEFAULT.digest("member-1");
+        when(mockContext.isActive(inactiveDigest)).thenReturn(false);
+
+        var protocol = new CommitteeVotingProtocol(mockContext, config, scheduler);
+        var proposal = createProposal();
+        var committee = createCommittee(3);
+        var future = protocol.requestConsensus(proposal, committee);
+
+        // YES from an active member (counts) + YES from the inactive member (dropped) → only 1 counts.
+        protocol.recordVote(new Vote(proposal.proposalId(), DigestAlgorithm.DEFAULT.digest("member-0"), true, viewId));
+        protocol.recordVote(new Vote(proposal.proposalId(), inactiveDigest, true, viewId));
+        assertFalse(future.isDone(),
+                    "the inactive member's vote must not count — quorum (2) not reached with 1 active YES");
+
+        // A second ACTIVE YES reaches quorum.
+        protocol.recordVote(new Vote(proposal.proposalId(), DigestAlgorithm.DEFAULT.digest("member-2"), true, viewId));
+        assertTrue(future.get(1, TimeUnit.SECONDS),
+                   "two active YES votes must reach quorum once the inactive vote is excluded");
     }
 
     /**

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/FirefliesViewMonitorIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/FirefliesViewMonitorIntegrationTest.java
@@ -124,6 +124,7 @@ class FirefliesViewMonitorIntegrationTest {
         when(mockContext.getId()).thenReturn(viewId);
         when(mockContext.allMembers()).thenReturn(java.util.stream.Stream.empty());
 
+
         return new FirefliesMembershipView(mockView);
     }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/MigrationProposalTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/MigrationProposalTest.java
@@ -114,4 +114,29 @@ class MigrationProposalTest {
         // Then: Proposals are different
         assertNotEquals(proposal1, proposal2);
     }
+
+    /**
+     * RDR-020 S3: the back-compatible 6-arg constructor defaults {@code kind} to
+     * {@link ProposalKind#ENTITY_MIGRATION}, so the ~70 existing entity-migration construction
+     * sites compile and behave unchanged.
+     */
+    @Test
+    void sixArgConstructorDefaultsToEntityMigration() {
+        var proposal = new MigrationProposal(UUID.randomUUID(), UUID.randomUUID(),
+                                             DigestAlgorithm.DEFAULT.random(), DigestAlgorithm.DEFAULT.random(),
+                                             DigestAlgorithm.DEFAULT.random(), 1000L);
+        assertEquals(ProposalKind.ENTITY_MIGRATION, proposal.kind(),
+                     "6-arg ctor must default kind to ENTITY_MIGRATION");
+    }
+
+    /**
+     * RDR-020 S3: the canonical 7-arg constructor carries an explicit {@link ProposalKind}.
+     */
+    @Test
+    void sevenArgConstructorCarriesExplicitKind() {
+        var proposal = new MigrationProposal(UUID.randomUUID(), UUID.randomUUID(),
+                                             DigestAlgorithm.DEFAULT.random(), DigestAlgorithm.DEFAULT.random(),
+                                             DigestAlgorithm.DEFAULT.random(), 1000L, ProposalKind.TOPOLOGY);
+        assertEquals(ProposalKind.TOPOLOGY, proposal.kind(), "explicit kind must be retained");
+    }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/NullViewIdConsensusTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/NullViewIdConsensusTest.java
@@ -78,6 +78,8 @@ public class NullViewIdConsensusTest {
         when(context.bftSubset(Mockito.any(Digest.class))).thenReturn((java.util.SequencedSet) committee);
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
         when(context.active()).thenAnswer(invocation -> members.stream());
+        when(context.isActive(org.mockito.Mockito.any(com.hellblazer.delos.cryptography.Digest.class))).thenReturn(true);
+
 
 
         selector = new ViewCommitteeSelector(context);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/NullViewIdConsensusTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/NullViewIdConsensusTest.java
@@ -77,6 +77,8 @@ public class NullViewIdConsensusTest {
         var committee = new java.util.LinkedHashSet<>(members.subList(0, 3));
         when(context.bftSubset(Mockito.any(Digest.class))).thenReturn((java.util.SequencedSet) committee);
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
+        when(context.active()).thenAnswer(invocation -> members.stream());
+
 
         selector = new ViewCommitteeSelector(context);
         var config = CommitteeConfig.defaultConfig();

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/OptimisticMigratorIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/OptimisticMigratorIntegrationTest.java
@@ -82,6 +82,8 @@ public class OptimisticMigratorIntegrationTest {
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
         when(context.active()).thenAnswer(invocation -> members.stream());
+        when(context.isActive(org.mockito.Mockito.any(com.hellblazer.delos.cryptography.Digest.class))).thenReturn(true);
+
 
 
         // Create mock view monitor

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/OptimisticMigratorIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/OptimisticMigratorIntegrationTest.java
@@ -81,6 +81,8 @@ public class OptimisticMigratorIntegrationTest {
         // Mock allMembers for Byzantine validation (ViewCommitteeSelector.isNodeInView)
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
+        when(context.active()).thenAnswer(invocation -> members.stream());
+
 
         // Create mock view monitor
         mockMonitor = new MockViewMonitor(view1);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeConsensusTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeConsensusTest.java
@@ -88,6 +88,8 @@ public class ViewCommitteeConsensusTest {
 
         // Mock allMembers() to return a new stream each time (Byzantine validation)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
+        when(context.active()).thenAnswer(invocation -> members.stream());
+
 
         // Create mock view monitor
         mockMonitor = new MockViewMonitor(view1);
@@ -290,6 +292,27 @@ public class ViewCommitteeConsensusTest {
         assertTrue(future.isDone(), "ENTITY_MIGRATION self-source proposal must be rejected immediately");
         assertFalse(future.get(100, TimeUnit.MILLISECONDS),
                     "ENTITY_MIGRATION self-migration must be rejected (source == target)");
+    }
+
+    @Test
+    public void testEvictedButNotGcdTargetRejectedByActiveOnlyGate() throws Exception {
+        // RDR-020 S6 end-to-end (non-tautological): make members.get(2) present in allMembers() but
+        // ABSENT from active() — an evicted-but-not-GC'd member. A proposal targeting it must be
+        // rejected by validateProposal's isNodeInView gate, which (post-S6) consults active() only.
+        when(context.active()).thenAnswer(inv -> Stream.of(members.get(0), members.get(1)));
+
+        var source = members.get(0).getId();       // active
+        var evictedTarget = members.get(2).getId(); // in allMembers, NOT active
+        var proposal = new MigrationProposal(
+            UUID.randomUUID(), UUID.randomUUID(),
+            source, evictedTarget,
+            view1, ZE0EQ_CLOCK.currentTimeMillis());
+
+        var future = consensus.requestConsensus(proposal);
+        assertTrue(future.isDone(),
+                   "a proposal targeting an evicted (inactive) member must be rejected immediately");
+        assertFalse(future.get(100, TimeUnit.MILLISECONDS),
+                    "isNodeInView (active-only) must reject an evicted-but-not-GC'd target");
     }
 
     // ===== Per-entity in-flight migration mutex (Luciferase-0frcy.94) =====

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeConsensusTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeConsensusTest.java
@@ -229,6 +229,69 @@ public class ViewCommitteeConsensusTest {
         assertFalse(result, "Proposal with old viewId should be rejected immediately");
     }
 
+    // ===== RDR-020 S3: TOPOLOGY-kind self-source proposals skip the self-migration reject =====
+
+    @Test
+    public void testTopologyKindSkipsSelfMigrationReject() throws Exception {
+        // A TOPOLOGY proposal is single-region: source == target == owner(region). A committee
+        // member (members.get(0)) is both source and target. validateProposal must NOT self-migration-
+        // reject it; instead it proceeds to voting (future remains in-flight pending votes), then
+        // reaches quorum.
+        var owner = members.get(0).getId();
+        var proposal = new MigrationProposal(
+            UUID.randomUUID(), UUID.randomUUID(),
+            owner, owner,                       // self-source == self-target
+            view1, ZE0EQ_CLOCK.currentTimeMillis(),
+            ProposalKind.TOPOLOGY);
+
+        var future = consensus.requestConsensus(proposal);
+        assertFalse(future.isDone(),
+                    "TOPOLOGY self-owner proposal must pass validateProposal and enter voting (not self-rejected)");
+
+        for (int i = 0; i < 2; i++) {
+            votingProtocol.recordVote(new Vote(proposal.proposalId(), members.get(i).getId(), true, view1));
+        }
+        assertTrue(future.get(1, TimeUnit.SECONDS),
+                   "TOPOLOGY proposal must reach quorum once it passes validation");
+    }
+
+    @Test
+    public void testTopologyKindStillEnforcesInViewMembership() throws Exception {
+        // RDR-020 S3: TOPOLOGY skips ONLY the self-migration reject. The isNodeInView gate still
+        // applies — a TOPOLOGY proposal whose owner is NOT a current-view member is rejected. (The
+        // owner digest here is absent from the committee's member set.)
+        var outOfViewOwner = DigestAlgorithm.DEFAULT.digest("not-a-cluster-member");
+        var proposal = new MigrationProposal(
+            UUID.randomUUID(), UUID.randomUUID(),
+            outOfViewOwner, outOfViewOwner,
+            view1, ZE0EQ_CLOCK.currentTimeMillis(),
+            ProposalKind.TOPOLOGY);
+
+        var future = consensus.requestConsensus(proposal);
+        assertTrue(future.isDone(), "out-of-view TOPOLOGY owner must be rejected immediately");
+        assertFalse(future.get(100, TimeUnit.MILLISECONDS),
+                    "TOPOLOGY proposal with owner not in view must be rejected by isNodeInView");
+    }
+
+    @Test
+    public void testEntityMigrationKindSelfMigrationRejected() throws Exception {
+        // The SAME self-source proposal as ENTITY_MIGRATION (the default kind / old-peer encoding)
+        // IS self-migration-rejected — immediately completes false. This pins both the kind-branch
+        // and the mixed-version contract: a pre-amendment validator reads TOPOLOGY as ENTITY_MIGRATION
+        // and rejects it.
+        var owner = members.get(0).getId();
+        var proposal = new MigrationProposal(
+            UUID.randomUUID(), UUID.randomUUID(),
+            owner, owner,                       // self-source == self-target
+            view1, ZE0EQ_CLOCK.currentTimeMillis(),
+            ProposalKind.ENTITY_MIGRATION);
+
+        var future = consensus.requestConsensus(proposal);
+        assertTrue(future.isDone(), "ENTITY_MIGRATION self-source proposal must be rejected immediately");
+        assertFalse(future.get(100, TimeUnit.MILLISECONDS),
+                    "ENTITY_MIGRATION self-migration must be rejected (source == target)");
+    }
+
     // ===== Per-entity in-flight migration mutex (Luciferase-0frcy.94) =====
 
     @Test

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeConsensusTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeConsensusTest.java
@@ -89,6 +89,8 @@ public class ViewCommitteeConsensusTest {
         // Mock allMembers() to return a new stream each time (Byzantine validation)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
         when(context.active()).thenAnswer(invocation -> members.stream());
+        when(context.isActive(org.mockito.Mockito.any(com.hellblazer.delos.cryptography.Digest.class))).thenReturn(true);
+
 
 
         // Create mock view monitor
@@ -295,10 +297,43 @@ public class ViewCommitteeConsensusTest {
     }
 
     @Test
+    public void testViewChangeReleasesInFlightEntitySlot() {
+        // Luciferase-0frcy.132: a view change that rolls back a pending proposal must release the
+        // entity's in-flight slot — otherwise the entity is permanently blocked from re-migration.
+        // Coverage boundary: this exercises the sequential onViewChange slot-release path (the reorder
+        // ensures pendingProposals holds the entry before onViewChange scans). The concurrent window
+        // the reorder + post-write re-check close (onViewChange scanning between the two writes) is not
+        // deterministically reproducible single-threaded; the post-write re-check in requestConsensus
+        // is the structural guard for that interleaving.
+        var entityId = UUID.randomUUID();
+        var p1 = new MigrationProposal(UUID.randomUUID(), entityId,
+                                       members.get(0).getId(), members.get(1).getId(),
+                                       view1, ZE0EQ_CLOCK.currentTimeMillis());
+        var f1 = consensus.requestConsensus(p1);
+        assertFalse(f1.isDone(), "first proposal must be in-flight pending votes");
+
+        // View changes; onViewChange rolls back the stale-view proposal and releases the entity slot.
+        mockMonitor.setCurrentViewId(view2);
+        consensus.onViewChange(view2);
+
+        // A fresh proposal for the SAME entity in the new view must be accepted (slot released), not
+        // rejected as a duplicate in-flight migration.
+        var p2 = new MigrationProposal(UUID.randomUUID(), entityId,
+                                       members.get(0).getId(), members.get(1).getId(),
+                                       view2, ZE0EQ_CLOCK.currentTimeMillis());
+        var f2 = consensus.requestConsensus(p2);
+        assertFalse(f2.isDone(),
+                    "a new proposal for the same entity must be accepted once the view change released "
+                    + "the in-flight slot (regression guard for the orphaned-slot bug)");
+    }
+
+    @Test
     public void testEvictedButNotGcdTargetRejectedByActiveOnlyGate() throws Exception {
         // RDR-020 S6 end-to-end (non-tautological): make members.get(2) present in allMembers() but
         // ABSENT from active() — an evicted-but-not-GC'd member. A proposal targeting it must be
         // rejected by validateProposal's isNodeInView gate, which (post-S6) consults active() only.
+        // isNodeInView consults context.active() (not context.isActive), so re-stubbing active() here
+        // is sufficient; no isActive stub needed for this proposal-admission gate.
         when(context.active()).thenAnswer(inv -> Stream.of(members.get(0), members.get(1)));
 
         var source = members.get(0).getId();       // active

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeSelectorTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeSelectorTest.java
@@ -152,6 +152,30 @@ class ViewCommitteeSelectorTest {
         verify(context).bftSubset(viewDiadem2);
     }
 
+    /**
+     * RDR-020 S6 (RDR-005 active-only invariant): {@code isNodeInView} matches against
+     * {@code context.active()}, so a current-view active member is in-view and an evicted-but-not-GC'd
+     * member (still in {@code allMembers()} but absent from {@code active()}) is NOT in-view.
+     */
+    @Test
+    void isNodeInViewMatchesActiveOnly() {
+        var context = mockContext();
+        var active = new com.hellblazer.delos.membership.MockMember(DigestAlgorithm.DEFAULT.getOrigin().prefix(1));
+        var evicted = new com.hellblazer.delos.membership.MockMember(DigestAlgorithm.DEFAULT.getOrigin().prefix(2));
+
+        // active() contains only the active member; the evicted member is intentionally absent even
+        // though a real all-members backing might still carry it (not GC'd).
+        when(context.active()).thenAnswer(inv -> java.util.stream.Stream.of(active));
+
+        var selector = new ViewCommitteeSelector(context);
+
+        assertTrue(selector.isNodeInView(active.getId()), "an active member must be in view");
+        assertFalse(selector.isNodeInView(evicted.getId()),
+                    "an evicted-but-not-GC'd member must NOT be in view (active-only gate)");
+        // The active-only invariant requires the gate never consult the all-members backing.
+        verify(context, never()).allMembers();
+    }
+
     // Helper method to create mock DynamicContext
     @SuppressWarnings("unchecked")
     private DynamicContext<Member> mockContext() {

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewIdRaceConditionTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewIdRaceConditionTest.java
@@ -93,6 +93,8 @@ public class ViewIdRaceConditionTest {
         // Mock allMembers for Byzantine validation (ViewCommitteeSelector.isNodeInView)
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
+        when(context.active()).thenAnswer(invocation -> members.stream());
+
 
         // Create view IDs
         view1 = DigestAlgorithm.DEFAULT.digest("view1".getBytes());

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewIdRaceConditionTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewIdRaceConditionTest.java
@@ -94,6 +94,8 @@ public class ViewIdRaceConditionTest {
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
         when(context.active()).thenAnswer(invocation -> members.stream());
+        when(context.isActive(org.mockito.Mockito.any(com.hellblazer.delos.cryptography.Digest.class))).thenReturn(true);
+
 
 
         // Create view IDs

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ByzantineRobustnessIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ByzantineRobustnessIntegrationTest.java
@@ -92,6 +92,8 @@ public class ByzantineRobustnessIntegrationTest {
         // Mock allMembers for Byzantine validation (ViewCommitteeSelector.isNodeInView)
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
+        when(context.active()).thenAnswer(invocation -> members.stream());
+
 
         // Create view monitor
         viewMonitor = new MockViewMonitor(viewId);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ByzantineRobustnessIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ByzantineRobustnessIntegrationTest.java
@@ -93,6 +93,8 @@ public class ByzantineRobustnessIntegrationTest {
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
         when(context.active()).thenAnswer(invocation -> members.stream());
+        when(context.isActive(org.mockito.Mockito.any(com.hellblazer.delos.cryptography.Digest.class))).thenReturn(true);
+
 
 
         // Create view monitor

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/EndToEndMigrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/EndToEndMigrationTest.java
@@ -92,6 +92,8 @@ public class EndToEndMigrationTest {
         // Mock allMembers for Byzantine validation (ViewCommitteeSelector.isNodeInView)
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
+        when(context.active()).thenAnswer(invocation -> members.stream());
+
 
         // Create view monitor
         viewMonitor = new MockViewMonitor(viewId);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/EndToEndMigrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/EndToEndMigrationTest.java
@@ -93,6 +93,8 @@ public class EndToEndMigrationTest {
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
         when(context.active()).thenAnswer(invocation -> members.stream());
+        when(context.isActive(org.mockito.Mockito.any(com.hellblazer.delos.cryptography.Digest.class))).thenReturn(true);
+
 
 
         // Create view monitor

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/FiveNodeIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/FiveNodeIntegrationTest.java
@@ -94,6 +94,8 @@ public class FiveNodeIntegrationTest {
         // Mock allMembers for Byzantine validation (ViewCommitteeSelector.isNodeInView)
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
+        when(context.active()).thenAnswer(invocation -> members.stream());
+
 
         // Create view monitor
         viewMonitor = new MockViewMonitor(viewId);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/FiveNodeIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/FiveNodeIntegrationTest.java
@@ -95,6 +95,8 @@ public class FiveNodeIntegrationTest {
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
         when(context.active()).thenAnswer(invocation -> members.stream());
+        when(context.isActive(org.mockito.Mockito.any(com.hellblazer.delos.cryptography.Digest.class))).thenReturn(true);
+
 
 
         // Create view monitor

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/Rdr020MvvIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/Rdr020MvvIntegrationTest.java
@@ -121,6 +121,8 @@ class Rdr020MvvIntegrationTest {
         when(context.bftSubset(any(Digest.class))).thenReturn(committee);
         when(context.allMembers()).thenAnswer(inv -> members.stream().map(m -> (Member) m));
         when(context.active()).thenAnswer(inv -> members.stream().map(m -> (Member) m));
+        when(context.isActive(org.mockito.Mockito.any(com.hellblazer.delos.cryptography.Digest.class))).thenReturn(true);
+
 
         viewMonitor = new ScheduledViewMonitor(viewId);
         selector    = new ViewCommitteeSelector(context);
@@ -413,6 +415,8 @@ class Rdr020MvvIntegrationTest {
         when(soloContext.bftSubset(any(Digest.class))).thenReturn(soloCommittee);
         when(soloContext.allMembers()).thenAnswer(inv -> Stream.of((Member) soloMember));
         when(soloContext.active()).thenAnswer(inv -> Stream.of((Member) soloMember));
+        when(soloContext.isActive(org.mockito.Mockito.any(com.hellblazer.delos.cryptography.Digest.class))).thenReturn(true);
+
 
         var soloSelector = new ViewCommitteeSelector(soloContext);
         var soloProtocol = new CommitteeVotingProtocol(soloContext, CommitteeConfig.defaultConfig(),

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/Rdr020MvvIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/Rdr020MvvIntegrationTest.java
@@ -1,0 +1,713 @@
+/**
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase Simulation Framework.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.consensus.committee.integration;
+
+import com.hellblazer.delos.context.DynamicContext;
+import com.hellblazer.delos.cryptography.Digest;
+import com.hellblazer.delos.cryptography.DigestAlgorithm;
+import com.hellblazer.delos.membership.Member;
+import com.hellblazer.delos.membership.MockMember;
+import com.hellblazer.luciferase.common.time.Clock;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
+import com.hellblazer.luciferase.simulation.bubble.EnhancedBubbleMigrationIntegration;
+import com.hellblazer.luciferase.simulation.bubble.TetreeBubbleGrid;
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationStateMachine;
+import com.hellblazer.luciferase.simulation.causality.FirefliesViewMonitor;
+import com.hellblazer.luciferase.simulation.consensus.committee.*;
+import com.hellblazer.luciferase.simulation.consensus.ownership.BubbleOwnershipResolver;
+import com.hellblazer.luciferase.simulation.consensus.ownership.FirefliesBubbleOwnershipResolver;
+import com.hellblazer.luciferase.simulation.consensus.ownership.RendezvousOwnershipFunction;
+import com.hellblazer.luciferase.simulation.delos.MembershipView;
+import com.hellblazer.luciferase.simulation.delos.mock.MockFirefliesView;
+import com.hellblazer.luciferase.simulation.distributed.migration.OptimisticMigratorImpl;
+import com.hellblazer.luciferase.simulation.distributed.network.BubbleNetworkChannel;
+import com.hellblazer.luciferase.simulation.distributed.network.DistributedBubbleNode;
+import com.hellblazer.luciferase.simulation.topology.SplitPlane;
+import com.hellblazer.luciferase.simulation.topology.SplitProposal;
+import com.hellblazer.luciferase.simulation.topology.TopologyConsensusCoordinator;
+import com.hellblazer.luciferase.simulation.von.FirefliesMemberLookup;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.vecmath.Point3f;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * RDR-020 Minimum Viable Validation (MVV) integration test.
+ * <p>
+ * Exercises the real wired path end-to-end: FirefliesBubbleOwnershipResolver (HRW, S1–S2),
+ * TopologyConsensusCoordinator (S3), OptimisticMigratorImpl + OptimisticMigratorIntegration (S4),
+ * DistributedBubbleNode hint validation (S5), ViewCommitteeConsensus active-only gate (S6).
+ * <p>
+ * Identity-alignment constraint (RDR-020 MVV requirement): the same member Digests must flow
+ * through BOTH the Mockito DynamicContext stubs (for ViewCommitteeConsensus.validateProposal's
+ * active() gate) AND the MockFirefliesView (for FirefliesBubbleOwnershipResolver's activeMembers()
+ * path). One {@code List<MockMember> members} is shared between both sides.
+ * <p>
+ * Gap-2 coverage: Scenario 1b drives a cross-node ENTITY_MIGRATION whose target is a DIFFERENT
+ * active member through the real committee to quorum — the path the old {@code digestOf} broke. The
+ * S5 node-hint scenarios 6a–6c use inline stub resolvers to isolate {@code DistributedBubbleNode}'s
+ * guard logic; 6d exercises the same guard through the REAL {@code FirefliesBubbleOwnershipResolver}
+ * (canonical {@code memberDigestForNode} + {@code isActiveMember}).
+ *
+ * @author hal.hildebrand
+ */
+class Rdr020MvvIntegrationTest {
+
+    // -------------------------------------------------------------------------
+    // Shared state wired once per test
+    // -------------------------------------------------------------------------
+
+    private static final int MEMBER_COUNT = 3;
+
+    private List<MockMember>              members;
+    private DynamicContext<Member>        context;
+    private ViewCommitteeSelector         selector;
+    private CommitteeVotingProtocol       votingProtocol;
+    private ViewCommitteeConsensus        consensus;
+    private ScheduledViewMonitor          viewMonitor;
+    private ScheduledExecutorService      scheduler;
+    private Digest                        viewId;
+
+    // Fixed deterministic clock
+    private static final long FIXED_MILLIS = 1_000_000L;
+    private final TestClock testClock = new TestClock(FIXED_MILLIS);
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        viewId = DigestAlgorithm.DEFAULT.digest("mvv-view-id".getBytes());
+
+        // Build members — MockMember from com.hellblazer.delos.membership.MockMember
+        members = new ArrayList<>();
+        for (int i = 0; i < MEMBER_COUNT; i++) {
+            members.add(new MockMember(DigestAlgorithm.DEFAULT.getOrigin().prefix(i)));
+        }
+
+        // Wire DynamicContext with active() returning every member
+        // (identity-alignment: same member instances as MockFirefliesView below)
+        context = Mockito.mock(DynamicContext.class);
+        when(context.size()).thenReturn(MEMBER_COUNT);
+        when(context.toleranceLevel()).thenReturn(1); // t=1 → quorum=2
+        var committee = new LinkedHashSet<Member>(members);
+        when(context.bftSubset(any(Digest.class))).thenReturn(committee);
+        when(context.allMembers()).thenAnswer(inv -> members.stream().map(m -> (Member) m));
+        when(context.active()).thenAnswer(inv -> members.stream().map(m -> (Member) m));
+
+        viewMonitor = new ScheduledViewMonitor(viewId);
+        selector    = new ViewCommitteeSelector(context);
+
+        var config = CommitteeConfig.defaultConfig();
+        scheduler  = Executors.newScheduledThreadPool(2);
+        votingProtocol = new CommitteeVotingProtocol(context, config, scheduler);
+
+        consensus = new ViewCommitteeConsensus();
+        consensus.setViewMonitor(viewMonitor);
+        consensus.setCommitteeSelector(selector);
+        consensus.setVotingProtocol(votingProtocol);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: build a real FirefliesBubbleOwnershipResolver
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds a production {@link FirefliesBubbleOwnershipResolver} aligned with {@link #members}.
+     * All members are added to the MockFirefliesView; {@code evicted} members are marked inactive.
+     * {@code bubbleKeys} is the grid map (bubbleId → TetreeKey).
+     */
+    @SuppressWarnings("unchecked")
+    private FirefliesBubbleOwnershipResolver buildResolver(
+            MockMember localMember,
+            List<MockMember> evicted,
+            Map<UUID, TetreeKey<?>> bubbleKeys) {
+
+        var mockView = new MockFirefliesView<MockMember>();
+        for (var m : members) {
+            mockView.addMember(m);
+        }
+        for (var m : evicted) {
+            mockView.markInactive(m);
+        }
+
+        MembershipView<Member> membershipView =
+            (MembershipView<Member>) (MembershipView<?>) mockView;
+
+        return new FirefliesBubbleOwnershipResolver(
+            () -> localMember,
+            // nodeResolver: node UUID → Optional<Member> via the CANONICAL derivation (RDR-020 B4):
+            // node UUID == FirefliesMemberLookup.digestToUuid(member.getId()), matching how
+            // FirefliesMemberLookup.getMemberByUuid resolves the reverse mapping.
+            nodeUuid -> members.stream()
+                               .filter(m -> FirefliesMemberLookup.digestToUuid(m.getId()).equals(nodeUuid))
+                               .map(m -> (Member) m)
+                               .findFirst(),
+            bubbleKeys::get,
+            membershipView,
+            new RendezvousOwnershipFunction()
+        );
+    }
+
+    /** Helper: same as above but no evicted members. */
+    private FirefliesBubbleOwnershipResolver buildResolver(
+            MockMember localMember,
+            Map<UUID, TetreeKey<?>> bubbleKeys) {
+        return buildResolver(localMember, List.of(), bubbleKeys);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: add entities to a bubble for valid split (>5000)
+    // -------------------------------------------------------------------------
+
+    private void addEntities(EnhancedBubble bubble, int count) {
+        for (int i = 0; i < count; i++) {
+            bubble.addEntity(
+                "e-" + i,
+                new Point3f(i * 0.001f, i * 0.001f, i * 0.001f),
+                null
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: createSplitProposal following TopologyConsensusCoordinatorTest pattern
+    // -------------------------------------------------------------------------
+
+    private SplitProposal createSplitProposal(TetreeBubbleGrid grid, UUID bubbleId) {
+        var bubble = grid.getBubbleById(bubbleId);
+
+        float minX = Float.POSITIVE_INFINITY;
+        float maxX = Float.NEGATIVE_INFINITY;
+        for (var record : bubble.getAllEntityRecords()) {
+            var pos = record.position();
+            minX = Math.min(minX, pos.x);
+            maxX = Math.max(maxX, pos.x);
+        }
+        float centroidX = (minX + maxX) / 2.0f;
+
+        var splitPlane = new SplitPlane(new Point3f(1.0f, 0.0f, 0.0f), centroidX);
+        return new SplitProposal(UUID.randomUUID(), bubbleId, splitPlane, viewId, testClock.currentTimeMillis());
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: record quorum votes for a proposal
+    // -------------------------------------------------------------------------
+
+    private void castQuorumVotes(MigrationProposal mp, int quorum) {
+        for (int i = 0; i < quorum; i++) {
+            votingProtocol.recordVote(new Vote(mp.proposalId(), members.get(i).getId(), true, viewId));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario (1): TOPOLOGY path — committee reaches real quorum on a split proposal
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Scenario 1: TOPOLOGY split reaches real committee quorum through wired path")
+    void topologySplitReachesRealQuorum() throws Exception {
+        // t=1 → quorum=2 (toleranceLevel+1)
+        int quorum = context.toleranceLevel() + 1;
+
+        var bubbleGrid = new TetreeBubbleGrid((byte) 2);
+        bubbleGrid.createBubbles(1, (byte) 1, 10);
+        var bubble = bubbleGrid.getAllBubbles().iterator().next();
+        addEntities(bubble, 5100);
+        var bubbleId = bubble.id();
+
+        // Determine the HRW owner for this bubble
+        var bubbleKey = bubbleGrid.getKeyForBubble(bubbleId);
+        assertNotNull(bubbleKey, "Grid must have a TetreeKey for the created bubble");
+
+        // Probe ownership with any member as local — we care about the owner Digest
+        Map<UUID, TetreeKey<?>> probeKeys = new HashMap<>();
+        probeKeys.put(bubbleId, bubbleKey);
+        var probeResolver = buildResolver(members.get(0), probeKeys);
+        var ownerDigest = probeResolver.resolveOwningMember(bubbleId);
+
+        // Find the MockMember whose Digest matches the HRW owner
+        var ownerMember = members.stream()
+                                 .filter(m -> m.getId().equals(ownerDigest))
+                                 .findFirst()
+                                 .orElseThrow(() -> new AssertionError(
+                                     "Owner digest not found in member list: " + ownerDigest));
+
+        // Build the real resolver with localMember == owner (so ownership guard passes)
+        Map<UUID, TetreeKey<?>> resolverKeys = new HashMap<>();
+        resolverKeys.put(bubbleId, bubbleKey);
+        var resolver = buildResolver(ownerMember, resolverKeys);
+
+        // Wire a real TopologyConsensusCoordinator with the real consensus and resolver
+        var coordinator = new TopologyConsensusCoordinator(bubbleGrid);
+        coordinator.setClock(testClock);
+        coordinator.setConsensusProtocol(consensus);
+        coordinator.setOwnershipResolver(resolver);
+
+        var splitProposal = createSplitProposal(bubbleGrid, bubbleId);
+
+        // Submit — should be pending (validateProposal passes: owner is active in both sides)
+        var future = coordinator.requestConsensus(splitProposal);
+        assertFalse(future.isDone(), "Future must be pending — proposal passed validateProposal, awaiting committee votes");
+
+        // Capture the MigrationProposal that arrived at the consensus engine
+        // (we need its proposalId to cast votes; record it before voting)
+        // Cast quorum YES votes with real member Digests (in the active() set)
+        for (int i = 0; i < quorum; i++) {
+            // The MigrationProposal built by TopologyConsensusCoordinator.toMigrationProposal uses
+            // the SplitProposal's proposalId as the MigrationProposal's proposalId.
+            votingProtocol.recordVote(
+                new Vote(splitProposal.proposalId(), members.get(i).getId(), true, viewId));
+        }
+
+        var approved = future.get(3, TimeUnit.SECONDS);
+        assertTrue(approved, "Split proposal must be approved after real quorum YES votes");
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario (1b): GAP-2 CLOSING — cross-node ENTITY_MIGRATION whose target bubble is owned
+    // by a DIFFERENT current-view member passes validateProposal (isNodeInView for a NON-LOCAL
+    // digest) and reaches real quorum. This is the exact path the old digestOf hash broke: it
+    // produced a digest unrelated to any member, rejected at isNodeInView. The TOPOLOGY scenario
+    // above can only ever exercise owner==local (single-owner guard), so it does NOT cover this.
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Scenario 1b (Gap-2): cross-node ENTITY_MIGRATION to a DIFFERENT active owner reaches real quorum")
+    void entityMigrationCrossNodeReachesRealQuorum() throws Exception {
+        int quorum = context.toleranceLevel() + 1;
+        var local = members.get(0);
+
+        // Find a target bubble whose HRW owner is a DIFFERENT member than local. The owner depends
+        // only on the TetreeKey + the (fixed) member digests, so the first qualifying key is
+        // deterministic across runs.
+        long[] candidateBits = {0x1L, 0x2L, 0x3L, 0x4L, 0x5L, 0x6L, 0x7L, 0x8L, 0x9L, 0xAL, 0xBL, 0xCL};
+        UUID targetBubble = null;
+        Digest ownerDigest = null;
+        Map<UUID, TetreeKey<?>> resolverKeys = null;
+        for (long bits : candidateBits) {
+            var bid = UUID.nameUUIDFromBytes(("mvv-cross-node-" + bits).getBytes());
+            Map<UUID, TetreeKey<?>> km = new HashMap<>();
+            km.put(bid, TetreeKey.create((byte) 3, bits, 0L));
+            var owner = buildResolver(local, km).resolveOwningMember(bid);
+            if (!owner.equals(local.getId())) {
+                targetBubble = bid;
+                ownerDigest = owner;
+                resolverKeys = km;
+                break;
+            }
+        }
+        assertNotNull(targetBubble, "must find a target bubble owned by a non-local member");
+        assertNotEquals(local.getId(), ownerDigest, "precondition: owner must be a DIFFERENT member than local");
+
+        var resolver = buildResolver(local, resolverKeys);
+
+        // Wire the real S4 path: OptimisticMigratorImpl -> real OptimisticMigratorIntegration -> real consensus.
+        var integration = new OptimisticMigratorIntegration(consensus, viewMonitor);
+        integration.setClock(testClock);
+        var migrator = new OptimisticMigratorImpl();
+        migrator.setConsensusIntegration(integration);
+        migrator.setOwnershipResolver(resolver);
+
+        var entityId = UUID.randomUUID();
+        var future = migrator.requestMigrationApproval(entityId, targetBubble);
+
+        // The integration built the proposal synchronously before submitting; read it to vote.
+        var mp = integration.getLastProposal();
+        assertNotNull(mp, "integration must have built a MigrationProposal");
+        assertEquals(local.getId(), mp.sourceNodeId(), "source must be the local member (possession)");
+        assertEquals(ownerDigest, mp.targetNodeId(), "target must be the HRW owner — a DIFFERENT member");
+        assertNotEquals(mp.sourceNodeId(), mp.targetNodeId(), "cross-node: source != target");
+
+        assertFalse(future.isDone(),
+            "future must be pending — a non-local target digest PASSED isNodeInView and entered voting "
+            + "(this is the Gap-2 path the old digestOf broke)");
+
+        // Cast real quorum YES votes on the integration-generated proposalId.
+        for (int i = 0; i < quorum; i++) {
+            votingProtocol.recordVote(new Vote(mp.proposalId(), members.get(i).getId(), true, viewId));
+        }
+        assertTrue(future.get(3, TimeUnit.SECONDS),
+            "cross-node ENTITY_MIGRATION must reach real quorum and be approved");
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario (2): HRW convergence — two independent resolvers return identical owner
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Scenario 2: Two independent resolvers over same active set return identical HRW owner")
+    void hrwConvergenceTwoIndependentResolvers() {
+        // Build several (bubbleId, TetreeKey) pairs
+        Map<UUID, TetreeKey<?>> keys = new HashMap<>();
+        keys.put(UUID.randomUUID(), TetreeKey.create((byte) 3, 0xCAFEBABE_DEADBEEFL, 0L));
+        keys.put(UUID.randomUUID(), TetreeKey.create((byte) 5, 0x1234567890ABCDEFL, 0L));
+        keys.put(UUID.randomUUID(), TetreeKey.create((byte) 7, 0xFEEDFACE0BAD_C0DEL, 0L));
+
+        // Two completely independent resolver instances — same members, same keys, no shared state
+        var resolver1 = buildResolver(members.get(0), new HashMap<>(keys));
+        var resolver2 = buildResolver(members.get(1), new HashMap<>(keys));
+
+        for (var entry : keys.entrySet()) {
+            var bubbleId = entry.getKey();
+            var owner1 = resolver1.resolveOwningMember(bubbleId);
+            var owner2 = resolver2.resolveOwningMember(bubbleId);
+            assertEquals(owner1, owner2,
+                "Two independent HRW resolvers must agree on owner for bubble " + bubbleId
+                + " — this is the view-derived registry-substitute property");
+            // Falsifying check: result must be a real member in the active set
+            var activeDigests = members.stream().map(MockMember::getId).toList();
+            assertTrue(activeDigests.contains(owner1),
+                "Resolved owner must be in the active member set");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario (3): Single-member view — ENTITY_MIGRATION self-migration rejected
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Scenario 3: ENTITY_MIGRATION source==target is rejected by validateProposal (cross-node semantics)")
+    void entityMigrationSelfMigrationRejectedBySingleMemberView() throws Exception {
+        // Use only one member in the context to represent single-member view
+        var soloMember = members.get(0);
+        @SuppressWarnings("unchecked")
+        DynamicContext<Member> soloContext = Mockito.mock(DynamicContext.class);
+        when(soloContext.size()).thenReturn(1);
+        when(soloContext.toleranceLevel()).thenReturn(0); // t=0 → quorum=1
+        var soloCommittee = new LinkedHashSet<Member>(List.of(soloMember));
+        when(soloContext.bftSubset(any(Digest.class))).thenReturn(soloCommittee);
+        when(soloContext.allMembers()).thenAnswer(inv -> Stream.of((Member) soloMember));
+        when(soloContext.active()).thenAnswer(inv -> Stream.of((Member) soloMember));
+
+        var soloSelector = new ViewCommitteeSelector(soloContext);
+        var soloProtocol = new CommitteeVotingProtocol(soloContext, CommitteeConfig.defaultConfig(),
+            scheduler);
+        var soloConsensus = new ViewCommitteeConsensus();
+        soloConsensus.setViewMonitor(viewMonitor);
+        soloConsensus.setCommitteeSelector(soloSelector);
+        soloConsensus.setVotingProtocol(soloProtocol);
+
+        // Build ENTITY_MIGRATION proposal with source == target == the one member
+        var soloDigest = soloMember.getId();
+        var migrationProposal = new MigrationProposal(
+            UUID.randomUUID(),
+            UUID.randomUUID(),     // entityId
+            soloDigest,           // source == the one member
+            soloDigest,           // target == the one member (self-migration)
+            viewId,
+            testClock.currentTimeMillis()
+            // kind defaults to ENTITY_MIGRATION via the 6-arg ctor
+        );
+
+        var future = soloConsensus.requestConsensus(migrationProposal);
+
+        // validateProposal rejects source==target for ENTITY_MIGRATION synchronously
+        // future must be done and false (not pending, not approved)
+        assertTrue(future.isDone(),
+            "Future must be immediately done — validateProposal rejects self-migration synchronously");
+        assertFalse(future.get(1, TimeUnit.SECONDS),
+            "Self-migration ENTITY_MIGRATION proposal must be rejected (cross-node-only semantics)");
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario (4a): Fail-loud on unresolvable bubble — TopologyConsensusCoordinator
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Scenario 4a: SplitProposal for bubble not in resolver's key map throws (fail-loud, no silent approve)")
+    void topologyUnresolvableBubbleThrows() {
+        var bubbleGrid = new TetreeBubbleGrid((byte) 2);
+        bubbleGrid.createBubbles(1, (byte) 1, 10);
+        var bubble = bubbleGrid.getAllBubbles().iterator().next();
+        addEntities(bubble, 5100); // valid entity count so SplitProposal.validate() passes
+
+        // Build resolver with an EMPTY key map — the bubble EXISTS in the grid (validate passes)
+        // but the resolver has no key entry for it, so resolveOwningMember throws IllegalStateException.
+        var emptyResolver = buildResolver(members.get(0), Map.of());
+
+        var coordinator = new TopologyConsensusCoordinator(bubbleGrid);
+        coordinator.setClock(testClock);
+        coordinator.setConsensusProtocol(consensus);
+        coordinator.setOwnershipResolver(emptyResolver);
+
+        var splitProposal = createSplitProposal(bubbleGrid, bubble.id());
+
+        // resolveOwningMember throws IllegalStateException because bubbleKeyResolver has no entry
+        assertThrows(IllegalStateException.class,
+            () -> coordinator.requestConsensus(splitProposal),
+            "requestConsensus for bubble absent from resolver key map must throw fail-loud — no silent approve");
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario (4b): Fail-loud on unresolvable bubble — OptimisticMigratorImpl path
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Scenario 4b: OptimisticMigratorImpl.requestMigrationApproval for unknown bubble throws (no silent approve)")
+    void optimisticMigratorUnresolvableTargetThrows() {
+        // Build resolver with empty bubble grid — resolveOwningMember(unknownBubble) throws
+        var emptyResolver = buildResolver(members.get(0), Map.of());
+
+        var migrator = new OptimisticMigratorImpl();
+        migrator.setConsensusIntegration(new OptimisticMigratorIntegration(consensus, viewMonitor));
+        migrator.setOwnershipResolver(emptyResolver);
+
+        var entityId = UUID.randomUUID();
+        var unknownBubble = UUID.randomUUID();
+
+        // resolveOwningMember(unknownBubble) throws because emptyResolver has no key for it
+        assertThrows(IllegalStateException.class,
+            () -> migrator.requestMigrationApproval(entityId, unknownBubble),
+            "requestMigrationApproval for unresolvable target bubble must throw — no silent approve");
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario (5): Active-only ownership invariant via MockFirefliesView
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Scenario 5: Evicted-but-not-GC'd member is never owner; isActiveMember(evicted)==false")
+    void activeOnlyOwnershipEvictedMemberNeverReturned() {
+        // Add an evicted member beyond the base set (not in the DynamicContext stubs)
+        var evictedDigest = DigestAlgorithm.DEFAULT.digest("evicted-mvv-member".getBytes());
+        var evictedMember = new MockMember(evictedDigest);
+
+        // Add evictedMember to members for the MockFirefliesView but mark it inactive
+        members.add(evictedMember);
+
+        var bubbleId = UUID.randomUUID();
+        TetreeKey<?> key = TetreeKey.create((byte) 3, 0xDEAD_C0DE_CAFE_1234L, 0L);
+        Map<UUID, TetreeKey<?>> initialKeys = new HashMap<>();
+        initialKeys.put(bubbleId, key);
+
+        var resolver = buildResolver(members.get(0), List.of(evictedMember), initialKeys);
+
+        // isActiveMember must return false for the evicted member
+        assertFalse(resolver.isActiveMember(evictedDigest),
+            "resolver.isActiveMember(evictedDigest) must return false — evicted member not active");
+
+        // resolveOwningMember must never return the evicted digest across many keys
+        var activeDigests = members.subList(0, members.size() - 1)
+                                   .stream()
+                                   .map(MockMember::getId)
+                                   .toList();
+        for (int i = 0; i < 20; i++) {
+            TetreeKey<?> testKey = TetreeKey.create((byte) 3, (long) (i * 0xABCDEF13L + 3), 0L);
+            var testBubble = UUID.randomUUID();
+            Map<UUID, TetreeKey<?>> testKeys = new HashMap<>();
+            testKeys.put(testBubble, testKey);
+            var testResolver = buildResolver(members.get(0), List.of(evictedMember), testKeys);
+
+            var owner = testResolver.resolveOwningMember(testBubble);
+            assertNotEquals(evictedDigest, owner,
+                "Evicted-but-inactive member must never be returned as owner (key " + i + ")");
+            assertTrue(activeDigests.contains(owner),
+                "Owner must be in the active (non-evicted) member set (key " + i + ")");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario (6): Node-UUID hint validation in DistributedBubbleNode (S5 guard)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Scenario 6a: DistributedBubbleNode — canonical active node UUID passes hint validation")
+    void distributedBubbleNodeActiveNodePasses() {
+        var targetNodeId = UUID.randomUUID();
+        var targetDigest = members.get(1).getId();
+        var entityId = UUID.randomUUID();
+
+        // Inline resolver for S5 guard: targetNodeId maps to an active member digest
+        var hintResolver = stubHintResolver(targetNodeId, targetDigest, true);
+
+        var node = buildDistributedBubbleNode(hintResolver);
+        var initiated = node.initiateRemoteMigration(entityId, targetNodeId);
+
+        assertTrue(initiated, "Active canonical node UUID must pass S5 hint validation and initiate migration");
+    }
+
+    @Test
+    @DisplayName("Scenario 6b: DistributedBubbleNode — unknown node UUID throws (fail-loud)")
+    void distributedBubbleNodeUnknownNodeThrows() {
+        var unknownNodeId = UUID.randomUUID();
+        var entityId = UUID.randomUUID();
+
+        // Resolver throws for any unknown UUID — matches FirefliesBubbleOwnershipResolver behavior
+        var hintResolver = new BubbleOwnershipResolver() {
+            @Override
+            public Digest resolveOwningMember(UUID bubbleId) {
+                throw new UnsupportedOperationException("not used in node-hint test");
+            }
+            @Override
+            public Digest localMember() {
+                return members.get(0).getId();
+            }
+            @Override
+            public Digest memberDigestForNode(UUID nodeId) {
+                throw new IllegalStateException("No Fireflies member found for node UUID: " + nodeId);
+            }
+            @Override
+            public boolean isActiveMember(Digest member) {
+                return false;
+            }
+        };
+
+        var node = buildDistributedBubbleNode(hintResolver);
+
+        assertThrows(IllegalStateException.class,
+            () -> node.initiateRemoteMigration(entityId, unknownNodeId),
+            "Unknown node UUID must throw — no silent migration toward non-member");
+    }
+
+    @Test
+    @DisplayName("Scenario 6c: DistributedBubbleNode — inactive (evicted) node UUID throws")
+    void distributedBubbleNodeInactiveNodeThrows() {
+        var evictedNodeId = UUID.randomUUID();
+        var evictedDigest = DigestAlgorithm.DEFAULT.digest("evicted-node-mvv".getBytes());
+        var entityId = UUID.randomUUID();
+
+        // Resolver resolves the UUID but returns inactive
+        var hintResolver = stubHintResolver(evictedNodeId, evictedDigest, false);
+
+        var node = buildDistributedBubbleNode(hintResolver);
+
+        var ex = assertThrows(IllegalStateException.class,
+            () -> node.initiateRemoteMigration(entityId, evictedNodeId),
+            "Evicted (inactive) node must throw — cannot migrate to non-active-view member");
+        assertTrue(ex.getMessage().contains("not a current-view active member"),
+            "Exception message must name inactive-member cause, was: " + ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("Scenario 6d: DistributedBubbleNode S5 guard through the REAL resolver — canonical active node UUID passes")
+    void distributedBubbleNodeRealResolverActiveNodePasses() {
+        // Exercise the REAL FirefliesBubbleOwnershipResolver chain (memberDigestForNode via the
+        // canonical digestToUuid lambda + isActiveMember via MockFirefliesView.activeMembers) through
+        // DistributedBubbleNode, not an inline stub. The node UUID is canonically derived from an
+        // active member's digest (RDR-020 B4).
+        var targetMember = members.get(1);
+        var canonicalNodeId = FirefliesMemberLookup.digestToUuid(targetMember.getId());
+        var resolver = buildResolver(members.get(0), Map.of()); // node-UUID path only; grid unused
+
+        // Sanity: the real resolver resolves the canonical UUID to the member and reports it active.
+        assertEquals(targetMember.getId(), resolver.memberDigestForNode(canonicalNodeId),
+            "real memberDigestForNode must resolve the canonical node UUID to its member digest");
+        assertTrue(resolver.isActiveMember(targetMember.getId()),
+            "real isActiveMember must report the active member as active");
+
+        var node = buildDistributedBubbleNode(resolver);
+        assertTrue(node.initiateRemoteMigration(UUID.randomUUID(), canonicalNodeId),
+            "canonical active node UUID must pass S5 hint validation through the real resolver");
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers for Scenario (6)
+    // -------------------------------------------------------------------------
+
+    private BubbleOwnershipResolver stubHintResolver(UUID nodeId, Digest digest, boolean active) {
+        return new BubbleOwnershipResolver() {
+            @Override
+            public Digest resolveOwningMember(UUID bubbleId) {
+                throw new UnsupportedOperationException("not used in node-hint test");
+            }
+            @Override
+            public Digest localMember() {
+                return members.get(0).getId();
+            }
+            @Override
+            public Digest memberDigestForNode(UUID id) {
+                if (!id.equals(nodeId)) {
+                    throw new IllegalStateException("No Fireflies member found for node UUID: " + id);
+                }
+                return digest;
+            }
+            @Override
+            public boolean isActiveMember(Digest member) {
+                return active && member.equals(digest);
+            }
+        };
+    }
+
+    private DistributedBubbleNode buildDistributedBubbleNode(BubbleOwnershipResolver resolver) {
+        var bubble           = new EnhancedBubble(UUID.randomUUID(), (byte) 5, 16);
+        var networkChannel   = Mockito.mock(BubbleNetworkChannel.class);
+        when(networkChannel.isNodeReachable(any())).thenReturn(true);
+        var migrationInteg   = Mockito.mock(EnhancedBubbleMigrationIntegration.class);
+        var migrator         = new OptimisticMigratorImpl();
+        when(migrationInteg.getOptimisticMigrator()).thenReturn(migrator);
+        var fsm              = Mockito.mock(EntityMigrationStateMachine.class);
+
+        var node = new DistributedBubbleNode(UUID.randomUUID(), bubble, networkChannel, migrationInteg, fsm);
+        node.setOwnershipResolver(resolver);
+        return node;
+    }
+
+    // -------------------------------------------------------------------------
+    // Inner helpers
+    // -------------------------------------------------------------------------
+
+    /** Deterministic clock backed by a mutable long. */
+    private static class TestClock implements Clock {
+        private long millis;
+
+        TestClock(long millis) { this.millis = millis; }
+
+        @Override public long currentTimeMillis() { return millis; }
+        @Override public long nanoTime() { return millis * 1_000_000L; }
+    }
+
+    /** Minimal FirefliesViewMonitor stand-in providing a fixed viewId. */
+    private static class ScheduledViewMonitor extends FirefliesViewMonitor {
+        private final Digest currentViewId;
+
+        ScheduledViewMonitor(Digest viewId) {
+            super(new NoopMembershipView());
+            this.currentViewId = viewId;
+        }
+
+        @Override
+        public Digest getCurrentViewId() { return currentViewId; }
+    }
+
+    /** No-op MembershipView used only to satisfy FirefliesViewMonitor's constructor. */
+    private static class NoopMembershipView implements MembershipView<Member> {
+        @Override public void addListener(Consumer<MembershipView.ViewChange<Member>> listener) {}
+        @Override public Stream<Member> getMembers() { return Stream.empty(); }
+        @Override public Stream<Member> activeMembers() { return Stream.empty(); }
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ThreeNodeIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ThreeNodeIntegrationTest.java
@@ -93,6 +93,8 @@ public class ThreeNodeIntegrationTest {
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
         when(context.active()).thenAnswer(invocation -> members.stream());
+        when(context.isActive(org.mockito.Mockito.any(com.hellblazer.delos.cryptography.Digest.class))).thenReturn(true);
+
 
 
         // Create view monitor

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ThreeNodeIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ThreeNodeIntegrationTest.java
@@ -92,6 +92,8 @@ public class ThreeNodeIntegrationTest {
         // Mock allMembers for Byzantine validation (ViewCommitteeSelector.isNodeInView)
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
+        when(context.active()).thenAnswer(invocation -> members.stream());
+
 
         // Create view monitor
         viewMonitor = new MockViewMonitor(viewId);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/TwoNodeIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/TwoNodeIntegrationTest.java
@@ -93,6 +93,8 @@ public class TwoNodeIntegrationTest {
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
         when(context.active()).thenAnswer(invocation -> members.stream());
+        when(context.isActive(org.mockito.Mockito.any(com.hellblazer.delos.cryptography.Digest.class))).thenReturn(true);
+
 
 
         // Create view monitor

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/TwoNodeIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/TwoNodeIntegrationTest.java
@@ -92,6 +92,8 @@ public class TwoNodeIntegrationTest {
         // Mock allMembers for Byzantine validation (ViewCommitteeSelector.isNodeInView)
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
+        when(context.active()).thenAnswer(invocation -> members.stream());
+
 
         // Create view monitor
         viewMonitor = new MockViewMonitor(viewId);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ViewChangeIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ViewChangeIntegrationTest.java
@@ -94,6 +94,8 @@ public class ViewChangeIntegrationTest {
         // Mock allMembers for Byzantine validation (ViewCommitteeSelector.isNodeInView)
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
+        when(context.active()).thenAnswer(invocation -> members.stream());
+
 
         // Create view monitor
         viewMonitor = new MockViewMonitor(view1);

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ViewChangeIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/ViewChangeIntegrationTest.java
@@ -95,6 +95,8 @@ public class ViewChangeIntegrationTest {
         // Use thenAnswer to create fresh stream for each call (streams can only be consumed once)
         when(context.allMembers()).thenAnswer(invocation -> members.stream());
         when(context.active()).thenAnswer(invocation -> members.stream());
+        when(context.isActive(org.mockito.Mockito.any(com.hellblazer.delos.cryptography.Digest.class))).thenReturn(true);
+
 
 
         // Create view monitor

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/ownership/OwnershipTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/ownership/OwnershipTest.java
@@ -1,0 +1,593 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.consensus.ownership;
+
+import com.hellblazer.delos.cryptography.Digest;
+import com.hellblazer.delos.cryptography.DigestAlgorithm;
+import com.hellblazer.delos.membership.Member;
+import com.hellblazer.delos.membership.MockMember;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+import com.hellblazer.luciferase.simulation.delos.MembershipView;
+import com.hellblazer.luciferase.simulation.delos.mock.MockFirefliesView;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+import java.util.stream.Stream;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for SpatialOwnershipFunction (RendezvousOwnershipFunction),
+ * BubbleOwnershipResolver (StubBubbleOwnershipResolver test double), and
+ * FirefliesBubbleOwnershipResolver (production class, narrow-seam constructor).
+ * <p>
+ * Tests cover: HRW determinism (falsifiable: list-order independent), dependency on
+ * both inputs, fail-loud on empty active set, active-only ownership enforcement,
+ * resolveOwningMember happy/error paths, localMember, memberDigestForNode, null-input
+ * guards, and the production resolver's active-only invariant via MockFirefliesView.
+ */
+class OwnershipTest {
+
+    private static final int MEMBER_COUNT = 5;
+
+    private List<Digest> memberDigests;
+    private SpatialOwnershipFunction hrwFunction;
+
+    @BeforeEach
+    void setUp() {
+        memberDigests = new ArrayList<>();
+        for (int i = 0; i < MEMBER_COUNT; i++) {
+            memberDigests.add(DigestAlgorithm.DEFAULT.digest(("member-" + i).getBytes()));
+        }
+        hrwFunction = new RendezvousOwnershipFunction();
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 1: HRW determinism / convergence — FALSIFIABLE for list-order independence
+    // -------------------------------------------------------------------------
+
+    /**
+     * List-order independence is the load-bearing MVV property of Option β.
+     * <p>
+     * Falsifiability: if {@code owner()} returned {@code activeMembers.get(0)} (first-wins),
+     * then with list1 and list2 shuffled into DIFFERENT orders list1.get(0) != list2.get(0)
+     * in general, so {@code fn1.owner(key, list1) != fn2.owner(key, list2)} and this test
+     * would fail. The HRW max-weight scan is a set function — order-independent — so the
+     * real implementation always passes.
+     */
+    @Test
+    void hrwDeterminism_twoIndependentInstances_listOrderIndependent() {
+        var fn1 = new RendezvousOwnershipFunction();
+        var fn2 = new RendezvousOwnershipFunction();
+
+        // Build two copies in DIFFERENT shuffle orders; neither matches setUp order.
+        var list1 = new ArrayList<>(memberDigests);
+        var list2 = new ArrayList<>(memberDigests);
+        Collections.shuffle(list1, new Random(42L));
+        Collections.shuffle(list2, new Random(99L));
+
+        // Sanity: the two shuffled orders must differ from each other (different seeds).
+        // With 5 elements and seeds 42/99 they do — but assert it so the test self-documents.
+        assertNotEquals(list1, list2,
+            "Precondition: the two shuffled lists must be in different orders");
+
+        // Several distinct keys
+        var keys = List.of(
+            TetreeKey.create((byte) 3, 0x123456789ABCDEFL, 0L),
+            TetreeKey.create((byte) 5, 0xDEADBEEFCAFEBABEL, 0L),
+            TetreeKey.create((byte) 7, 0xFEEDFACE0BAD_C0DEL, 0L),
+            TetreeKey.create((byte) 2, 0L, 0L),
+            TetreeKey.create((byte) 1, 1L, 0L)
+        );
+
+        for (var key : keys) {
+            var owner1 = fn1.owner(key, list1);
+            var owner2 = fn2.owner(key, list2);
+            assertEquals(owner1, owner2,
+                "Two independent HRW instances must return identical owner regardless of list order for key " + key);
+        }
+    }
+
+    @Test
+    void hrwConvergence_multipleCallsSameInputs_alwaysSameResult() {
+        var key = TetreeKey.create((byte) 5, 0x5A5A5A5A5A5A5A5AL, 0L);
+
+        // Each iteration gets a fresh fn and a differently-shuffled list
+        // so we also exercise list-order independence here.
+        Digest first = null;
+        for (int i = 0; i < 10; i++) {
+            var fn = new RendezvousOwnershipFunction();
+            var shuffled = new ArrayList<>(memberDigests);
+            Collections.shuffle(shuffled, new Random(i * 7L + 13L));
+            var result = fn.owner(key, shuffled);
+            if (first == null) {
+                first = result;
+            } else {
+                assertEquals(first, result,
+                    "All HRW calls (different instances, different list orders) must return the same owner " +
+                    "(call " + i + ", seed " + (i * 7L + 13L) + ")");
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 2: HRW depends on both inputs
+    // -------------------------------------------------------------------------
+
+    @Test
+    void hrwDependsOnKey_differentKeysMayYieldDifferentOwners() {
+        var key1 = TetreeKey.create((byte) 3, 0x111111111111L, 0L);
+        var key2 = TetreeKey.create((byte) 3, 0x999999999999L, 0L);
+
+        var owner1 = hrwFunction.owner(key1, memberDigests);
+        var owner2 = hrwFunction.owner(key2, memberDigests);
+
+        // With 5 members, different keys should yield different owners at least sometimes.
+        // We verify that the function actually varies; if by coincidence they're equal
+        // we use a third key to show variation.
+        var key3 = TetreeKey.create((byte) 8, 0xABCDEF123456789L, 0L);
+        var owner3 = hrwFunction.owner(key3, memberDigests);
+
+        // At least two of the three keys should have different owners — with 5 members
+        // the probability all three map to the same is (1/5)^2 = 4% — but with seeded
+        // Digests it is fully deterministic, not actually probabilistic.
+        boolean someVariation = !owner1.equals(owner2) || !owner1.equals(owner3) || !owner2.equals(owner3);
+        assertTrue(someVariation, "HRW must distribute keys across members, not always return the same owner");
+    }
+
+    @Test
+    void hrwDependsOnMemberSet_changingMembersChangesDistribution() {
+        var key = TetreeKey.create((byte) 4, 0xCAFEBABE12345678L, 0L);
+
+        var subset = memberDigests.subList(0, 2); // just 2 of 5 members
+        var ownerSubset = hrwFunction.owner(key, subset);
+
+        // The subset can only return one of 2 members; verify the result is within the subset.
+        assertTrue(subset.contains(ownerSubset),
+            "Owner from a 2-member subset must be one of those 2 members");
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 3: Empty active set → throws
+    // -------------------------------------------------------------------------
+
+    @Test
+    void owner_emptyActiveSet_throwsIllegalStateException() {
+        var key = TetreeKey.create((byte) 3, 0x1L, 0L);
+        assertThrows(IllegalStateException.class,
+            () -> hrwFunction.owner(key, Collections.emptyList()),
+            "owner() must throw IllegalStateException when activeMembers is empty");
+    }
+
+    @Test
+    void owner_nullKey_throwsNullPointerException() {
+        assertThrows(NullPointerException.class,
+            () -> hrwFunction.owner(null, memberDigests));
+    }
+
+    @Test
+    void owner_nullMemberList_throwsNullPointerException() {
+        var key = TetreeKey.create((byte) 3, 0x1L, 0L);
+        assertThrows(NullPointerException.class,
+            () -> hrwFunction.owner(key, null));
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 4: Active-only ownership — evicted member never selected
+    // -------------------------------------------------------------------------
+
+    @Test
+    void hrwActiveOnly_evictedMemberNeverSelected() {
+        // Seed: "evicted" member NOT in active set
+        var evictedDigest = DigestAlgorithm.DEFAULT.digest("evicted-member".getBytes());
+        var activeSet = List.copyOf(memberDigests); // 5 members, no evicted
+
+        // For many keys, the owner is always in activeSet
+        for (int i = 0; i < 20; i++) {
+            var key = TetreeKey.create((byte) 3, (long) (i * 0xDEADBEEF13L + 7), 0L);
+            var owner = hrwFunction.owner(key, activeSet);
+            assertTrue(activeSet.contains(owner),
+                "Owner must be in active set only, not an evicted member");
+            assertNotEquals(evictedDigest, owner,
+                "Evicted member must never be selected when not in active set");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // StubBubbleOwnershipResolver (test double) tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void resolveOwningMember_knownBubble_returnsOwner() {
+        var bubbleId = UUID.randomUUID();
+        var tetreeKey = TetreeKey.create((byte) 3, 0xABCDEF0123456789L, 0L);
+        var localDigest = memberDigests.get(0);
+        var localNodeId = UUID.randomUUID();
+
+        var stub = new StubBubbleOwnershipResolver(
+            Map.of(bubbleId, tetreeKey),
+            memberDigests,
+            localDigest,
+            Map.of(localNodeId, localDigest)
+        );
+
+        var owner = stub.resolveOwningMember(bubbleId);
+        assertNotNull(owner, "resolveOwningMember must return a non-null Digest for a known bubble");
+        assertTrue(memberDigests.contains(owner),
+            "Resolved owner must be in the active member set");
+    }
+
+    @Test
+    void resolveOwningMember_unknownBubble_throwsIllegalStateException() {
+        var stub = new StubBubbleOwnershipResolver(
+            Collections.emptyMap(),
+            memberDigests,
+            memberDigests.get(0),
+            Collections.emptyMap()
+        );
+
+        assertThrows(IllegalStateException.class,
+            () -> stub.resolveOwningMember(UUID.randomUUID()),
+            "resolveOwningMember must throw when bubble is not in grid");
+    }
+
+    @Test
+    void resolveOwningMember_emptyActiveSet_throwsIllegalStateException() {
+        var bubbleId = UUID.randomUUID();
+        var tetreeKey = TetreeKey.create((byte) 3, 0x1111L, 0L);
+
+        var stub = new StubBubbleOwnershipResolver(
+            Map.of(bubbleId, tetreeKey),
+            Collections.emptyList(), // no active members
+            DigestAlgorithm.DEFAULT.digest("local".getBytes()),
+            Collections.emptyMap()
+        );
+
+        assertThrows(IllegalStateException.class,
+            () -> stub.resolveOwningMember(bubbleId),
+            "resolveOwningMember must throw when active member set is empty");
+    }
+
+    @Test
+    void localMember_returnsSeededLocalDigest() {
+        var localDigest = memberDigests.get(2);
+        var stub = new StubBubbleOwnershipResolver(
+            Collections.emptyMap(),
+            memberDigests,
+            localDigest,
+            Collections.emptyMap()
+        );
+
+        assertEquals(localDigest, stub.localMember(),
+            "localMember() must return the seeded local member digest");
+    }
+
+    @Test
+    void memberDigestForNode_knownNodeId_returnsItsDigest() {
+        var nodeId = UUID.randomUUID();
+        var expectedDigest = memberDigests.get(1);
+
+        var stub = new StubBubbleOwnershipResolver(
+            Collections.emptyMap(),
+            memberDigests,
+            memberDigests.get(0),
+            Map.of(nodeId, expectedDigest)
+        );
+
+        assertEquals(expectedDigest, stub.memberDigestForNode(nodeId),
+            "memberDigestForNode must return the digest for a known node UUID");
+    }
+
+    @Test
+    void memberDigestForNode_unknownNodeId_throwsIllegalStateException() {
+        var stub = new StubBubbleOwnershipResolver(
+            Collections.emptyMap(),
+            memberDigests,
+            memberDigests.get(0),
+            Collections.emptyMap()
+        );
+
+        assertThrows(IllegalStateException.class,
+            () -> stub.memberDigestForNode(UUID.randomUUID()),
+            "memberDigestForNode must throw when node UUID is not found");
+    }
+
+    // -------------------------------------------------------------------------
+    // Owner result must be from the provided active set
+    // -------------------------------------------------------------------------
+
+    @Test
+    void owner_resultAlwaysInActiveSet() {
+        for (int i = 0; i < 30; i++) {
+            var key = TetreeKey.create((byte) ((i % 10) + 1), (long) i * 0xBEEFC0DE1234L + i, 0L);
+            var owner = hrwFunction.owner(key, memberDigests);
+            assertTrue(memberDigests.contains(owner),
+                "owner() result must always be in the provided active member set, key=" + key);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // L1: Null-input throw tests (BubbleOwnershipResolver contract guards)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void stub_resolveOwningMember_null_throwsNullPointerException() {
+        var stub = new StubBubbleOwnershipResolver(
+            Collections.emptyMap(),
+            memberDigests,
+            memberDigests.get(0),
+            Collections.emptyMap()
+        );
+        assertThrows(NullPointerException.class,
+            () -> stub.resolveOwningMember(null),
+            "resolveOwningMember(null) must throw NullPointerException");
+    }
+
+    @Test
+    void stub_memberDigestForNode_null_throwsNullPointerException() {
+        var stub = new StubBubbleOwnershipResolver(
+            Collections.emptyMap(),
+            memberDigests,
+            memberDigests.get(0),
+            Collections.emptyMap()
+        );
+        assertThrows(NullPointerException.class,
+            () -> stub.memberDigestForNode(null),
+            "memberDigestForNode(null) must throw NullPointerException");
+    }
+
+    // -------------------------------------------------------------------------
+    // SIGNIFICANT: FirefliesBubbleOwnershipResolver direct tests
+    //
+    // Uses the narrow-seam constructor + MockFirefliesView<MockMember> to test:
+    // (a) active-only invariant: evicted member is never returned as owner
+    // (b) resolveOwningMember resolves correctly
+    // (c) localMember() delegates to the supplier
+    // (d) memberDigestForNode() delegates to the resolver
+    // (e) null-guard on resolveOwningMember and memberDigestForNode
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds a {@link FirefliesBubbleOwnershipResolver} wired to a
+     * {@link MockFirefliesView} containing the given members and with {@code inactive}
+     * members marked inactive.  Bubble grid is a simple map with one entry.
+     */
+    private FirefliesBubbleOwnershipResolver buildProductionResolver(
+            List<MockMember> allMembers,
+            List<MockMember> inactive,
+            UUID bubbleId,
+            TetreeKey<?> bubbleKey,
+            MockMember localMember) {
+
+        var mockView = new MockFirefliesView<MockMember>();
+        for (var m : allMembers) {
+            mockView.addMember(m);
+        }
+        for (var m : inactive) {
+            mockView.markInactive(m);
+        }
+
+        // Adapt MockFirefliesView<MockMember> → MembershipView<com.hellblazer.delos.membership.Member>
+        // MockMember implements Member so the cast is safe; use raw-typed helper.
+        @SuppressWarnings("unchecked")
+        MembershipView<Member> membershipView =
+            (MembershipView<Member>) (MembershipView<?>) mockView;
+
+        Map<UUID, TetreeKey<?>> grid = Map.of(bubbleId, bubbleKey);
+
+        return new FirefliesBubbleOwnershipResolver(
+            () -> localMember,
+            uuid -> allMembers.stream()
+                              .filter(m -> m.getId().equals(
+                                  DigestAlgorithm.DEFAULT.digest(uuid.toString().getBytes())))
+                              .map(m -> (Member) m)
+                              .findFirst(),
+            grid::get,
+            membershipView,
+            new RendezvousOwnershipFunction()
+        );
+    }
+
+    @Test
+    void productionResolver_resolveOwningMember_returnsActiveMember() {
+        var digests = memberDigests;
+        var members = new ArrayList<MockMember>();
+        for (var d : digests) {
+            members.add(new MockMember(d));
+        }
+        var bubbleId = UUID.randomUUID();
+        var key = TetreeKey.create((byte) 3, 0xCAFEBABE_DEADBEEFL, 0L);
+        var localMember = members.get(0);
+
+        var resolver = buildProductionResolver(members, List.of(), bubbleId, key, localMember);
+
+        var owner = resolver.resolveOwningMember(bubbleId);
+        assertNotNull(owner, "resolveOwningMember must return a non-null Digest");
+        assertTrue(digests.contains(owner), "Owner must be in the active member set");
+    }
+
+    @Test
+    void productionResolver_activeOnly_evictedMemberNeverReturned() {
+        var digests = memberDigests;
+        var members = new ArrayList<MockMember>();
+        for (var d : digests) {
+            members.add(new MockMember(d));
+        }
+
+        // Add an extra member and mark it inactive (evicted-but-not-GC'd)
+        var evictedDigest = DigestAlgorithm.DEFAULT.digest("evicted".getBytes());
+        var evictedMember = new MockMember(evictedDigest);
+        members.add(evictedMember);
+
+        // activeSet is all but evicted
+        var activeDigests = new ArrayList<>(digests); // original 5, no evicted
+
+        var bubbleId = UUID.randomUUID();
+        var key = TetreeKey.create((byte) 3, 0xDEAD_C0DE_CAFE_1234L, 0L);
+        var localMember = members.get(0);
+
+        // Build resolver with evictedMember inactive
+        var mockView = new MockFirefliesView<MockMember>();
+        for (var m : members) {
+            mockView.addMember(m);
+        }
+        mockView.markInactive(evictedMember);
+
+        @SuppressWarnings("unchecked")
+        MembershipView<Member> membershipView =
+            (MembershipView<Member>) (MembershipView<?>) mockView;
+
+        Map<UUID, TetreeKey<?>> grid = Map.of(bubbleId, key);
+
+        var resolver = new FirefliesBubbleOwnershipResolver(
+            () -> localMember,
+            uuid -> Optional.empty(),
+            grid::get,
+            membershipView,
+            new RendezvousOwnershipFunction()
+        );
+
+        // Test across several keys — evicted must never be selected
+        for (int i = 0; i < 20; i++) {
+            var testKey = TetreeKey.create((byte) 3, (long) (i * 0xABCDEF13L + 3), 0L);
+            var testBubbleId = UUID.randomUUID();
+            // Extend the grid on-the-fly: rebuild with this key
+            Map<UUID, TetreeKey<?>> testGrid = Map.of(testBubbleId, testKey);
+
+            var testResolver = new FirefliesBubbleOwnershipResolver(
+                () -> localMember,
+                uuid -> Optional.empty(),
+                testGrid::get,
+                membershipView,
+                new RendezvousOwnershipFunction()
+            );
+            var owner = testResolver.resolveOwningMember(testBubbleId);
+            assertTrue(activeDigests.contains(owner),
+                "Owner must be in the active (non-evicted) set, key=" + testKey);
+            assertNotEquals(evictedDigest, owner,
+                "Evicted-but-inactive member must never be selected as owner");
+        }
+    }
+
+    @Test
+    void productionResolver_localMember_delegatesToSupplier() {
+        var localDigest = memberDigests.get(2);
+        var localMember = new MockMember(localDigest);
+
+        var mockView = new MockFirefliesView<MockMember>();
+        @SuppressWarnings("unchecked")
+        MembershipView<Member> membershipView =
+            (MembershipView<Member>) (MembershipView<?>) mockView;
+
+        var resolver = new FirefliesBubbleOwnershipResolver(
+            () -> localMember,
+            uuid -> Optional.empty(),
+            uuid -> null,
+            membershipView,
+            new RendezvousOwnershipFunction()
+        );
+
+        assertEquals(localDigest, resolver.localMember(),
+            "localMember() must return the digest from the injected supplier");
+    }
+
+    @Test
+    void productionResolver_memberDigestForNode_delegatesToResolver() {
+        var targetDigest = memberDigests.get(1);
+        var targetMember = new MockMember(targetDigest);
+        var nodeId = UUID.randomUUID();
+
+        var mockView = new MockFirefliesView<MockMember>();
+        @SuppressWarnings("unchecked")
+        MembershipView<Member> membershipView =
+            (MembershipView<Member>) (MembershipView<?>) mockView;
+
+        var resolver = new FirefliesBubbleOwnershipResolver(
+            () -> new MockMember(memberDigests.get(0)),
+            uuid -> uuid.equals(nodeId) ? Optional.of(targetMember) : Optional.empty(),
+            uid -> null,
+            membershipView,
+            new RendezvousOwnershipFunction()
+        );
+
+        assertEquals(targetDigest, resolver.memberDigestForNode(nodeId),
+            "memberDigestForNode must return the digest from the injected node resolver");
+    }
+
+    @Test
+    void productionResolver_memberDigestForNode_unknownNode_throwsISE() {
+        var mockView = new MockFirefliesView<MockMember>();
+        @SuppressWarnings("unchecked")
+        MembershipView<Member> membershipView =
+            (MembershipView<Member>) (MembershipView<?>) mockView;
+
+        var resolver = new FirefliesBubbleOwnershipResolver(
+            () -> new MockMember(memberDigests.get(0)),
+            uuid -> Optional.empty(),
+            uid -> null,
+            membershipView,
+            new RendezvousOwnershipFunction()
+        );
+
+        assertThrows(IllegalStateException.class,
+            () -> resolver.memberDigestForNode(UUID.randomUUID()),
+            "memberDigestForNode must throw ISE when node UUID is not found");
+    }
+
+    @Test
+    void productionResolver_resolveOwningMember_null_throwsNPE() {
+        var mockView = new MockFirefliesView<MockMember>();
+        @SuppressWarnings("unchecked")
+        MembershipView<Member> membershipView =
+            (MembershipView<Member>) (MembershipView<?>) mockView;
+
+        var resolver = new FirefliesBubbleOwnershipResolver(
+            () -> new MockMember(memberDigests.get(0)),
+            uuid -> Optional.empty(),
+            uid -> null,
+            membershipView,
+            new RendezvousOwnershipFunction()
+        );
+
+        assertThrows(NullPointerException.class,
+            () -> resolver.resolveOwningMember(null),
+            "resolveOwningMember(null) must throw NullPointerException");
+    }
+
+    @Test
+    void productionResolver_memberDigestForNode_null_throwsNPE() {
+        var mockView = new MockFirefliesView<MockMember>();
+        @SuppressWarnings("unchecked")
+        MembershipView<Member> membershipView =
+            (MembershipView<Member>) (MembershipView<?>) mockView;
+
+        var resolver = new FirefliesBubbleOwnershipResolver(
+            () -> new MockMember(memberDigests.get(0)),
+            uuid -> Optional.empty(),
+            uid -> null,
+            membershipView,
+            new RendezvousOwnershipFunction()
+        );
+
+        assertThrows(NullPointerException.class,
+            () -> resolver.memberDigestForNode(null),
+            "memberDigestForNode(null) must throw NullPointerException");
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/OptimisticMigratorConsensusGateTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/OptimisticMigratorConsensusGateTest.java
@@ -17,44 +17,155 @@
 
 package com.hellblazer.luciferase.simulation.distributed.migration;
 
+import com.hellblazer.delos.cryptography.Digest;
+import com.hellblazer.delos.cryptography.DigestAlgorithm;
 import com.hellblazer.luciferase.simulation.consensus.committee.OptimisticMigratorIntegration;
+import com.hellblazer.luciferase.simulation.consensus.ownership.BubbleOwnershipResolver;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
- * Consensus-gate regression for {@link OptimisticMigratorImpl#requestMigrationApproval}
- * (Luciferase-0frcy.35).
+ * Consensus-gate behavior for {@link OptimisticMigratorImpl#requestMigrationApproval}
+ * (Luciferase-0frcy.35 → RDR-020 S4).
  *
- * <p>Pre-fix: when a consensus integration was wired, the method logged "Delegating ..." but
- * returned {@code completedFuture(true)} unconditionally — silently bypassing the committee-quorum
- * gate. Any caller relying on the gate would skip it with no signal. The fix fails loud
- * (UnsupportedOperationException) rather than silently approving, because the UUID→Digest mapping
- * needed to actually delegate is not available in this impl. The no-integration path keeps its
- * documented default-approve behavior.
+ * <p>History: the method once silently returned {@code completedFuture(true)} when a consensus
+ * integration was wired, bypassing the committee-quorum gate; that was replaced by a fail-loud
+ * {@code UnsupportedOperationException} because no UUID→Digest mapping existed. RDR-020 S4 supplies
+ * that mapping via {@link BubbleOwnershipResolver}: the target bubble UUID resolves to its HRW owning
+ * member (target node), the local member is the source node, and approval delegates to the committee.
+ * The fail-loud invariant is preserved for the misconfigured (integration-without-resolver) and
+ * unresolvable-target cases; the no-integration path keeps its documented default-approve behavior.
  *
  * @author hal.hildebrand
  */
 class OptimisticMigratorConsensusGateTest {
 
-    @Test
-    void doesNotSilentlyApproveWhenConsensusIntegrationIsSet() {
-        var migrator = new OptimisticMigratorImpl();
-        migrator.setConsensusIntegration(mock(OptimisticMigratorIntegration.class));
+    private static BubbleOwnershipResolver resolver(Digest local, Digest owner) {
+        return new BubbleOwnershipResolver() {
+            @Override
+            public Digest resolveOwningMember(UUID bubbleId) {
+                return owner;
+            }
 
+            @Override
+            public Digest localMember() {
+                return local;
+            }
+
+            @Override
+            public Digest memberDigestForNode(UUID nodeId) {
+                return owner;
+            }
+        };
+    }
+
+    @Test
+    void delegatesToCommitteeWithResolvedDigestsWhenIntegrationAndResolverSet() throws Exception {
+        var local = DigestAlgorithm.DEFAULT.digest("s4-local-source");
+        var owner = DigestAlgorithm.DEFAULT.digest("s4-target-owner");
         var entityId = UUID.randomUUID();
         var targetBubble = UUID.randomUUID();
 
-        // Must NOT silently return an approved future — it must fail loud so callers know the
-        // quorum gate is not actually being enforced.
-        assertThrows(UnsupportedOperationException.class,
-                     () -> migrator.requestMigrationApproval(entityId, targetBubble),
-                     "With a consensus integration wired but no UUID→Digest mapping, approval must "
-                     + "fail loud rather than silently bypass the quorum gate");
+        var integration = mock(OptimisticMigratorIntegration.class);
+        when(integration.requestMigrationApproval(eq(entityId), eq(local), eq(owner)))
+            .thenReturn(CompletableFuture.completedFuture(true));
+
+        // Mock resolver (not the input-blind helper) so we can pin WHICH UUID is resolved as the
+        // target — it must be the BUBBLE uuid, resolved via HRW directly, not a node uuid or the
+        // entity id.
+        var resolver = mock(BubbleOwnershipResolver.class);
+        when(resolver.resolveOwningMember(eq(targetBubble))).thenReturn(owner);
+        when(resolver.localMember()).thenReturn(local);
+
+        var migrator = new OptimisticMigratorImpl();
+        migrator.setConsensusIntegration(integration);
+        migrator.setOwnershipResolver(resolver);
+
+        var approved = migrator.requestMigrationApproval(entityId, targetBubble).get(2, TimeUnit.SECONDS);
+
+        assertTrue(approved, "approval must reflect the committee's decision (true here)");
+        // target = HRW owner of the target BUBBLE uuid (pin the bubble-uuid-not-node-uuid invariant);
+        // source = local member (possession).
+        verify(resolver, times(1)).resolveOwningMember(targetBubble);
+        verify(resolver, times(1)).localMember();
+        verify(integration, times(1)).requestMigrationApproval(entityId, local, owner);
+    }
+
+    @Test
+    void propagatesCommitteeRejection() throws Exception {
+        var local = DigestAlgorithm.DEFAULT.digest("s4-local-source");
+        var owner = DigestAlgorithm.DEFAULT.digest("s4-target-owner");
+        var entityId = UUID.randomUUID();
+
+        var integration = mock(OptimisticMigratorIntegration.class);
+        when(integration.requestMigrationApproval(eq(entityId), eq(local), eq(owner)))
+            .thenReturn(CompletableFuture.completedFuture(false));
+
+        var migrator = new OptimisticMigratorImpl();
+        migrator.setConsensusIntegration(integration);
+        migrator.setOwnershipResolver(resolver(local, owner));
+
+        var approved = migrator.requestMigrationApproval(entityId, UUID.randomUUID()).get(2, TimeUnit.SECONDS);
+        assertFalse(approved, "a committee rejection must propagate, not be overridden to approve");
+        verify(integration, times(1)).requestMigrationApproval(entityId, local, owner);
+    }
+
+    @Test
+    void failsLoudWhenIntegrationSetButNoResolver() {
+        var migrator = new OptimisticMigratorImpl();
+        migrator.setConsensusIntegration(mock(OptimisticMigratorIntegration.class));
+        // No resolver injected.
+
+        // Must NOT silently approve — without a resolver the bubble→member mapping is unavailable,
+        // so the quorum gate cannot be enforced. Fail loud.
+        assertThrows(IllegalStateException.class,
+                     () -> migrator.requestMigrationApproval(UUID.randomUUID(), UUID.randomUUID()),
+                     "integration wired without a resolver must fail loud, not bypass the quorum gate");
+    }
+
+    @Test
+    void failsLoudWhenTargetUnresolvable() {
+        var entityId = UUID.randomUUID();
+        var integration = mock(OptimisticMigratorIntegration.class);
+
+        var migrator = new OptimisticMigratorImpl();
+        migrator.setConsensusIntegration(integration);
+        // Resolver that cannot resolve the target bubble (fail-loud per the S1 contract).
+        migrator.setOwnershipResolver(new BubbleOwnershipResolver() {
+            @Override
+            public Digest resolveOwningMember(UUID bubbleId) {
+                throw new IllegalStateException("unresolvable target bubble (test): " + bubbleId);
+            }
+
+            @Override
+            public Digest localMember() {
+                return DigestAlgorithm.DEFAULT.digest("s4-local");
+            }
+
+            @Override
+            public Digest memberDigestForNode(UUID nodeId) {
+                return DigestAlgorithm.DEFAULT.digest("s4-local");
+            }
+        });
+
+        assertThrows(IllegalStateException.class,
+                     () -> migrator.requestMigrationApproval(entityId, UUID.randomUUID()),
+                     "an unresolvable target must throw, never silently approve");
+        // The committee must never be consulted for an unresolvable target.
+        verify(integration, never()).requestMigrationApproval(org.mockito.ArgumentMatchers.any(),
+                                                               org.mockito.ArgumentMatchers.any(),
+                                                               org.mockito.ArgumentMatchers.any());
     }
 
     @Test

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/OptimisticMigratorConsensusGateTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/migration/OptimisticMigratorConsensusGateTest.java
@@ -67,6 +67,11 @@ class OptimisticMigratorConsensusGateTest {
             public Digest memberDigestForNode(UUID nodeId) {
                 return owner;
             }
+
+            @Override
+            public boolean isActiveMember(Digest member) {
+                return true;
+            }
         };
     }
 
@@ -156,6 +161,11 @@ class OptimisticMigratorConsensusGateTest {
             @Override
             public Digest memberDigestForNode(UUID nodeId) {
                 return DigestAlgorithm.DEFAULT.digest("s4-local");
+            }
+
+            @Override
+            public boolean isActiveMember(Digest member) {
+                return true;
             }
         });
 

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/network/DistributedBubbleNodeHintValidationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/network/DistributedBubbleNodeHintValidationTest.java
@@ -120,6 +120,21 @@ class DistributedBubbleNodeHintValidationTest {
     }
 
     @Test
+    void noResolverWired_randomNodeUuidIsNotValidated() {
+        // RDR-020 S7 (Luciferase-h3lc6): the S5 hint validation is OPT-IN — it runs only when a
+        // resolver is wired. With no resolver (the default), an arbitrary/random node UUID that does
+        // not resolve to any member is NOT validated and the migration proceeds. This is the contract
+        // the performance/resilience suites rely on (they drive initiateRemoteMigration with random
+        // node UUIDs and no resolver); pinning it here guards against a regression that made
+        // validation unconditional. Canonical (digestToUuid-derived) identities become required only
+        // once a resolver is wired by the multi-node bootstrap (bead Luciferase-s23eu).
+        var node = nodeWith(/* resolver */ null, UUID.randomUUID());
+        var initiated = node.node().initiateRemoteMigration(UUID.randomUUID(), node.targetNodeId());
+        assertTrue(initiated, "with no resolver wired, a random node UUID must not be validated (no throw)");
+        verify(node.migrator()).initiateOptimisticMigration(any(), any());
+    }
+
+    @Test
     void clearingResolverDisablesValidation() {
         var targetNodeId = UUID.randomUUID();
         var entityId = UUID.randomUUID();

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/network/DistributedBubbleNodeHintValidationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/network/DistributedBubbleNodeHintValidationTest.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase Simulation Framework.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.distributed.network;
+
+import com.hellblazer.delos.cryptography.Digest;
+import com.hellblazer.delos.cryptography.DigestAlgorithm;
+import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
+import com.hellblazer.luciferase.simulation.bubble.EnhancedBubbleMigrationIntegration;
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationStateMachine;
+import com.hellblazer.luciferase.simulation.consensus.ownership.BubbleOwnershipResolver;
+import com.hellblazer.luciferase.simulation.distributed.migration.OptimisticMigrator;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * RDR-020 S5: explicit node-UUID hint validation in
+ * {@link DistributedBubbleNode#initiateRemoteMigration} (B1/B4).
+ *
+ * <p>{@code targetNodeId} carries no destination region key, so the HRW {@code owner(destKey)}
+ * cross-check is not applicable here (that lives at the bubble-keyed consensus entry points, S3/S4).
+ * The implementable guard is the canonical node-UUID → member-Digest resolution plus an active-only
+ * membership check: a random/unknown UUID resolves to no member (throws); an evicted-but-not-GC'd
+ * node resolves but is inactive (throws); a canonical active node passes. When no resolver is wired
+ * the hint is not validated (backward compatibility) — covered by
+ * {@link DistributedBubbleNodeMigrationTargetTest}.
+ *
+ * @author hal.hildebrand
+ */
+class DistributedBubbleNodeHintValidationTest {
+
+    private record Fixture(DistributedBubbleNode node, OptimisticMigrator migrator, UUID targetNodeId) {
+    }
+
+    /**
+     * Build a node whose target is reachable, wiring the supplied resolver. The migrator is a mock so
+     * we can assert whether the migration was initiated (valid hint) or short-circuited (bad hint).
+     */
+    private static Fixture nodeWith(BubbleOwnershipResolver resolver, UUID targetNodeId) {
+        var bubble = new EnhancedBubble(UUID.randomUUID(), (byte) 5, 16);
+        var migrator = mock(OptimisticMigrator.class);
+        var networkChannel = mock(BubbleNetworkChannel.class);
+        when(networkChannel.isNodeReachable(any())).thenReturn(true);
+        var integration = mock(EnhancedBubbleMigrationIntegration.class);
+        when(integration.getOptimisticMigrator()).thenReturn(migrator);
+        var fsm = mock(EntityMigrationStateMachine.class);
+
+        var node = new DistributedBubbleNode(UUID.randomUUID(), bubble, networkChannel, integration, fsm);
+        node.setOwnershipResolver(resolver);
+        return new Fixture(node, migrator, targetNodeId);
+    }
+
+    @Test
+    void canonicalActiveNodeUuidPasses() {
+        var targetNodeId = UUID.randomUUID();
+        var targetDigest = DigestAlgorithm.DEFAULT.digest("active-target");
+        var entityId = UUID.randomUUID();
+
+        var fx = nodeWith(resolver(targetNodeId, targetDigest, /*active*/ true), targetNodeId);
+
+        var initiated = fx.node().initiateRemoteMigration(entityId, targetNodeId);
+
+        assertTrue(initiated, "a canonical, active target node must pass hint validation");
+        verify(fx.migrator()).initiateOptimisticMigration(entityId, targetNodeId);
+    }
+
+    @Test
+    void unknownNodeUuidThrows() {
+        var targetNodeId = UUID.randomUUID();
+        var entityId = UUID.randomUUID();
+        // Resolver that resolves no member for this UUID (random / not digestToUuid-derived).
+        var resolver = mock(BubbleOwnershipResolver.class);
+        when(resolver.memberDigestForNode(targetNodeId))
+            .thenThrow(new IllegalStateException("No Fireflies member found for node UUID: " + targetNodeId));
+
+        var fx = nodeWith(resolver, targetNodeId);
+
+        assertThrows(IllegalStateException.class,
+                     () -> fx.node().initiateRemoteMigration(entityId, targetNodeId),
+                     "an unknown node UUID must fail loud, not initiate a migration toward a non-member");
+        verify(fx.migrator(), never()).initiateOptimisticMigration(any(), any());
+    }
+
+    @Test
+    void inactiveNodeUuidThrows() {
+        var targetNodeId = UUID.randomUUID();
+        var targetDigest = DigestAlgorithm.DEFAULT.digest("evicted-target");
+        var entityId = UUID.randomUUID();
+        // Resolves to a member (still in all-members backing) but it is NOT active (evicted-not-GC'd).
+        var fx = nodeWith(resolver(targetNodeId, targetDigest, /*active*/ false), targetNodeId);
+
+        var ex = assertThrows(IllegalStateException.class,
+                              () -> fx.node().initiateRemoteMigration(entityId, targetNodeId),
+                              "an inactive (evicted) node must fail loud");
+        assertTrue(ex.getMessage().contains("not a current-view active member"),
+                   "message must name the inactive-member cause, was: " + ex.getMessage());
+        verify(fx.migrator(), never()).initiateOptimisticMigration(any(), any());
+    }
+
+    @Test
+    void clearingResolverDisablesValidation() {
+        var targetNodeId = UUID.randomUUID();
+        var entityId = UUID.randomUUID();
+        // Resolver that would reject this node (inactive) — proves validation is active while wired.
+        var fx = nodeWith(resolver(targetNodeId, DigestAlgorithm.DEFAULT.digest("evicted"), /*active*/ false),
+                          targetNodeId);
+        assertThrows(IllegalStateException.class,
+                     () -> fx.node().initiateRemoteMigration(entityId, targetNodeId),
+                     "while wired, the inactive node must be rejected");
+
+        // Clearing the resolver returns to the backward-compat (unvalidated) path: the same call now
+        // proceeds. This pins the null-downgrade bridge used until S7 wires resolvers everywhere.
+        fx.node().setOwnershipResolver(null);
+        var initiated = fx.node().initiateRemoteMigration(entityId, targetNodeId);
+        assertTrue(initiated, "with no resolver wired, the hint is not validated (backward compatibility)");
+        verify(fx.migrator()).initiateOptimisticMigration(entityId, targetNodeId);
+    }
+
+    private static BubbleOwnershipResolver resolver(UUID nodeId, Digest digest, boolean active) {
+        return new BubbleOwnershipResolver() {
+            @Override
+            public Digest resolveOwningMember(UUID bubbleId) {
+                throw new UnsupportedOperationException("not used in node-hint validation");
+            }
+
+            @Override
+            public Digest localMember() {
+                return DigestAlgorithm.DEFAULT.digest("local");
+            }
+
+            @Override
+            public Digest memberDigestForNode(UUID id) {
+                if (!id.equals(nodeId)) {
+                    throw new IllegalStateException("No Fireflies member found for node UUID: " + id);
+                }
+                return digest;
+            }
+
+            @Override
+            public boolean isActiveMember(Digest member) {
+                return active && member.equals(digest);
+            }
+        };
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/TopologyConsensusCoordinatorTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/TopologyConsensusCoordinatorTest.java
@@ -16,9 +16,13 @@
  */
 package com.hellblazer.luciferase.simulation.topology;
 
+import com.hellblazer.delos.cryptography.Digest;
 import com.hellblazer.delos.cryptography.DigestAlgorithm;
 import com.hellblazer.luciferase.simulation.bubble.TetreeBubbleGrid;
+import com.hellblazer.luciferase.simulation.consensus.committee.MigrationProposal;
+import com.hellblazer.luciferase.simulation.consensus.committee.ProposalKind;
 import com.hellblazer.luciferase.simulation.consensus.committee.ViewCommitteeConsensus;
+import com.hellblazer.luciferase.simulation.consensus.ownership.BubbleOwnershipResolver;
 import com.hellblazer.luciferase.common.time.Clock;
 import com.hellblazer.luciferase.simulation.distributed.integration.EntityAccountant;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,6 +52,7 @@ class TopologyConsensusCoordinatorTest {
     private TopologyConsensusCoordinator coordinator;
     private TestClock testClock;
     private ViewCommitteeConsensus mockConsensus;
+    private Digest localDigest;
 
     @BeforeEach
     void setUp() {
@@ -62,8 +67,41 @@ class TopologyConsensusCoordinatorTest {
         mockConsensus = Mockito.mock(ViewCommitteeConsensus.class);
         coordinator.setConsensusProtocol(mockConsensus);
 
+        // RDR-020 S3: requestConsensus now resolves the region owner through a BubbleOwnershipResolver.
+        // For the cooldown / pre-validation / clock tests the consensus is fully mocked (validateProposal
+        // never runs), so the only requirement is that the two coordinator-level guards pass: the local
+        // node must own the region (owner == local) and a merge's two bubbles must share one owner. A
+        // fixed-owner resolver — owner == local == one digest for every bubble — satisfies both for any
+        // bubble created per-test. Tests that exercise the guard failure paths inject their own resolver.
+        localDigest = DigestAlgorithm.DEFAULT.digest("s3-local-member");
+        coordinator.setOwnershipResolver(fixedOwnerResolver(localDigest, localDigest));
+
         // Mock consensus to always approve
         when(mockConsensus.requestConsensus(any())).thenReturn(CompletableFuture.completedFuture(true));
+    }
+
+    /**
+     * A deterministic {@link BubbleOwnershipResolver} returning fixed owner / local digests for
+     * every bubble (RDR-020 S3). With {@code owner == local} both coordinator-level guards
+     * (ownership, same-owner merge) pass; setting them unequal forces the ownership-guard throw.
+     */
+    private static BubbleOwnershipResolver fixedOwnerResolver(Digest owner, Digest local) {
+        return new BubbleOwnershipResolver() {
+            @Override
+            public Digest resolveOwningMember(UUID bubbleId) {
+                return owner;
+            }
+
+            @Override
+            public Digest localMember() {
+                return local;
+            }
+
+            @Override
+            public Digest memberDigestForNode(UUID nodeId) {
+                return owner;
+            }
+        };
     }
 
     @Test
@@ -270,6 +308,7 @@ class TopologyConsensusCoordinatorTest {
 
         coordinator2.setClock(testClock);
         coordinator2.setConsensusProtocol(mockConsensus);
+        coordinator2.setOwnershipResolver(fixedOwnerResolver(localDigest, localDigest));
 
         testClock.setMillis(1000L);
         var proposal = createSplitProposal(bubble.id());
@@ -582,28 +621,23 @@ class TopologyConsensusCoordinatorTest {
     }
 
     /**
-     * Luciferase-7wzml.182 (toMigrationProposal non-member digests).
+     * RDR-020 S3: {@code toMigrationProposal} builds a TOPOLOGY-kind proposal under the
+     * single-owner node-identity model.
      * <p>
-     * Verifies that {@code toMigrationProposal} produces a non-null, well-formed
-     * {@link com.hellblazer.luciferase.simulation.consensus.committee.MigrationProposal}
-     * that is accepted by a mock consensus (which does not enforce Fireflies membership). The mock
-     * must be invoked exactly once, confirming the proposal reaches the committee and is not
-     * short-circuited by a null/malformed sourceNode or targetNode.
-     * <p>
-     * The known limitation (Luciferase-vhbw3) — that bubble-UUID-derived digests are rejected by
-     * a membership-enforcing consensus — is documented in the Javadoc of {@code toMigrationProposal}
-     * and is out of scope for this test. This test confirms the mock path works and that the
-     * surrounding code does not produce a NullPointerException or other failure from the mapping.
+     * The owner is resolved through the injected {@link BubbleOwnershipResolver}, and because a
+     * topology change is single-region the proposal carries {@code source == target == owner(region)}
+     * with {@code kind == TOPOLOGY}. (The old {@code digestOf}-of-bubble-UUID model — which produced
+     * distinct, non-member source/target digests the live membership-enforcing consensus silently
+     * rejected — is deleted; Luciferase-vhbw3 / Gap 2.)
      */
     @Test
-    void toMigrationProposal_producesWellFormedProposalAcceptedByMockConsensus() {
+    void toMigrationProposal_producesTopologyKindSingleOwnerProposal() {
         bubbleGrid.createBubbles(1, (byte) 1, 10);
         var bubble = bubbleGrid.getAllBubbles().iterator().next();
         addEntities(bubble, 5100);
 
         // Capture the MigrationProposal that reaches the mock consensus.
-        var captured = new java.util.concurrent.atomic.AtomicReference<
-            com.hellblazer.luciferase.simulation.consensus.committee.MigrationProposal>();
+        var captured = new java.util.concurrent.atomic.AtomicReference<MigrationProposal>();
         when(mockConsensus.requestConsensus(any())).thenAnswer(inv -> {
             captured.set(inv.getArgument(0));
             return CompletableFuture.completedFuture(true);
@@ -617,15 +651,111 @@ class TopologyConsensusCoordinatorTest {
 
         var mp = captured.get();
         assertNotNull(mp, "MigrationProposal must have been passed to consensus");
-        assertNotNull(mp.proposalId(), "proposalId must not be null");
-        assertNotNull(mp.entityId(), "entityId must not be null");
-        assertNotNull(mp.sourceNodeId(), "sourceNodeId must not be null (digestOf(bubbleId))");
-        assertNotNull(mp.targetNodeId(), "targetNodeId must not be null (digestOf(proposalId))");
+        assertEquals(ProposalKind.TOPOLOGY, mp.kind(), "Topology change must carry kind=TOPOLOGY");
+        assertEquals(localDigest, mp.sourceNodeId(), "sourceNode must be the resolved region owner");
+        assertEquals(localDigest, mp.targetNodeId(), "targetNode must equal sourceNode (single-owner model)");
+        assertEquals(mp.sourceNodeId(), mp.targetNodeId(),
+                     "TOPOLOGY proposal is source == target == owner(region)");
+        assertEquals(bubble.id(), mp.entityId(), "entityId must be the primary affected bubble");
+        assertEquals(proposal.proposalId(), mp.proposalId(), "proposalId must be threaded through unchanged");
         assertNotNull(mp.viewId(), "viewId must not be null");
-        assertNotEquals(mp.sourceNodeId(), mp.targetNodeId(),
-                        "sourceNode and targetNode must differ (self-migration would be rejected by real consensus)");
-        assertEquals(proposal.proposalId(), mp.proposalId(),
-                     "proposalId must be threaded through unchanged");
+    }
+
+    /**
+     * RDR-020 S3 ownership guard: a node may only propose a topology change for a region it owns.
+     * When the resolved owner differs from the local member, {@code toMigrationProposal} throws
+     * (fail-loud) rather than emitting a proposal to restructure another node's region.
+     */
+    @Test
+    void requestConsensus_nonOwnerProposer_throws() {
+        bubbleGrid.createBubbles(1, (byte) 1, 10);
+        var bubble = bubbleGrid.getAllBubbles().iterator().next();
+        addEntities(bubble, 5100);
+
+        var owner = DigestAlgorithm.DEFAULT.digest("region-owner");
+        var local = DigestAlgorithm.DEFAULT.digest("some-other-node");
+        coordinator.setOwnershipResolver(fixedOwnerResolver(owner, local));
+
+        var proposal = createSplitProposal(bubble.id());
+        // The guard throws synchronously from toMigrationProposal (before any future is returned), so
+        // no .join() — requestConsensus itself throws.
+        var ex = assertThrows(IllegalStateException.class,
+                              () -> coordinator.requestConsensus(proposal));
+        assertTrue(ex.getMessage().contains("may not propose a topology change"),
+                   "Ownership guard message expected, was: " + ex.getMessage());
+        verify(mockConsensus, never()).requestConsensus(any());
+        // The Stage 1 cooldown reservation must be restored on the synchronous-throw path: a rejected
+        // proposal must not lock the bubble out of future topology changes (regression guard for the
+        // orphaned-cooldown bug).
+        assertTrue(coordinator.canProposeTopologyChange(proposal),
+                   "cooldown must be restored after a guard throw, not orphaned");
+        assertEquals(0L, coordinator.getRemainingCooldown(bubble.id()),
+                     "no cooldown should be held after a guard throw");
+    }
+
+    /**
+     * RDR-020 S3 cross-region merge guard: a merge whose two bubbles resolve to different HRW
+     * owners cannot be represented by the single-owner model and throws fail-loud. A two-node merge
+     * protocol is explicitly out of scope (s23eu / RDR-015 follow-on).
+     */
+    @Test
+    void requestConsensus_crossRegionMerge_throws() {
+        // Create the full 8-child set so an adjacent pair is guaranteed, then pick one
+        // deterministically (merge pre-validation requires the two bubbles to be neighbors).
+        bubbleGrid.createBubbles(8, (byte) 1, 10);
+        var all = bubbleGrid.getAllBubbles().stream().toList();
+        UUID id1 = null;
+        UUID id2 = null;
+        outer:
+        for (var a : all) {
+            var neighbors = bubbleGrid.getNeighbors(a.id());
+            for (var b : all) {
+                if (!a.id().equals(b.id()) && neighbors.contains(b.id())) {
+                    id1 = a.id();
+                    id2 = b.id();
+                    break outer;
+                }
+            }
+        }
+        assertNotNull(id1, "an adjacent bubble pair must exist in the 8-child set");
+        var bubble1 = bubbleGrid.getBubbleById(id1);
+        var bubble2 = bubbleGrid.getBubbleById(id2);
+        addEntities(bubble1, 300);
+        addEntities(bubble2, 300);
+
+        // Resolver assigning each bubble a distinct owner; local owns bubble1 so only the
+        // cross-region (two-owner) condition — not the ownership guard — is what trips.
+        var ownerA = DigestAlgorithm.DEFAULT.digest("owner-A");
+        var ownerB = DigestAlgorithm.DEFAULT.digest("owner-B");
+        final UUID firstId = id1;
+        coordinator.setOwnershipResolver(new BubbleOwnershipResolver() {
+            @Override
+            public Digest resolveOwningMember(UUID bubbleId) {
+                return bubbleId.equals(firstId) ? ownerA : ownerB;
+            }
+
+            @Override
+            public Digest localMember() {
+                return ownerA;
+            }
+
+            @Override
+            public Digest memberDigestForNode(UUID nodeId) {
+                return ownerA;
+            }
+        });
+
+        var proposal = new MergeProposal(UUID.randomUUID(), bubble1.id(), bubble2.id(),
+                                         DigestAlgorithm.DEFAULT.getOrigin(), testClock.currentTimeMillis());
+        var ex = assertThrows(IllegalStateException.class,
+                              () -> coordinator.requestConsensus(proposal));
+        assertEquals("cross-region merge not yet supported", ex.getMessage());
+        verify(mockConsensus, never()).requestConsensus(any());
+        // Both merge bubbles' cooldown reservations must be restored after the guard throw.
+        assertEquals(0L, coordinator.getRemainingCooldown(bubble1.id()),
+                     "bubble1 cooldown must be restored after cross-region merge throw");
+        assertEquals(0L, coordinator.getRemainingCooldown(bubble2.id()),
+                     "bubble2 cooldown must be restored after cross-region merge throw");
     }
 
     private SplitProposal createSplitProposal(UUID bubbleId) {

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/TopologyConsensusCoordinatorTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/topology/TopologyConsensusCoordinatorTest.java
@@ -101,6 +101,11 @@ class TopologyConsensusCoordinatorTest {
             public Digest memberDigestForNode(UUID nodeId) {
                 return owner;
             }
+
+            @Override
+            public boolean isActiveMember(Digest member) {
+                return true;
+            }
         };
     }
 
@@ -742,6 +747,11 @@ class TopologyConsensusCoordinatorTest {
             @Override
             public Digest memberDigestForNode(UUID nodeId) {
                 return ownerA;
+            }
+
+            @Override
+            public boolean isActiveMember(Digest member) {
+                return true;
             }
         });
 


### PR DESCRIPTION
## RDR-020: Bubble→Fireflies Member Digest Resolution for Migration Consensus

Closes the "hollow production stub behind a test mock" defect: migration consensus votes on **nodes** (Fireflies member `Digest`), but the simulation only had bubble `UUID`s and used `digestOf(bubbleUUID)` — a hash that never matches a real member, so a live `ViewCommitteeConsensus` rejected every proposal. Unit tests mocked `requestConsensus`, so the gap was invisible in CI.

Introduces a node-identity resolution boundary (`BubbleOwnershipResolver`) backed by a deterministic, view-derived HRW owner function, and makes both consensus entry points fail-loud rather than silently approve/reject.

### Steps (each stacked-reviewed: code-review-expert + substantive-critic)
| Step | Delivered |
|------|-----------|
| S1 | `SpatialOwnershipFunction` (HRW/rendezvous) + `BubbleOwnershipResolver` (Fireflies + Stub impls) |
| S2 | O(1) inverse `UUID→TetreeKey` index in `TetreeBubbleGrid` |
| S3 | `ProposalKind` discriminator; TOPOLOGY single-owner model; `digestOf` deleted |
| S4 | `OptimisticMigratorImpl` → resolver; `UnsupportedOperationException` gate removed |
| S5 | node-UUID hint validation + `isActiveMember` (active-only) |
| S6 | `isNodeInView` → `context.active()` (active-only at the validator) |
| S7 | opt-in-validation contract pinned |
| MVV | end-to-end integration over the **real** wired path (11 scenarios) |
| follow-ups | active-only committee voting (`recordVote`) + in-flight slot race |

Closes Gap bugs **Luciferase-vhbw3** (topology) and **Luciferase-l5c8q** (migrator).

### Validation
- Phase-review-gate **PASSED** (9/9 §Approach items, no silent scope reduction).
- Full simulation suite: **3241 tests, 0 failures**, 11 pre-existing skips.
- MVV proves the Gap-2-closing path: a cross-node `ENTITY_MIGRATION` to a *different* active owner passes `isNodeInView` for a non-local digest and reaches real quorum.

### Gated divergences (see post-mortem)
1. TOPOLOGY single-owner node-identity model (`source==target==owner`; self-migration reject skipped only for TOPOLOGY), carried on the wire via `ProposalKind`.
2. `BubbleOwnershipResolver` gained `isActiveMember` (4th method) — `memberDigestForNode` resolves over all-members, so the hint guard needs a separate active check.
3. Committee-composition active-only closed at vote-receipt (safety-conservative; keeps the quorum denominator at the original committee size).

### Named deferrals (tracked, out of scope)
- Production resolver wiring + placement-honors-HRW → `Luciferase-s23eu` (live path is single-process).
- Cross-region merge → fail-loud guard (two-node merge protocol later).
- Committee-resizing-under-churn liveness → `Luciferase-0frcy.134`.
- Pre-existing `TetreeBubbleGrid` dual-map atomicity → tracked under `0frcy`.

RDR: `docs/rdr/RDR-020-bubble-to-fireflies-member-digest-resolution.md` · Post-mortem: `docs/rdr/post-mortem/020-bubble-to-fireflies-member-digest-resolution.md`
