### PR TITLE
feat(simulation): construct partition fault subsystem in NodeBootstrap (RDR-021 S1)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/fault/SimpleFaultHandler.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/fault/SimpleFaultHandler.java
@@ -28,11 +28,15 @@ import java.util.function.Consumer;
  *   <li>Unit testing fault detection logic</li>
  *   <li>Integration test scaffolding</li>
  *   <li>Single-JVM distributed forest testing</li>
+ *   <li>Single-process production nodes with no periodic scheduler (RDR-021): unlike
+ *       {@code DefaultFaultHandler}, whose SUSPECTED&rarr;FAILED transition requires a periodic
+ *       {@code checkTimeouts()} poller, this handler escalates atomically per report call —
+ *       see {@code NodeBootstrap.assembleFaultTolerance} in the simulation module</li>
  * </ul>
  * <p>
  * Not suitable for:
  * <ul>
- *   <li>Production distributed deployments (no cross-process coordination)</li>
+ *   <li>Multi-process distributed deployments (no cross-process coordination)</li>
  *   <li>Consensus-based failure detection (no quorum)</li>
  * </ul>
  */

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
@@ -10,6 +10,10 @@ package com.hellblazer.luciferase.simulation.von;
 
 import com.hellblazer.delos.cryptography.Digest;
 import com.hellblazer.delos.membership.Member;
+import com.hellblazer.luciferase.common.time.Clock;
+import com.hellblazer.luciferase.lucien.balancing.fault.FaultConfiguration;
+import com.hellblazer.luciferase.lucien.balancing.fault.InMemoryPartitionTopology;
+import com.hellblazer.luciferase.lucien.balancing.fault.SimpleFaultHandler;
 import com.hellblazer.luciferase.simulation.causality.EntityMigrationStateMachine;
 import com.hellblazer.luciferase.simulation.lifecycle.PersistenceManagerAdapter;
 import com.hellblazer.luciferase.simulation.lifecycle.SocketConnectionManagerAdapter;
@@ -179,6 +183,96 @@ public final class NodeBootstrap {
         // schedulers up), so the migration WAL bracket can durably log against it.
         migrator.setPersistenceManager(pmAdapter.getPersistenceManager());
         log.info("Migration durability wired: BubbleMigrator → {}", pmAdapter.name());
+    }
+
+    /**
+     * The assembled partition fault subsystem (RDR-021): a started {@link SimpleFaultHandler} and
+     * {@link InMemoryPartitionTopology} backing a {@link RecoveryIntegration} subscribed to the
+     * live VON {@link Manager}.
+     * <p>
+     * <b>Shutdown ordering contract (mirrors the migrator-before-WAL contract on
+     * {@link #assemble(Manager, SocketConnectionManagerAdapter, PersistenceManagerAdapter,
+     * BubbleMigrator)}).</b> {@link #close()} MUST run <b>before</b> the VON manager stops — it
+     * unsubscribes the recovery integration from VON and fault events (so no event fires into a
+     * half-torn handler), then stops the fault handler. Lifecycle-integrating this ordering into
+     * {@code Manager.close()} is RDR-021 S3 (Luciferase-0frcy.135.4).
+     *
+     * @param recovery     the VON↔fault-recovery integration, subscribed at construction
+     * @param faultHandler the started fault handler driving partition status
+     * @param topology     the partition topology the recovery integration registers into
+     */
+    public record FaultSubsystem(RecoveryIntegration recovery, SimpleFaultHandler faultHandler,
+                                 InMemoryPartitionTopology topology) implements AutoCloseable {
+
+        public FaultSubsystem {
+            Objects.requireNonNull(recovery, "recovery cannot be null");
+            Objects.requireNonNull(faultHandler, "faultHandler cannot be null");
+            Objects.requireNonNull(topology, "topology cannot be null");
+        }
+
+        /**
+         * Tear down in dependency order: unsubscribe the recovery integration (VON + fault-event
+         * listeners) first, then stop the fault handler.
+         * <p>
+         * Idempotency is compositional: it holds because {@code RecoveryIntegration.close()}
+         * (listener removal + subscription {@code active} guard) and
+         * {@code SimpleFaultHandler.stop()} (CAS) are each individually idempotent.
+         * <p>
+         * <b>Sole-subscriber invariant.</b> {@code SimpleFaultHandler.stop()} clears the
+         * <em>entire</em> subscriber list, not just this subsystem's subscription. This subsystem
+         * assumes it is the sole manager of {@code faultHandler}'s subscribers; any subscriber
+         * registered externally via {@code faultHandler().subscribeToChanges(...)} is silently
+         * dropped here, not notified of shutdown.
+         */
+        @Override
+        public void close() {
+            recovery.close();
+            faultHandler.stop();
+        }
+    }
+
+    /**
+     * Construct and wire the partition fault subsystem against the node's VON manager (RDR-021).
+     * <p>
+     * Hand-wires {@code SimpleFaultHandler + InMemoryPartitionTopology + RecoveryIntegration}; the
+     * {@link RecoveryIntegration} constructor subscribes to VON events and fault-handler partition
+     * changes, closing the loop: a VON {@code Leave} for a registered bubble escalates partition
+     * health ({@code reportSyncFailure}: HEALTHY&rarr;SUSPECTED on the first, SUSPECTED&rarr;FAILED on
+     * the second), and a later VON {@code Join}/{@code GhostSync} marks it healthy — the
+     * FAILED&rarr;HEALTHY transition that drives {@code vonManager.joinAt} rejoin of the partition's
+     * bubbles.
+     * <p>
+     * Locked design decisions (RDR-021 §Decision Rationale — do not reopen):
+     * <ul>
+     *   <li>{@link SimpleFaultHandler}, NOT {@code DefaultFaultHandler}: the latter's
+     *       SUSPECTED&rarr;FAILED transition requires a periodic {@code checkTimeouts()} poller the
+     *       bootstrap does not have — partitions would stall at SUSPECTED.</li>
+     *   <li>No {@code PartitionRecovery} strategy is registered: {@code RecoveryIntegration}
+     *       recovers via {@code markHealthy}-on-VON-join and never calls
+     *       {@code initiateRecovery}.</li>
+     *   <li>{@code faultHandler.start()} is load-bearing: {@code notifySubscribers} drops events
+     *       when the handler is not running, which would silently kill the recovery chain.</li>
+     * </ul>
+     * Per-bubble registration ({@code recovery().registerBubble(bubbleId, partitionId)} with the
+     * node's identity as the partition id) is driven from the bubble-creation path — RDR-021 S2
+     * (Luciferase-0frcy.135.3).
+     *
+     * @param manager the live VON manager the recovery integration subscribes to
+     * @param clock   the clock for fault-handler and recovery timestamps (TestClock in tests)
+     * @return the assembled subsystem; close it before the VON manager stops
+     */
+    public static FaultSubsystem assembleFaultTolerance(Manager manager, Clock clock) {
+        Objects.requireNonNull(manager, "manager cannot be null");
+        Objects.requireNonNull(clock, "clock cannot be null");
+
+        var faultHandler = new SimpleFaultHandler(FaultConfiguration.defaultConfig());
+        // setClock BEFORE start(): no report/markHealthy call may ever stamp Clock.system() time.
+        faultHandler.setClock(clock);
+        faultHandler.start();
+        var topology = new InMemoryPartitionTopology();
+        var recovery = new RecoveryIntegration(manager, topology, faultHandler, clock);
+        log.info("Partition fault subsystem assembled: SimpleFaultHandler (started) + InMemoryPartitionTopology + RecoveryIntegration subscribed to VON manager");
+        return new FaultSubsystem(recovery, faultHandler, topology);
     }
 
     /**

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapFaultToleranceTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapFaultToleranceTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.von;
+
+import com.hellblazer.luciferase.lucien.balancing.fault.PartitionStatus;
+import com.hellblazer.luciferase.simulation.bubble.SpatialLevelHeuristic;
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3d;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * RDR-021 S1 (Luciferase-0frcy.135.2) — {@code NodeBootstrap.assembleFaultTolerance} constructs the
+ * partition fault subsystem: a <b>started</b> {@code SimpleFaultHandler} +
+ * {@code InMemoryPartitionTopology} backing a {@code RecoveryIntegration} subscribed to the live
+ * VON {@link Manager}.
+ */
+class NodeBootstrapFaultToleranceTest {
+
+    private LocalServerTransport.Registry registry;
+    private Manager manager;
+    private TestClock clock;
+    private NodeBootstrap.FaultSubsystem subsystem;
+
+    @BeforeEach
+    void setUp() {
+        registry = LocalServerTransport.Registry.create();
+        clock = new TestClock(1_000L);
+        manager = new Manager(registry, SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL, 16L,
+                              SpatialLevelHeuristic.DEFAULT_AOI_RADIUS, clock);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (subsystem != null) {
+            subsystem.close();
+        }
+        if (manager != null) {
+            manager.close();
+        }
+        if (registry != null) {
+            registry.close();
+        }
+    }
+
+    @Test
+    void assembleConstructsStartedWiredSubsystem() {
+        subsystem = NodeBootstrap.assembleFaultTolerance(manager, clock);
+
+        assertThat(subsystem.recovery()).isNotNull();
+        assertThat(subsystem.topology()).isNotNull();
+        assertThat(subsystem.faultHandler()).isNotNull();
+        // start() is load-bearing: SimpleFaultHandler.notifySubscribers drops events when not
+        // running, which would silently kill the FAILED->HEALTHY recovery chain.
+        assertThat(subsystem.faultHandler().isRunning()).isTrue();
+
+        // The three objects are wired to each other: registering a bubble through the returned
+        // RecoveryIntegration must register the partition in the returned topology.
+        var partitionId = UUID.randomUUID();
+        subsystem.recovery().registerBubble(UUID.randomUUID(), partitionId);
+        assertThat(subsystem.topology().rankFor(partitionId)).isPresent();
+    }
+
+    @Test
+    void vonLeaveEscalatesThroughAssembledSubsystem() {
+        subsystem = NodeBootstrap.assembleFaultTolerance(manager, clock);
+
+        var bubbleId = UUID.randomUUID();
+        var partitionId = UUID.randomUUID();
+        subsystem.recovery().registerBubble(bubbleId, partitionId);
+
+        // RecoveryIntegration's constructor subscribed to the live manager: a VON Leave for a
+        // registered bubble must reach the fault handler, which escalates one level per failure.
+        manager.dispatchEvent(new Event.Leave(bubbleId, new Point3d(0, 0, 0)));
+        assertThat(subsystem.faultHandler().checkHealth(partitionId))
+            .isEqualTo(PartitionStatus.SUSPECTED);
+
+        manager.dispatchEvent(new Event.Leave(bubbleId, new Point3d(0, 0, 0)));
+        assertThat(subsystem.faultHandler().checkHealth(partitionId))
+            .isEqualTo(PartitionStatus.FAILED);
+    }
+
+    @Test
+    void nullArgumentsFailLoud() {
+        assertThrows(NullPointerException.class,
+                     () -> NodeBootstrap.assembleFaultTolerance(null, clock));
+        assertThrows(NullPointerException.class,
+                     () -> NodeBootstrap.assembleFaultTolerance(manager, null));
+    }
+
+    @Test
+    void closeStopsHandlerAndUnsubscribesFromVon() {
+        subsystem = NodeBootstrap.assembleFaultTolerance(manager, clock);
+
+        var bubbleId = UUID.randomUUID();
+        var partitionId = UUID.randomUUID();
+        subsystem.recovery().registerBubble(bubbleId, partitionId);
+        manager.dispatchEvent(new Event.Leave(bubbleId, new Point3d(0, 0, 0)));
+        assertThat(subsystem.faultHandler().checkHealth(partitionId))
+            .isEqualTo(PartitionStatus.SUSPECTED);
+
+        subsystem.close();
+        assertThat(subsystem.faultHandler().isRunning()).isFalse();
+
+        // Unsubscribed: a post-close Leave must not keep escalating. SimpleFaultHandler escalation
+        // does NOT gate on running, so a still-attached VON listener would step SUSPECTED->FAILED.
+        manager.dispatchEvent(new Event.Leave(bubbleId, new Point3d(0, 0, 0)));
+        assertThat(subsystem.faultHandler().checkHealth(partitionId))
+            .isEqualTo(PartitionStatus.SUSPECTED);
+    }
+
+    @Test
+    void closeIsIdempotent() {
+        subsystem = NodeBootstrap.assembleFaultTolerance(manager, clock);
+
+        subsystem.close();
+        subsystem.close(); // second close must be a safe no-op
+        assertThat(subsystem.faultHandler().isRunning()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

RDR-021 S1 (bead `Luciferase-0frcy.135.2`): construct the partition fault subsystem in the production node bootstrap.

- New `NodeBootstrap.assembleFaultTolerance(Manager, Clock)` — hand-wires a **started** `SimpleFaultHandler` (`FaultConfiguration.defaultConfig()`, injected `Clock`) + `InMemoryPartitionTopology` + `RecoveryIntegration` subscribed to the live VON manager.
- New `NodeBootstrap.FaultSubsystem` record (`AutoCloseable`): `close()` unsubscribes the recovery integration (VON + fault-event listeners) **before** stopping the fault handler. Full lifecycle integration ordered ahead of the VON manager stop is S3 (`Luciferase-0frcy.135.4`).
- `SimpleFaultHandler` class javadoc aligned with its single-process production use (was flatly 'not suitable for production'; the caveat is multi-process).

Locked design (RDR-021 gate PASSED — `docs/rdr/RDR-021-wire-partition-fault-tolerance-node-bootstrap.md`): `SimpleFaultHandler` not `DefaultFaultHandler` (no periodic `checkTimeouts()` poller exists in the bootstrap; Default would stall at SUSPECTED); no `PartitionRecovery` strategy registered (recovery is markHealthy-on-VON-join); hand-wired, not `FaultAwarePartitionRegistry` (that's a barrier-timeout decorator).

## Review

Stacked review run at this increment: code-review-expert (approved, 0 Critical) + substantive-critic (0 Critical, 2 Significant — both addressed: `SimpleFaultHandler` javadoc contradiction, sole-subscriber invariant documented on `FaultSubsystem.close()`).

## Tests

- `NodeBootstrapFaultToleranceTest` (5 new): wiring liveness (registerBubble → topology rank), VON Leave escalation SUSPECTED→FAILED through the assembled subsystem, null-arg fail-loud, close() unsubscription (proves listener removal via the escalation-doesn't-gate-on-running side channel), close idempotency.
- von package: 226 tests, 0 failures.

Bead: Luciferase-0frcy.135.2 (parent epic Luciferase-0frcy.135 / RDR-021)