### PR TITLE
feat(simulation): lifecycle-integrate fault subsystem shutdown ordering (RDR-021 S3)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/EnhancedBubbleAdapter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/EnhancedBubbleAdapter.java
@@ -31,6 +31,12 @@ import java.util.Objects;
  */
 public class EnhancedBubbleAdapter extends AbstractLifecycleAdapter {
 
+    /**
+     * Component-name prefix for bubble adapters: {@code NAME_PREFIX + bubble.id()}. Used by
+     * {@link RecoveryIntegrationAdapter} to compute its dynamic bubble dependencies (RDR-021 S3).
+     */
+    public static final String NAME_PREFIX = "EnhancedBubble-";
+
     private static final Logger log = LoggerFactory.getLogger(EnhancedBubbleAdapter.class);
 
     private final EnhancedBubble bubble;
@@ -70,7 +76,7 @@ public class EnhancedBubbleAdapter extends AbstractLifecycleAdapter {
 
     @Override
     protected String getComponentName() {
-        return "EnhancedBubble-" + bubble.id();
+        return NAME_PREFIX + bubble.id();
     }
 
     @Override

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/LifecycleComponent.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/LifecycleComponent.java
@@ -148,4 +148,23 @@ public interface LifecycleComponent {
      * @return list of component names this component depends on, never null (may be empty)
      */
     List<String> dependencies();
+
+    /**
+     * Whether this component's {@link #dependencies()} are <b>ordering-only hints</b> rather than
+     * liveness requirements (RDR-021 S3, Luciferase-0frcy.135.4).
+     * <p>
+     * A liveness dependency (the default) means this component needs the dependency alive to
+     * function; {@link LifecycleCoordinator#stopAndUnregister} refuses to remove a component that
+     * others depend on. An ordering-only dependent merely uses the dependency edge to be stopped
+     * <em>earlier</em> during full shutdown ({@code computeLayers} reverse order) and tolerates
+     * its dependencies being removed out from under it at any time — so the dependents guard in
+     * {@code stopAndUnregister} skips it. Components returning {@code true} typically compute
+     * {@link #dependencies()} dynamically (e.g. {@code RecoveryIntegrationAdapter}'s live bubble
+     * set).
+     *
+     * @return true if dependencies are ordering hints only; false (default) for liveness deps
+     */
+    default boolean dependenciesAreOrderingOnly() {
+        return false;
+    }
 }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/LifecycleCoordinator.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/LifecycleCoordinator.java
@@ -113,7 +113,9 @@ public class LifecycleCoordinator {
     private static final long MAX_LAYER_TIMEOUT_MS = 300_000; // 5 minutes
     private static final long DEFAULT_COMPONENT_TIMEOUT_MS = 5000L; // 5 seconds per component
 
-    final ConcurrentHashMap<String, LifecycleComponent> components;  // Package-private for Test 27 dual-map race detection
+    // Package-private for Test 27 dual-map race detection AND the componentNames() production
+    // read (RDR-021 S3) — do not make private without relocating both.
+    final ConcurrentHashMap<String, LifecycleComponent> components;
     private final ConcurrentHashMap<String, LifecycleState> states;
     private final ConcurrentHashMap<String, ReentrantReadWriteLock> componentLocks;  // Luciferase-ucks: Per-component locks
     private final AtomicBoolean isStarted;
@@ -360,7 +362,10 @@ public class LifecycleCoordinator {
      * Then the component is unregistered from lifecycle management.
      * <p>
      * This method checks if any other components depend on this one and throws if so.
-     * This prevents removing components that are dependencies of others.
+     * This prevents removing components that are dependencies of others. Dependents whose
+     * dependencies are {@linkplain LifecycleComponent#dependenciesAreOrderingOnly() ordering-only}
+     * (shutdown-ordering hints over a dynamic set, e.g. {@code RecoveryIntegrationAdapter}) do
+     * not block removal — they tolerate dependencies vanishing at any time (RDR-021 S3).
      *
      * @param componentName the name of the component to stop and remove
      * @throws LifecycleException if other components depend on this one
@@ -377,7 +382,7 @@ public class LifecycleCoordinator {
 
             // CRITICAL: Check if any component depends on this one
             for (var comp : components.values()) {
-                if (comp.dependencies().contains(componentName)) {
+                if (!comp.dependenciesAreOrderingOnly() && comp.dependencies().contains(componentName)) {
                     throw new LifecycleException(
                         "Cannot remove " + componentName + " - " + comp.name() + " depends on it");
                 }
@@ -670,6 +675,21 @@ public class LifecycleCoordinator {
     }
 
     /**
+     * Live view of registered component names, for dynamic dependency resolution (RDR-021 S3).
+     * <p>
+     * Package-private by design: the only sanctioned production caller is
+     * {@link RecoveryIntegrationAdapter#dependencies()}, which is invoked from inside
+     * {@code computeLayers()} while {@code inCoordinatorCall} is set — it must therefore be a
+     * plain map read with <b>no</b> {@code checkReentrancy()} guard and must never call back
+     * into a public coordinator method. Do NOT widen visibility.
+     *
+     * @return the live key set of registered components (weakly-consistent concurrent view)
+     */
+    java.util.Set<String> componentNames() {
+        return components.keySet();
+    }
+
+    /**
      * Get the current lifecycle state of a component.
      *
      * @param componentName the component name
@@ -722,6 +742,16 @@ public class LifecycleCoordinator {
             for (var depName : component.dependencies()) {
                 // Validate dependency exists
                 if (!components.containsKey(depName)) {
+                    if (component.dependenciesAreOrderingOnly()) {
+                        // RDR-021 S3 TOCTOU: an ordering-only (dynamic) dependency can vanish
+                        // between the dependencies() snapshot and this check (concurrent
+                        // stopAndUnregister during stop()). The vanished component cannot
+                        // participate in shutdown ordering anyway — skip it rather than abort
+                        // the whole coordinated shutdown.
+                        log.debug("Ordering-only dependency {} of {} vanished concurrently - skipping",
+                                  depName, name);
+                        continue;
+                    }
                     throw new LifecycleException(
                     "Component " + name + " depends on non-existent component: " + depName);
                 }

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/RecoveryIntegrationAdapter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/RecoveryIntegrationAdapter.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.lifecycle;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Lifecycle adapter for the partition fault subsystem (RDR-021 S3, Luciferase-0frcy.135.4).
+ * <p>
+ * Makes {@code RecoveryIntegration} an explicit lifecycle participant ordered to stop <b>ahead of
+ * the bubble adapters</b>, so {@code Manager.close()} deterministically unsubscribes the recovery
+ * integration (VON + fault-event listeners) and stops the fault handler <b>before</b> any bubble's
+ * {@code broadcastLeave()} can dispatch a VON {@code Leave} into a still-subscribed handler.
+ * Without this ordering, a node would report sync failures against its own partitions during
+ * normal shutdown — in-process neighbor bubbles synchronously re-dispatch the departing bubble's
+ * LEAVE as a VON event. Mirrors the RDR-017 migrator-before-WAL shutdown contract.
+ * <p>
+ * <b>Dynamic dependencies.</b> Bubble adapters are created and removed at runtime, so the
+ * dependency set cannot be fixed at registration. {@link #dependencies()} returns the
+ * currently-registered {@code EnhancedBubble-*} component names via the package-private
+ * {@code LifecycleCoordinator.componentNames()} view (a plain map read with no
+ * {@code checkReentrancy()} guard, so no reentrancy violation when the coordinator invokes this
+ * during {@code computeLayers()}). Kahn's sort then places this adapter in the layer above every
+ * live bubble; shutdown processes layers in reverse, stopping this adapter first. At registration
+ * time (before any bubble exists) the set is empty, so registration always succeeds. These
+ * dependencies are {@linkplain #dependenciesAreOrderingOnly() ordering-only}: a live bubble
+ * removal is never blocked by them, and {@code computeLayers} skips one that vanishes
+ * concurrently (TOCTOU under concurrent {@code leave()} + {@code close()}).
+ * <p>
+ * {@code doStart()} is a no-op: the recovery integration subscribes in its constructor and the
+ * fault handler is started by {@code NodeBootstrap.assembleFaultTolerance} before this adapter is
+ * registered. {@code doStop()} closes the subsystem (idempotent — a caller that already invoked
+ * {@code FaultSubsystem.close()} manually per the S1 contract is absorbed safely).
+ *
+ * @author hal.hildebrand
+ */
+public final class RecoveryIntegrationAdapter extends AbstractLifecycleAdapter {
+
+    /** Component name in the lifecycle coordinator. */
+    public static final String NAME = "RecoveryIntegration";
+
+    private final AutoCloseable faultSubsystem;
+    private final LifecycleCoordinator coordinator;
+
+    /**
+     * @param faultSubsystem the assembled fault subsystem ({@code NodeBootstrap.FaultSubsystem});
+     *                       its {@code close()} unsubscribes the recovery integration, then stops
+     *                       the fault handler
+     * @param coordinator    the coordinator this adapter will be registered with, whose component
+     *                       map supplies the dynamic bubble dependencies
+     */
+    public RecoveryIntegrationAdapter(AutoCloseable faultSubsystem, LifecycleCoordinator coordinator) {
+        this.faultSubsystem = Objects.requireNonNull(faultSubsystem, "faultSubsystem cannot be null");
+        this.coordinator = Objects.requireNonNull(coordinator, "coordinator cannot be null");
+    }
+
+    @Override
+    protected String getComponentName() {
+        return NAME;
+    }
+
+    @Override
+    public String name() {
+        return getComponentName();
+    }
+
+    @Override
+    public List<String> dependencies() {
+        // Live snapshot of registered bubble adapters. Names come from the coordinator's own
+        // component map, so they always pass computeLayers' existence validation — no dangling
+        // dependency is possible even if a bubble bypassed adapter registration.
+        // ConcurrentHashMap.keySet() iteration is safe under concurrent modification: a bubble
+        // registered concurrently with computeLayers() may or may not appear in this snapshot —
+        // acceptable, the coordinator already tolerates late registerAndStart racing stop() at
+        // the layer level.
+        return coordinator.componentNames().stream()
+                          .filter(name -> name.startsWith(EnhancedBubbleAdapter.NAME_PREFIX))
+                          .toList();
+    }
+
+    @Override
+    public boolean dependenciesAreOrderingOnly() {
+        // The bubble dependencies exist solely to stop this adapter ahead of the bubbles at full
+        // shutdown. A live bubble removal (Manager.leave via stopAndUnregister) must NOT be
+        // blocked by them — the dependency set self-heals on the next dependencies() call.
+        // Without this, stopAndUnregister's dependents guard rejects every bubble removal and
+        // Manager.leave silently falls back to a direct close, leaking the bubble adapter in the
+        // coordinator (S3 review Critical).
+        return true;
+    }
+
+    @Override
+    protected void doStart() {
+        // No-op: RecoveryIntegration subscribes in its constructor; the fault handler is
+        // started by NodeBootstrap.assembleFaultTolerance before this adapter is registered.
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        faultSubsystem.close();
+    }
+}

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
@@ -16,6 +16,7 @@ import com.hellblazer.luciferase.lucien.balancing.fault.InMemoryPartitionTopolog
 import com.hellblazer.luciferase.lucien.balancing.fault.SimpleFaultHandler;
 import com.hellblazer.luciferase.simulation.causality.EntityMigrationStateMachine;
 import com.hellblazer.luciferase.simulation.lifecycle.PersistenceManagerAdapter;
+import com.hellblazer.luciferase.simulation.lifecycle.RecoveryIntegrationAdapter;
 import com.hellblazer.luciferase.simulation.lifecycle.SocketConnectionManagerAdapter;
 import com.hellblazer.luciferase.simulation.persistence.MigrationRecoveryStateSink;
 import com.hellblazer.luciferase.simulation.persistence.PersistenceManager;
@@ -194,8 +195,11 @@ public final class NodeBootstrap {
      * {@link #assemble(Manager, SocketConnectionManagerAdapter, PersistenceManagerAdapter,
      * BubbleMigrator)}).</b> {@link #close()} MUST run <b>before</b> the VON manager stops — it
      * unsubscribes the recovery integration from VON and fault events (so no event fires into a
-     * half-torn handler), then stops the fault handler. Lifecycle-integrating this ordering into
-     * {@code Manager.close()} is RDR-021 S3 (Luciferase-0frcy.135.4).
+     * half-torn handler), then stops the fault handler. Since RDR-021 S3 (Luciferase-0frcy.135.4)
+     * this ordering is lifecycle-integrated: {@link #assembleFaultTolerance} registers a
+     * {@code RecoveryIntegrationAdapter} whose dynamic bubble dependencies order it to stop ahead
+     * of every bubble adapter, so {@code Manager.close()} drives this {@code close()}
+     * deterministically. Calling {@code close()} manually beforehand remains safe (idempotent).
      *
      * @param recovery     the VON↔fault-recovery integration, subscribed at construction
      * @param faultHandler the started fault handler driving partition status
@@ -256,10 +260,17 @@ public final class NodeBootstrap {
      * Per-bubble registration ({@code recovery().registerBubble(bubbleId, partitionId)} with the
      * node's identity as the partition id) is driven from the bubble-creation path — RDR-021 S2
      * (Luciferase-0frcy.135.3).
+     * <p>
+     * <b>Lifecycle integration (RDR-021 S3).</b> The subsystem is registered with the manager's
+     * coordinator as a {@link RecoveryIntegrationAdapter} whose dynamic dependencies on the live
+     * {@code EnhancedBubble-*} adapters order it to stop <b>ahead of every bubble</b>:
+     * {@code Manager.close()} unsubscribes the recovery integration before any bubble's
+     * {@code broadcastLeave()} can re-enter it as a VON event (which would otherwise self-report
+     * sync failures against the node's own partitions during normal shutdown).
      *
      * @param manager the live VON manager the recovery integration subscribes to
      * @param clock   the clock for fault-handler and recovery timestamps (TestClock in tests)
-     * @return the assembled subsystem; close it before the VON manager stops
+     * @return the assembled subsystem, lifecycle-registered; {@code Manager.close()} stops it
      */
     public static FaultSubsystem assembleFaultTolerance(Manager manager, Clock clock) {
         Objects.requireNonNull(manager, "manager cannot be null");
@@ -271,8 +282,11 @@ public final class NodeBootstrap {
         faultHandler.start();
         var topology = new InMemoryPartitionTopology();
         var recovery = new RecoveryIntegration(manager, topology, faultHandler, clock);
-        log.info("Partition fault subsystem assembled: SimpleFaultHandler (started) + InMemoryPartitionTopology + RecoveryIntegration subscribed to VON manager");
-        return new FaultSubsystem(recovery, faultHandler, topology);
+        var subsystem = new FaultSubsystem(recovery, faultHandler, topology);
+        var coordinator = manager.coordinator();
+        coordinator.registerAndStart(new RecoveryIntegrationAdapter(subsystem, coordinator));
+        log.info("Partition fault subsystem assembled: SimpleFaultHandler (started) + InMemoryPartitionTopology + RecoveryIntegration subscribed to VON manager; lifecycle participant {} registered", RecoveryIntegrationAdapter.NAME);
+        return subsystem;
     }
 
     /**

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/lifecycle/OrderingOnlyDependenciesTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/lifecycle/OrderingOnlyDependenciesTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.lifecycle;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * RDR-021 S3 (Luciferase-0frcy.135.4) — coordinator semantics for
+ * {@link LifecycleComponent#dependenciesAreOrderingOnly() ordering-only} dependencies:
+ * <ul>
+ *   <li>{@code stopAndUnregister}'s dependents guard skips ordering-only dependents (a live
+ *       bubble removal must not be blocked by the recovery adapter's dynamic dependency);</li>
+ *   <li>{@code computeLayers} tolerates an ordering-only dependency that vanished between the
+ *       {@code dependencies()} snapshot and the existence check (TOCTOU under concurrent
+ *       {@code leave()} + {@code close()} — S3 critique Significant 1). Without tolerance, the
+ *       whole coordinated shutdown aborts and the ordering invariant is bypassed;</li>
+ *   <li>static (liveness) dependencies keep their strict behavior: guard blocks removal, unknown
+ *       dependency still fails loud.</li>
+ * </ul>
+ */
+class OrderingOnlyDependenciesTest {
+
+    private LifecycleCoordinator coordinator;
+
+    /** Minimal stub component; dependencies and ordering-only flag are configurable. */
+    private static final class StubComponent implements LifecycleComponent {
+        private final String name;
+        private final AtomicReference<List<String>> deps;
+        private final boolean orderingOnly;
+        private final AtomicReference<LifecycleState> state = new AtomicReference<>(LifecycleState.CREATED);
+
+        StubComponent(String name, List<String> deps, boolean orderingOnly) {
+            this.name = name;
+            this.deps = new AtomicReference<>(deps);
+            this.orderingOnly = orderingOnly;
+        }
+
+        void setDependencies(List<String> newDeps) {
+            deps.set(newDeps);
+        }
+
+        @Override
+        public CompletableFuture<Void> start() {
+            state.set(LifecycleState.RUNNING);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletableFuture<Void> stop() {
+            state.set(LifecycleState.STOPPED);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public LifecycleState getState() {
+            return state.get();
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public List<String> dependencies() {
+            return deps.get();
+        }
+
+        @Override
+        public boolean dependenciesAreOrderingOnly() {
+            return orderingOnly;
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        coordinator = new LifecycleCoordinator();
+        coordinator.start();
+    }
+
+    @Test
+    void orderingOnlyDependentDoesNotBlockStopAndUnregister() {
+        var base = new StubComponent("base", List.of(), false);
+        coordinator.registerAndStart(base);
+        var watcher = new StubComponent("watcher", List.of("base"), true);
+        coordinator.registerAndStart(watcher);
+
+        assertThatCode(() -> coordinator.stopAndUnregister("base")).doesNotThrowAnyException();
+        assertThat(coordinator.getState("base")).isNull();
+        assertThat(coordinator.getState("watcher")).isEqualTo(LifecycleState.RUNNING);
+    }
+
+    @Test
+    void livenessDependentStillBlocksStopAndUnregister() {
+        var base = new StubComponent("base", List.of(), false);
+        coordinator.registerAndStart(base);
+        var dependent = new StubComponent("dependent", List.of("base"), false);
+        coordinator.registerAndStart(dependent);
+
+        assertThatThrownBy(() -> coordinator.stopAndUnregister("base"))
+            .isInstanceOf(LifecycleException.class)
+            .hasMessageContaining("depends on it");
+    }
+
+    @Test
+    void computeLayersToleratesVanishedOrderingOnlyDependency() {
+        // TOCTOU: an ordering-only dependency vanishing between the dependencies() snapshot and
+        // computeLayers' existence check (concurrent stopAndUnregister during stop()) must be
+        // skipped, not abort the whole coordinated shutdown. Mirrors the real adapter: empty
+        // deps at registration, the dependency vanishes later.
+        var watcher = new StubComponent("watcher", List.of(), true);
+        coordinator.registerAndStart(watcher);
+        watcher.setDependencies(List.of("vanished-component"));
+
+        assertThatCode(() -> coordinator.computeLayers()).doesNotThrowAnyException();
+        assertThatCode(() -> coordinator.stop(5_000)).doesNotThrowAnyException();
+        assertThat(coordinator.getState("watcher")).isEqualTo(LifecycleState.STOPPED);
+    }
+
+    @Test
+    void computeLayersStillFailsLoudForUnknownLivenessDependency() {
+        var broken = new StubComponent("broken", List.of(), false);
+        coordinator.registerAndStart(broken);
+        broken.setDependencies(List.of("never-registered"));
+
+        assertThatThrownBy(() -> coordinator.computeLayers())
+            .isInstanceOf(LifecycleException.class)
+            .hasMessageContaining("non-existent");
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapShutdownOrderingTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapShutdownOrderingTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.von;
+
+import com.hellblazer.luciferase.simulation.bubble.SpatialLevelHeuristic;
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+import com.hellblazer.luciferase.simulation.lifecycle.LifecycleState;
+import com.hellblazer.luciferase.simulation.lifecycle.PersistenceManagerAdapter;
+import com.hellblazer.luciferase.simulation.lifecycle.RecoveryIntegrationAdapter;
+import com.hellblazer.luciferase.simulation.lifecycle.SocketConnectionManagerAdapter;
+import com.hellblazer.luciferase.simulation.persistence.PersistenceManager;
+import com.hellblazer.luciferase.simulation.von.transport.ProcessAddress;
+import com.hellblazer.luciferase.simulation.von.transport.SocketConnectionManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RDR-021 S3 (Luciferase-0frcy.135.4) — the dedicated shutdown-ordering test. The fault subsystem
+ * is a lifecycle participant ordered to stop AHEAD of the bubble adapters, so {@code Manager.close()}
+ * drives {@code RecoveryIntegration.close()} (unsubscribe VON + fault listeners) then
+ * {@code SimpleFaultHandler.stop()} BEFORE any bubble's {@code broadcastLeave()} can fire a VON
+ * event into a half-torn handler (mirrors the RDR-017 migrator-before-WAL contract).
+ * <p>
+ * Uses the fully assembled node (SCM + PM at Layer 0, bubbles at Layer 1) so the coordinator path —
+ * not the standalone fallback — is what is exercised.
+ */
+class NodeBootstrapShutdownOrderingTest {
+
+    private LocalServerTransport.Registry registry;
+    private Manager manager;
+    private TestClock clock;
+    private SocketConnectionManager scm;
+    private NodeBootstrap.FaultSubsystem subsystem;
+    private UUID nodeId;
+    private boolean managerClosed;
+
+    @BeforeEach
+    void setUp(@TempDir Path walDir) throws IOException {
+        registry = LocalServerTransport.Registry.create();
+        clock = new TestClock(1_000L);
+        manager = new Manager(registry, SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL, 16L,
+                              SpatialLevelHeuristic.DEFAULT_AOI_RADIUS, clock);
+        scm = new SocketConnectionManager(ProcessAddress.localhost("s3-shutdown", 0), msg -> {});
+        var pm = new PersistenceManager(UUID.randomUUID(), walDir);
+        NodeBootstrap.assemble(manager, new SocketConnectionManagerAdapter(scm),
+                               new PersistenceManagerAdapter(pm));
+        subsystem = NodeBootstrap.assembleFaultTolerance(manager, clock);
+        nodeId = UUID.randomUUID();
+        managerClosed = false;
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (!managerClosed && manager != null) {
+            manager.close();
+        }
+        if (registry != null) {
+            registry.close();
+        }
+    }
+
+    @Test
+    void assembleRegistersRecoveryAsLifecycleParticipant() {
+        assertThat(manager.coordinator().getState(RecoveryIntegrationAdapter.NAME))
+            .isEqualTo(LifecycleState.RUNNING);
+    }
+
+    @Test
+    void managerCloseStopsRecoveryBeforeBubbleAdapters() {
+        // The ordering test proper. bubble1 (registered) and bubble2 are in-process neighbors:
+        // when a bubble adapter stops, its broadcastLeave() synchronously delivers LEAVE to the
+        // sibling, whose handleLeave dispatches Event.Leave back through the manager. If the
+        // recovery integration were still subscribed at that point (stopped after — or in the
+        // same layer as — the bubbles), the node would report a sync failure against its own
+        // partition during normal shutdown. The dynamic bubble dependencies of
+        // RecoveryIntegrationAdapter put it in the layer ABOVE all bubbles, so it stops first.
+        var bubble1 = NodeBootstrap.createRegisteredBubble(manager, subsystem.recovery(), nodeId);
+        var bubble2 = manager.createBubble();
+        bubble1.addNeighbor(bubble2.id());
+        bubble2.addNeighbor(bubble1.id());
+
+        manager.close();
+        managerClosed = true;
+
+        // Recovery stopped through the coordinator (Manager.close() drove it)...
+        assertThat(manager.coordinator().getState(RecoveryIntegrationAdapter.NAME))
+            .isEqualTo(LifecycleState.STOPPED);
+        assertThat(subsystem.faultHandler().isRunning()).isFalse();
+        // ...and BEFORE the bubble adapters: no self-escalation happened during shutdown.
+        assertThat(subsystem.faultHandler().checkHealth(nodeId)).isNull();
+        assertThat(subsystem.faultHandler().getAggregateMetrics().failureCount()).isZero();
+    }
+
+    @Test
+    void liveBubbleRemovalNotBlockedByRecoveryDependency() {
+        // The recovery adapter's dynamic dependency on bubble adapters must be ORDERING-ONLY:
+        // stopAndUnregister's dependents guard would otherwise reject every live bubble removal
+        // ("Cannot remove EnhancedBubble-X - RecoveryIntegration depends on it"), which
+        // Manager.leave silently absorbs by falling back to a direct bubble.close() — losing
+        // coordinated shutdown AND leaking the bubble adapter in the coordinator forever
+        // (S3 review Critical).
+        var bubble = NodeBootstrap.createRegisteredBubble(manager, subsystem.recovery(), nodeId);
+        var adapterName = "EnhancedBubble-" + bubble.id();
+        assertThat(manager.coordinator().getState(adapterName)).isEqualTo(LifecycleState.RUNNING);
+
+        NodeBootstrap.removeRegisteredBubble(manager, subsystem.recovery(), bubble);
+
+        // The COORDINATOR path must have run: the adapter is genuinely unregistered, not leaked
+        // as a RUNNING component whose bubble was closed behind its back by the fallback path.
+        assertThat(manager.coordinator().getState(adapterName)).isNull();
+        // And the recovery adapter no longer lists it as a dependency.
+        assertThat(manager.getBubble(bubble.id())).isNull();
+    }
+
+    @Test
+    void managerCloseWithNoBubblesStopsRecoveryCleanly() {
+        manager.close();
+        managerClosed = true;
+
+        assertThat(manager.coordinator().getState(RecoveryIntegrationAdapter.NAME))
+            .isEqualTo(LifecycleState.STOPPED);
+        assertThat(subsystem.faultHandler().isRunning()).isFalse();
+    }
+
+    @Test
+    void manualSubsystemCloseBeforeManagerCloseRemainsSafe() {
+        // The S1 caller contract (subsystem.close() before Manager.close()) must remain valid
+        // alongside lifecycle integration: the adapter's doStop finds an already-closed
+        // subsystem and the compositional idempotency absorbs the double close.
+        NodeBootstrap.createRegisteredBubble(manager, subsystem.recovery(), nodeId);
+
+        subsystem.close();
+        manager.close();
+        managerClosed = true;
+
+        assertThat(manager.coordinator().getState(RecoveryIntegrationAdapter.NAME))
+            .isEqualTo(LifecycleState.STOPPED);
+        assertThat(subsystem.faultHandler().isRunning()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

RDR-021 S3 (bead `Luciferase-0frcy.135.4`): the fault subsystem becomes a lifecycle participant ordered to stop **ahead of every bubble adapter**, so `Manager.close()` drives `RecoveryIntegration.close()` (unsubscribe VON + fault listeners) then `SimpleFaultHandler.stop()` deterministically — before any bubble's `broadcastLeave()` can re-enter the handler as a VON event (which would self-report sync failures against the node's own partitions during normal shutdown). Mirrors the RDR-017 migrator-before-WAL contract. Stacked on #226 (S2, merged).

**Mechanism**: `RecoveryIntegrationAdapter` with **dynamic dependencies** — a live snapshot of registered `EnhancedBubble-*` component names via a new package-private `LifecycleCoordinator.componentNames()` view (plain map read, no `checkReentrancy()`, safe from inside `computeLayers`). Kahn's sort places it above all live bubbles; shutdown processes layers N→0.

## Stacked review at this increment — and what it caught

- **Critical (code-review-expert)**: `stopAndUnregister`'s dependents guard rejected **every live bubble removal** once the adapter was registered; `Manager.leave` silently swallowed the `LifecycleException` and fell back to direct `bubble.close()` — losing coordinated shutdown and **leaking the bubble adapter as RUNNING in the coordinator forever**. Fix: `LifecycleComponent.dependenciesAreOrderingOnly()` (default false — zero behavior change for existing components); ordering-only dependents don't block removal. Reproduced red-first by `liveBubbleRemovalNotBlockedByRecoveryDependency`.
- **Significant (substantive-critic)**: TOCTOU — an ordering-only dep vanishing between the `dependencies()` snapshot and `computeLayers`' existence check (concurrent `leave()`+`close()`) threw and aborted the entire coordinated shutdown, bypassing the ordering invariant. Fix: `computeLayers` skips vanished ordering-only deps (static deps stay fail-loud). Red-first test.
- **Significant (substantive-critic)**: production read of the test-visibility `components` field → documented `componentNames()` accessor.

## Verification

- **Mutation check**: `dependencies()` → `List.of()` deterministically fails `managerCloseStopsRecoveryBeforeBubbleAdapters` (recovery drops to layer 0, bubbles stop first, self-escalation observed).
- `NodeBootstrapShutdownOrderingTest` (5 tests, **fully assembled node** — SCM+PM Layer 0, bubbles Layer 1, coordinator path not the fallback) + `OrderingOnlyDependenciesTest` (4 tests, coordinator semantics).
- von + lifecycle packages: **351 tests, 0 failures**.

Bead: Luciferase-0frcy.135.4 (parent epic Luciferase-0frcy.135 / RDR-021)