### PR TITLE
fix(render): wire ESVT far-pointer table through GPU paths (Luciferase-8putk)

### DIFF
--- a/portal/src/main/java/com/hellblazer/luciferase/portal/esvt/renderer/ESVTGPURenderBridge.java
+++ b/portal/src/main/java/com/hellblazer/luciferase/portal/esvt/renderer/ESVTGPURenderBridge.java
@@ -205,7 +205,13 @@ public class ESVTGPURenderBridge implements AutoCloseable {
             gpuMemory = new ESVTGPUMemory(data);
             gpuMemory.uploadToGPU();
 
-            log.debug("Uploaded ESVT data to GPU: {} nodes", data.nodeCount());
+            // Far-pointer table travels separately from the node SSBO; without this the
+            // renderer binds its zero placeholder and far-flagged nodes resolve to offset 0
+            // (silently corrupt geometry, Luciferase-8putk).
+            gpuRenderer.uploadData(data);
+
+            log.debug("Uploaded ESVT data to GPU: {} nodes, {} far pointers", data.nodeCount(),
+                      data.farPointerCount());
         }, glThread);
     }
 

--- a/render/src/main/java/com/hellblazer/luciferase/esvt/gpu/ESVTComputeRenderer.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvt/gpu/ESVTComputeRenderer.java
@@ -16,6 +16,7 @@
  */
 package com.hellblazer.luciferase.esvt.gpu;
 
+import com.hellblazer.luciferase.esvt.core.ESVTData;
 import com.hellblazer.luciferase.resource.UnifiedResourceManager;
 import com.hellblazer.luciferase.resource.opengl.BufferResource;
 import com.hellblazer.luciferase.resource.opengl.ShaderProgramResource;
@@ -29,6 +30,8 @@ import javax.vecmath.Matrix4f;
 import javax.vecmath.Vector3f;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 import java.nio.charset.StandardCharsets;
 
@@ -63,6 +66,8 @@ public final class ESVTComputeRenderer {
     public static final int RENDER_FLAGS_UBO_BINDING = 3;
     public static final int COARSE_OUTPUT_BINDING = 4;
     public static final int COARSE_INPUT_BINDING = 5;
+    // CONTOUR_BUFFER_BINDING = 6 is defined in the shader but not yet wired in Java
+    public static final int FAR_POINTER_BUFFER_BINDING = 7;
 
     // Beam optimization constants
     public static final int DEFAULT_COARSE_SIZE = 4;
@@ -82,6 +87,10 @@ public final class ESVTComputeRenderer {
     private TextureResource outputTexture;
     private TextureResource coarseTexture;
     private int coarseSampler;
+
+    // Far-pointer SSBO (binding 7). Always bound — contains a 4-byte placeholder
+    // when no far pointers are present so the shader binding slot is always valid.
+    private BufferResource farPointerSSBO;
 
     // Camera UBO size: 4 matrices (4x4) + 2 vec4 (position+nearPlane, direction+farPlane)
     private static final int CAMERA_UBO_SIZE = 64 * 4 + 16 * 2;
@@ -141,6 +150,50 @@ public final class ESVTComputeRenderer {
     }
 
     /**
+     * Upload far-pointer data from an ESVTData instance to the GPU SSBO at binding 7.
+     *
+     * <p>When {@code data.hasFarPointers()} is false (empty array) a minimal 4-byte
+     * placeholder buffer is uploaded so the shader binding slot is always valid — the
+     * same convention the OpenCL path uses for its far-pointer cl_mem arg.
+     *
+     * <p>Must be called from the OpenGL context thread, after {@link #initialize()}.
+     *
+     * @param data the ESVT data whose far-pointer table to upload
+     */
+    public void uploadData(ESVTData data) {
+        if (!initialized) {
+            throw new IllegalStateException("Renderer not initialized");
+        }
+        if (disposed) {
+            throw new IllegalStateException("Renderer has been disposed");
+        }
+
+        int[] fps = data.hasFarPointers() ? data.farPointers() : null;
+        int byteCount = (fps != null && fps.length > 0) ? fps.length * Integer.BYTES : Integer.BYTES;
+
+        if (farPointerSSBO == null) {
+            farPointerSSBO = resourceManager.createStorageBuffer(byteCount, "ESVTFarPointerSSBO");
+        }
+
+        ByteBuffer buf = ByteBuffer.allocateDirect(byteCount).order(ByteOrder.nativeOrder());
+        if (fps != null && fps.length > 0) {
+            for (int fp : fps) {
+                buf.putInt(fp);
+            }
+        } else {
+            buf.putInt(0);  // 4-byte placeholder
+        }
+        buf.flip();
+
+        glBindBuffer(GL_SHADER_STORAGE_BUFFER, farPointerSSBO.getOpenGLId());
+        glBufferData(GL_SHADER_STORAGE_BUFFER, buf, GL_STATIC_DRAW);
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, FAR_POINTER_BUFFER_BINDING, farPointerSSBO.getOpenGLId());
+
+        log.debug("Uploaded {} far-pointer entries ({} bytes) to SSBO binding {}",
+                  fps != null ? fps.length : 0, byteCount, FAR_POINTER_BUFFER_BINDING);
+    }
+
+    /**
      * Render a frame using the ESVT data
      *
      * @param esvtMemory GPU memory containing ESVT node data
@@ -162,6 +215,18 @@ public final class ESVTComputeRenderer {
 
         // Bind ESVT data
         esvtMemory.bindToShader(ESVT_BUFFER_BINDING);
+
+        // Bind far-pointer SSBO (binding 7) — if not yet uploaded, bind a minimal placeholder
+        // so the shader binding slot is always valid regardless of whether uploadData() was called.
+        if (farPointerSSBO == null) {
+            farPointerSSBO = resourceManager.createStorageBuffer(Integer.BYTES, "ESVTFarPointerSSBOPlaceholder");
+            ByteBuffer placeholder = ByteBuffer.allocateDirect(Integer.BYTES).order(ByteOrder.nativeOrder());
+            placeholder.putInt(0);
+            placeholder.flip();
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, farPointerSSBO.getOpenGLId());
+            glBufferData(GL_SHADER_STORAGE_BUFFER, placeholder, GL_STATIC_DRAW);
+        }
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, FAR_POINTER_BUFFER_BINDING, farPointerSSBO.getOpenGLId());
 
         // Update camera uniforms
         updateCameraUniforms(viewMatrix, projMatrix, objectToWorld, tetreeToObject);
@@ -248,6 +313,17 @@ public final class ESVTComputeRenderer {
 
         // Bind ESVT data
         esvtMemory.bindToShader(ESVT_BUFFER_BINDING);
+
+        // Bind far-pointer SSBO (binding 7) — always required by the shader
+        if (farPointerSSBO == null) {
+            farPointerSSBO = resourceManager.createStorageBuffer(Integer.BYTES, "ESVTFarPointerSSBOPlaceholder");
+            ByteBuffer placeholder = ByteBuffer.allocateDirect(Integer.BYTES).order(ByteOrder.nativeOrder());
+            placeholder.putInt(0);
+            placeholder.flip();
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, farPointerSSBO.getOpenGLId());
+            glBufferData(GL_SHADER_STORAGE_BUFFER, placeholder, GL_STATIC_DRAW);
+        }
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, FAR_POINTER_BUFFER_BINDING, farPointerSSBO.getOpenGLId());
 
         // Update camera uniforms
         updateCameraUniforms(viewMatrix, projMatrix, objectToWorld, tetreeToObject);
@@ -488,6 +564,11 @@ public final class ESVTComputeRenderer {
             if (coarseSampler != 0) {
                 glDeleteSamplers(coarseSampler);
                 coarseSampler = 0;
+            }
+
+            if (farPointerSSBO != null) {
+                farPointerSSBO.close();
+                farPointerSSBO = null;
             }
         } catch (Exception e) {
             log.error("Error disposing GPU resources", e);

--- a/render/src/main/java/com/hellblazer/luciferase/esvt/gpu/ESVTOpenCLRenderer.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvt/gpu/ESVTOpenCLRenderer.java
@@ -25,6 +25,7 @@ import com.hellblazer.luciferase.sparse.gpu.AbstractOpenCLRenderer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 
 import static org.lwjgl.opencl.CL10.*;
@@ -56,6 +57,7 @@ public final class ESVTOpenCLRenderer extends AbstractOpenCLRenderer<ESVTNodeUni
 
     // Raw cl_mem handles for ByteBuffer upload
     private long clNodeBuffer;
+    private long clFarPointerBuffer;
     private long clContourBuffer;
 
     // Additional GPU buffers for ESVT
@@ -145,25 +147,55 @@ public final class ESVTOpenCLRenderer extends AbstractOpenCLRenderer<ESVTNodeUni
         sceneMinBuffer.upload(new float[]{0.0f, 0.0f, 0.0f, 0.0f});
         sceneMaxBuffer.upload(new float[]{1.0f, 1.0f, 1.0f, 0.0f});
 
-        // Initialize empty node/contour buffers (will be replaced when data is uploaded)
+        // Initialize empty node/contour/far-pointer buffers (will be replaced when data is uploaded)
         clNodeBuffer = 0;
+        clFarPointerBuffer = 0;
         clContourBuffer = 0;
     }
 
     @Override
     protected void uploadDataBuffers(ESVTData data) {
-        // Release old node buffer if exists
+        // Release old node buffer if exists (G4: include untrackRawHandle to prevent double-free on dispose)
         if (clNodeBuffer != 0) {
             clReleaseMemObject(clNodeBuffer);
+            untrackRawHandle(clNodeBuffer);
+            clNodeBuffer = 0;
         }
 
         // Upload node data using raw ByteBuffer
         var nodeData = data.nodesToByteBuffer();
         clNodeBuffer = createRawBuffer(nodeData, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR);
 
-        // Upload contour data if present
+        // Upload far-pointer table (arg slot always bound; may be a 4-byte stub when empty)
+        if (clFarPointerBuffer != 0) {
+            clReleaseMemObject(clFarPointerBuffer);
+            untrackRawHandle(clFarPointerBuffer);
+            clFarPointerBuffer = 0;
+        }
+        var farPointers = data.farPointers();
+        if (farPointers != null && farPointers.length > 0) {
+            log.debug("Uploading {} far pointer(s) to GPU", farPointers.length);
+            var fpData = memAlloc(farPointers.length * Integer.BYTES);
+            fpData.order(ByteOrder.nativeOrder());
+            for (int fp : farPointers) {
+                fpData.putInt(fp);
+            }
+            fpData.flip();
+            try {
+                clFarPointerBuffer = createRawBuffer(fpData, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR);
+            } finally {
+                memFree(fpData);
+            }
+        } else {
+            // No far pointers — supply a minimal placeholder buffer so the kernel arg slot is always bound
+            clFarPointerBuffer = createEmptyRawBuffer(Integer.BYTES, CL_MEM_READ_ONLY);
+        }
+
+        // Upload contour data if present (G4: include untrackRawHandle to prevent double-free on dispose)
         if (clContourBuffer != 0) {
             clReleaseMemObject(clContourBuffer);
+            untrackRawHandle(clContourBuffer);
+            clContourBuffer = 0;
         }
 
         if (data.hasContours()) {
@@ -176,25 +208,31 @@ public final class ESVTOpenCLRenderer extends AbstractOpenCLRenderer<ESVTNodeUni
             clContourBuffer = createEmptyRawBuffer(4, CL_MEM_READ_ONLY);
         }
 
-        log.debug("Uploaded ESVT data: {} nodes, {} contours", nodeCount, contourCount);
+        log.debug("Uploaded ESVT data: {} nodes, {} far pointers, {} contours",
+                  data.nodeCount(), data.farPointerCount(), contourCount);
     }
 
     @Override
     protected void setKernelArguments() {
-        // Set node buffer (arg 1)
+        // arg 0: rays — set by base class (AbstractOpenCLRenderer.executeKernel)
+
+        // arg 1: node buffer
         setRawBufferArg(1, clNodeBuffer);
 
-        // Set contour buffer (arg 2)
-        setRawBufferArg(2, clContourBuffer);
+        // arg 2: far-pointer indirection table (always bound; may be a 4-byte stub when no far pointers)
+        setRawBufferArg(2, clFarPointerBuffer);
 
-        // Set result buffer (arg 3)
-        kernel.setBufferArg(3, resultBuffer, ComputeKernel.BufferAccess.WRITE);
+        // arg 3: contour buffer
+        setRawBufferArg(3, clContourBuffer);
 
-        // Set normal buffer (arg 4)
-        kernel.setBufferArg(4, normalBuffer, ComputeKernel.BufferAccess.WRITE);
+        // arg 4: result buffer (write)
+        kernel.setBufferArg(4, resultBuffer, ComputeKernel.BufferAccess.WRITE);
 
-        // Set maxDepth (arg 5)
-        kernel.setIntArg(5, maxDepth);
+        // arg 5: normal buffer (write)
+        kernel.setBufferArg(5, normalBuffer, ComputeKernel.BufferAccess.WRITE);
+
+        // arg 6: maxDepth
+        kernel.setIntArg(6, maxDepth);
 
         // Note: sceneMin/sceneMax removed from kernel - not used, was causing type mismatch
     }
@@ -249,10 +287,17 @@ public final class ESVTOpenCLRenderer extends AbstractOpenCLRenderer<ESVTNodeUni
         // Release raw OpenCL buffers
         if (clNodeBuffer != 0) {
             clReleaseMemObject(clNodeBuffer);
+            untrackRawHandle(clNodeBuffer);
             clNodeBuffer = 0;
+        }
+        if (clFarPointerBuffer != 0) {
+            clReleaseMemObject(clFarPointerBuffer);
+            untrackRawHandle(clFarPointerBuffer);
+            clFarPointerBuffer = 0;
         }
         if (clContourBuffer != 0) {
             clReleaseMemObject(clContourBuffer);
+            untrackRawHandle(clContourBuffer);
             clContourBuffer = 0;
         }
 

--- a/render/src/main/resources/kernels/esvt_ray_traversal.cl
+++ b/render/src/main/resources/kernels/esvt_ray_traversal.cl
@@ -49,7 +49,7 @@ inline float getRayTmaxFromBuffer(__global const float* rays, int rayIdx) {
 
 // ESVT Node Structure - 8 bytes (matches ESVTNodeUnified.java)
 typedef struct {
-    uint childDescriptor;   // [valid(1)|childptr(14)|far(1)|childmask(8)|leafmask(8)]
+    uint childDescriptor;   // [childptr(15)|far(1)|childmask(8)|leafmask(8)]
     uint contourDescriptor; // [contour_ptr(20)|normals(4)|contour(4)|type(3)|pad(1)]
 } ESVTNode;
 
@@ -177,20 +177,20 @@ bool isChildLeaf(ESVTNode node, int childIdx) {
 }
 
 uint getChildPtr(ESVTNode node) {
-    return (node.childDescriptor >> 17) & 0x3FFFu;
+    return (node.childDescriptor >> 17) & 0x7FFFu;
 }
 
 bool isFar(ESVTNode node) {
     return (node.childDescriptor & 0x10000u) != 0;
 }
 
-uint getChildIndex(__global const ESVTNode* nodes, ESVTNode node, int childIdx, uint parentIdx) {
+uint getChildIndex(__global const int* farPointers, ESVTNode node, int childIdx, uint parentIdx) {
     uint childPtr = getChildPtr(node);
     uint mask = getChildMask(node);
     uint offset = popcount(mask & ((1u << childIdx) - 1u));
 
     if (isFar(node)) {
-        childPtr = nodes[parentIdx + childPtr].childDescriptor;
+        childPtr = (uint) farPointers[childPtr];
     }
 
     return parentIdx + childPtr + offset;
@@ -618,12 +618,13 @@ void getChildVertices(int parentType, int childIdx, float scale,
 // ============================================================================
 
 __kernel void traverseESVT(
-    __global const float* rays,     // Raw float buffer, 8 floats per ray
-    __global const ESVTNode* nodes,
-    __global const int* contours,
-    __global float4* hitResults,    // xyz = hit point, w = distance
-    __global float4* hitNormals,    // xyz = normal, w = 1 if hit
-    const uint maxDepth)
+    __global const float* rays,       // Raw float buffer, 8 floats per ray (arg 0)
+    __global const ESVTNode* nodes,   // Node array (arg 1)
+    __global const int* farPointers,  // Far-pointer indirection table (arg 2; may be a 4-byte stub)
+    __global const int* contours,     // Contour data (arg 3)
+    __global float4* hitResults,      // xyz = hit point, w = distance (arg 4)
+    __global float4* hitNormals,      // xyz = normal, w = 1 if hit (arg 5)
+    const uint maxDepth)              // (arg 6)
     // Note: sceneMin/sceneMax removed - root tetrahedron uses SIMPLEX_STANDARD
 {
     int gid = get_global_id(0);
@@ -804,7 +805,7 @@ __kernel void traverseESVT(
 
                 // Check if leaf
                 if (isChildLeaf(node, childIdx)) {
-                    uint childNodeIdx = getChildIndex(nodes, node, childIdx, parentIdx);
+                    uint childNodeIdx = getChildIndex(farPointers, node, childIdx, parentIdx);
                     ESVTNode childNode = nodes[childNodeIdx];
                     float childScale = scaleExp2 * 0.5f;
 
@@ -865,7 +866,7 @@ __kernel void traverseESVT(
                 stack[scale].v3 = pv3;
 
                 // Update state for child - child vertices become new parent vertices
-                parentIdx = getChildIndex(nodes, node, childIdx, parentIdx);
+                parentIdx = getChildIndex(farPointers, node, childIdx, parentIdx);
                 // childIdx is Morton index; convert to Bey index for type lookup
                 int beyIdx = INDEX_TO_BEY_NUMBER[parentType * 8 + childIdx];
                 parentType = PARENT_TYPE_TO_CHILD_TYPE[parentType * 8 + beyIdx];

--- a/render/src/main/resources/shaders/raycast_esvt.comp
+++ b/render/src/main/resources/shaders/raycast_esvt.comp
@@ -100,7 +100,7 @@ shared int stack_type[64 * CAST_STACK_DEPTH];
 shared int stack_entryFace[64 * CAST_STACK_DEPTH];
 
 // SSBO for ESVT nodes (8 bytes per node = 2 x uint)
-// childDescriptor: [valid(1)|childptr(14)|far(1)|childmask(8)|leafmask(8)]
+// childDescriptor: [childptr(15)|far(1)|childmask(8)|leafmask(8)]
 // contourDescriptor: [contour_ptr(20)|normals(4)|contour(4)|type(3)|pad(1)]
 layout(std430, binding = 0) readonly buffer ESVTBuffer {
     uvec2 nodes[];  // First uint = childDescriptor, Second uint = contourDescriptor
@@ -111,6 +111,15 @@ layout(std430, binding = 0) readonly buffer ESVTBuffer {
 layout(std430, binding = 6) readonly buffer ContourBuffer {
     int contours[];  // Encoded contour values
 } contourData;
+
+// SSBO for far-pointer table (binding 7)
+// farPointers[i] is the RELATIVE offset stored for far-flagged child pointers.
+// When a node has isFar()==true, its childPtr field is an index into this table,
+// and the actual relative child offset is farPointers[childPtr].
+// When no far pointers are present a minimal 1-element placeholder buffer is bound.
+layout(std430, binding = 7) readonly buffer FarPointerBuffer {
+    int farPointers[];
+};
 
 // Output image
 layout(rgba8, binding = 1) uniform image2D outputImage;
@@ -220,9 +229,9 @@ bool isChildLeaf(uvec2 node, int childIdx) {
     return (getLeafMask(node) & (1u << childIdx)) != 0u;
 }
 
-// Get child pointer (bits 17-30)
+// Get child pointer (bits 17-31, 15-bit field)
 uint getChildPtr(uvec2 node) {
-    return (node.x >> 17) & 0x3FFFu;
+    return (node.x >> 17) & 0x7FFFu;
 }
 
 // Check if far pointer (bit 16)
@@ -230,14 +239,16 @@ bool isFar(uvec2 node) {
     return (node.x & 0x10000u) != 0u;
 }
 
-// Get sparse child index using popcount
+// Get sparse child index using popcount.
+// When the far flag is set, childPtr is an index into farPointers[] which holds
+// the actual RELATIVE offset — do NOT perform an in-band nodes[] read here.
 uint getChildIndex(uvec2 node, int childIdx, uint parentIdx) {
     uint childPtr = getChildPtr(node);
     uint mask = getChildMask(node);
     uint offset = bitCount(mask & ((1u << childIdx) - 1u));
 
     if (isFar(node)) {
-        childPtr = esvt.nodes[parentIdx + childPtr].x;
+        childPtr = uint(farPointers[childPtr]);
     }
 
     return parentIdx + childPtr + offset;

--- a/render/src/test/java/com/hellblazer/luciferase/esvt/gpu/ESVTGPUCPUParityTest.java
+++ b/render/src/test/java/com/hellblazer/luciferase/esvt/gpu/ESVTGPUCPUParityTest.java
@@ -220,13 +220,10 @@ class ESVTGPUCPUParityTest {
                 float gpuHitFlag = normalBuffer.get(i * 4 + 3);
                 boolean gpuHit = gpuHitFlag > 0.5f;
 
-                // CPU traversal
-                ESVTResult cpuResult;
-                if (contours != null) {
-                    cpuResult = cpuTraversal.castRay(ray, nodes, contours, farPointers, 0);
-                } else {
-                    cpuResult = cpuTraversal.castRay(ray, nodes, 0);
-                }
+                // CPU traversal — always pass farPointers; the 5-arg overload tolerates null
+                // contours, and the short overload would silently drop the far-pointer table
+                // (throwing or going vacuous on any far node).
+                var cpuResult = cpuTraversal.castRay(ray, nodes, contours, farPointers, 0);
 
                 // Compare results
                 boolean matches = compareResults(gpuHit, gpuX, gpuY, gpuZ, gpuDist,
@@ -462,6 +459,136 @@ class ESVTGPUCPUParityTest {
         System.out.println("Inserted " + inserted + " entities for sphere at depth " + depth);
 
         return builder.build(tetree);
+    }
+
+    /**
+     * GPU/CPU parity test for a far-pointer model tree (Luciferase-8putk).
+     *
+     * <p>Builds an ESVTData with a far node at a NON-zero index (index 2, children at index 5)
+     * so that relative != absolute — the structural case root-only trees hide.
+     * Renders a 64×64 frame on GPU and compares against CPU ESVTTraversal, requiring
+     * ≥ 95% ray agreement with tolerance 1e-4f.
+     */
+    @Test
+    @DisplayName("GPU/CPU parity - far-pointer model (far node at non-zero index)")
+    void testFarPointerModelParity() {
+        Assumptions.assumeTrue(openclAvailable, "OpenCL not available");
+
+        var farData = buildFarPointerParityData();
+        System.out.println("Far-pointer parity data: " + farData.nodeCount() + " nodes, "
+                           + farData.farPointerCount() + " far pointer(s)");
+
+        var cameraPos = new Vector3f(2.0f, 2.0f, 2.0f);
+        var lookAt = new Vector3f(0.5f, 0.5f, 0.5f);
+        float fov = 60.0f;
+
+        var result = runParityTestWithData(farData, cameraPos, lookAt, fov);
+
+        System.out.println("\n=== Far-Pointer Model GPU/CPU Parity Test ===");
+        result.printReport();
+
+        assertTrue(result.accuracy >= ACCURACY_THRESHOLD,
+                String.format("Far-pointer model accuracy %.2f%% below threshold %.2f%%",
+                        result.accuracy * 100, ACCURACY_THRESHOLD * 100));
+    }
+
+    /**
+     * Build ESVTData with a far node at index 2 (children at index 5, relative offset 3).
+     * This tests the N>0 case where relative != absolute.
+     */
+    private ESVTData buildFarPointerParityData() {
+        // 6-node tree:
+        //   0: root (near, childMask=0x01, childPtr=2 => child at index 2)
+        //   1: filler leaf
+        //   2: far interior node (far=true, childMask=0x01, childPtr=0 => farPointers[0]=3)
+        //   3: filler leaf
+        //   4: filler leaf
+        //   5: leaf child of node 2
+        var nodes = new com.hellblazer.luciferase.esvt.core.ESVTNodeUnified[6];
+
+        nodes[0] = new com.hellblazer.luciferase.esvt.core.ESVTNodeUnified();
+        nodes[0].setChildMask(0x01);
+        nodes[0].setChildPtr(2);
+
+        nodes[1] = new com.hellblazer.luciferase.esvt.core.ESVTNodeUnified();
+        nodes[1].setLeafMask(0xFF);
+
+        nodes[2] = new com.hellblazer.luciferase.esvt.core.ESVTNodeUnified();
+        nodes[2].setChildMask(0x01);
+        nodes[2].setFar(true);
+        nodes[2].setChildPtr(0); // farPointers[0] = 3
+
+        nodes[3] = new com.hellblazer.luciferase.esvt.core.ESVTNodeUnified();
+        nodes[3].setLeafMask(0xFF);
+
+        nodes[4] = new com.hellblazer.luciferase.esvt.core.ESVTNodeUnified();
+        nodes[4].setLeafMask(0xFF);
+
+        nodes[5] = new com.hellblazer.luciferase.esvt.core.ESVTNodeUnified();
+        nodes[5].setLeafMask(0xFF);
+
+        return ESVTData.builder()
+                       .nodes(nodes)
+                       .farPointers(new int[]{ 3 }) // relative offset: 5 - 2 = 3
+                       .rootType(0)
+                       .maxDepth(3)
+                       .leafCount(4)
+                       .internalCount(2)
+                       .build();
+    }
+
+    /**
+     * Run a parity test with explicitly supplied ESVTData.
+     */
+    private ParityResult runParityTestWithData(ESVTData data, Vector3f cameraPos, Vector3f lookAt, float fov) {
+        var result = new ParityResult();
+
+        try (var renderer = new ESVTOpenCLRenderer(FRAME_SIZE, FRAME_SIZE)) {
+            renderer.initialize();
+            renderer.uploadData(data);
+
+            renderer.renderFrame(cameraPos, lookAt, fov);
+
+            var resultBuffer = renderer.getResultBufferForTesting();
+            var normalBuffer = renderer.getNormalBufferForTesting();
+
+            var rays = generateRays(cameraPos, lookAt, fov, FRAME_SIZE, FRAME_SIZE);
+            var cpuTraversal = new ESVTTraversal();
+            var nodes = data.nodes();
+            // Always pass both contours and farPointers via the 5-arg overload so that far nodes
+            // (isFar()==true) are resolved correctly regardless of whether contours are present.
+            // The 5-arg castRay tolerates null contours (delegates to the no-contour path internally).
+            var contours = data.hasContours() ? data.contours() : null;
+            var farPointers = data.hasFarPointers() ? data.farPointers() : null;
+
+            result.totalRays = rays.size();
+
+            for (int i = 0; i < rays.size(); i++) {
+                var ray = rays.get(i);
+
+                float gpuX = resultBuffer.get(i * 4);
+                float gpuY = resultBuffer.get(i * 4 + 1);
+                float gpuZ = resultBuffer.get(i * 4 + 2);
+                float gpuDist = resultBuffer.get(i * 4 + 3);
+                float gpuHitFlag = normalBuffer.get(i * 4 + 3);
+                boolean gpuHit = gpuHitFlag > 0.5f;
+
+                // Always use the 5-arg overload: if this is a far-pointer tree (farPointers != null)
+                // the 3-arg shortcut would drop farPointers and throw IllegalStateException when
+                // any ray reaches a far node (isFar()==true with null farPointer table).
+                ESVTResult cpuResult = cpuTraversal.castRay(ray, nodes, contours, farPointers, 0);
+
+                boolean matches = compareResults(gpuHit, gpuX, gpuY, gpuZ, gpuDist,
+                        cpuResult, result, i, ray);
+                if (matches) {
+                    result.matches++;
+                }
+            }
+
+            result.accuracy = (double) result.matches / result.totalRays;
+        }
+
+        return result;
     }
 
     /**

--- a/render/src/test/java/com/hellblazer/luciferase/esvt/gpu/ESVTOpenCLRendererFarPointerTest.java
+++ b/render/src/test/java/com/hellblazer/luciferase/esvt/gpu/ESVTOpenCLRendererFarPointerTest.java
@@ -1,0 +1,431 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.esvt.gpu;
+
+import com.hellblazer.luciferase.esvt.core.ESVTData;
+import com.hellblazer.luciferase.esvt.core.ESVTNodeUnified;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for ESVTOpenCLRenderer far-pointer wiring (Luciferase-8putk).
+ *
+ * <p>Far pointers must be wired end-to-end:
+ * <ul>
+ *   <li>{@code esvt_ray_traversal.cl} must receive a {@code farPointers[]} buffer (arg 2)
+ *       and resolve far-flagged childPtr via indirection table, NOT in-band node read.</li>
+ *   <li>{@link ESVTOpenCLRenderer#uploadDataBuffers} must upload the far-pointer table as
+ *       a separate {@code cl_mem} buffer alongside the node and contour buffers.</li>
+ *   <li>When no far pointers are present a minimal 4-byte placeholder buffer is still
+ *       uploaded so the kernel arg slot is always bound.</li>
+ * </ul>
+ *
+ * <p>All headless tests are CPU-side (no GPU/OpenCL required): they exercise the
+ * byte-buffer layout and CPU resolution path.  The GPU render test is gated behind
+ * {@code RUN_GPU_TESTS=true}.
+ */
+class ESVTOpenCLRendererFarPointerTest {
+
+    // -------------------------------------------------------------------------
+    // Headless CPU-side correctness tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * A near-only tree (no far pointers) must NOT throw.
+     */
+    @Test
+    void nearOnlyTree_doesNotThrow() {
+        var data = buildNearOnlyTree();
+        assertDoesNotThrow(() -> {
+            // ESVTData.nodesToByteBuffer() exercises the serialisation path used by the renderer
+            var buf = data.nodesToByteBuffer();
+            assertNotNull(buf, "ByteBuffer must be non-null for near-only tree");
+        }, "Near-only tree must not throw");
+    }
+
+    /**
+     * A tree with far pointers must also succeed.
+     */
+    @Test
+    void farPointerTree_doesNotThrow() {
+        var data = buildFarPointerTree();
+        assertDoesNotThrow(() -> {
+            var buf = data.nodesToByteBuffer();
+            assertNotNull(buf, "ByteBuffer must be non-null for far-pointer tree");
+        }, "Far-pointer tree must not throw");
+    }
+
+    /**
+     * Empty far-pointer array (length 0) must NOT throw.
+     */
+    @Test
+    void emptyFarPointerArray_doesNotThrow() {
+        var data = buildNearOnlyTree();
+        // Rebuild with explicit empty far pointer array
+        var dataWithEmpty = ESVTData.builder(data).farPointers(new int[0]).build();
+        assertDoesNotThrow(() -> dataWithEmpty.nodesToByteBuffer(),
+                "Empty far-pointer array must not throw");
+    }
+
+    /**
+     * Verify byte-buffer layout for a near-only tree:
+     * 2 nodes × 8 bytes each = 16 bytes; root childPtr at bits 17-31 (15-bit field,
+     * mask 0x7FFF), far flag at bit 16 = 0x10000.
+     */
+    @Test
+    void nearOnlyTree_byteBufferLayout() {
+        var data = buildNearOnlyTree();
+        var buf = data.nodesToByteBuffer();
+        assertNotNull(buf);
+
+        // 2 nodes × 8 bytes (childDescriptor + contourDescriptor)
+        assertEquals(2 * ESVTNodeUnified.SIZE_BYTES, buf.limit(),
+                "Near-only tree with 2 nodes should produce " + (2 * ESVTNodeUnified.SIZE_BYTES) + " bytes");
+
+        // Root node (index 0): childPtr stored in bits 17-31 (15 bits), mask 0x7FFF
+        int rootDescriptor = buf.getInt(0);
+        assertEquals(0, rootDescriptor & 0x10000,
+                "Root node must not have far flag (bit 16 = 0x10000) set");
+        assertEquals(1, (rootDescriptor >> 17) & 0x7FFF,
+                "Root childPtr (bits 17-31, mask 0x7FFF) must be 1");
+    }
+
+    /**
+     * Verify the far flag (bit 16 = 0x10000) is set in the byte buffer for a far-pointer tree.
+     */
+    @Test
+    void farPointerTree_byteBufferHasFarFlagSet() {
+        var data = buildFarPointerTree();
+        var buf = data.nodesToByteBuffer();
+        assertNotNull(buf);
+
+        // Root node (index 0): far flag (bit 16 = 0x10000) must be set
+        int rootDescriptor = buf.getInt(0);
+        assertNotEquals(0, rootDescriptor & 0x10000,
+                "Root descriptor must have far flag (bit 16 = 0x10000) set for far-pointer tree");
+    }
+
+    /**
+     * CRITICAL: far node at non-zero index — catches the relative==absolute coincidence
+     * that root-only tests hide.
+     *
+     * <p>Layout:
+     * <ul>
+     *   <li>index 0 — root (near, childPtr = relative 2, children start at index 2)</li>
+     *   <li>index 1 — filler leaf</li>
+     *   <li>index 2 — far interior node; children start at index 5 → relative = 5 - 2 = 3;
+     *       childPtr = 0 (index into farPointers[]); farPointers[0] = 3</li>
+     *   <li>index 3, 4 — filler leaves</li>
+     *   <li>index 5 — first child of the far node</li>
+     * </ul>
+     *
+     * <p>Verifies:
+     * <ol>
+     *   <li>farPointers[0] stores the RELATIVE offset (3, not the absolute index 5).</li>
+     *   <li>{@link ESVTNodeUnified#getChildIndex(int, int, int[])} resolves to 5:
+     *       currentNodeIdx(2) + relativeOffset(3) + popcount(0) = 5.</li>
+     * </ol>
+     */
+    @Test
+    void farNodeAtNonZeroIndex_cpuResolutionCorrect() {
+        var nodes = new ESVTNodeUnified[6];
+
+        // Root: near, childMask=0x01, childPtr=2 (relative: first child at index 2)
+        nodes[0] = new ESVTNodeUnified();
+        nodes[0].setChildMask(0x01);
+        nodes[0].setChildPtr(2);
+
+        // Index 1: filler leaf
+        nodes[1] = new ESVTNodeUnified();
+        nodes[1].setLeafMask(0xFF);
+
+        // Index 2: far interior node — childMask=0x01 (one child), far=true, childPtr=0 (farPointers[0])
+        // farPointers[0] = 3 (relative: firstChildIndex=5, currentIndex=2, diff=3)
+        nodes[2] = new ESVTNodeUnified();
+        nodes[2].setChildMask(0x01);
+        nodes[2].setFar(true);
+        nodes[2].setChildPtr(0);
+
+        // Indices 3, 4: filler leaves
+        nodes[3] = new ESVTNodeUnified();
+        nodes[3].setLeafMask(0xFF);
+        nodes[4] = new ESVTNodeUnified();
+        nodes[4].setLeafMask(0xFF);
+
+        // Index 5: first child of the far node
+        nodes[5] = new ESVTNodeUnified();
+        nodes[5].setLeafMask(0xFF);
+
+        int relativeOffset = 5 - 2; // = 3
+        var data = ESVTData.builder()
+                           .nodes(nodes)
+                           .farPointers(new int[]{ relativeOffset })
+                           .rootType(0)
+                           .maxDepth(3)
+                           .leafCount(4)
+                           .internalCount(2)
+                           .build();
+
+        // Verify far-pointer encoding: must be RELATIVE, not absolute
+        int[] fp = data.farPointers();
+        assertNotNull(fp, "farPointers must be set");
+        assertEquals(1, fp.length, "Exactly one far pointer expected");
+        assertEquals(3, fp[0],
+                "farPointers[0] must store the RELATIVE offset (firstChildIndex - currentIndex = 5 - 2 = 3)");
+
+        // Verify CPU getChildIndex for the far node at index 2
+        // childMask=0x01, childIdx=0, popcount = 0
+        // Expected: currentNodeIdx(2) + relativeOffset(3) + 0 = 5
+        ESVTNodeUnified farNode = data.nodes()[2];
+        assertTrue(farNode.isFar(), "Node at index 2 must have isFar()=true");
+        int resolvedIndex = farNode.getChildIndex(0, 2, fp);
+        assertEquals(5, resolvedIndex,
+                "CPU getChildIndex for far node at index 2, childIdx=0 must resolve to 5 "
+                + "(currentNodeIdx=2 + relativeOffset=3 + popcount=0)");
+    }
+
+    /**
+     * Kernel source MUST contain the exact {@code getChildIndex} signature with
+     * {@code __global const int* farPointers} as its first parameter. Also asserts:
+     * <ul>
+     *   <li>Mask {@code 0x7FFF} (15-bit childPtr) is present — NOT {@code 0x3FFF} (14-bit).</li>
+     *   <li>In-band node read for far case ({@code nodes[parentIdx + childPtr].childDescriptor})
+     *       is ABSENT — the defect this fix removes.</li>
+     * </ul>
+     *
+     * <p>The signature substring check is exact so comments cannot produce false positives.
+     */
+    @Test
+    void kernelSource_containsFarPointersArg() {
+        var source = ESVTKernels.getOpenCLKernel();
+        assertNotNull(source, "Kernel source must not be null");
+
+        // farPointers buffer must appear in the traverseESVT signature
+        assertTrue(source.contains("__global const int* farPointers"),
+                "Kernel traverseESVT must declare '__global const int* farPointers' parameter");
+
+        // getChildIndex must accept farPointers: check the exact declaration to avoid comment hits
+        assertTrue(source.contains("getChildIndex(__global const int* farPointers"),
+                "getChildIndex must declare exact signature 'getChildIndex(__global const int* farPointers ...'");
+
+        // 15-bit mask 0x7FFF must be present (replaces old 14-bit 0x3FFF)
+        assertTrue(source.contains("0x7FFF"),
+                "Kernel must use 15-bit childPtr mask 0x7FFF (not 14-bit 0x3FFF)");
+
+        // The old in-band defect must be ABSENT:
+        //   nodes[parentIdx + childPtr].childDescriptor  — the wrong far resolution
+        assertFalse(source.contains("nodes[parentIdx + childPtr].childDescriptor"),
+                "Kernel must NOT use in-band nodes[] read for far resolution "
+                + "(old defect: nodes[parentIdx + childPtr].childDescriptor)");
+    }
+
+    /**
+     * GLSL compute shader source must carry the same far-pointer fixes as the OpenCL path:
+     * <ul>
+     *   <li>Contains {@code farPointers} — the binding-7 SSBO identifier.</li>
+     *   <li>Contains {@code 0x7FFFu} — 15-bit childPtr mask (replaces old 14-bit {@code 0x3FFFu}).</li>
+     *   <li>Does NOT contain {@code 0x3FFFu} — old, wrong mask.</li>
+     *   <li>Does NOT contain {@code esvt.nodes[parentIdx + childPtr].x} — the in-band far
+     *       resolution defect that this PR removes.</li>
+     * </ul>
+     *
+     * <p>Headless: no GL context required — reads shader source string directly from
+     * {@link ESVTKernels#GLSL_RAY_TRAVERSAL}.
+     */
+    @Test
+    void glslShaderSource_containsFarPointersBinding() {
+        var source = ESVTKernels.GLSL_RAY_TRAVERSAL;
+        assertNotNull(source, "GLSL shader source must not be null");
+        assertFalse(source.isEmpty(), "GLSL shader source must not be empty");
+
+        // Binding 7 SSBO identifier must be present
+        assertTrue(source.contains("farPointers"),
+                "GLSL shader must declare farPointers SSBO (binding 7)");
+
+        // 15-bit mask must be present
+        assertTrue(source.contains("0x7FFFu"),
+                "GLSL shader must use 15-bit childPtr mask 0x7FFFu (not 0x3FFFu)");
+
+        // Old 14-bit mask must be gone
+        assertFalse(source.contains("0x3FFFu"),
+                "GLSL shader must NOT contain the old 14-bit childPtr mask 0x3FFFu");
+
+        // In-band far resolution via nodes[] must be gone
+        assertFalse(source.contains("esvt.nodes[parentIdx + childPtr].x"),
+                "GLSL shader must NOT perform in-band nodes[] read for far resolution "
+                + "(old defect: esvt.nodes[parentIdx + childPtr].x)");
+    }
+
+    // -------------------------------------------------------------------------
+    // GPU render test — gated behind RUN_GPU_TESTS=true
+    // -------------------------------------------------------------------------
+
+    /**
+     * GPU renders a far-pointer tree without throwing.
+     *
+     * <p>Asserts: render completes without exception; output buffer is non-null and
+     * has the expected byte count (64 × 64 × 4 bytes).
+     *
+     * <p>Run with: {@code RUN_GPU_TESTS=true mvn test -pl render
+     * -Dtest=ESVTOpenCLRendererFarPointerTest#farPointerTree_gpuRendersWithoutThrowing}
+     */
+    @Test
+    @EnabledIfEnvironmentVariable(named = "RUN_GPU_TESTS", matches = "true",
+            disabledReason = "GPU test requires a real OpenCL device — set RUN_GPU_TESTS=true")
+    void farPointerTree_gpuRendersWithoutThrowing() {
+        if (!ESVTOpenCLRenderer.isOpenCLAvailable()) {
+            System.out.println("OpenCL not available on this machine — skipping GPU far-pointer render test");
+            return;
+        }
+
+        // Use a non-degenerate 6-node tree (far node at index 2, children at 5, farPointers[0]=3)
+        // to avoid the root-only coincidence where relative == absolute.
+        var data = buildNonDegenerateFarPointerTree();
+
+        try (var renderer = new ESVTOpenCLRenderer(64, 64)) {
+            renderer.initialize();
+            renderer.uploadData(data);
+
+            var cameraPos = new javax.vecmath.Vector3f(0.5f, 0.5f, 2.0f);
+            var lookAt = new javax.vecmath.Vector3f(0.5f, 0.5f, 0.5f);
+            assertDoesNotThrow(() -> renderer.renderFrame(cameraPos, lookAt, 60.0f),
+                    "GPU traversal of far-pointer tree must not throw");
+
+            var outputImage = renderer.getOutputImage();
+            assertNotNull(outputImage, "Output image must be non-null after rendering");
+            assertEquals(64 * 64 * 4, outputImage.limit(),
+                    "Output image must be 64×64 RGBA = 16384 bytes");
+
+            System.out.println("GPU far-pointer render test: completed without throwing ("
+                               + data.nodeCount() + " nodes, "
+                               + data.farPointerCount() + " far pointer(s)).");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Minimal 2-node near-only tree: root (childPtr=1, near) + leaf child.
+     */
+    private ESVTData buildNearOnlyTree() {
+        var nodes = new ESVTNodeUnified[2];
+
+        // Root: near, single child at relative offset 1
+        nodes[0] = new ESVTNodeUnified();
+        nodes[0].setChildMask(0x01);
+        nodes[0].setChildPtr(1);
+
+        // Child: leaf
+        nodes[1] = new ESVTNodeUnified();
+        nodes[1].setLeafMask(0x01);
+
+        return ESVTData.builder()
+                       .nodes(nodes)
+                       .rootType(0)
+                       .maxDepth(2)
+                       .leafCount(1)
+                       .internalCount(1)
+                       .build();
+    }
+
+    /**
+     * 2-node far-pointer tree: root (far=true, childPtr=0) + leaf child at index 1.
+     * farPointers[0] = 1 (relative: firstChildIndex=1, currentIndex=0, diff=1).
+     * For root at index 0, relative == absolute — so this is the simple root-only case.
+     */
+    private ESVTData buildFarPointerTree() {
+        var nodes = new ESVTNodeUnified[2];
+
+        // Root: far=true, childMask=0x01, childPtr=0 (index into farPointers[])
+        nodes[0] = new ESVTNodeUnified();
+        nodes[0].setChildMask(0x01);
+        nodes[0].setFar(true);
+        nodes[0].setChildPtr(0);
+
+        // Child: leaf
+        nodes[1] = new ESVTNodeUnified();
+        nodes[1].setLeafMask(0x01);
+
+        return ESVTData.builder()
+                       .nodes(nodes)
+                       .farPointers(new int[]{ 1 })
+                       .rootType(0)
+                       .maxDepth(2)
+                       .leafCount(1)
+                       .internalCount(1)
+                       .build();
+    }
+
+    /**
+     * Non-degenerate 6-node far-pointer tree equivalent to the parity test's layout.
+     *
+     * <ul>
+     *   <li>index 0 — root (near, childPtr = 2, children start at index 2)</li>
+     *   <li>index 1 — filler leaf</li>
+     *   <li>index 2 — far interior node; children start at index 5 → relative = 3;
+     *       childPtr = 0 (farPointers[0] = 3)</li>
+     *   <li>index 3, 4 — filler leaves</li>
+     *   <li>index 5 — first child of the far node (leaf)</li>
+     * </ul>
+     *
+     * This layout ensures relative != absolute (farPointers[0]=3 != 5), catching the
+     * root-only coincidence where relative == absolute that {@link #buildFarPointerTree()}
+     * would silently hide.
+     */
+    private ESVTData buildNonDegenerateFarPointerTree() {
+        var nodes = new ESVTNodeUnified[6];
+
+        // Index 0: root — near, childMask=0x01, children start at index 2 (relative = 2)
+        nodes[0] = new ESVTNodeUnified();
+        nodes[0].setChildMask(0x01);
+        nodes[0].setChildPtr(2);
+
+        // Index 1: filler leaf
+        nodes[1] = new ESVTNodeUnified();
+        nodes[1].setLeafMask(0xFF);
+
+        // Index 2: far interior node — far=true, childPtr=0 (index into farPointers[])
+        // farPointers[0] = 3 (relative: firstChildIndex=5, currentIndex=2, diff=3)
+        nodes[2] = new ESVTNodeUnified();
+        nodes[2].setChildMask(0x01);
+        nodes[2].setFar(true);
+        nodes[2].setChildPtr(0);
+
+        // Index 3, 4: filler leaves
+        nodes[3] = new ESVTNodeUnified();
+        nodes[3].setLeafMask(0xFF);
+        nodes[4] = new ESVTNodeUnified();
+        nodes[4].setLeafMask(0xFF);
+
+        // Index 5: child of the far node (leaf)
+        nodes[5] = new ESVTNodeUnified();
+        nodes[5].setLeafMask(0xFF);
+
+        return ESVTData.builder()
+                       .nodes(nodes)
+                       .farPointers(new int[]{ 3 })   // relative offset: 5 - 2 = 3
+                       .rootType(0)
+                       .maxDepth(3)
+                       .leafCount(4)
+                       .internalCount(2)
+                       .build();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes **Luciferase-8putk** (P1): the ESVT GPU paths disagreed with the CPU far-pointer protocol, silently corrupting geometry for any model whose tree needs far pointers (e.g. the Stanford Bunny: 22 far pointers in a 163k-node tree).

Three protocol defects, all verified against source:

1. **In-band vs table resolution** — `esvt_ray_traversal.cl` resolved far-flagged children by reading `nodes[parentIdx + childPtr].childDescriptor` in-band; the builder and CPU traversal (`ESVTNodeUnified.getChildIndex`, `ESVTData.resolveChildPtr`) store relative offsets in a separate `farPointers[]` table that was never uploaded.
2. **14-bit vs 15-bit childPtr** — the kernel masked `& 0x3FFF`; the Java layout is 15 bits (bits 17–31, `MAX_CHILD_PTR = 32767`), truncating near offsets ≥ 16384.
3. **GLSL path** — `raycast_esvt.comp` / `ESVTComputeRenderer` carried both defects too (surfaced by substantive review; fixed in-PR rather than carved out).

## Changes

- **`esvt_ray_traversal.cl`** — `getChildPtr` mask `0x7FFFu`; `getChildIndex` resolves far via new `__global const int* farPointers` arg (in-band read removed, dead `nodes` param dropped, both call sites updated); `traverseESVT` takes `farPointers` as arg 2; struct comment corrected to `[childptr(15)|far(1)|childmask(8)|leafmask(8)]`. `traverseESVTBeam` untouched (non-traversing stub).
- **`ESVTOpenCLRenderer`** — uploads the far-pointer table (4-byte placeholder when empty so the arg slot is always bound, matching the ESVO convention), renumbers kernel args, releases+untracks on re-upload and dispose. Also fixes a pre-existing `untrackRawHandle` omission on node/contour re-upload (double-free hazard).
- **`raycast_esvt.comp`** — same mask fix; far resolution via `FarPointerBuffer` SSBO (binding 7); struct comment fix.
- **`ESVTComputeRenderer`** — new `uploadData(ESVTData)` uploads the far table; placeholder lazily bound in all render paths; released on dispose.
- **`ESVTGPURenderBridge` (portal)** — forwards far-pointer data to the compute renderer on `uploadData`.

Mirrors the proven ESVO fix (Luciferase-7wzml.222). The build-time far-count guard already exists (`ESVTBuilder`, yhue6).

## Tests

- **New `ESVTOpenCLRendererFarPointerTest`** — headless (CI-safe): byte-buffer encoding round-trip, 15-bit childPtr layout, far flag, CPU resolution of a far node at NON-zero index (catches the relative==absolute coincidence root-only tests hide), OpenCL kernel-source and GLSL shader-source wiring assertions. GPU-gated (`RUN_GPU_TESTS=true`): render of a non-degenerate far tree.
- **`ESVTGPUCPUParityTest`** — new far-pointer parity model (GPU-gated, ≥95% ray agreement); CPU reference now always receives the far table (previous conditional silently dropped it).

## Verification

- TDD: kernel-wiring test observed RED before the fix, GREEN after.
- `mvn test -pl render`: green (221 test classes). Known pre-existing local-only JVM crash in `DynamicKernelSelectionTest` (ESVO, untouched, crashes identically on main) filed as **Luciferase-vkl96**.
- Portal compiles in-reactor; `ESVTRenderPipelineTest` hangs locally in JavaFX toolkit init from non-GUI shells (environmental, pre-existing) — CI portal batch arbitrates.
- Stacked review (bead 8putk.3): code-review-expert **APPROVED**, substantive-critic **PASSED** after three remediation rounds (parity-test CPU branch, GLSL path, assertion robustness, non-degenerate GPU test tree).

Beads: Luciferase-8putk, .1 (tests), .2 (wiring), .3 (stacked review). Follow-up filed: Luciferase-vkl96.