### PR TITLE
RDR-021 research pass 1 — fault subsystem verified real

### DIFF
--- a/docs/rdr/RDR-021-wire-partition-fault-tolerance-node-bootstrap.md
+++ b/docs/rdr/RDR-021-wire-partition-fault-tolerance-node-bootstrap.md
@@ -91,35 +91,63 @@ half (and should decide whether resolver wiring belongs here or in a sibling RDR
 
 ### Investigation
 
-To be completed in `/conexus:rdr-research`. Initial source reading confirms `RecoveryIntegration` is a
-complete, unit-tested component whose production wiring is absent from `NodeBootstrap.assemble`.
+Source Search completed 2026-06-09 (T2 `Luciferase_rdr/021-research-1`). The entire escalation +
+recovery chain is **real, substantial logic — not a stub** (refuting the `yogvu` "hollow balancing/fault
+recovery stubs" concern for this path). The only gap is composition: `NodeBootstrap.assemble`
+constructs neither the fault subsystem nor `RecoveryIntegration`.
+
+Verified chain (all file:line confirmed):
+`vonManager.addEventListener` → `RecoveryIntegration.handleVonEvent` → `onNeighborLeave` →
+`faultHandler.reportSyncFailure(partitionId)` → `DefaultFaultHandler` HEALTHY→SUSPECTED→FAILED →
+`faultHandler.subscribeToChanges` callback → `handleRecoveryEvent` → (FAILED→HEALTHY) →
+`onPartitionRecovered` (cooldown + BFS over dependents with cycle prevention) →
+`processPartitionRecovery` → per-bubble `vonManager.joinAt(bubble, position)` (the real VON rejoin).
 
 #### Dependency Source Verification
 
 | Dependency | Source Searched? | Key Findings |
 | --- | --- | --- |
-| `RecoveryIntegration` (simulation) | Partial | Component complete; `onNeighborLeave → faultHandler.reportSyncFailure` is the escalation seam; not constructed in `NodeBootstrap`. |
-| `FaultHandler` / `PartitionTopology` (lucien balancing/fault) | No | Status model, recovery-callback contract, and thread-safety to verify (`subscribeToChanges`, `reportSyncFailure`, partition FAILED→recovered transitions). |
-| VON `Manager` event stream | No | How `RecoveryIntegration` subscribes to `Event.Leave` (push vs poll), and the lifecycle ordering vs `NodeBootstrap`. |
+| `RecoveryIntegration` (simulation/von) | Yes | Complete. Subscribes via `vonManager.addEventListener(Consumer<Event>)` + `faultHandler.subscribeToChanges` in its constructor (`:173-178`); `close()` (`:351+`) unsubscribes both. `onNeighborLeave` → `reportSyncFailure`; `processPartitionRecovery` → `vonManager.joinAt` is the real rejoin. Not constructed in `NodeBootstrap`. |
+| `FaultHandler` (lucien balancing/fault) | Yes | Rich interface (290L): `reportSyncFailure`, `subscribeToChanges`, `reportPartitionFailed`, `registerRecovery`/`initiateRecovery`/`notifyRecoveryComplete`, HEALTHY→SUSPECTED→FAILED→HEALTHY. **Two real impls**: `DefaultFaultHandler` (645L, barrier-timeout detection, 0 stub marks), `SimpleFaultHandler` (529L, atomic local escalation). |
+| `PartitionTopology` (lucien balancing/fault) | Yes | Interface (104L) + `InMemoryPartitionTopology` (89L), 0 stub marks — real, in-memory single-node topology bridge. |
+| `PartitionRecovery` strategies | Yes | `CascadingRecoveryImpl` (383L) and `BarrierRecoveryImpl` (377L) are real; `NoOpRecoveryImpl` (149L) is the explicit no-op variant. RDR must CHOOSE the strategy registered per partition. |
+| `FaultAwarePartitionRegistry` (lucien) | Yes | Existing production assembly that constructs `FaultHandler` — a possible composition to reuse rather than hand-wiring in `NodeBootstrap`. |
+| VON `Manager` event stream | Yes | `addEventListener(Consumer<Event>)` is the push subscription seam; `getBubble`, `getAllBubbles`, `joinAt(bubble, position)` are the rejoin primitives. No VON internal change needed. |
+| `NodeBootstrap.assemble` (simulation/von) | Yes | Wires Layer-0 SocketConnectionManager + PersistenceManager (+ optional BubbleMigrator); **constructs NO `FaultHandler`/`PartitionTopology`**. Live `main()` is a fail-loud Phase-0 skeleton (RDR-017 P0). |
 
 ### Key Discoveries
 
-- **Documented** — `RecoveryIntegration.onNeighborLeave` is the sole production escalation path; absent
-  from the bootstrap graph.
-- **Assumed** — the `FaultHandler`/`PartitionTopology` partition-status machine is production-ready and
-  only the wiring is missing (needs source verification — it may itself be a stub, cf. the deep-review
-  "hollow balancing/fault recovery stubs" theme, `Luciferase-yogvu`).
+- **Documented (file:line)** — the full escalation→recovery chain is real; `RecoveryIntegration`
+  subscribes in-constructor and tears down via `close()`.
+- **Documented (file:line)** — `FaultHandler` (Default/Simple), `PartitionTopology` (InMemory), and
+  `PartitionRecovery` (Cascading/Barrier) are all real, non-stub. The `yogvu` hollow-stub concern is
+  **refuted** for the partition-fault path.
+- **Scope refinement (load-bearing)** — `NodeBootstrap.assemble` holds no fault subsystem today, so
+  RDR-021 is **"construct + wire the fault subsystem into the node bootstrap"**, not merely "wire
+  `RecoveryIntegration`". The RDR must decide: (a) `DefaultFaultHandler` vs `SimpleFaultHandler`;
+  (b) the per-partition `PartitionRecovery` strategy (Cascading/Barrier/NoOp); (c) topology source
+  (`InMemoryPartitionTopology` for single-process, or a real distributed topology); (d) whether to
+  reuse `FaultAwarePartitionRegistry` as the assembly. This is composition of real parts, not building
+  a state machine.
+- **Coupling** — production activation is coupled to the still-skeletal live `main()` (RDR-017 P0,
+  currently fails loud). The MVV can run against an assembled-in-test node without the live `main()`.
 
 ### Critical Assumptions
 
-- [ ] `FaultHandler`/`PartitionTopology` implement a real (non-stub) partition-status machine with a
-  working FAILED→recovered transition and bubble-rejoin callback. — **Status**: Unverified —
-  **Method**: Source Search
-- [ ] VON `Manager` exposes a neighbor-leave event stream that `RecoveryIntegration` can subscribe to
-  in the assembled node without changing VON internals. — **Status**: Unverified — **Method**: Source Search
-- [ ] The recovery subscription can be created/torn down at a well-defined point in the RDR-017
-  lifecycle graph without reordering the existing Layer 0/bubble dependencies. — **Status**: Unverified
-  — **Method**: Source Search
+- [x] `FaultHandler`/`PartitionTopology` implement a real (non-stub) partition-status machine with a
+  working FAILED→recovered transition and bubble-rejoin callback. — **Status**: **VERIFIED** (Source
+  Search) — DefaultFaultHandler 645L / SimpleFaultHandler 529L real state machines;
+  `RecoveryIntegration.processPartitionRecovery` → `vonManager.joinAt` is the real rejoin.
+- [x] VON `Manager` exposes a neighbor-leave event stream that `RecoveryIntegration` can subscribe to
+  in the assembled node without changing VON internals. — **Status**: **VERIFIED** (Source Search) —
+  `Manager.addEventListener(Consumer<Event>)`; `getBubble`/`joinAt` for rejoin.
+- [~] The recovery subscription can be created/torn down at a well-defined point in the RDR-017
+  lifecycle graph without reordering the existing Layer 0/bubble dependencies. — **Status**:
+  **PARTIAL / REFINED** (Source Search) — the subscription start (constructor) / stop (`close()`) maps
+  cleanly onto a lifecycle participant stopped BEFORE the VON manager. BUT the bootstrap constructs no
+  fault subsystem today, so the real prerequisite is constructing `FaultHandler` + `PartitionTopology`
+  + a `PartitionRecovery` strategy in the node (the scope refinement above), and production activation
+  is gated on the live `main()` skeleton (RDR-017 P0).
 
 **Method definitions**: Source Search = API verified against dependency source. Spike = behavior
 verified by running code. Docs Only = insufficient for load-bearing assumptions.
@@ -128,12 +156,25 @@ verified by running code. Docs Only = insufficient for load-bearing assumptions.
 
 ### Approach
 
-Preliminary (to be refined post-research): construct `RecoveryIntegration` inside
-`NodeBootstrap.assemble` once the VON `Manager`, `PartitionTopology`, and `FaultHandler` are available;
-register it as a lifecycle participant so its VON-event subscription starts after the manager is up and
-is torn down before the manager stops; and drive the bubble→partition registration from the existing
-bubble-creation path. Decide whether the RDR-020 production resolver wiring
-(`FirefliesBubbleOwnershipResolver`) is in-scope here or a sibling RDR.
+Refined post-research: the escalation/recovery components are all real, so the work is **composition**,
+not building a state machine. In (or alongside) `NodeBootstrap.assemble`:
+1. Construct the fault subsystem — a `FaultHandler` (decide `DefaultFaultHandler` barrier-timeout vs
+   `SimpleFaultHandler` local), a `PartitionTopology` (`InMemoryPartitionTopology` for the
+   single-process node), and a per-partition `PartitionRecovery` strategy (Cascading/Barrier/NoOp) —
+   or reuse `FaultAwarePartitionRegistry` if it already assembles these coherently (audit below).
+2. Construct `RecoveryIntegration(vonManager, topology, faultHandler)` — its constructor subscribes to
+   VON events (`addEventListener`) and fault changes (`subscribeToChanges`).
+3. Register it as a lifecycle participant whose subscription starts after the VON manager is up and
+   whose `close()` runs **before** the manager stops (mirrors the RDR-017 shutdown-ordering contract for
+   the migrator-before-WAL hazard).
+4. Drive `registerBubble(bubbleId, partitionId)` from the existing bubble-creation path so neighbor
+   departures map to a partition.
+
+Open scope decisions for the gate: (a) `DefaultFaultHandler` vs `SimpleFaultHandler` and the default
+recovery strategy; (b) whether RDR-020's production resolver wiring (`FirefliesBubbleOwnershipResolver`
+into the bootstrap, the other half of `s23eu`) belongs here or in a sibling RDR; (c) production
+activation is gated on the live `main()` skeleton (RDR-017 P0) — the MVV runs against a test-assembled
+node, but live activation is a named dependency.
 
 ### Technical Design
 
@@ -146,9 +187,12 @@ silent no-op).
 
 | Proposed Component | Existing Module | Decision |
 | --- | --- | --- |
-| Recovery wiring | `RecoveryIntegration` (simulation/von) | Reuse — wire the existing component, do not reimplement. |
-| Partition fault detection | `FaultHandler`/`PartitionTopology` (lucien balancing/fault) | Reuse if non-stub (verify); else this RDR's scope expands or splits. |
-| Lifecycle composition | `NodeBootstrap.assemble` | Extend — add the recovery participant to the existing graph. |
+| Recovery wiring | `RecoveryIntegration` (simulation/von) | Reuse — verified complete; wire, do not reimplement. |
+| Partition fault detection | `DefaultFaultHandler` / `SimpleFaultHandler` (lucien balancing/fault) | Reuse — both verified real; RDR chooses which. |
+| Partition topology | `InMemoryPartitionTopology` (lucien balancing/fault) | Reuse for single-process; distributed topology is a later dependency. |
+| Recovery strategy | `CascadingRecoveryImpl` / `BarrierRecoveryImpl` / `NoOpRecoveryImpl` | Reuse — RDR chooses the per-partition default. |
+| Fault-subsystem assembly | `FaultAwarePartitionRegistry` (lucien) | Audit — reuse as the assembly if it composes FaultHandler+topology coherently; else hand-wire in bootstrap. |
+| Lifecycle composition | `NodeBootstrap.assemble` | Extend — construct the fault subsystem + add the recovery participant to the existing graph. |
 
 ### Decision Rationale
 
@@ -203,6 +247,14 @@ To be decomposed after research/gate (`/conexus:rdr-research` → `/conexus:rdr-
 
 ## Revision History
 
-- 2026-06-09: created (draft) — scoped from `Luciferase-s23eu` (RDR-017 acknowledged boundary). Next:
-  `/conexus:rdr-research` to verify the Critical Assumptions (esp. `FaultHandler`/`PartitionTopology`
-  non-stub status and the VON event-subscription seam), then `/conexus:rdr-gate`.
+- 2026-06-09: created (draft) — scoped from `Luciferase-s23eu` (RDR-017 acknowledged boundary).
+- 2026-06-09: **research pass 1** (Source Search; T2 `Luciferase_rdr/021-research-1`). **CA#1 VERIFIED**
+  (`DefaultFaultHandler` 645L / `SimpleFaultHandler` 529L real machines; `PartitionTopology`/`Recovery`
+  real; `RecoveryIntegration.processPartitionRecovery → vonManager.joinAt` is the real rejoin — the
+  `yogvu` hollow-stub concern is **refuted** for this path). **CA#2 VERIFIED**
+  (`Manager.addEventListener(Consumer<Event>)` subscription seam; `getBubble`/`joinAt` rejoin). **CA#3
+  PARTIAL/REFINED** — subscription start/stop maps cleanly onto a lifecycle participant, but
+  `NodeBootstrap.assemble` constructs no fault subsystem today, so the scope is **construct + wire the
+  fault subsystem**, not just wire `RecoveryIntegration`; live activation gated on the `main()`
+  skeleton (RDR-017 P0). Approach + audit refined accordingly. Next: `/conexus:rdr-gate` (which should
+  scrutinize the FaultHandler-variant + recovery-strategy choices and the resolver-wiring scope split).


### PR DESCRIPTION
Records the `/conexus:rdr-research` Source Search for RDR-021 (s23eu partition fault tolerance).

**Findings:**
- **CA#1 VERIFIED** — the full `VON Leave → reportSyncFailure → FAILED → onPartitionRecovered → vonManager.joinAt` chain is real, substantial logic. `DefaultFaultHandler` (645L) / `SimpleFaultHandler` (529L) are real state machines; `PartitionTopology`/`InMemoryPartitionTopology` and `Cascading/Barrier` recovery strategies are real. The deep-review `yogvu` hollow-stub concern is **refuted for this path**.
- **CA#2 VERIFIED** — `Manager.addEventListener(Consumer<Event>)` is the push subscription seam; `getBubble`/`joinAt` are the rejoin primitives. No VON internal change needed.
- **CA#3 PARTIAL/REFINED** — `NodeBootstrap.assemble` constructs **no** fault subsystem today, so RDR-021 is *construct + wire the fault subsystem*, not merely wire `RecoveryIntegration`. Live activation is gated on the `main()` Phase-0 skeleton (RDR-017 P0); the MVV runs against a test-assembled node.

Open for the gate: DefaultFaultHandler vs SimpleFaultHandler + default recovery strategy; whether the RDR-020 resolver wiring belongs here or a sibling RDR. Draft RDR; next is `/conexus:rdr-gate`.