### PR TITLE
fix(render): ESVO GPU near-pointer child resolution, raycast.comp protocol, kernel ray/stack infrastructure (Luciferase-0bn1q)

### DIFF
--- a/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/ComputeShaderRenderer.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/ComputeShaderRenderer.java
@@ -1,5 +1,6 @@
 package com.hellblazer.luciferase.esvo.gpu;
 
+import com.hellblazer.luciferase.esvo.core.ESVOOctreeData;
 import com.hellblazer.luciferase.resource.UnifiedResourceManager;
 import com.hellblazer.luciferase.resource.opengl.BufferResource;
 import com.hellblazer.luciferase.resource.opengl.ShaderProgramResource;
@@ -14,6 +15,8 @@ import javax.vecmath.Matrix4f;
 import javax.vecmath.Vector3f;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 import java.nio.charset.StandardCharsets;
 
@@ -41,10 +44,13 @@ public final class ComputeShaderRenderer {
     public static final int WORKGROUP_SIZE_Y = 8;
     public static final int WORKGROUP_SIZE_Z = 1;
     
-    // Binding points for shader resources
-    public static final int OCTREE_BUFFER_BINDING = 0;
-    public static final int OUTPUT_IMAGE_BINDING = 1;
-    public static final int CAMERA_UBO_BINDING = 2;
+    // Binding points for shader resources (must match raycast.comp layout declarations)
+    public static final int OCTREE_BUFFER_BINDING   = 0;
+    public static final int OUTPUT_IMAGE_BINDING    = 1;
+    public static final int CAMERA_UBO_BINDING      = 2;
+    // FAR_POINTER_BUFFER_BINDING must not conflict with bindings 0-2 above.
+    // Matches the layout(std430, binding = 3) declaration in raycast.comp.
+    public static final int FAR_POINTER_BUFFER_BINDING = 3;
     
     // Resource manager for GPU resources
     private final UnifiedResourceManager resourceManager = UnifiedResourceManager.getInstance();
@@ -54,12 +60,17 @@ public final class ComputeShaderRenderer {
     private ShaderProgramResource raycastProgram;
     private BufferResource cameraUBO;
     private TextureResource outputTexture;
-    
+
+    // Far-pointer SSBO (binding 3). Always bound — contains a 4-byte placeholder
+    // when no far pointers are present so the shader binding slot is always valid.
+    // Mirrors ESVTComputeRenderer.farPointerSSBO (PR #232).
+    private BufferResource farPointerSSBO;
+
     private static final int CAMERA_UBO_SIZE = 64 * 4 + 16 * 4; // 4x4 matrices + vectors
-    
+
     private int frameWidth;
     private int frameHeight;
-    
+
     private boolean initialized = false;
     private boolean disposed = false;
     
@@ -100,11 +111,55 @@ public final class ComputeShaderRenderer {
     }
     
     /**
+     * Upload far-pointer data from an {@link ESVOOctreeData} to the GPU SSBO at binding 3.
+     *
+     * <p>When the data has no far pointers (empty or null array) a minimal 4-byte
+     * placeholder buffer is uploaded so the shader binding slot is always valid —
+     * matching the convention in ESVTComputeRenderer (PR #232).
+     *
+     * <p>Must be called from the OpenGL context thread, after {@link #initialize()}.
+     *
+     * @param data the octree data whose far-pointer table to upload
+     */
+    public void uploadData(ESVOOctreeData data) {
+        if (!initialized) {
+            throw new IllegalStateException("Renderer not initialized");
+        }
+        if (disposed) {
+            throw new IllegalStateException("Renderer has been disposed");
+        }
+
+        int[] fps = data.getFarPointers();
+        int byteCount = (fps != null && fps.length > 0) ? fps.length * Integer.BYTES : Integer.BYTES;
+
+        if (farPointerSSBO == null) {
+            farPointerSSBO = resourceManager.createStorageBuffer(byteCount, "ESVOFarPointerSSBO");
+        }
+
+        ByteBuffer buf = ByteBuffer.allocateDirect(byteCount).order(ByteOrder.nativeOrder());
+        if (fps != null && fps.length > 0) {
+            for (int fp : fps) {
+                buf.putInt(fp);
+            }
+        } else {
+            buf.putInt(0);  // 4-byte placeholder so binding 3 is always valid
+        }
+        buf.flip();
+
+        glBindBuffer(GL_SHADER_STORAGE_BUFFER, farPointerSSBO.getOpenGLId());
+        glBufferData(GL_SHADER_STORAGE_BUFFER, buf, GL_STATIC_DRAW);
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, FAR_POINTER_BUFFER_BINDING, farPointerSSBO.getOpenGLId());
+
+        log.debug("Uploaded {} far-pointer entries ({} bytes) to SSBO binding {}",
+                  fps != null ? fps.length : 0, byteCount, FAR_POINTER_BUFFER_BINDING);
+    }
+
+    /**
      * Render a frame using the octree data
-     * 
+     *
      * @param octreeMemory GPU memory containing octree node data
      * @param viewMatrix Camera view matrix
-     * @param projMatrix Camera projection matrix  
+     * @param projMatrix Camera projection matrix
      * @param objectToWorld Transform from object to world space
      * @param octreeToObject Transform from octree [0,1] to object space
      */
@@ -114,21 +169,33 @@ public final class ComputeShaderRenderer {
         if (!initialized) {
             throw new IllegalStateException("Renderer not initialized");
         }
-        
+
         if (disposed) {
             throw new IllegalStateException("Renderer has been disposed");
         }
-        
+
         // Bind octree data
         octreeMemory.bindToShader(OCTREE_BUFFER_BINDING);
-        
+
+        // Bind far-pointer SSBO (binding 3) — always required by the shader.
+        // If uploadData() was not called, bind a minimal placeholder so the binding slot is valid.
+        if (farPointerSSBO == null) {
+            farPointerSSBO = resourceManager.createStorageBuffer(Integer.BYTES, "ESVOFarPointerSSBOPlaceholder");
+            ByteBuffer placeholder = ByteBuffer.allocateDirect(Integer.BYTES).order(ByteOrder.nativeOrder());
+            placeholder.putInt(0);
+            placeholder.flip();
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, farPointerSSBO.getOpenGLId());
+            glBufferData(GL_SHADER_STORAGE_BUFFER, placeholder, GL_STATIC_DRAW);
+        }
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, FAR_POINTER_BUFFER_BINDING, farPointerSSBO.getOpenGLId());
+
         // Update camera uniforms
         updateCameraUniforms(viewMatrix, projMatrix, objectToWorld, octreeToObject);
-        
+
         // Bind output texture
-        glBindImageTexture(OUTPUT_IMAGE_BINDING, outputTexture.getOpenGLId(), 0, false, 0, 
+        glBindImageTexture(OUTPUT_IMAGE_BINDING, outputTexture.getOpenGLId(), 0, false, 0,
                           GL_WRITE_ONLY, GL_RGBA8);
-        
+
         // Use compute shader program
         glUseProgram(raycastProgram.getOpenGLId());
 
@@ -146,7 +213,7 @@ public final class ComputeShaderRenderer {
 
         // Ensure all image writes are visible to subsequent samplers / readback.
         glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
-        
+
         // Check for errors
         int error = glGetError();
         if (error != GL_NO_ERROR) {
@@ -217,13 +284,18 @@ public final class ComputeShaderRenderer {
                 outputTexture.close();
                 outputTexture = null;
             }
+
+            if (farPointerSSBO != null) {
+                farPointerSSBO.close();
+                farPointerSSBO = null;
+            }
         } catch (Exception e) {
             log.error("Error disposing GPU resources", e);
         }
-        
+
         disposed = true;
         initialized = false;
-        
+
         log.info("Disposed ComputeShaderRenderer");
     }
     

--- a/render/src/main/resources/kernels/esvo_ray_traversal.cl
+++ b/render/src/main/resources/kernels/esvo_ray_traversal.cl
@@ -11,12 +11,35 @@
 #define MAX_TRAVERSAL_DEPTH 16    // Default: Stream A optimized for occupancy
 #endif
 
+// Ray data is read from a raw float buffer, NOT a struct pointer.
+// The host (AbstractOpenCLRenderer) packs rays tightly at 8 floats / 32 bytes
+// (RAY_SIZE_FLOATS = 8); an OpenCL struct with float3 members would have
+// 16-byte member alignment (48-byte stride) and read garbage for gid >= 1.
+// Same pattern as esvt_ray_traversal.cl. Fix: Luciferase-gva5z (Luciferase-0bn1q).
+//
+// Layout per ray (8 floats = 32 bytes):
+//   [0] origin.x, [1] origin.y, [2] origin.z
+//   [3] direction.x, [4] direction.y, [5] direction.z
+//   [6] tmin, [7] tmax
+#define RAY_STRIDE 8
+
 typedef struct {
     float3 origin;
     float3 direction;
     float tMin;
     float tMax;
 } Ray;
+
+// Helper to extract ray data from the raw float buffer
+inline Ray loadRayFromBuffer(__global const float* rays, int rayIdx) {
+    int base = rayIdx * RAY_STRIDE;
+    Ray ray;
+    ray.origin    = (float3)(rays[base + 0], rays[base + 1], rays[base + 2]);
+    ray.direction = (float3)(rays[base + 3], rays[base + 4], rays[base + 5]);
+    ray.tMin = rays[base + 6];
+    ray.tMax = rays[base + 7];
+    return ray;
+}
 
 // UNIFIED ESVO Node Structure - Matches CUDA Reference Implementation
 // This structure MUST be identical to ESVONodeUnified.java
@@ -76,7 +99,7 @@ uint getChildIndex(float3 pos, float3 center) {
 
 // Main ray traversal kernel
 __kernel void traverseOctree(
-    __global const Ray* rays,
+    __global const float* rays,   // tightly packed, RAY_STRIDE floats per ray
     __global const OctreeNode* octree,
     __global const int* farPointers,  // far-pointer indirection table (may be empty)
     __global float4* hitResults,  // xyz = hit point, w = distance
@@ -85,7 +108,7 @@ __kernel void traverseOctree(
     const float3 sceneMax)
 {
     int gid = get_global_id(0);
-    Ray ray = rays[gid];
+    Ray ray = loadRayFromBuffer(rays, gid);
 
     // Initialize result (distance < 0 means no hit)
     hitResults[gid] = (float4)(0.0f, 0.0f, 0.0f, -1.0f);
@@ -99,7 +122,11 @@ __kernel void traverseOctree(
 
     // Stack for traversal - size configurable via MAX_TRAVERSAL_DEPTH
     // Reduced from hardcoded 32 for occupancy optimization (Stream A Phase 5)
-    __local StackEntry stack[MAX_TRAVERSAL_DEPTH];
+    // PRIVATE (per work-item), NOT __local: a __local array here is shared by the
+    // whole workgroup (LOCAL_WORK_SIZE=64) with no per-thread offset — a data race
+    // that corrupts every traversal. Same as esvt_ray_traversal.cl's private stack.
+    // Fix: Luciferase-gva5z (Luciferase-0bn1q).
+    StackEntry stack[MAX_TRAVERSAL_DEPTH];
     int stackPtr = 0;
 
     // Track stack overflow (graceful termination on overflow)
@@ -161,10 +188,9 @@ __kernel void traverseOctree(
         //     is likewise a RELATIVE offset from the current node index.
         //     Correct child index = current.nodeIdx + farPointers[childPtr] + popcount(sparse-offset)
         //
-        // NOTE: The near path below does NOT add current.nodeIdx — this is a pre-existing
-        // bug that is accidentally correct for root-only traversal (index 0) but wrong for
-        // any non-root interior node. Fixing the near path is tracked separately; this
-        // change only corrects the FAR path to match the CPU reference (ESVONodeUnified.getChildIndex).
+        // Both paths add current.nodeIdx to convert the stored relative offset to an absolute
+        // array index — matching the CPU reference ESVONodeUnified.getChildIndex.
+        // Fix: Luciferase-04ubq (Luciferase-0bn1q).
         uint rawChildPtr = (node.childDescriptor >> 17) & 0x3FFF;
         uint childPtr;
         if (node.childDescriptor & FAR_FLAG_BIT) {
@@ -173,8 +199,9 @@ __kernel void traverseOctree(
             // This matches CPU: currentNodeIdx + farPointers[childPtr] + getChildOffset(childIdx)
             childPtr = current.nodeIdx + (uint) farPointers[rawChildPtr];
         } else {
-            // Near case (pre-existing behaviour — see note above).
-            childPtr = rawChildPtr;
+            // Near case: add current.nodeIdx to convert relative offset to absolute index.
+            // This matches CPU: currentNodeIdx + rawChildPtr + getChildOffset(childIdx)
+            childPtr = current.nodeIdx + rawChildPtr;
         }
 
         // Add children to stack in reverse order for correct traversal
@@ -227,7 +254,7 @@ __kernel void traverseOctree(
 
 // Optimized beam traversal for coherent rays
 __kernel void traverseBeam(
-    __global const Ray* rays,
+    __global const float* rays,   // tightly packed, RAY_STRIDE floats per ray
     __global const OctreeNode* octree,
     __global float4* hitResults,
     const uint raysPerBeam,
@@ -237,13 +264,13 @@ __kernel void traverseBeam(
 {
     int beamId = get_global_id(0);
     int firstRay = beamId * raysPerBeam;
-    
+
     // Compute beam frustum from ray bundle
     float3 frustumMin = (float3)(INFINITY);
     float3 frustumMax = (float3)(-INFINITY);
-    
+
     for (uint i = 0; i < raysPerBeam; i++) {
-        Ray ray = rays[firstRay + i];
+        Ray ray = loadRayFromBuffer(rays, firstRay + (int) i);
         float3 nearPoint = ray.origin + ray.direction * ray.tMin;
         float3 farPoint = ray.origin + ray.direction * ray.tMax;
         

--- a/render/src/main/resources/shaders/raycast.comp
+++ b/render/src/main/resources/shaders/raycast.comp
@@ -12,9 +12,9 @@ const float EPSILON = exp2(-23.0);
 shared uint stack_nodes[64 * CAST_STACK_DEPTH];
 shared float stack_tmax[64 * CAST_STACK_DEPTH];
 
-// SSBO for octree nodes (8 bytes per node = 2 x uint)
+// SSBO for octree nodes (8 bytes per node = 1 x uvec2; parentIdx is node-unit indexed)
 layout(std430, binding = 0) readonly buffer OctreeBuffer {
-    uvec2 nodes[];  // First uint = childDescriptor, Second uint = contourDescriptor  
+    uvec2 nodes[];  // First uint = childDescriptor, Second uint = contourDescriptor
 } octree;
 
 // Output image
@@ -31,6 +31,14 @@ layout(std140, binding = 2) uniform CameraData {
     vec3 cameraDir;
     float farPlane;
 } camera;
+
+// Far-pointer side table (binding = 3). Always bound — 4-byte placeholder when no far pointers.
+// Far nodes store childPtr as an index into this table; farPointers[childPtr] is the RELATIVE
+// offset from parentIdx to the children block. Matches CPU: ESVONodeUnified.getChildIndex.
+// Fix: Luciferase-04ubq (Luciferase-0bn1q).
+layout(std430, binding = 3) readonly buffer FarPointerBuffer {
+    int farPointers[];
+};
 
 // Ray structure with screen-space size tracking for LOD
 struct Ray {
@@ -165,11 +173,20 @@ void castRay(inout Ray ray, out vec3 hitPoint, out vec3 hitNormal) {
         uint childDesc = child_descriptor.x;
         uint contourDesc = child_descriptor.y;
         
-        // Extract node data (bit layout must match Java OctreeNode exactly)
-        uint nonLeafMask = childDesc & 0xFFu;
-        uint validMask = (childDesc >> 8) & 0xFFu;
+        // Extract node data (bit layout must match Java ESVONodeUnified exactly):
+        //   bits 0-7  = leafmask  (1 = child IS a leaf)  — Java getLeafMask()
+        //   bits 8-15 = childmask (1 = child exists)     — Java getChildMask()
+        // VERIFIED (Luciferase-7stji / Luciferase-0bn1q): the Laine-Karras CUDA
+        // reference stores a NON-leaf mask in bits 0-7 (1 = descend) and packs child
+        // descriptors for non-leaf children only; the Java encoder (OctreeBuilder /
+        // ESVONodeUnified) stores leaf=1 and packs ALL existing children. The shifted-
+        // mask tests below are polarity-adjusted and the sparse offset counts
+        // childmask bits accordingly.
+        uint childMask8 = (childDesc >> 8) & 0xFFu;
         bool isFar = (childDesc & 0x10000u) != 0u;
-        uint childPtr = childDesc >> 17;
+        // Mask to 14 bits (bits 17-30): ESVO childPtr is 14 bits; bit 31 is the valid flag.
+        // Without the mask, valid=1 leaks +0x4000 into childPtr. Fix: Luciferase-04ubq.
+        uint childPtr = (childDesc >> 17) & 0x3FFFu;
         
         // Calculate corner t-values
         float tx_corner = pos.x * tx_coef - tx_bias;
@@ -179,10 +196,12 @@ void castRay(inout Ray ray, out vec3 hitPoint, out vec3 hitNormal) {
         
         // Apply mirroring to child index
         int childShift = idx ^ octantMask;
-        // CRITICAL: Shift the ENTIRE child descriptor for mask testing
+        // CRITICAL: Shift the ENTIRE child descriptor for mask testing.
+        // The shifted-mask trick maps child slot = 7 - childShift: bit 15 of the
+        // shifted value is childmask bit (8 + slot), bit 7 is leafmask bit (slot).
         uint childMasks = childDesc << childShift;
-        
-        // Check if child exists (test bit 15 of shifted descriptor) and t-span valid
+
+        // Check if child exists (childmask bit for this slot — Java getChildMask)
         if ((childMasks & 0x8000u) != 0u && t_min <= t_max) {
             // INTERSECT
             float tv_max = min(t_max, tc_max);
@@ -200,6 +219,11 @@ void castRay(inout Ray ray, out vec3 hitPoint, out vec3 hitNormal) {
             float tz_center = halfScale * tz_coef + tz_corner;
             
             // CONTOUR INTERSECTION for sub-voxel surface refinement
+            // VERIFIED (Luciferase-7stji): units/source mismatch vs the CUDA reference —
+            // the reference reads contour values PARENT-RELATIVE from the raw int stream;
+            // this reads node-absolute from nodes[]. No current Java producer uploads
+            // contour data for this renderer (OctreeBuilder emits contourMask=0), so this
+            // branch is unreachable today. Tracked: Luciferase-yyx35.
             uint contourMask = (contourDesc & 0xFFu) << childShift;
             if ((contourMask & 0x80u) != 0u) {
                 // Extract contour data pointer
@@ -227,8 +251,15 @@ void castRay(inout Ray ray, out vec3 hitPoint, out vec3 hitNormal) {
                 }
             }
             
-            // Check if child is non-leaf (test bit 7 of shifted descriptor)
-            if ((childMasks & 0x0080u) != 0u && t_min <= tv_max) {
+            if (t_min <= tv_max) {
+                // Java leafmask polarity (bit 7 of shifted descriptor = leafmask bit for
+                // this slot, 1 = leaf): a set bit means the child is a LEAF voxel — hit.
+                // The CUDA reference stores non-leaf=1 and descends on set; with the Java
+                // encoder we terminate on set instead. Fix: Luciferase-7stji (Luciferase-0bn1q).
+                if ((childMasks & 0x0080u) != 0u) {
+                    break; // leaf voxel hit at t_min
+                }
+
                 // PUSH - Save parent on stack (with optimization to avoid redundant pushes)
                 if (tc_max < h && stackPtr < CAST_STACK_DEPTH - 1) {
                     stack_nodes[stackBase + stackPtr] = parentIdx;
@@ -237,17 +268,30 @@ void castRay(inout Ray ray, out vec3 hitPoint, out vec3 hitNormal) {
                 }
                 h = tc_max;
                 
-                // DESCEND to child
+                // DESCEND to child.
+                // nodes[] is uvec2[] — one element per node, so parentIdx is already node-unit.
+                // Pointers (near childPtr and farPointers[] entries) are RELATIVE offsets in
+                // node-units from parentIdx.  Do NOT multiply by 2 — that was a 2x over-step bug.
+                // Fix: Luciferase-04ubq (Luciferase-0bn1q).
                 uint ofs = childPtr;
-                
-                // Handle far pointer
+
+                // Far pointer: dereference side table to get relative offset.
+                // farPointers[ofs] is the relative offset from parentIdx to the children block.
+                // The pre-fix code read the far offset inline from the node buffer (wrong);
+                // the corrected path uses the dedicated farPointers[] side table.
                 if (isFar) {
-                    ofs = uint(octree.nodes[parentIdx + ofs * 2u].x);
+                    ofs = uint(farPointers[ofs]);
                 }
-                
-                // Add offset for specific child using shifted masks
-                ofs += popc8(childMasks & 0x7Fu);
-                parentIdx = parentIdx + ofs * 2u;
+
+                // Add per-child sparse offset: count existing children BEFORE this slot.
+                // Java packs ALL existing children consecutively (ESVONodeUnified.getChildOffset
+                // counts childmask bits below the slot). The CUDA reference instead packs only
+                // non-leaf children and counts its non-leaf mask — do NOT use the shifted-mask
+                // popc8 idiom here. Fix: Luciferase-7stji (Luciferase-0bn1q).
+                uint childSlot = 7u - uint(childShift);
+                ofs += uint(bitCount(childMask8 & ((1u << childSlot) - 1u)));
+                // parentIdx is node-unit: add ofs directly (no *2u stride).
+                parentIdx = parentIdx + ofs;
                 
                 // Update position for child octant
                 scale--;

--- a/render/src/test/java/com/hellblazer/luciferase/esvo/gpu/ESVOOpenCLRendererFarPointerTest.java
+++ b/render/src/test/java/com/hellblazer/luciferase/esvo/gpu/ESVOOpenCLRendererFarPointerTest.java
@@ -156,6 +156,62 @@ class ESVOOpenCLRendererFarPointerTest {
     // -------------------------------------------------------------------------
 
     /**
+     * Headless CPU-side consistency test: NEAR interior node at a NON-zero array index.
+     *
+     * <p>This pins the CPU reference for the near-path case that the pre-fix kernel
+     * ({@code childPtr = rawChildPtr}) handles incorrectly for non-root nodes.
+     *
+     * <p>Layout:
+     * <ul>
+     *   <li>index 0 — root (leaf, not the node under test)</li>
+     *   <li>index 1 — padding leaf</li>
+     *   <li>index 2 — padding leaf</li>
+     *   <li>index 3 — near interior node; childPtr = 2 (relative offset), so children start at 3+2=5</li>
+     *   <li>index 4 — padding leaf</li>
+     *   <li>index 5 — first child of the near node</li>
+     * </ul>
+     *
+     * <p>The CPU reference {@link ESVONodeUnified#getChildIndex(int, int, int[])} must
+     * resolve to 5: {@code currentNodeIdx(3) + relativeOffset(2) + popcount(0) = 5}.
+     *
+     * <p>This test passes NOW (the CPU path is correct) and pins the CPU near-path
+     * reference headlessly. The GPU-gated {@code nearAndFarNodeAtNonZeroIndex_gpuParity}
+     * below exercises the same near-non-root case on hardware with its own tree and
+     * CPU reference assertions.
+     */
+    @Test
+    void nearNodeAtNonZeroIndex_cpuResolutionCorrect() {
+        var data = new ESVOOctreeData(1024);
+
+        // Root — leaf, not the node under test
+        data.setNode(0, new ESVONodeUnified((byte) 0x00, (byte) 0x00, false, 0, (byte) 0, 1));
+        // index 1: leaf filler
+        data.setNode(1, new ESVONodeUnified((byte) 0xFF, (byte) 0x00, false, 0, (byte) 0, 1));
+        // index 2: leaf filler
+        data.setNode(2, new ESVONodeUnified((byte) 0xFF, (byte) 0x00, false, 0, (byte) 0, 1));
+        // index 3: near interior node — childMask=0x01 (one child), far=false, childPtr=2
+        // children start at 3 + 2 = 5
+        var nearNode = new ESVONodeUnified((byte) 0x01, (byte) 0x01, false, 2, (byte) 0, 0);
+        data.setNode(3, nearNode);
+        // index 4: leaf filler
+        data.setNode(4, new ESVONodeUnified((byte) 0xFF, (byte) 0x00, false, 0, (byte) 0, 1));
+        // index 5: child of the near node
+        data.setNode(5, new ESVONodeUnified((byte) 0xFF, (byte) 0x00, false, 0, (byte) 0, 1));
+
+        ESVONodeUnified node = data.getNode(3);
+        assertFalse(node.isFar(), "Node at index 3 must NOT have isFar()=true (near path)");
+        assertEquals(2, node.getChildPtr(),
+                "nearNode childPtr must be 2 (relative offset from index 3 to children at 5)");
+
+        // CPU reference: currentNodeIdx(3) + relativeOffset(2) + getChildOffset(0)=0 = 5
+        int resolvedIndex = node.getChildIndex(0, 3, null);
+        assertEquals(5, resolvedIndex,
+                "CPU getChildIndex for near node at index 3, childIdx=0 must resolve to 5 "
+                + "(currentNodeIdx=3 + relativeOffset=2 + popcount=0). "
+                + "This is the value the GPU must also produce after Fix 1 (Luciferase-04ubq).");
+    }
+
+    /**
      * Headless CPU-side consistency test: far node at a NON-zero array index.
      *
      * <p>This is the structural case the original {@code buildFarPointerOctree} octree
@@ -275,6 +331,149 @@ class ESVOOpenCLRendererFarPointerTest {
         }
     }
 
+    /**
+     * GPU render parity: an octree requiring correct near AND far resolution at non-root indices,
+     * with BOTH interior nodes reachable from the root and each chaining to its own hittable leaf.
+     *
+     * <p>Tree (all interior nodes reachable; the two subtrees occupy disjoint x-octants):
+     * <ul>
+     *   <li>index 0 — root: near, childMask=0x03 (slots 0 and 1), childPtr=1.
+     *       Slot 0 → index 1, slot 1 → index 2.</li>
+     *   <li>index 1 — FAR interior node at non-zero index (slot 0: x∈[0,0.5)):
+     *       childMask=0x01, far=true, childPtr=0; farPointers[0]=2 → child at 1+2=3.</li>
+     *   <li>index 2 — NEAR interior node at non-zero index (slot 1: x∈[0.5,1)):
+     *       childMask=0x01, far=false, childPtr=2 → child at 2+2=4.</li>
+     *   <li>index 3 — leaf (contourPtr=42 → hit), region x∈[0,0.25), y,z∈[0,0.25).</li>
+     *   <li>index 4 — leaf (contourPtr=43 → hit), region x∈[0.5,0.75), y,z∈[0,0.25).</li>
+     * </ul>
+     *
+     * <p><b>Why this distinguishes the fixed kernel from the pre-fix kernel</b>: with the
+     * pre-fix near branch ({@code childPtr = rawChildPtr}, missing {@code current.nodeIdx}),
+     * the near node at index 2 resolves its child to raw 2 = itself, self-loops to maxDepth
+     * and never reaches the leaf at index 4 — so no hit is produced anywhere in the near
+     * subtree's half of the image. The far path (fixed in 7wzml.222) still hits leaf@3 in
+     * the other half. Asserting hit pixels in BOTH image halves therefore fails on the
+     * pre-fix kernel and passes on the fixed one (an any-hit assertion would be masked by
+     * the far-path hit).
+     *
+     * <p><b>Pixel mapping</b>: camera at (0.5,0.5,2) looking at (0.5,0.5,0.5) down −z;
+     * AbstractOpenCLRenderer.generateRays uses ndcX = 2x/W−1, so world-x maps monotonically
+     * to pixel-x. The far leaf (x&lt;0.25) and near leaf (x≥0.5) land in opposite image
+     * halves; the both-halves assertion is also invariant under a horizontal flip.
+     *
+     * <p><b>Hit detection</b>: misses are NOT zero — ESVOOpenCLRenderer.computePixelColor
+     * writes background RGB (20,20,30) with alpha 255 on miss. A pixel is a hit iff its RGB
+     * differs from the background triple.
+     *
+     * <p>Gated behind {@code RUN_GPU_TESTS=true} — do NOT run in headless CI.
+     * Run locally: {@code RUN_GPU_TESTS=true mvn test -pl render -Dtest=ESVOOpenCLRendererFarPointerTest#nearAndFarNodeAtNonZeroIndex_gpuParity}
+     */
+    @Test
+    @EnabledIfEnvironmentVariable(named = "RUN_GPU_TESTS", matches = "true",
+            disabledReason = "GPU test requires a real OpenCL device — set RUN_GPU_TESTS=true; bead oceo6")
+    void nearAndFarNodeAtNonZeroIndex_gpuParity() {
+        if (!ESVOOpenCLRenderer.isOpenCLAvailable()) {
+            System.out.println("OpenCL not available — skipping nearAndFarNodeAtNonZeroIndex_gpuParity");
+            return;
+        }
+
+        var data = new ESVOOctreeData(1024);
+
+        // Index 0: root — near, children in slots 0 and 1 (childMask=0x03), childPtr=1.
+        // slot 0: 0 + 1 + popcount(0x03 & 0x00)=0 → index 1
+        // slot 1: 0 + 1 + popcount(0x03 & 0x01)=1 → index 2
+        var root = new ESVONodeUnified((byte) 0x00, (byte) 0x03, false, 1, (byte) 0, 0);
+        data.setNode(0, root);
+
+        // Index 1: FAR interior node — childMask=0x01, far=true, childPtr=0 (index into
+        // farPointers[]). farPointers[0]=2 → child at 1+2+0=3. leafMask=0x01: its one
+        // child is a leaf (OctreeBuilder convention).
+        var farNode = new ESVONodeUnified((byte) 0x01, (byte) 0x01, true, 0, (byte) 0, 0);
+        data.setNode(1, farNode);
+
+        // Index 2: NEAR interior node at non-zero index — childMask=0x01, far=false,
+        // childPtr=2 (relative) → child at 2+2+0=4. THIS is the node the pre-fix kernel
+        // resolves wrongly (raw 2 → itself instead of 4).
+        var nearNode = new ESVONodeUnified((byte) 0x01, (byte) 0x01, false, 2, (byte) 0, 0);
+        data.setNode(2, nearNode);
+
+        // Index 3: leaf hit — child of the FAR node. contourPtr != 0 → hit (kernel hit
+        // condition: childMask==0 && contourPtr!=0). leafMask=0xFF: leaf-node convention.
+        data.setNode(3, new ESVONodeUnified((byte) 0xFF, (byte) 0x00, false, 0, (byte) 0xFF, 42));
+
+        // Index 4: leaf hit — child of the NEAR node. contourPtr != 0 → hit.
+        data.setNode(4, new ESVONodeUnified((byte) 0xFF, (byte) 0x00, false, 0, (byte) 0xFF, 43));
+
+        // Far-pointer table: farPointers[0] = 2 (relative offset from index 1 to index 3).
+        data.setFarPointers(new int[] { 2 });
+
+        // Tree depth: root (0) → interior (1) → leaves (2). The kernel treats
+        // current.scale >= maxDepth as a forced leaf, so maxDepth must exceed the leaf
+        // depth or every ray terminates at the root with no hit (maxDepth defaults to 0
+        // on hand-built ESVOOctreeData — found during oceo6 hardware verification).
+        data.setMaxDepth(3);
+
+        // --- CPU reference (gospel): verify child resolution for every edge of the tree ---
+        int[] fp = data.getFarPointers();
+        assertEquals(1, data.getNode(0).getChildIndex(0, 0, fp),
+                "CPU root slot 0 must resolve to 1 (far interior node)");
+        assertEquals(2, data.getNode(0).getChildIndex(1, 0, fp),
+                "CPU root slot 1 must resolve to 2 (near interior node)");
+        assertEquals(3, data.getNode(1).getChildIndex(0, 1, fp),
+                "CPU far-path: farNode@1 must resolve child to 3 (1 + farPointers[0]=2 + 0)");
+        assertEquals(4, data.getNode(2).getChildIndex(0, 2, fp),
+                "CPU near-path: nearNode@2 must resolve child to 4 (2 + 2 + 0) — "
+                + "the pre-fix GPU kernel resolves raw 2 (itself) instead");
+
+        // --- GPU render ---
+        try (var renderer = new ESVOOpenCLRenderer(64, 64)) {
+            renderer.initialize();
+            renderer.uploadData(data);
+
+            var cameraPos = new javax.vecmath.Vector3f(0.5f, 0.5f, 2.0f);
+            var lookAt    = new javax.vecmath.Vector3f(0.5f, 0.5f, 0.5f);
+            assertDoesNotThrow(() -> renderer.renderFrame(cameraPos, lookAt, 60.0f),
+                    "GPU traversal must not throw for near+far non-root octree");
+
+            var outputImage = renderer.getOutputImage();
+            assertNotNull(outputImage, "Output image must be non-null");
+            assertEquals(64 * 64 * 4, outputImage.limit(),
+                    "Output image must be 64x64 RGBA = 16384 bytes");
+
+            // Count hit pixels per image half. Background (miss) RGB is (20,20,30) per
+            // ESVOOpenCLRenderer.computePixelColor; anything else is a hit.
+            int hitsLeft = 0, hitsRight = 0;
+            outputImage.rewind();
+            for (int y = 0; y < 64; y++) {
+                for (int x = 0; x < 64; x++) {
+                    int base = (y * 64 + x) * 4;
+                    int r = outputImage.get(base)     & 0xFF;
+                    int g = outputImage.get(base + 1) & 0xFF;
+                    int b = outputImage.get(base + 2) & 0xFF;
+                    boolean hit = !(r == 20 && g == 20 && b == 30);
+                    if (hit) {
+                        if (x < 32) hitsLeft++;
+                        else        hitsRight++;
+                    }
+                }
+            }
+
+            // The far leaf (x<0.25) and near leaf (x in [0.5,0.75)) occupy opposite image
+            // halves. The pre-fix kernel hits only the far leaf → one half stays empty.
+            assertTrue(hitsLeft > 0 && hitsRight > 0,
+                    "GPU render must produce hit pixels in BOTH image halves "
+                    + "(far-path leaf and near-path leaf are in opposite halves). "
+                    + "hitsLeft=" + hitsLeft + ", hitsRight=" + hitsRight + " — a half with "
+                    + "zero hits means that traversal path (near non-root child resolution "
+                    + "or far-pointer table resolution) is broken on the GPU");
+
+            System.out.println("[nearAndFarNodeAtNonZeroIndex_gpuParity] PASS — GPU hits in both halves: "
+                               + "left=" + hitsLeft + " (far subtree), right=" + hitsRight
+                               + " (near subtree). farPointers[0]=2; far child@3, near child@4. "
+                               + "Nodes=" + data.getNodeCount() + ", fp.length=" + fp.length);
+        }
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
@@ -288,6 +487,9 @@ class ESVOOpenCLRendererFarPointerTest {
         var child = new ESVONodeUnified((byte) 0x00, (byte) 0x00, false, 0, (byte) 0, 1);
         data.setNode(1, child);
         // No far pointers set
+        // Depth metadata: hand-built data defaults to maxDepth=0, which makes the kernel
+        // treat the root as a forced leaf if this helper is ever used in a GPU test.
+        data.setMaxDepth(2);
         return data;
     }
 
@@ -303,6 +505,9 @@ class ESVOOpenCLRendererFarPointerTest {
         data.setNode(1, child);
         // Far-pointer table: farPointers[0] = 1 (relative offset from root=0 to child=1).
         data.setFarPointers(new int[] { 1 });
+        // Depth metadata: root → leaf at depth 1 (hand-built data defaults to maxDepth=0,
+        // which makes the kernel treat the root as a forced leaf).
+        data.setMaxDepth(2);
         return data;
     }
 }

--- a/render/src/test/java/com/hellblazer/luciferase/esvo/gpu/ESVOShaderSourcePinTest.java
+++ b/render/src/test/java/com/hellblazer/luciferase/esvo/gpu/ESVOShaderSourcePinTest.java
@@ -1,0 +1,276 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.esvo.gpu;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Source-pin tests for ESVO GPU shader and kernel correctness.
+ *
+ * <p>Ten headless tests pin the post-fix textual contracts for:
+ * <ol>
+ *   <li>{@code esvo_ray_traversal.cl} — near-branch adds {@code current.nodeIdx} (Luciferase-0bn1q Fix 1)</li>
+ *   <li>{@code esvo_ray_traversal.cl} — stale NOTE block absent after fix</li>
+ *   <li>{@code raycast.comp} — childPtr extract is masked {@code (childDesc >> 17) & 0x3FFFu} (Fix 2a)</li>
+ *   <li>{@code raycast.comp} — descend does NOT use the 2x over-step {@code + ofs * 2u} (Fix 2b)</li>
+ *   <li>{@code raycast.comp} — FarPointerBuffer SSBO declaration present (Fix 2c)</li>
+ *   <li>{@code raycast.comp} — in-band far read absent (Fix 2c)</li>
+ *   <li>{@code raycast.comp} — leafmask polarity: break-on-leaf, not descend-on-leaf (Fix 2d,
+ *       Luciferase-7stji review finding)</li>
+ *   <li>{@code raycast.comp} — sparse offset counts childmask bits, not the CUDA shifted
+ *       non-leaf idiom (Fix 2e, Luciferase-7stji review finding)</li>
+ *   <li>{@code esvo_ray_traversal.cl} — rays read via raw float buffer with RAY_STRIDE,
+ *       not a misaligned {@code Ray*} struct (Luciferase-gva5z, found during oceo6 hardware run)</li>
+ *   <li>{@code esvo_ray_traversal.cl} — traversal stack is private, not {@code __local}
+ *       (Luciferase-gva5z)</li>
+ * </ol>
+ *
+ * <p>All tests are headless (no GPU/OpenCL required); they pin the source text
+ * loaded via the same {@link ShaderResourceLoader} / resource path used at runtime.
+ * Tests 1–2 and 9–10 pin the kernel; tests 3–8 pin the compute shader.
+ *
+ * <p>Bead: Luciferase-pyqsi (RED phase, TDD). Corresponding fix bead: Luciferase-04ubq.
+ * Pins 7–8 added during the Luciferase-7stji stacked review (mask-semantics verification
+ * item from the approved design — evidence: Java ESVONodeUnified/OctreeBuilder store
+ * leafmask 1=leaf and pack ALL children; the Laine-Karras CUDA reference stores
+ * non-leaf 1=descend and packs only non-leaf children).
+ */
+class ESVOShaderSourcePinTest {
+
+    private static String clSource;
+    private static String compSource;
+
+    @BeforeAll
+    static void loadSources() {
+        // Clear cache so stale process-level cache does not mask on-disk changes during tests
+        ShaderResourceLoader.clearCache();
+        clSource   = ShaderResourceLoader.loadShader("kernels/esvo_ray_traversal.cl");
+        compSource = ShaderResourceLoader.loadShader("shaders/raycast.comp");
+
+        assertNotNull(clSource,   "esvo_ray_traversal.cl must be loadable");
+        assertFalse(clSource.isBlank(), "esvo_ray_traversal.cl must not be empty");
+        assertNotNull(compSource, "raycast.comp must be loadable");
+        assertFalse(compSource.isBlank(), "raycast.comp must not be empty");
+    }
+
+    // -------------------------------------------------------------------------
+    // esvo_ray_traversal.cl pins
+    // -------------------------------------------------------------------------
+
+    /**
+     * Pin 1: near branch must add {@code current.nodeIdx} to the raw child pointer.
+     *
+     * <p>The CPU reference (ESVONodeUnified.getChildIndex) computes:
+     * {@code currentNodeIdx + relativeOffset + getChildOffset(childIdx)}.
+     * The pre-fix kernel omits {@code current.nodeIdx} in the near case, giving
+     * wrong absolute indices for any non-root interior node.
+     *
+     * <p>Expected post-fix text: {@code childPtr = current.nodeIdx + rawChildPtr;}
+     * This test is RED before Fix 1.
+     */
+    @Test
+    void cl_nearBranch_includesNodeIdx() {
+        assertTrue(clSource.contains("current.nodeIdx + rawChildPtr"),
+                "esvo_ray_traversal.cl near branch must assign "
+                + "'childPtr = current.nodeIdx + rawChildPtr;' — pre-fix assigns 'childPtr = rawChildPtr;' "
+                + "which is wrong for non-root interior nodes");
+    }
+
+    /**
+     * Pin 2: stale NOTE block must be absent after fix.
+     *
+     * <p>The pre-fix kernel contains a self-documenting bug note at :164-167 that says
+     * the near path does not add nodeIdx and that "Fixing the near path is tracked separately".
+     * After Fix 1 that note must be replaced with an accurate comment.
+     *
+     * <p>Two sub-assertions:
+     * <ul>
+     *   <li>Source must NOT contain {@code "pre-existing"}</li>
+     *   <li>Source must NOT contain {@code "Fixing the near path is tracked separately"}</li>
+     * </ul>
+     * Both are RED before Fix 1.
+     */
+    @Test
+    void cl_staleNote_absent() {
+        assertFalse(clSource.contains("pre-existing"),
+                "esvo_ray_traversal.cl must not contain the stale 'pre-existing' NOTE after fix");
+        assertFalse(clSource.contains("Fixing the near path is tracked separately"),
+                "esvo_ray_traversal.cl must not contain the stale 'Fixing the near path is tracked separately' "
+                + "text after fix — the near path IS fixed by Luciferase-04ubq");
+    }
+
+    /**
+     * Pin 9: kernel must read rays from the raw float buffer, not a {@code Ray*} struct pointer.
+     *
+     * <p>The host ({@code AbstractOpenCLRenderer}) packs rays tightly at 8 floats / 32 bytes.
+     * An OpenCL struct with {@code float3} members has 16-byte member alignment (48-byte
+     * stride), so {@code rays[gid]} on a {@code __global const Ray*} reads garbage for
+     * every gid ≥ 1 — the pre-fix kernel produced zero correct GPU hits, masked by vacuous
+     * assertions. Post-fix the kernel takes {@code __global const float* rays} and decodes
+     * via {@code loadRayFromBuffer} with explicit {@code RAY_STRIDE} indexing (the
+     * esvt_ray_traversal.cl pattern).
+     *
+     * <p>This test is RED before the Luciferase-gva5z fix.
+     */
+    @Test
+    void cl_rayAccess_usesFloatBufferStride() {
+        assertFalse(clSource.contains("__global const Ray* rays"),
+                "esvo_ray_traversal.cl must not take '__global const Ray* rays' — float3 struct "
+                + "alignment makes the kernel stride 48B vs the host's tightly packed 32B rays");
+        assertTrue(clSource.contains("loadRayFromBuffer"),
+                "esvo_ray_traversal.cl must decode rays via loadRayFromBuffer with explicit "
+                + "RAY_STRIDE indexing (esvt_ray_traversal.cl pattern)");
+        assertTrue(clSource.contains("#define RAY_STRIDE 8"),
+                "esvo_ray_traversal.cl must define RAY_STRIDE 8 matching the host's "
+                + "RAY_SIZE_FLOATS = 8 packing");
+    }
+
+    /**
+     * Pin 10: traversal stack must be PRIVATE, not {@code __local}.
+     *
+     * <p>The pre-fix kernel declared {@code __local StackEntry stack[MAX_TRAVERSAL_DEPTH]}
+     * — one stack shared by all threads of the workgroup (LOCAL_WORK_SIZE=64) with no
+     * per-thread offset, a data race corrupting every traversal. Post-fix the stack is a
+     * private per-work-item array (the esvt_ray_traversal.cl pattern).
+     *
+     * <p>This test is RED before the Luciferase-gva5z fix.
+     */
+    @Test
+    void cl_traversalStack_isPrivate() {
+        assertFalse(clSource.contains("__local StackEntry"),
+                "esvo_ray_traversal.cl traversal stack must not be __local — a workgroup-shared "
+                + "stack with no per-thread offset is a data race across the 64-thread workgroup");
+    }
+
+    // -------------------------------------------------------------------------
+    // raycast.comp pins
+    // -------------------------------------------------------------------------
+
+    /**
+     * Pin 3: childPtr extract must be masked with {@code & 0x3FFFu}.
+     *
+     * <p>Pre-fix line :172: {@code uint childPtr = childDesc >> 17;} leaks bit 31 (valid flag)
+     * into childPtr when valid=1, producing a +0x4000 bias.
+     * Post-fix: {@code uint childPtr = (childDesc >> 17) & 0x3FFFu;} (14-bit mask, correct for ESVO).
+     *
+     * <p>This test is RED before Fix 2a.
+     */
+    @Test
+    void raycast_childPtrExtract_isMasked() {
+        assertTrue(compSource.contains("(childDesc >> 17) & 0x3FFFu"),
+                "raycast.comp childPtr extract must apply the 14-bit mask: '(childDesc >> 17) & 0x3FFFu' — "
+                + "pre-fix has unmasked 'childDesc >> 17' which leaks bit 31");
+    }
+
+    /**
+     * Pin 4: descend must NOT contain {@code + ofs * 2u} stride.
+     *
+     * <p>Pre-fix line :250: {@code parentIdx = parentIdx + ofs * 2u;} is wrong because
+     * {@code nodes[]} is a {@code uvec2[]} (one element = one node = 8 bytes) so the
+     * index is already in node-units; multiplying by 2 produces a 2x over-step.
+     * Post-fix: {@code parentIdx = parentIdx + ofs;}.
+     *
+     * <p>This test is RED before Fix 2b.
+     */
+    @Test
+    void raycast_descend_noTwoUStride() {
+        assertFalse(compSource.contains("+ ofs * 2u"),
+                "raycast.comp descend block must not contain '+ ofs * 2u' — "
+                + "uvec2[] is already node-unit indexed; the *2u stride is a 2x over-step bug");
+    }
+
+    /**
+     * Pin 5: FarPointerBuffer SSBO declaration must be present.
+     *
+     * <p>Pre-fix: no FarPointerBuffer SSBO in raycast.comp.
+     * Post-fix: {@code layout(std430, binding = 3) readonly buffer FarPointerBuffer { int farPointers[]; };}
+     * The test checks for both the block name and the field name.
+     *
+     * <p>This test is RED before Fix 2c.
+     */
+    @Test
+    void raycast_farPointers_ssbo_present() {
+        assertTrue(compSource.contains("buffer FarPointerBuffer"),
+                "raycast.comp must declare 'buffer FarPointerBuffer' SSBO — absent pre-fix");
+        assertTrue(compSource.contains("farPointers[]"),
+                "raycast.comp FarPointerBuffer must contain 'farPointers[]' field — absent pre-fix");
+    }
+
+    /**
+     * Pin 6: in-band far read via {@code octree.nodes[parentIdx + ofs} must be absent.
+     *
+     * <p>Pre-fix line :245: {@code ofs = uint(octree.nodes[parentIdx + ofs * 2u].x);} reads
+     * the far offset inline from the node buffer — wrong because the CPU path uses a side
+     * table ({@code farPointers[]}).
+     * Post-fix: far case reads via {@code ofs = uint(farPointers[ofs]);}.
+     *
+     * <p>This test is RED before Fix 2c.
+     */
+    @Test
+    void raycast_inbandFarRead_absent() {
+        assertFalse(compSource.contains("octree.nodes[parentIdx + ofs"),
+                "raycast.comp must not contain the in-band far read 'octree.nodes[parentIdx + ofs' — "
+                + "post-fix must use 'farPointers[ofs]' side-table indirection instead");
+    }
+
+    /**
+     * Pin 7: leafmask polarity — descend gate must break on a set leaf bit, not descend.
+     *
+     * <p>The Java encoder ({@code ESVONodeUnified}/{@code OctreeBuilder}) stores bits 0-7
+     * as a leafmask with 1 = leaf. The CUDA reference stores a NON-leaf mask there
+     * (1 = descend). The pre-fix shader copied the CUDA polarity, descending INTO leaf
+     * children (via garbage child pointers) and terminating at internal children.
+     * Post-fix: inside the t-span gate, a set bit 7 of the shifted descriptor breaks
+     * (leaf voxel hit); descend happens only when the bit is clear.
+     *
+     * <p>This test is RED before Fix 2d (Luciferase-7stji).
+     */
+    @Test
+    void raycast_leafBit_breaksNotDescends() {
+        assertTrue(compSource.contains("break; // leaf voxel hit"),
+                "raycast.comp must break (register a hit) when the shifted leafmask bit is set — "
+                + "Java leafmask is 1=leaf, unlike the CUDA non-leaf mask");
+        assertFalse(compSource.contains("if ((childMasks & 0x0080u) != 0u && t_min <= tv_max)"),
+                "raycast.comp must not use the pre-fix combined descend gate "
+                + "'(childMasks & 0x0080u) != 0u && t_min <= tv_max' — with Java leafmask "
+                + "semantics that descends into leaves and never descends into internal nodes");
+    }
+
+    /**
+     * Pin 8: sparse child offset must count CHILDMASK bits, not the CUDA shifted idiom.
+     *
+     * <p>The CUDA reference packs child descriptors for non-leaf children only and counts
+     * its non-leaf mask via {@code popc8(child_masks & 0x7F)}. The Java encoder packs ALL
+     * existing children consecutively ({@code ESVONodeUnified.getChildOffset} counts
+     * childmask bits below the slot). The pre-fix shader used the CUDA idiom against
+     * Java-encoded data, computing wrong sparse offsets.
+     *
+     * <p>This test is RED before Fix 2e (Luciferase-7stji).
+     */
+    @Test
+    void raycast_sparseOffset_usesChildMask() {
+        assertFalse(compSource.contains("popc8(childMasks & 0x7Fu)"),
+                "raycast.comp must not compute the sparse child offset with the CUDA idiom "
+                + "'popc8(childMasks & 0x7Fu)' — that counts leafmask bits under the Java encoding");
+        assertTrue(compSource.contains("bitCount(childMask8 &"),
+                "raycast.comp sparse child offset must count childmask bits below the slot "
+                + "('bitCount(childMask8 & ...)') to match ESVONodeUnified.getChildOffset");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the ESVO GPU near-pointer child-resolution bug (P2, Luciferase-0bn1q) plus every defect found on the way to verifying it on hardware. CPU reference (gospel): `ESVONodeUnified.getChildIndex = currentNodeIdx + (far ? farPointers[childPtr] : childPtr) + childOffset`.

### esvo_ray_traversal.cl (OpenCL, live ESVO path)
- **Near branch adds `current.nodeIdx`** — the pre-fix kernel resolved wrong children for every non-root interior node (accidentally correct only at root index 0). Luciferase-04ubq.
- **Ray access rewritten to raw float buffer (`RAY_STRIDE 8`)** — the old `__global const Ray*` struct had 48-byte stride (OpenCL `float3` alignment) against the host's tightly packed 32-byte rays: garbage rays for every gid ≥ 1. Luciferase-gva5z.
- **Traversal stack now private per work-item** — the old `__local` stack was shared by the whole 64-thread workgroup with no per-thread offset. Luciferase-gva5z.

Both infrastructure bugs were pre-existing and masked by vacuous GPU assertions — this kernel had plausibly never produced a correct hit. Fix pattern ported from the proven `esvt_ray_traversal.cl`.

### raycast.comp (GLSL compute, ComputeShaderRenderer path)
- Masked 14-bit childPtr extract (`(childDesc >> 17) & 0x3FFFu`) — bit 31 no longer leaks.
- Far pointers via `FarPointerBuffer` SSBO (binding 3) side table, not in-band node reads — matches the CPU/builder contract and the ESVT pattern from #232.
- Dropped the `* 2u` descend stride (`nodes[]` is `uvec2[]`, node-unit indexed — 2x over-step).
- **Leafmask polarity fixed**: Java stores 1=leaf in bits 0–7; the CUDA reference stores a non-leaf mask. The shader descended *into* leaves via garbage pointers — now breaks (hit) on leaf. Found by the design's mask-semantics verification item during stacked review.
- **Sparse offset fixed**: counts childmask bits below the slot (Java packs ALL children), replacing the CUDA non-leaf `popc8` idiom.
- contourPtr units mismatch documented; branch unreachable with current producers (Luciferase-yyx35).

### ComputeShaderRenderer.java
Far-pointer SSBO upload at binding 3 (placeholder when empty), released on dispose.

### Tests
- **ESVOShaderSourcePinTest** (new): 10 headless source pins, all observed RED pre-fix (TDD, Luciferase-pyqsi).
- **ESVOOpenCLRendererFarPointerTest**: GPU parity test rebuilt — near and far interior nodes at non-zero indices both reachable from root in disjoint x-octants, asserting hit pixels in both image halves against the actual miss color (the prior any-non-zero-byte assertion was vacuous). Hand-built trees now set `maxDepth` (default 0 force-leafs the root on GPU).

## Verification

- **Hardware (Luciferase-oceo6, Apple M4 Max, OpenCL)**: pins 10/10; far-pointer suite 9/9 on GPU; parity test passes with hits in both halves (79 far / 63 near) — near-pointer fix verified on hardware.
- **ESVT siblings**: far-pointer test 9/9 on GPU, closing the Luciferase-8putk hardware caveat. Pre-existing ESVT GPU/CPU accuracy divergence (80.6% vs 95%) filed as Luciferase-jk5tk.
- **Headless**: full render suite 2041 run, 0 failures (`-Dtest='!DynamicKernelSelectionTest'`, bead vkl96).
- **Stacked review (Luciferase-7stji)**: 3 rounds, code-review-expert APPROVE + substantive-critic CLEAN; review records in T2.

Follow-ups filed: Luciferase-yyx35 (contour path), Luciferase-z2ysz (SSBO size metadata), Luciferase-jk5tk (ESVT parity divergence).

Beads: Luciferase-0bn1q, Luciferase-pyqsi, Luciferase-04ubq, Luciferase-7stji, Luciferase-oceo6, Luciferase-gva5z