### PR TITLE
Fix RDR-021 markdownlint MD004 (restore docs CI)

### DIFF
--- a/docs/rdr/RDR-021-wire-partition-fault-tolerance-node-bootstrap.md
+++ b/docs/rdr/RDR-021-wire-partition-fault-tolerance-node-bootstrap.md
@@ -145,9 +145,9 @@ Verified chain (all file:line confirmed):
   lifecycle graph without reordering the existing Layer 0/bubble dependencies. — **Status**:
   **PARTIAL / REFINED** (Source Search) — the subscription start (constructor) / stop (`close()`) maps
   cleanly onto a lifecycle participant stopped BEFORE the VON manager. BUT the bootstrap constructs no
-  fault subsystem today, so the real prerequisite is constructing `FaultHandler` + `PartitionTopology`
-  + a `PartitionRecovery` strategy in the node (the scope refinement above), and production activation
-  is gated on the live `main()` skeleton (RDR-017 P0).
+  fault subsystem today, so the real prerequisite is constructing a `FaultHandler`, a
+  `PartitionTopology`, and a `PartitionRecovery` strategy in the node (the scope refinement above), and
+  production activation is gated on the live `main()` skeleton (RDR-017 P0).
 
 **Method definitions**: Source Search = API verified against dependency source. Spike = behavior
 verified by running code. Docs Only = insufficient for load-bearing assumptions.


### PR DESCRIPTION
PR #221 turned Documentation Checks red on main: a sentence wrap put `+ a PartitionRecovery strategy` at line start, which markdownlint reads as a plus-style list bullet (repo config requires dash, MD004). Reworded to avoid a line-leading `+`. Verified clean locally with `.github/markdownlint-config.json`. Docs-only.

(Separately: the #217 Java CI red was a flaky `SimulationBubbleTest.testTicksExecute` timing test — #218/#219 Java CI passed on the same code plus more.)