### PR TITLE
0frcy.134: keep deterministic committee selection (active-only selection rejected)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeVotingProtocol.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/CommitteeVotingProtocol.java
@@ -170,8 +170,15 @@ public class CommitteeVotingProtocol {
         // proposal times out (then retries in the next view). This is the conservative choice: it
         // preserves a genuine majority-of-the-original-committee requirement (safety) at the cost of
         // liveness under heavy churn, rather than shrinking the committee toward the unsafe
-        // committeeQuorum(2)==1 floor. Resizing the committee to the active set under churn is tracked
-        // as a follow-up (Luciferase-0frcy.134).
+        // committeeQuorum(2)==1 floor.
+        //
+        // 0frcy.134 (decided): active-only committee SELECTION (bftSubset(viewDiadem, isActive)) was
+        // investigated as the alternative and REJECTED — context.isActive is failure-detector state
+        // set by per-node round timers (View.gc → context.offline), not synchronized at the view
+        // boundary, so two nodes could select different committees (split-brain quorum) and the
+        // committee could shrink below the BFT-safe size. Deterministic full-ring selection + this
+        // vote-receipt drop is the correct design; the liveness-under-churn stall is the safe failure
+        // mode (stall-and-retry, never decide under-quorum).
         if (!context.isActive(vote.voterId())) {
             // Vote from an inactive (evicted-but-not-GC'd) committee member (ignore)
             return;

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeSelector.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/consensus/committee/ViewCommitteeSelector.java
@@ -84,9 +84,16 @@ public class ViewCommitteeSelector {
      * <b>source/target node identity</b> at the validator.
      * <p>
      * Scope: this gate covers the source/target membership check only. Committee <em>composition</em>
-     * ({@link #selectCommittee} → {@code context.bftSubset}) still draws from the full ring and may
-     * include an offline member as a <em>voter</em> — a distinct, adjacent active-only gap tracked
-     * separately (Luciferase-yagnw.1), not closed here.
+     * ({@link #selectCommittee} → {@code context.bftSubset}) deliberately draws from the full ring,
+     * NOT an active-only subset: committee selection must be deterministic across nodes (same view →
+     * same committee), but {@code context.active()}/{@code isActive} is failure-detector state set by
+     * per-node round timers ({@code View.gc} → {@code context.offline}), not synchronized at the view
+     * boundary — so an active-only walk could yield different committees on different nodes (split-brain
+     * quorum) and could under-size the committee below the BFT-safe threshold. The offline-member-as-
+     * voter case is instead handled at vote-receipt in {@code CommitteeVotingProtocol.recordVote}
+     * (drops inactive votes; the cluster stalls-and-retries rather than deciding under-quorum). This
+     * was investigated and decided under Luciferase-0frcy.134 (active-only selection rejected as
+     * unsound).
      *
      * @param nodeId Node identifier (member ID) to check
      * @return true if the node is a current-view active member, false otherwise


### PR DESCRIPTION
Resolves **Luciferase-0frcy.134** as a deliberate **won't-fix (option a)** decision.

## Investigation
0frcy.134 (filed during RDR-020) asked whether committee composition should be made active-only at *selection* time (`bftSubset(viewDiadem, context::isActive)`) to remove offline members from the quorum denominator. I prototyped it, then rejected it after stacked review + tracing the Delos source (`~/git/Delos`):

1. **Non-determinism / split-brain.** Committee selection must be deterministic across nodes (same view → same committee, else nodes compute different quorums). But `context.isActive`/`active()` is *failure-detector* state: `View.gc(member) → context.offline(member)` is scheduled by **per-node round/rebuttal timers** (`View.java:275,860,893`), with the view change scheduled *afterward*. It is **not** synchronized at the view boundary, so an active-only walk can yield **different committees on different nodes** within the same view → divergent quorum.
2. **BFT under-sizing.** `bftSubset(viewDiadem, isActive)` walks each ring to its first *active* successor; if the active set has fewer than `toleranceLevel+1` distinct members the committee shrinks → `committeeQuorum(2)==1` → a single node could approve a migration under degradation.

## Decision
Deterministic full-ring **selection** (`bftSubset(viewDiadem)`, view-synchronized membership) **+** dropping inactive votes at **vote-receipt** (`CommitteeVotingProtocol.recordVote`, already shipped with yagnw.1) is the correct design. The liveness-under-churn stall (>floor(n/2) of the committee offline → timeout + retry) is the **safe** failure mode — stall-and-retry, never decide under-quorum.

## Change
Doc/comment-only — no behavioral change. Updates the stale `isNodeInView` javadoc (previously "tracked by yagnw.1, not closed") and the `recordVote` comment to record this decision and its rationale. 180 committee tests green.

The stacked review caught a consensus split-brain risk before it was committed.