### PR TITLE
RDR-022: Wire bubble ownership resolution into the production node bootstrap

### DIFF
--- a/docs/rdr/RDR-022-wire-bubble-ownership-resolver-node-bootstrap.md
+++ b/docs/rdr/RDR-022-wire-bubble-ownership-resolver-node-bootstrap.md
@@ -1,0 +1,423 @@
+---
+title: "Wire Bubble Ownership Resolution into the Production Node Bootstrap"
+id: RDR-022
+type: Architecture
+status: accepted
+priority: medium
+author: self
+reviewed-by: self
+created: 2026-06-10
+accepted_date: 2026-06-10
+related_issues: [Luciferase-s23eu, Luciferase-0frcy]
+---
+
+# RDR-022: Wire Bubble Ownership Resolution into the Production Node Bootstrap
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+RDR-020 built the bubble→node ownership primitive — `FirefliesBubbleOwnershipResolver` (HRW over the
+active Fireflies view) — and gave its three production consumers explicit injection seams. But **no
+production code path constructs the resolver**: a project-wide search finds
+`new FirefliesBubbleOwnershipResolver` only in tests. The production bootstrap (`NodeBootstrap`,
+RDR-017/RDR-021) never assembles it, so in any assembled node every consensus entry point that needs
+node identity is **fail-loud dead**: it throws on first use rather than resolving ownership. This is
+the second half of the `Luciferase-s23eu` boundary ("make the assembled node actually
+multi-node-ready"); RDR-021 closed the fault-tolerance half and explicitly scoped this half to a
+sibling RDR (RDR-021 gate decision S3 / locked decision 5). This RDR decides whether and how to close it.
+
+### Enumerated gaps to close
+
+#### Gap 1: No production construction or injection of the resolver
+
+`FirefliesBubbleOwnershipResolver` (`simulation/.../consensus/ownership/FirefliesBubbleOwnershipResolver.java`)
+is constructed nowhere in `src/main`. Its three consumers each hold a `volatile BubbleOwnershipResolver`
+that is never set in production:
+
+- `TopologyConsensusCoordinator.setOwnershipResolver(...)` (`topology/TopologyConsensusCoordinator.java:194`);
+  unset → `toMigrationProposal` throws `IllegalStateException("ownershipResolver not set")` (`:329`),
+  so **every topology consensus proposal fails** in an assembled node.
+- `OptimisticMigratorImpl.setOwnershipResolver(...)` (`distributed/migration/OptimisticMigratorImpl.java:130`);
+  unset → consensus-gated migration approval throws (`:169`), so **the quorum gate is dead**.
+- `DistributedBubbleNode.setOwnershipResolver(...)` (`distributed/network/DistributedBubbleNode.java:124`);
+  unset → the explicit-target-node hint validation path (RDR-020 B1/B4) is unavailable.
+
+The fail-loud contract is working as designed (RDR-020: never silently approve/reject) — but the
+production wiring that makes the paths *live* was deferred to `s23eu` and does not exist.
+
+#### Gap 2: The bootstrap lacks the resolver's construction dependencies at the assembly seam
+
+The production convenience constructor needs `(FirefliesMemberLookup, MembershipView<Member>,
+TetreeBubbleGrid, SpatialOwnershipFunction)`. `NodeBootstrap.assemble`/`assembleFaultTolerance` hold
+none of these today: `FirefliesMemberLookup` requires a live Fireflies `View`
+(`von/FirefliesMemberLookup.java:58`) — the same dependency that keeps the live `main()` a fail-loud
+skeleton (RDR-017 P1) — and no `TetreeBubbleGrid` or `MembershipView` flows through the assemble
+signatures. The RDR must define the assembly seam (an `assembleOwnership(...)` sibling of RDR-021's
+`assembleFaultTolerance`, or parameters on `assemble`), and decide what is constructed vs injected.
+The narrow-seam primary constructor (function seams; no live `View` needed) is the likely MVV path,
+mirroring RDR-021's test-assembled-node strategy.
+
+#### Gap 3: The resolver's consumers may not be part of the assembled node at all
+
+`NodeBootstrap.assemble` wires `SocketConnectionManagerAdapter` + `PersistenceManagerAdapter`
+(+ optional migrator adapter, RDR-017 P2; + fault subsystem, RDR-021). It does **not** construct
+`TopologyConsensusCoordinator`, `OptimisticMigratorImpl`, or `DistributedBubbleNode`. "Wire the
+resolver into the bootstrap" is therefore under-specified until research establishes **which
+consumers the assembled node actually owns** — the scope may refine to "construct + wire the
+ownership subsystem into the consumers the node assembles," exactly as RDR-021's scope refined from
+"wire RecoveryIntegration" to "construct + wire the fault subsystem." It may equally refine to a
+narrower contract: provide the assembled resolver and the injection helper, leaving consumer
+construction to the (separate) arcs that assemble those consumers.
+
+#### Gap 4: No end-to-end proof that an assembled node resolves ownership
+
+Existing coverage is unit/integration at the resolver and consumer level (`OwnershipTest`,
+`Rdr020MvvIntegrationTest`) with test doubles or directly-constructed objects. Nothing proves that a
+**bootstrap-assembled** node produces a resolver whose `localMember()`/`resolveOwningMember()`
+agree with the node identity used everywhere else (`NodeBootstrap.resolveNodeId` =
+`FirefliesMemberLookup.digestToUuid(member.getId())`, the canonical derivation — gate C1/B4 of
+RDR-020). The MVV must exercise the wired chain against the assembled node, mirroring the RDR-020/021
+MVV lesson (mocking the integration boundary hides the gap).
+
+### Explicitly in question (decide, do not assume)
+
+- **Placement-honors-HRW**: RDR-020 named the contract — the partition/placement layer must seed each
+  bubble onto `owner(bubbleKey, view)` and re-home on view change — and deferred it to the
+  `s23eu`/RDR-015 follow-on. Is it this RDR's scope, or does it remain a named deferral here too?
+  (Without it, multi-node steady-state correctness is still gated; with it, this RDR's blast radius
+  grows substantially.)
+
+## Context
+
+### Background
+
+RDR-020 (implemented 2026-06-09) made migration/topology consensus functional against a live
+committee by replacing the bogus `digestOf(UUID)` node identities with a real ownership resolution:
+source = local member (possession), target = HRW owner of the destination region over the
+active-only view. Its post-mortem names "placement-honors-HRW partition seeding and production
+resolver wiring → `s23eu`" as the explicit deferral. RDR-021 (implemented 2026-06-09) closed the
+fault-tolerance half of `s23eu` — `NodeBootstrap.assembleFaultTolerance` constructs and
+lifecycle-integrates the partition fault subsystem — and locked decision 5: "Resolver wiring →
+sibling RDR." This RDR is that sibling.
+
+The live production path today is single-process: every consensus proposal is a correctly-rejected
+self-migration (RDR-020 §Approach, two-node-roles analysis). Resolver wiring is what makes the
+multi-node consensus path *reachable* from an assembled node; multi-node steady-state correctness
+additionally depends on the placement contract (Gap/question above).
+
+### Technical Environment
+
+- `FirefliesBubbleOwnershipResolver` (`simulation/.../consensus/ownership/`): primary narrow-seam
+  constructor `(Supplier<Member> localMemberSupplier, Function<UUID,Optional<Member>> nodeResolver,
+  Function<UUID,TetreeKey<?>> bubbleKeyResolver, MembershipView<Member>, SpatialOwnershipFunction)`;
+  convenience constructor `(FirefliesMemberLookup, MembershipView<Member>, TetreeBubbleGrid,
+  SpatialOwnershipFunction)`. Fail-loud (`IllegalStateException`) on unresolvable inputs.
+- `RendezvousOwnershipFunction` — the HRW `SpatialOwnershipFunction` implementation (stateless).
+- `StubBubbleOwnershipResolver` — seeded deterministic double living in `src/main` (used by tests and
+  available for single-process assembly decisions).
+- Consumers + seams: `TopologyConsensusCoordinator.setOwnershipResolver` (`:194`),
+  `OptimisticMigratorImpl.setOwnershipResolver` (`:130`), `DistributedBubbleNode.setOwnershipResolver`
+  (`:124`).
+- `NodeBootstrap` (`simulation/.../von/NodeBootstrap.java`, 369L): `resolveNodeId` (canonical
+  member→UUID), `assemble(...)` overloads, `assembleFaultTolerance(Manager, Clock)` → `FaultSubsystem`
+  record + `RecoveryIntegrationAdapter` lifecycle participant (the RDR-021 pattern to mirror),
+  `createRegisteredBubble`/`removeRegisteredBubble` (the bubble-creation seam), fail-loud `main()`.
+- `FirefliesMemberLookup(View view[, Random])` (`von/FirefliesMemberLookup.java:58-71`): requires a
+  live Fireflies `View`; `getLocalMember()` → `view.getNode()`; `getMemberByUuid` (all-members backed
+  — misnamed accessor caveat, RDR-020 B4); `digestToUuid` (canonical).
+- Adjacent open work: `Luciferase-n6jrh.1` (assemble-before-createBubble guard), `n6jrh.2`
+  (BubbleMigrator lifecycle integration) — same bootstrap, potential merge-conflict neighbors.
+
+## Research Findings
+
+### Investigation
+
+Research pass 1 completed 2026-06-10 (Source Search; T2 `Luciferase_rdr/022-research-1`). All five
+assumptions resolved. The decisive finding: **all three resolver consumers are test-only
+constructions** — zero `new TopologyConsensusCoordinator/OptimisticMigratorImpl/DistributedBubbleNode`
+sites exist in `src/main` (the latter two carry explicit comments: "no bootstrap assembly calls this
+yet — the live path is single-process; multi-node wiring lands with bead Luciferase-s23eu"). So the
+bootstrap has no production consumer to inject into; the correct scope is **expose the assembled
+resolver via a bootstrap factory** (mirroring `assembleFaultTolerance`), with consumer injection
+owned by whatever future arc assembles each consumer.
+
+#### Dependency Source Verification
+
+| Dependency | Source Searched? | Key Findings |
+| --- | --- | --- |
+| `FirefliesBubbleOwnershipResolver` | Yes | All five fields `final`, set at construction, never mutated; no `AutoCloseable`/`close()`, no threads, no subscriptions; `resolveOwningMember` snapshots `activeMembers()` fresh per call (no cached view data). Lifecycle-passive. |
+| `RendezvousOwnershipFunction` | Yes | Stateless (zero instance fields); pure Murmur3 deterministic function. |
+| Consumer injection seams | Yes | Exactly three consumers (exhaustive search): `TopologyConsensusCoordinator:194`, `OptimisticMigratorImpl:130`, `DistributedBubbleNode:124`; all `volatile` setter injection, fail-loud when unset (coordinator `:329`, migrator `:169`). |
+| Consumer construction sites | Yes | **Zero in `src/main` for all three** — every ctor call is in tests (`TopologyConsensusCoordinatorTest:61`, `Rdr020MvvIntegrationTest:278,467`, 20+ migrator test sites, 14+ node test sites). No production injection target exists. |
+| `NodeBootstrap` assembly surface | Yes | No resolver, no `TetreeBubbleGrid`, no `MembershipView`, no consumer construction. `assembleFaultTolerance(Manager, Clock)` is the factory pattern to mirror; resolver needs no lifecycle registration (A2). |
+| `Manager` / `createRegisteredBubble` ↔ grid | Yes | `Manager` fields: `Map<UUID,Bubble>`, transport registry, clock, coordinator — **no `TetreeBubbleGrid`**. `Manager.createBubble` never calls `grid.addBubble`; `createRegisteredBubble` (`:311-324`) touches no grid. Grid construction in `src/main`: `MultiBubbleSimulation:129` (separate orchestrator) and `PredatorPreyGridDemo:73` (demo) only. |
+| Test membership infrastructure | Yes | `MockFirefliesView` lives in `src/main` (`delos/mock/MockFirefliesView.java:39`, addMember/removeMember/markInactive); `MockMember` from Delos (`new MockMember(DigestAlgorithm.DEFAULT.getOrigin().prefix(i))`). Exact wiring proven in `Rdr020MvvIntegrationTest:157-174`. |
+| Consensus validity vs resolver wiring | Yes | `ViewCommitteeConsensus.validateProposal:352-410`: null guards, self-migration reject (`:388-392`), `isNodeInView` (`:396,:403`) all operate on `Digest`s/committee selector, independent of resolver wiring. `OptimisticMigratorImpl.requestMigrationApproval:166` and `DistributedBubbleNode.initiateRemoteMigration:157` branch on null integration/resolver — wiring is purely enabling. |
+| Placement seeding blast radius | Yes | Placement key selection happens at `TetreeBubbleGrid.addBubble(bubble, key)` call sites (`MultiBubbleSimulation` + tests). Absorbing HRW seeding would force `NodeBootstrap` to own a grid and intercept key selection — large, cross-cutting. Out. |
+
+### Key Discoveries
+
+- **Documented (file:line)** — the resolver and HRW function are real, tested, and **lifecycle-passive**;
+  the gap is pure composition (no new mechanism, no lifecycle participant), simpler than RDR-021's.
+- **Scope resolution (Gap 3, load-bearing)** — no production code constructs any of the three
+  consumers; therefore RDR-022 **cannot and should not wire consumers**. It owns one factory:
+  assemble the resolver in `NodeBootstrap`, return it, document the injection contract for future
+  consumer-assembly arcs.
+- **Seam correction (Gap 2/A4)** — `NodeBootstrap`/`Manager` have **no `TetreeBubbleGrid`**; the
+  `bubbleKeyResolver` function must be a caller-supplied parameter of the factory, not bound
+  internally. The resolver's convenience ctor (taking a grid) is for callers that own one.
+- **Documented** — the consumers fail loud when unwired, so the current assembled node cannot
+  silently mis-resolve; the cost of the gap is *unavailability* of consensus paths, not corruption.
+
+### Critical Assumptions
+
+- [x] **A1**: The production consumer set is exactly the three found, and their construction sites
+  determine scope. — **Status**: **PARTIAL → resolved by finding** (Source Search) — consumer set
+  VERIFIED exhaustive (3); construction sites REFUTED the "wire consumers" framing: all three are
+  test-only constructions with explicit `s23eu` markers. Scope shape: factory-exposes-resolver, no
+  consumer wiring (no target exists).
+- [x] **A2**: The resolver is lifecycle-passive — no `LifecycleComponent` participant, no shutdown
+  ordering. — **Status**: **VERIFIED** (Source Search) — all-final fields, no close/threads/
+  subscriptions/caching; `RendezvousOwnershipFunction` stateless.
+- [x] **A3**: The MVV can assemble the resolver without a live Fireflies `View`. — **Status**:
+  **VERIFIED** (Source Search) — `MockFirefliesView` (in `src/main`) + Delos `MockMember` satisfy
+  the narrow seams; the pattern is already proven in `Rdr020MvvIntegrationTest:157-174` and the
+  no-live-View bootstrap test pattern in `Rdr021MvvIntegrationTest`.
+- [x] **A4**: The grid backing `bubbleKeyResolver` is reachable at the assembly seam. — **Status**:
+  **REFUTED** (Source Search) — `TetreeBubbleGrid` is absent from the `NodeBootstrap`/`Manager`
+  domain (grid lives in `MultiBubbleSimulation`/demo/caller code). Consequence: `bubbleKeyResolver`
+  (or a grid) is a **factory parameter**, caller-supplied.
+- [x] **A5**: Placement-honors-HRW is separable; resolver wiring is purely enabling. — **Status**:
+  **VERIFIED** (Source Search) — validity gates (`validateProposal:352-410`) are
+  resolver-independent; null-integration/null-resolver branches mean wiring alone changes no
+  behavior. Placement seeding stays **out** (named deferral, partition layer / `s23eu` follow-on).
+
+**Method definitions**: Source Search = API verified against dependency source. Spike = behavior
+verified by running code. Docs Only = insufficient for load-bearing assumptions.
+
+## Proposed Solution
+
+### Approach
+
+Refined post-research-pass-1: no production consumer exists to inject into (A1), the resolver is
+lifecycle-passive (A2), and the bootstrap has no grid (A4). The work is therefore a **single
+bootstrap factory + the end-to-end proof**, deliberately smaller than RDR-021.
+
+Locked decisions:
+1. **One factory: `NodeBootstrap.assembleOwnershipResolver(...)`** mirroring the
+   `assembleFaultTolerance` precedent — external deps as parameters, the method does the wiring,
+   returns the assembled `BubbleOwnershipResolver`. It constructs the `RendezvousOwnershipFunction`
+   internally (the one canonical HRW choice, RDR-020) and the `FirefliesBubbleOwnershipResolver`
+   around the supplied seams.
+2. **`bubbleKeyResolver` is caller-supplied** (`Function<UUID, TetreeKey<?>>`). The bootstrap/`Manager`
+   domain has no `TetreeBubbleGrid` (A4 refuted); callers that own a grid pass `grid::getKeyForBubble`.
+   No grid is constructed or owned by `NodeBootstrap`.
+3. **No consumer wiring in this RDR.** All three consumers are test-only constructions; the factory's
+   javadoc documents the injection contract (`setOwnershipResolver` at each consumer's assembly
+   point), and the consumer-assembly arcs (future multi-node work under `s23eu`/RDR-017 P1) perform
+   the injection. Wiring a consumer here would require first assembling the consumer — silent scope
+   creep in the other direction.
+4. **No lifecycle participant.** The resolver is stateless/subscription-free (A2 verified); it is
+   returned, not registered. No shutdown ordering exists for it.
+5. **Placement-honors-HRW stays OUT** (A5) — re-affirmed named deferral to the partition layer
+   (`s23eu`/RDR-015 follow-on), as in RDR-020. Resolver wiring is purely enabling and does not
+   depend on it.
+
+Named dependency (not a blocker): production activation — a live `FirefliesMemberLookup` requires
+the live Fireflies `View` that `main()` cannot yet build (RDR-017 P1). The MVV runs against a
+test-assembled node (`MockFirefliesView` + `MockMember`), so it does not depend on `main()` —
+identical to the RDR-021 MVV posture.
+
+### Technical Design
+
+**Factory (in `NodeBootstrap`, sibling of `assembleFaultTolerance`).** All signatures Verified
+against source.
+
+```text
+// Production form — memberLookup supplies localMember + node-UUID resolution (needs a live View):
+public static BubbleOwnershipResolver assembleOwnershipResolver(
+        FirefliesMemberLookup memberLookup,            // Verified ctor(View[, Random]); getLocalMember(), getMemberByUuid(UUID)
+        MembershipView<Member> membershipView,         // Verified — active-only member stream (RDR-020 B4 / RDR-005)
+        Function<UUID, TetreeKey<?>> bubbleKeyResolver // caller-supplied (A4: bootstrap owns no grid)
+) {
+    return new FirefliesBubbleOwnershipResolver(
+        memberLookup::getLocalMember,                  // Supplier<Member>
+        memberLookup::getMemberByUuid,                 // Function<UUID, Optional<Member>>
+        bubbleKeyResolver,
+        membershipView,
+        new RendezvousOwnershipFunction());            // Verified — stateless HRW
+}
+// Narrow-seam overload (test assembly / no live View) — matches the resolver's primary ctor
+// minus SpatialOwnershipFunction, which the factory fixes internally (locked decision 1):
+public static BubbleOwnershipResolver assembleOwnershipResolver(
+        Supplier<Member> localMemberSupplier,
+        Function<UUID, Optional<Member>> nodeResolver,
+        Function<UUID, TetreeKey<?>> bubbleKeyResolver,
+        MembershipView<Member> membershipView) { ... } // same body, seams direct
+```
+
+Notes:
+- The factory adds over a bare `new`: the canonical assembly point in the bootstrap (discoverable
+  next to `assembleFaultTolerance`), the locked HRW-function choice, and the documented injection
+  contract. `requireNonNull` validation lives in the resolver's ctor already (fail-loud preserved).
+- **No record wrapper** — unlike `FaultSubsystem` there is exactly one object and nothing to close.
+- **Injection contract (javadoc, normative):** a consumer assembly point that constructs
+  `TopologyConsensusCoordinator`, `OptimisticMigratorImpl`, or `DistributedBubbleNode` MUST call
+  `setOwnershipResolver(resolver)` with a bootstrap-assembled resolver before first consensus use;
+  the consumers' existing fail-loud guards (coordinator `:329`, migrator `:169`) enforce it.
+- **Active-only invariant**: the `membershipView` parameter is the *active-members* source
+  (RDR-020 B4); the factory must NOT derive membership from
+  `FirefliesMemberLookup.getActiveMembers()` (misnamed, all-members backed).
+
+**MVV shape (Verified seams).** Test-assembled node, mirroring `Rdr020MvvIntegrationTest:157-174`:
+`MockFirefliesView<Member>` seeded with ≥2 `MockMember`s; a real `TetreeBubbleGrid` with bubbles at
+real `TetreeKey`s, `grid::getKeyForBubble` as the key seam; factory-assembled resolver injected into
+a real `TopologyConsensusCoordinator`. Assertions: (1) canonical identity round-trip —
+`NodeBootstrap.resolveNodeId(member) == FirefliesMemberLookup.digestToUuid(resolver.localMember())`;
+(2) the previously-dead path produces a valid, `validateProposal`-passing proposal (vs today's
+`IllegalStateException("ownershipResolver not set")`); (3) fail-loud survives wiring — an
+unresolvable bubble still throws.
+
+### Decision Rationale
+
+- **Factory-exposes-resolver, not consumer wiring** — there is no production consumer to wire (A1):
+  every `setOwnershipResolver` target is constructed only in tests, each marked "multi-node wiring
+  lands with `s23eu`". Assembling consumers just to inject into them would smuggle the multi-node
+  consensus-stack assembly into this RDR; exposing the resolver at the canonical bootstrap seam is
+  the entire real gap.
+- **Caller-supplied `bubbleKeyResolver`** — forced by A4: the bootstrap/`Manager` own no grid, and
+  inventing grid ownership in `NodeBootstrap` would be a topology decision this RDR has no mandate
+  for. A function parameter keeps the seam narrow and testable.
+- **No lifecycle participant** — A2 verified the resolver holds no state, threads, or
+  subscriptions; registering it would be cargo-culting the RDR-021 adapter onto a passive object.
+- **`RendezvousOwnershipFunction` fixed inside the factory** — RDR-020 locked HRW as the ownership
+  function; making it a parameter invites divergent ownership functions across a cluster, which
+  breaks the every-node-computes-identically property HRW exists to provide.
+- **Placement seeding out** — A5: validity gates are resolver-independent and wiring is purely
+  enabling, so deferral costs nothing now; absorbing it would require bootstrap grid ownership
+  (large, cross-cutting with `MultiBubbleSimulation`).
+
+### Existing Infrastructure Audit
+
+| Proposed Component | Existing Module | Decision |
+| --- | --- | --- |
+| Ownership resolution | `FirefliesBubbleOwnershipResolver` + `RendezvousOwnershipFunction` (RDR-020) | Reuse — wire, do not reimplement. |
+| Assembly seam pattern | `NodeBootstrap.assembleFaultTolerance` (RDR-021) | Mirror the factory shape; **no** record wrapper, **no** lifecycle registration (one passive object). |
+| Lifecycle participation | `RecoveryIntegrationAdapter` (RDR-021) | **N/A** — A2 verified the resolver is lifecycle-passive. |
+| Single-process double | `StubBubbleOwnershipResolver` (src/main) | Test double only — never assembled in production (locked decision; wiring it would silently degrade ownership semantics). |
+| Consumer construction | `TopologyConsensusCoordinator` / `OptimisticMigratorImpl` / `DistributedBubbleNode` | **Out of scope** — all test-only today (A1); injection contract documented on the factory; assembly belongs to future `s23eu` multi-node arcs. |
+| Placement seeding | `TetreeBubbleGrid` add paths | **Out (named deferral)** — partition layer (`s23eu`/RDR-015 follow-on), per RDR-020 and A5. |
+
+## Alternatives Considered
+
+### Briefly Rejected
+
+- **Leave it unwired (status quo)**: consensus paths stay fail-loud dead in the assembled node;
+  `s23eu` never closes. Acceptable only while the live path is single-process — which is exactly the
+  condition this RDR-pair exists to end.
+- **Wire `StubBubbleOwnershipResolver` in production as a placeholder**: silently degrades the
+  ownership semantics (fixed seeded maps) — violates the fail-loud contract's purpose. Test double
+  stays a test double.
+
+(Full alternatives analysis after research.)
+
+## Trade-offs
+
+### Consequences
+
+- (+) The assembled node gains live node-identity resolution; the consensus entry points become
+  reachable instead of fail-loud dead; `s23eu` can close.
+- (−) Widens the bootstrap's dependency surface toward membership (`MembershipView`/`View`) and the
+  bubble grid; the wiring must be proven by integration tests against the assembled node, not just
+  compiled.
+
+### Risks and Mitigations
+
+- **Risk**: Gap-3 scope creep — "wire the resolver" balloons into "assemble the entire distributed
+  consensus stack." **Mitigation**: A1 research pins the consumer set and ownership; anything beyond
+  injection seams goes to named follow-on work.
+- **Risk**: the production convenience ctor needs a live `View`, which `main()` cannot build yet
+  (RDR-017 P1). **Mitigation**: mirror RDR-021 — MVV on a test-assembled node via the narrow-seam
+  ctor; live activation remains the named `main()` dependency.
+- **Risk**: placement-honors-HRW ambiguity leaks in as silent scope. **Mitigation**: §Explicitly in
+  question forces an explicit in/out decision at research; the gate checks it.
+
+### Failure Modes
+
+Today (unwired): every assembled-node consensus path throws on first use (`ownershipResolver not
+set` / UOE) — fail-loud, visible, but **dead**. After wiring: unresolvable bubbles / empty views
+still throw per the RDR-020 contract (correct); wiring misconfiguration fails loud at construction
+(`requireNonNull`). The new failure mode to guard: a resolver wired against the *wrong* grid or a
+non-canonical member identity would resolve *successfully but inconsistently* — the MVV's canonical
+round-trip assertion (`resolveNodeId` ↔ `localMember()`) exists to catch exactly this.
+
+## Implementation Plan
+
+### Prerequisites
+
+- [x] A1–A5 resolved via `/conexus:rdr-research` pass 1 (A1 decided scope shape:
+  factory-exposes-resolver).
+- [x] Placement-honors-HRW decision recorded: **out** (named deferral, A5).
+- [ ] Gate (`/conexus:rdr-gate`) → accept.
+
+### Minimum Viable Validation
+
+An integration test over a **test-assembled** node (factory-assembled resolver via the narrow-seam
+overload; real `RendezvousOwnershipFunction`; `MockFirefliesView` seeded with ≥2 `MockMember`s; a
+real `TetreeBubbleGrid` supplying `grid::getKeyForBubble`; a real `TopologyConsensusCoordinator` —
+not mocked at the resolution boundary) proving:
+1. **Supplier threading (non-vacuous form — gate finding)**: the factory-assembled resolver's
+   `localMember()` `Digest` equals `ownerMember.getId()` for the **specific** `MockMember` passed
+   as `localMemberSupplier` (catching swapped/mis-threaded factory parameters), and
+   `NodeBootstrap.resolveNodeId(ownerMember)` equals the expected canonical node UUID. Do NOT
+   assert `resolveNodeId(member) == digestToUuid(resolver.localMember())` alone — both sides reduce
+   to `digestToUuid(member.getId())`, which is trivially true regardless of wiring.
+2. **Gap closure with negative control (gate observation)**: an **uninjected** coordinator first
+   throws `IllegalStateException("ownershipResolver not set")` (`:329`) — the baseline — then the
+   same scenario with the factory-assembled resolver injected produces a **valid,
+   `validateProposal`-passing TOPOLOGY proposal** (≥2-member seeded view; single-owner model,
+   RDR-020 S3 amendment). **HRW probe step required (gate finding)**: with ≥2 members, HRW assigns
+   the bubble's region to one specific member; `localMemberSupplier` must return **that** member or
+   the ownership guard (`:347-352`) throws. Use the probe-resolver pattern from
+   `Rdr020MvvIntegrationTest:262-275` — probe to discover the HRW owner of the bubble's key, then
+   build the real resolver with `localMember = ownerMember`.
+3. The fail-loud contract survives wiring: an unresolvable bubble still throws.
+
+### Phase 1: Code Implementation
+
+To be decomposed after research/gate (`/conexus:rdr-research` → `/conexus:rdr-gate` →
+`/conexus:rdr-accept`).
+
+## Revision History
+
+- 2026-06-10: created (draft) — scoped from `Luciferase-s23eu` resolver half, per RDR-021 gate
+  decision S3 / locked decision 5 ("Resolver wiring → sibling RDR"). Pre-creation reconnaissance
+  confirmed: zero production construction sites for `FirefliesBubbleOwnershipResolver`; three
+  fail-loud consumer injection seams; `NodeBootstrap` holds neither the resolver's dependencies nor
+  its consumers (Gap 3 is the load-bearing scope question, A1). Next: `/conexus:rdr-research`.
+- 2026-06-10: **research pass 1** (Source Search; T2 `Luciferase_rdr/022-research-1`). **A1
+  PARTIAL→resolved**: consumer set verified exhaustive (3), but all three are **test-only
+  constructions** (zero `src/main` ctor sites; explicit "multi-node wiring lands with s23eu"
+  comments) — scope shape locked to **factory-exposes-resolver, no consumer wiring**. **A2
+  VERIFIED** (all-final fields, no close/threads/subscriptions; HRW function stateless → no
+  lifecycle participant). **A3 VERIFIED** (`MockFirefliesView` in `src/main` + Delos `MockMember`;
+  pattern proven in `Rdr020MvvIntegrationTest:157-174`). **A4 REFUTED** (`Manager`/`NodeBootstrap`
+  own no `TetreeBubbleGrid`; grid lives in `MultiBubbleSimulation`/demos) — `bubbleKeyResolver`
+  becomes a caller-supplied factory parameter. **A5 VERIFIED** (validity gates
+  resolver-independent; null-integration/null-resolver branches make wiring purely enabling) —
+  placement-honors-HRW stays **out**, named deferral re-affirmed. Locked decisions 1–5 recorded;
+  §Technical Design + §Decision Rationale filled. Next: `/conexus:rdr-gate`.
+- 2026-06-10: **gate PASSED** (substantive-critic; 0 Critical, 2 Significant, 3 Observations).
+  Design, scope honesty (factory-exposes-resolver is the right conclusion, not silent reduction),
+  and cross-RDR consistency with RDR-020/021 all confirmed against source. Both Significants were
+  MVV-spec defects, fixed in-place: (S1) the HRW **probe step** was missing — with ≥2 members the
+  ownership guard (`toMigrationProposal:347-352`) throws unless `localMemberSupplier` returns the
+  HRW owner; MVV now mandates the `Rdr020MvvIntegrationTest:262-275` probe pattern. (S2) the
+  canonical round-trip assertion was **vacuously true** as written (both sides reduce to
+  `digestToUuid(member.getId())`); restated as a supplier-threading assertion against the specific
+  `ownerMember`. Observations folded in: negative control (uninjected coordinator throws
+  `ownershipResolver not set` baseline before asserting gap closure); "mirrors primary ctor"
+  wording corrected to "minus `SpatialOwnershipFunction` (fixed internally)". Ready for
+  `/conexus:rdr-accept`.

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -32,6 +32,7 @@ See the [RDR process documentation](https://github.com/cwensel/rdr) for the full
 | [RDR-019](RDR-019-wal-checkpoint-recovery-durability.md) | WAL Checkpoint/Recovery Durability — Bound Replay Safely (Snapshot or Compaction) | accepted | Bug Fix | high |
 | [RDR-020](RDR-020-bubble-to-fireflies-member-digest-resolution.md) | Bubble→Fireflies Member Digest Resolution for Migration Consensus | implemented | Bug Fix | high |
 | [RDR-021](RDR-021-wire-partition-fault-tolerance-node-bootstrap.md) | Wire Partition Fault Tolerance into the Production Node Bootstrap | implemented | Architecture | medium |
+| [RDR-022](RDR-022-wire-bubble-ownership-resolver-node-bootstrap.md) | Wire Bubble Ownership Resolution into the Production Node Bootstrap | accepted | Architecture | medium |
 
 ## Post-Mortems
 

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
@@ -14,7 +14,12 @@ import com.hellblazer.luciferase.common.time.Clock;
 import com.hellblazer.luciferase.lucien.balancing.fault.FaultConfiguration;
 import com.hellblazer.luciferase.lucien.balancing.fault.InMemoryPartitionTopology;
 import com.hellblazer.luciferase.lucien.balancing.fault.SimpleFaultHandler;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
 import com.hellblazer.luciferase.simulation.causality.EntityMigrationStateMachine;
+import com.hellblazer.luciferase.simulation.consensus.ownership.BubbleOwnershipResolver;
+import com.hellblazer.luciferase.simulation.consensus.ownership.FirefliesBubbleOwnershipResolver;
+import com.hellblazer.luciferase.simulation.consensus.ownership.RendezvousOwnershipFunction;
+import com.hellblazer.luciferase.simulation.delos.MembershipView;
 import com.hellblazer.luciferase.simulation.lifecycle.PersistenceManagerAdapter;
 import com.hellblazer.luciferase.simulation.lifecycle.RecoveryIntegrationAdapter;
 import com.hellblazer.luciferase.simulation.lifecycle.SocketConnectionManagerAdapter;
@@ -28,7 +33,10 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Production node bootstrap — composes the distributed simulation node (RDR-017).
@@ -347,6 +355,82 @@ public final class NodeBootstrap {
         recovery.unregisterBubble(bubble.id());
         manager.leave(bubble);
         log.debug("Removed bubble {} (unregistered before leave)", bubble.id());
+    }
+
+    /**
+     * Assemble the bubble→node ownership resolver (RDR-022) — production form.
+     * <p>
+     * Constructs a {@link FirefliesBubbleOwnershipResolver} over a live
+     * {@link FirefliesMemberLookup}: local member via {@code memberLookup::getLocalMember}, node-UUID
+     * hint resolution via {@code memberLookup::getMemberByUuid} (RDR-020 B4), and the
+     * {@link RendezvousOwnershipFunction} (HRW) fixed internally — the one canonical ownership
+     * function; a parameterized function would invite divergent ownership across a cluster and break
+     * the every-node-computes-identically property (RDR-022 locked decision 1).
+     * <p>
+     * <b>The resolver is lifecycle-passive</b> (stateless, no subscriptions, nothing to close —
+     * RDR-022 A2): it is returned, not registered with the lifecycle coordinator, and needs no
+     * shutdown ordering.
+     * <p>
+     * <b>{@code bubbleKeyResolver} is caller-supplied</b> (RDR-022 A4): the bootstrap/{@link Manager}
+     * domain owns no {@code TetreeBubbleGrid}; a caller that owns one passes
+     * {@code grid::getKeyForBubble}.
+     * <p>
+     * <b>Active-only invariant (RDR-020 B4 / RDR-005):</b> {@code membershipView} is the
+     * <em>active-members</em> source consulted for ownership; the misnamed
+     * {@code FirefliesMemberLookup.getActiveMembers()} (all-members backed) is never used for it.
+     * <p>
+     * <b>Injection contract (normative):</b> a consumer assembly point that constructs
+     * {@code TopologyConsensusCoordinator}, {@code OptimisticMigratorImpl}, or
+     * {@code DistributedBubbleNode} MUST inject an assembled resolver via the consumer's
+     * {@code setOwnershipResolver(...)} before first consensus use; the consumers' existing
+     * fail-loud guards enforce this. No production consumer is constructed by this bootstrap today
+     * — consumer assembly lands with the multi-node arcs (Luciferase-s23eu); this factory is the
+     * canonical place they obtain the resolver from.
+     *
+     * @param memberLookup      the Fireflies member lookup (local member + canonical node-UUID
+     *                          mapping); requires a live Fireflies view at call time
+     * @param membershipView    the active-only membership source for ownership resolution
+     * @param bubbleKeyResolver maps a bubble {@code UUID} to its {@code TetreeKey} ({@code null} if
+     *                          unknown — the resolver fails loud); caller-supplied, e.g.
+     *                          {@code grid::getKeyForBubble}
+     * @return the assembled, lifecycle-passive resolver
+     */
+    public static BubbleOwnershipResolver assembleOwnershipResolver(
+            FirefliesMemberLookup memberLookup,
+            MembershipView<Member> membershipView,
+            Function<UUID, TetreeKey<?>> bubbleKeyResolver) {
+        Objects.requireNonNull(memberLookup, "memberLookup cannot be null");
+        return assembleOwnershipResolver(memberLookup::getLocalMember, memberLookup::getMemberByUuid,
+                                         bubbleKeyResolver, membershipView);
+    }
+
+    /**
+     * Assemble the bubble→node ownership resolver (RDR-022) — narrow-seam form.
+     * <p>
+     * Matches {@link FirefliesBubbleOwnershipResolver}'s primary constructor minus the
+     * {@code SpatialOwnershipFunction}, which this factory fixes to {@link RendezvousOwnershipFunction}
+     * (RDR-022 locked decision 1). Enables assembly without a live Fireflies view — the MVV /
+     * test-assembled-node path (RDR-022 A3); production callers use the
+     * {@link #assembleOwnershipResolver(FirefliesMemberLookup, MembershipView, Function)} overload.
+     * All seams are validated fail-loud by the resolver's constructor.
+     *
+     * @param localMemberSupplier returns this node's own {@link Member}
+     * @param nodeResolver        canonical node-UUID → {@link Member} mapping (RDR-020 B4)
+     * @param bubbleKeyResolver   bubble {@code UUID} → {@code TetreeKey} ({@code null} if unknown)
+     * @param membershipView      the active-only membership source for ownership resolution
+     * @return the assembled, lifecycle-passive resolver
+     */
+    public static BubbleOwnershipResolver assembleOwnershipResolver(
+            Supplier<Member> localMemberSupplier,
+            Function<UUID, Optional<Member>> nodeResolver,
+            Function<UUID, TetreeKey<?>> bubbleKeyResolver,
+            MembershipView<Member> membershipView) {
+        var resolver = new FirefliesBubbleOwnershipResolver(localMemberSupplier, nodeResolver,
+                                                            bubbleKeyResolver, membershipView,
+                                                            new RendezvousOwnershipFunction());
+        log.info("Bubble ownership resolver assembled: FirefliesBubbleOwnershipResolver + "
+                 + "RendezvousOwnershipFunction (HRW); lifecycle-passive, not registered");
+        return resolver;
     }
 
     /**

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
@@ -388,12 +388,18 @@ public final class NodeBootstrap {
      * canonical place they obtain the resolver from.
      *
      * @param memberLookup      the Fireflies member lookup (local member + canonical node-UUID
-     *                          mapping); requires a live Fireflies view at call time
+     *                          mapping); requires a live Fireflies view at <em>first use</em> —
+     *                          assembly wires method references lazily and does not dereference
+     *                          the view
      * @param membershipView    the active-only membership source for ownership resolution
      * @param bubbleKeyResolver maps a bubble {@code UUID} to its {@code TetreeKey} ({@code null} if
      *                          unknown — the resolver fails loud); caller-supplied, e.g.
      *                          {@code grid::getKeyForBubble}
      * @return the assembled, lifecycle-passive resolver
+     * @throws NullPointerException if any argument is null — {@code memberLookup} is validated at
+     *                              the factory (it is dereferenced here for method references);
+     *                              {@code membershipView}/{@code bubbleKeyResolver} are validated
+     *                              by the resolver's constructor (the throw site in the stack)
      */
     public static BubbleOwnershipResolver assembleOwnershipResolver(
             FirefliesMemberLookup memberLookup,

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/Rdr022MvvIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/Rdr022MvvIntegrationTest.java
@@ -287,7 +287,11 @@ class Rdr022MvvIntegrationTest {
         public Digest getCurrentViewId() { return currentViewId; }
     }
 
-    /** No-op MembershipView used only to satisfy FirefliesViewMonitor's constructor. */
+    /**
+     * No-op MembershipView used only to satisfy FirefliesViewMonitor's constructor. Safe: the
+     * monitor's view-change listener registration is dropped, but ScheduledViewMonitor overrides
+     * getCurrentViewId() directly and ViewCommitteeConsensus needs nothing else in this test.
+     */
     private static class NoopMembershipView implements MembershipView<Member> {
         @Override public void addListener(Consumer<MembershipView.ViewChange<Member>> listener) {}
         @Override public Stream<Member> getMembers() { return Stream.empty(); }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/Rdr022MvvIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/consensus/committee/integration/Rdr022MvvIntegrationTest.java
@@ -1,0 +1,296 @@
+/**
+ * Copyright (C) 2026 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase Simulation Framework.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.consensus.committee.integration;
+
+import com.hellblazer.delos.context.DynamicContext;
+import com.hellblazer.delos.cryptography.Digest;
+import com.hellblazer.delos.cryptography.DigestAlgorithm;
+import com.hellblazer.delos.membership.Member;
+import com.hellblazer.delos.membership.MockMember;
+import com.hellblazer.luciferase.common.time.Clock;
+import com.hellblazer.luciferase.simulation.bubble.EnhancedBubble;
+import com.hellblazer.luciferase.simulation.bubble.TetreeBubbleGrid;
+import com.hellblazer.luciferase.simulation.causality.FirefliesViewMonitor;
+import com.hellblazer.luciferase.simulation.consensus.committee.*;
+import com.hellblazer.luciferase.simulation.consensus.ownership.BubbleOwnershipResolver;
+import com.hellblazer.luciferase.simulation.delos.MembershipView;
+import com.hellblazer.luciferase.simulation.delos.mock.MockFirefliesView;
+import com.hellblazer.luciferase.simulation.topology.SplitPlane;
+import com.hellblazer.luciferase.simulation.topology.SplitProposal;
+import com.hellblazer.luciferase.simulation.topology.TopologyConsensusCoordinator;
+import com.hellblazer.luciferase.simulation.von.FirefliesMemberLookup;
+import com.hellblazer.luciferase.simulation.von.NodeBootstrap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.vecmath.Point3f;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * RDR-022 Minimum Viable Validation (MVV) integration test (Luciferase-0frcy.136.2).
+ * <p>
+ * Proves the bootstrap-assembled ownership resolver closes the production gap end-to-end against a
+ * test-assembled node: the resolver is obtained from
+ * {@link NodeBootstrap#assembleOwnershipResolver} (the RDR-022 factory — never a bare {@code new}),
+ * backed by a real {@code TetreeBubbleGrid}, a {@code MockFirefliesView} with ≥2 members, and a
+ * real {@code TopologyConsensusCoordinator} + {@code ViewCommitteeConsensus} — not mocked at the
+ * resolution boundary.
+ * <p>
+ * Gate-remediated assertions (RDR-022 gate 2026-06-10):
+ * <ol>
+ *   <li><b>Non-vacuous supplier threading</b> — {@code localMember()} is the digest of the
+ *       <em>specific</em> member passed to the factory (distinguished from a sibling member), and
+ *       the canonical node-UUID chain round-trips through the resolver's {@code nodeResolver} seam
+ *       ({@code resolveNodeId(owner) → memberDigestForNode → owner.getId()}).</li>
+ *   <li><b>Negative control then gap closure</b> — the same scenario first throws
+ *       {@code "ownershipResolver not set"} on an uninjected coordinator, then passes
+ *       {@code validateProposal} and reaches real committee quorum once the factory-assembled
+ *       resolver is injected. The <b>HRW probe step</b> discovers which member owns the bubble's
+ *       region so the ownership guard passes (pattern: {@code Rdr020MvvIntegrationTest}).</li>
+ *   <li><b>Fail-loud survives wiring</b> — an unresolvable bubble still throws through the
+ *       factory-assembled resolver.</li>
+ * </ol>
+ *
+ * @author hal.hildebrand
+ */
+class Rdr022MvvIntegrationTest {
+
+    private static final int MEMBER_COUNT = 3;
+    private static final long FIXED_MILLIS = 1_000_000L;
+
+    private List<MockMember>         members;
+    private DynamicContext<Member>   context;
+    private CommitteeVotingProtocol  votingProtocol;
+    private ViewCommitteeConsensus   consensus;
+    private ScheduledExecutorService scheduler;
+    private Digest                   viewId;
+
+    private final TestClock testClock = new TestClock(FIXED_MILLIS);
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        viewId = DigestAlgorithm.DEFAULT.digest("rdr022-mvv-view-id".getBytes());
+
+        members = new ArrayList<>();
+        for (int i = 0; i < MEMBER_COUNT; i++) {
+            members.add(new MockMember(DigestAlgorithm.DEFAULT.getOrigin().prefix(i)));
+        }
+
+        // Identity alignment (RDR-020 MVV lesson): the same member digests flow through BOTH the
+        // DynamicContext stubs (ViewCommitteeConsensus active() gate) AND the MockFirefliesView
+        // (the resolver's activeMembers() path).
+        context = Mockito.mock(DynamicContext.class);
+        when(context.size()).thenReturn(MEMBER_COUNT);
+        when(context.toleranceLevel()).thenReturn(1); // t=1 → quorum=2
+        when(context.bftSubset(any(Digest.class))).thenReturn(new LinkedHashSet<Member>(members));
+        when(context.allMembers()).thenAnswer(inv -> members.stream().map(m -> (Member) m));
+        when(context.active()).thenAnswer(inv -> members.stream().map(m -> (Member) m));
+        when(context.isActive(any(Digest.class))).thenReturn(true);
+
+        scheduler = Executors.newScheduledThreadPool(2);
+        votingProtocol = new CommitteeVotingProtocol(context, CommitteeConfig.defaultConfig(), scheduler);
+
+        consensus = new ViewCommitteeConsensus();
+        consensus.setViewMonitor(new ScheduledViewMonitor(viewId));
+        consensus.setCommitteeSelector(new ViewCommitteeSelector(context));
+        consensus.setVotingProtocol(votingProtocol);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Assembles the resolver through the RDR-022 bootstrap factory (narrow-seam form — the
+     * no-live-View MVV path, RDR-022 A3). This is the factory under test: the MVV never calls
+     * {@code new FirefliesBubbleOwnershipResolver} directly.
+     */
+    private BubbleOwnershipResolver assembleViaBootstrap(MockMember localMember, TetreeBubbleGrid grid) {
+        var mockView = new MockFirefliesView<Member>();
+        for (var m : members) {
+            mockView.addMember(m);
+        }
+        return NodeBootstrap.assembleOwnershipResolver(
+            () -> localMember,
+            // Canonical node-UUID → Member resolution (RDR-020 B4)
+            nodeUuid -> members.stream()
+                               .filter(m -> FirefliesMemberLookup.digestToUuid(m.getId()).equals(nodeUuid))
+                               .map(m -> (Member) m)
+                               .findFirst(),
+            grid::getKeyForBubble,
+            mockView);
+    }
+
+    private void addEntities(EnhancedBubble bubble, int count) {
+        for (int i = 0; i < count; i++) {
+            bubble.addEntity("e-" + i, new Point3f(i * 0.001f, i * 0.001f, i * 0.001f), null);
+        }
+    }
+
+    private SplitProposal createSplitProposal(TetreeBubbleGrid grid, UUID bubbleId) {
+        var bubble = grid.getBubbleById(bubbleId);
+        float minX = Float.POSITIVE_INFINITY;
+        float maxX = Float.NEGATIVE_INFINITY;
+        for (var record : bubble.getAllEntityRecords()) {
+            var pos = record.position();
+            minX = Math.min(minX, pos.x);
+            maxX = Math.max(maxX, pos.x);
+        }
+        var splitPlane = new SplitPlane(new Point3f(1.0f, 0.0f, 0.0f), (minX + maxX) / 2.0f);
+        return new SplitProposal(UUID.randomUUID(), bubbleId, splitPlane, viewId,
+                                 testClock.currentTimeMillis());
+    }
+
+    // -------------------------------------------------------------------------
+    // MVV
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("MVV: previously-dead topology path reaches committee quorum once the factory-assembled resolver is injected")
+    void factoryAssembledResolverClosesTheProductionGap() throws Exception {
+        var grid = new TetreeBubbleGrid((byte) 2);
+        grid.createBubbles(1, (byte) 1, 10);
+        var bubble = grid.getAllBubbles().iterator().next();
+        addEntities(bubble, 5100);
+        var bubbleId = bubble.id();
+        assertNotNull(grid.getKeyForBubble(bubbleId), "Grid must hold a TetreeKey for the bubble");
+
+        // --- Negative control (gate observation 3): the SAME scenario against an UNINJECTED
+        // coordinator throws — proving the gap exists and is closed BY the factory, not absent.
+        var bareCoordinator = new TopologyConsensusCoordinator(grid);
+        bareCoordinator.setClock(testClock);
+        bareCoordinator.setConsensusProtocol(consensus);
+        var negativeProposal = createSplitProposal(grid, bubbleId);
+        var unset = assertThrows(IllegalStateException.class,
+                                 () -> bareCoordinator.requestConsensus(negativeProposal));
+        assertTrue(unset.getMessage().contains("ownershipResolver not set"),
+                   "Baseline must be the unset-resolver fail-loud, was: " + unset.getMessage());
+
+        // --- HRW probe step (gate finding S1): discover which member owns the bubble's region so
+        // the real resolver's local member passes the ownership guard (single-owner TOPOLOGY model).
+        var probeResolver = assembleViaBootstrap(members.get(0), grid);
+        var ownerDigest = probeResolver.resolveOwningMember(bubbleId);
+        var ownerMember = members.stream()
+                                 .filter(m -> m.getId().equals(ownerDigest))
+                                 .findFirst()
+                                 .orElseThrow(() -> new AssertionError(
+                                     "HRW owner not in member list: " + ownerDigest));
+
+        // --- Factory-assembled resolver with localMember == HRW owner.
+        var resolver = assembleViaBootstrap(ownerMember, grid);
+
+        // (1) Non-vacuous supplier threading (gate finding S2): localMember() is the SPECIFIC
+        // member passed — distinguished from a sibling — and the canonical node-UUID chain
+        // round-trips through the resolver's nodeResolver seam in both directions.
+        assertEquals(ownerMember.getId(), resolver.localMember(),
+                     "localMember() must be the specific member assembled into the factory");
+        var sibling = members.stream().filter(m -> !m.getId().equals(ownerDigest)).findFirst().orElseThrow();
+        assertNotEquals(sibling.getId(), resolver.localMember());
+        var ownerNodeUuid = NodeBootstrap.resolveNodeId(ownerMember);
+        assertEquals(ownerMember.getId(), resolver.memberDigestForNode(ownerNodeUuid),
+                     "Canonical nodeId → member digest must round-trip through the assembled seam");
+
+        // (2) Gap closure: inject the factory-assembled resolver; the same scenario now passes
+        // validateProposal (pending, awaiting votes) and reaches real committee quorum.
+        var coordinator = new TopologyConsensusCoordinator(grid);
+        coordinator.setClock(testClock);
+        coordinator.setConsensusProtocol(consensus);
+        coordinator.setOwnershipResolver(resolver);
+
+        var proposal = createSplitProposal(grid, bubbleId);
+        var future = coordinator.requestConsensus(proposal);
+        assertFalse(future.isDone(),
+                    "Proposal must be pending — validateProposal passed, awaiting committee votes");
+
+        int quorum = context.toleranceLevel() + 1;
+        for (int i = 0; i < quorum; i++) {
+            votingProtocol.recordVote(new Vote(proposal.proposalId(), members.get(i).getId(), true, viewId));
+        }
+        assertTrue(future.get(3, TimeUnit.SECONDS),
+                   "Topology proposal must be approved after real quorum votes — the previously-dead "
+                   + "path is live through the bootstrap-assembled resolver");
+    }
+
+    @Test
+    @DisplayName("MVV: fail-loud contract survives factory wiring — unresolvable bubble still throws")
+    void failLoudSurvivesFactoryWiring() {
+        var grid = new TetreeBubbleGrid((byte) 2);
+        var resolver = assembleViaBootstrap(members.get(0), grid);
+
+        var unknownBubble = UUID.randomUUID();
+        var ex = assertThrows(IllegalStateException.class,
+                              () -> resolver.resolveOwningMember(unknownBubble),
+                              "A bubble with no grid key must throw — never a silently-rejectable digest");
+        assertTrue(ex.getMessage().contains(unknownBubble.toString()),
+                   "Fail-loud message must identify the unresolvable bubble");
+    }
+
+    // -------------------------------------------------------------------------
+    // Inner helpers (pattern: Rdr020MvvIntegrationTest)
+    // -------------------------------------------------------------------------
+
+    /** Deterministic clock backed by a mutable long. */
+    private static class TestClock implements Clock {
+        private final long millis;
+
+        TestClock(long millis) { this.millis = millis; }
+
+        @Override public long currentTimeMillis() { return millis; }
+        @Override public long nanoTime() { return millis * 1_000_000L; }
+    }
+
+    /** Minimal FirefliesViewMonitor stand-in providing a fixed viewId. */
+    private static class ScheduledViewMonitor extends FirefliesViewMonitor {
+        private final Digest currentViewId;
+
+        ScheduledViewMonitor(Digest viewId) {
+            super(new NoopMembershipView());
+            this.currentViewId = viewId;
+        }
+
+        @Override
+        public Digest getCurrentViewId() { return currentViewId; }
+    }
+
+    /** No-op MembershipView used only to satisfy FirefliesViewMonitor's constructor. */
+    private static class NoopMembershipView implements MembershipView<Member> {
+        @Override public void addListener(Consumer<MembershipView.ViewChange<Member>> listener) {}
+        @Override public Stream<Member> getMembers() { return Stream.empty(); }
+        @Override public Stream<Member> activeMembers() { return Stream.empty(); }
+    }
+}

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapOwnershipResolverTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapOwnershipResolverTest.java
@@ -1,0 +1,262 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.von;
+
+import com.hellblazer.delos.cryptography.Digest;
+import com.hellblazer.delos.cryptography.DigestAlgorithm;
+import com.hellblazer.delos.membership.Member;
+import com.hellblazer.delos.membership.MockMember;
+import com.hellblazer.luciferase.lucien.tetree.TetreeKey;
+import com.hellblazer.luciferase.simulation.consensus.ownership.BubbleOwnershipResolver;
+import com.hellblazer.luciferase.simulation.consensus.ownership.RendezvousOwnershipFunction;
+import com.hellblazer.luciferase.simulation.delos.MembershipView;
+import com.hellblazer.luciferase.simulation.delos.mock.MockFirefliesView;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RDR-022 S1 (Luciferase-0frcy.136.1): unit tests for
+ * {@link NodeBootstrap#assembleOwnershipResolver}.
+ * <p>
+ * Verifies the factory threads each injected seam through to the assembled
+ * {@link BubbleOwnershipResolver} (non-vacuous: assertions distinguish the specific member/seam
+ * passed from its siblings), fixes {@link RendezvousOwnershipFunction} internally (locked
+ * decision 1), enforces the active-only membership invariant (RDR-020 B4 / RDR-005), and
+ * preserves the RDR-020 fail-loud contract end-to-end.
+ *
+ * @author hal.hildebrand
+ */
+class NodeBootstrapOwnershipResolverTest {
+
+    private static final int MEMBER_COUNT = 3;
+
+    private List<MockMember>       members;
+    private MockFirefliesView<Member> mockView;
+    private Map<UUID, TetreeKey<?>> bubbleKeys;
+
+    @BeforeEach
+    void setUp() {
+        members = new ArrayList<>();
+        for (int i = 0; i < MEMBER_COUNT; i++) {
+            members.add(new MockMember(DigestAlgorithm.DEFAULT.getOrigin().prefix(i)));
+        }
+        mockView = new MockFirefliesView<>();
+        for (var m : members) {
+            mockView.addMember(m);
+        }
+        bubbleKeys = new HashMap<>();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Canonical node-UUID → Member resolution (RDR-020 B4): UUID == digestToUuid(member id). */
+    private Optional<Member> canonicalNodeResolver(UUID nodeUuid) {
+        return members.stream()
+                      .filter(m -> FirefliesMemberLookup.digestToUuid(m.getId()).equals(nodeUuid))
+                      .map(m -> (Member) m)
+                      .findFirst();
+    }
+
+    private BubbleOwnershipResolver assemble(Member localMember) {
+        return NodeBootstrap.assembleOwnershipResolver(
+            () -> localMember,
+            this::canonicalNodeResolver,
+            bubbleKeys::get,
+            mockView);
+    }
+
+    // -------------------------------------------------------------------------
+    // Seam threading (non-vacuous — gate finding S2)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("localMemberSupplier threads through: localMember() is the SPECIFIC member passed")
+    void localMemberSupplierThreadsThrough() {
+        var resolver = assemble(members.get(1));
+
+        assertNotNull(resolver);
+        assertEquals(members.get(1).getId(), resolver.localMember(),
+                     "localMember() must be the digest of the specific member passed as supplier");
+        // Non-vacuous: distinguishes the passed member from its siblings (a digestToUuid
+        // round-trip would be trivially true for ANY member — gate finding S2).
+        assertNotEquals(members.get(0).getId(), resolver.localMember());
+        assertNotEquals(members.get(2).getId(), resolver.localMember());
+    }
+
+    @Test
+    @DisplayName("nodeResolver threads through: canonical node UUID resolves to that member's digest")
+    void nodeResolverThreadsThrough() {
+        var resolver = assemble(members.get(0));
+
+        var node2Uuid = FirefliesMemberLookup.digestToUuid(members.get(2).getId());
+        assertEquals(members.get(2).getId(), resolver.memberDigestForNode(node2Uuid));
+
+        // Unknown node UUID fails loud (RDR-020 contract preserved through the factory).
+        assertThrows(IllegalStateException.class,
+                     () -> resolver.memberDigestForNode(UUID.randomUUID()));
+    }
+
+    @Test
+    @DisplayName("bubbleKeyResolver threads through and HRW is fixed internally (locked decision 1)")
+    void hrwOwnerMatchesRendezvousFunctionAndIsDeterministic() {
+        var bubbleId = UUID.randomUUID();
+        var key = TetreeKey.getRoot();
+        bubbleKeys.put(bubbleId, key);
+
+        var resolver = assemble(members.get(0));
+        var owner = resolver.resolveOwningMember(bubbleId);
+
+        // The factory must construct RendezvousOwnershipFunction internally: the resolved owner
+        // equals a direct HRW computation over the same active digests.
+        List<Digest> activeDigests = members.stream().map(m -> (Digest) m.getId()).toList();
+        var expected = new RendezvousOwnershipFunction().owner(key, activeDigests);
+        assertEquals(expected, owner, "Factory-assembled resolver must use rendezvous (HRW) ownership");
+
+        // Deterministic across calls.
+        assertEquals(owner, resolver.resolveOwningMember(bubbleId));
+        assertTrue(activeDigests.contains(owner), "Owner must be an active member digest");
+    }
+
+    // -------------------------------------------------------------------------
+    // Active-only invariant (RDR-020 B4 / RDR-005)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("membershipView threads through with the active-only invariant")
+    void activeOnlyInvariantHolds() {
+        mockView.markInactive(members.get(2));
+
+        var resolver = assemble(members.get(0));
+
+        assertTrue(resolver.isActiveMember(members.get(0).getId()));
+        assertFalse(resolver.isActiveMember(members.get(2).getId()),
+                    "Evicted-but-known member must not be active (RDR-005)");
+
+        // Ownership is computed over the ACTIVE set only: equals HRW over the two active digests.
+        var bubbleId = UUID.randomUUID();
+        var key = TetreeKey.getRoot();
+        bubbleKeys.put(bubbleId, key);
+        List<Digest> activeOnly = List.of(members.get(0).getId(), members.get(1).getId());
+        assertEquals(new RendezvousOwnershipFunction().owner(key, activeOnly),
+                     resolver.resolveOwningMember(bubbleId));
+    }
+
+    // -------------------------------------------------------------------------
+    // Fail-loud contract survives factory assembly
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("unresolvable bubble fails loud through the factory-assembled resolver")
+    void unresolvableBubbleFailsLoud() {
+        var resolver = assemble(members.get(0));
+        assertThrows(IllegalStateException.class,
+                     () -> resolver.resolveOwningMember(UUID.randomUUID()),
+                     "A bubble with no key must throw, never return a silently-rejectable digest");
+    }
+
+    @Test
+    @DisplayName("empty active member set fails loud")
+    void emptyActiveSetFailsLoud() {
+        var emptyView = new MockFirefliesView<Member>();
+        var bubbleId = UUID.randomUUID();
+        bubbleKeys.put(bubbleId, TetreeKey.getRoot());
+
+        var resolver = NodeBootstrap.assembleOwnershipResolver(
+            () -> members.get(0),
+            this::canonicalNodeResolver,
+            bubbleKeys::get,
+            emptyView);
+
+        assertThrows(IllegalStateException.class, () -> resolver.resolveOwningMember(bubbleId));
+    }
+
+    // -------------------------------------------------------------------------
+    // Null-argument fail-loud (both overloads)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("narrow-seam overload fails loud on every null argument")
+    void narrowSeamOverloadNullArgsFailLoud() {
+        Supplier<Member> local = () -> members.get(0);
+        Function<UUID, Optional<Member>> nodes = this::canonicalNodeResolver;
+        Function<UUID, TetreeKey<?>> keys = bubbleKeys::get;
+
+        assertThrows(NullPointerException.class,
+                     () -> NodeBootstrap.assembleOwnershipResolver(null, nodes, keys, mockView));
+        assertThrows(NullPointerException.class,
+                     () -> NodeBootstrap.assembleOwnershipResolver(local, null, keys, mockView));
+        assertThrows(NullPointerException.class,
+                     () -> NodeBootstrap.assembleOwnershipResolver(local, nodes, null, mockView));
+        assertThrows(NullPointerException.class,
+                     () -> NodeBootstrap.assembleOwnershipResolver(local, nodes, keys,
+                                                                   (MembershipView<Member>) null));
+    }
+
+    @Test
+    @DisplayName("production overload fails loud on null arguments at assembly time")
+    void productionOverloadNullArgsFailLoud() {
+        Function<UUID, TetreeKey<?>> keys = bubbleKeys::get;
+
+        // Null memberLookup must fail at the factory call, not defer an NPE to first use.
+        assertThrows(NullPointerException.class,
+                     () -> NodeBootstrap.assembleOwnershipResolver((FirefliesMemberLookup) null,
+                                                                   mockView, keys));
+        // Remaining nulls are rejected by the resolver's own ctor (fail-loud preserved). A live
+        // FirefliesMemberLookup needs a Fireflies View (RDR-017 P1), so the behavioral production
+        // path is exercised by the MVV/narrow-seam tests; null-rejection is asserted with a
+        // view-less lookup instance, which the factory must not dereference during assembly.
+        var viewlessLookup = new FirefliesMemberLookup(null);
+        assertThrows(NullPointerException.class,
+                     () -> NodeBootstrap.assembleOwnershipResolver(viewlessLookup, null, keys));
+        assertThrows(NullPointerException.class,
+                     () -> NodeBootstrap.assembleOwnershipResolver(viewlessLookup, mockView, null));
+    }
+
+    @Test
+    @DisplayName("production overload assembles without dereferencing the lookup (lazy seams)")
+    void productionOverloadAssemblesLazily() {
+        // FirefliesMemberLookup(view=null) is unusable at call time but must be acceptable at
+        // assembly time: the factory wires method references, it does not invoke them.
+        var viewlessLookup = new FirefliesMemberLookup(null);
+        var resolver = NodeBootstrap.assembleOwnershipResolver(viewlessLookup, mockView,
+                                                               bubbleKeys::get);
+        assertNotNull(resolver);
+        // First USE fails (null view), proving the seam is wired to the lookup — fail-loud at
+        // call time, not silently absorbed.
+        assertThrows(NullPointerException.class, resolver::localMember);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **RDR-022** (`docs/rdr/RDR-022-wire-bubble-ownership-resolver-node-bootstrap.md`, accepted 2026-06-10, gate PASSED 0 Critical) — the resolver half of the `Luciferase-s23eu` boundary, sibling of RDR-021 per its gate decision S3.

- **RDR-022 doc**: created → researched (A1–A5 resolved with file:line evidence) → gated → accepted. Key research finding: all three resolver consumers (`TopologyConsensusCoordinator`, `OptimisticMigratorImpl`, `DistributedBubbleNode`) are test-only constructions, and the bootstrap/`Manager` domain owns no `TetreeBubbleGrid` — so the correct scope is a bootstrap factory that exposes the assembled resolver, not consumer wiring.
- **`NodeBootstrap.assembleOwnershipResolver`** (S1, `Luciferase-0frcy.136.1`): production form over `FirefliesMemberLookup` + narrow-seam form (resolver primary ctor minus `SpatialOwnershipFunction` — `RendezvousOwnershipFunction` fixed internally). Lifecycle-passive: returned, never registered. `bubbleKeyResolver` caller-supplied. Normative injection contract documented for future consumer-assembly arcs.
- **`Rdr022MvvIntegrationTest`** (MVV, `Luciferase-0frcy.136.2`): negative control (uninjected coordinator throws `ownershipResolver not set`) → the same scenario reaches real committee quorum through the factory-assembled resolver (HRW probe step, single-owner TOPOLOGY model); non-vacuous supplier-threading + canonical nodeId round-trip; fail-loud unresolvable-bubble survives wiring. Mutation-verified (wrong-member assembly fails deterministically).
- **`NodeBootstrapOwnershipResolverTest`**: 9 unit tests (seam threading, HRW-fixed-internally, active-only invariant, fail-loud null/empty/unresolvable, lazy production seams).

## Validation

- Full simulation suite: **3279 tests, 0 failures, 0 errors, 11 skipped** (baseline 3268 + 11 new).
- Stacked review (`Luciferase-0frcy.136.3`): code-review-expert APPROVED (0 Critical/High) + substantive-critic justified (0 Critical, 1 Significant — javadoc layering, fixed). Verdicts in T2 `Luciferase/rdr-022-stacked-review.md`.

Refs: Luciferase-0frcy.136, Luciferase-0frcy.136.1, Luciferase-0frcy.136.2, Luciferase-0frcy.136.3, Luciferase-s23eu