### PR TITLE
ESVT front-to-back traversal with early-exit pruning (Luciferase-2s3jc)

### DIFF
--- a/render/src/main/java/com/hellblazer/luciferase/esvt/traversal/ESVTStack.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvt/traversal/ESVTStack.java
@@ -28,6 +28,22 @@ package com.hellblazer.luciferase.esvt.traversal;
  *
  * <p><b>Stack Size:</b> 22 entries for 21-level Tetree depth (root + 21 refinements)
  *
+ * <p><b>Front-to-back sorted order (2s3jc P2):</b> Each level stores a packed visit order
+ * word in {@code sortedOrderStack}. Layout:
+ * <ul>
+ *   <li>Bits 27–24: count of intersecting children (0–8, 4 bits)</li>
+ *   <li>Bits 23–21: sorted child index 0 (3 bits)</li>
+ *   <li>Bits 20–18: sorted child index 1 (3 bits)</li>
+ *   <li>Bits 17–15: sorted child index 2 (3 bits)</li>
+ *   <li>Bits 14–12: sorted child index 3 (3 bits)</li>
+ *   <li>Bits 11– 9: sorted child index 4 (3 bits)</li>
+ *   <li>Bits  8– 6: sorted child index 5 (3 bits)</li>
+ *   <li>Bits  5– 3: sorted child index 6 (3 bits)</li>
+ *   <li>Bits  2– 0: sorted child index 7 (3 bits)</li>
+ * </ul>
+ * The resume position ({@code sortedPos}) is stored in {@code siblingPosStack} (repurposed from
+ * its old "childIdx+1" semantics to "index into sorted order to resume from").
+ *
  * @author hal.hildebrand
  */
 public final class ESVTStack {
@@ -39,11 +55,17 @@ public final class ESVTStack {
     public static final int STACK_SIZE = 24;
 
     // Stack storage arrays - indexed by scale level
-    private final int[] nodeStack;      // Node indices
-    private final float[] tMaxStack;    // tMax values for each level
-    private final byte[] typeStack;     // Tet types (0-5) at each level
-    private final byte[] entryFaceStack; // Entry face (0-3) at each level
-    private final byte[] siblingPosStack; // Sibling position (0-8) for resuming after pop (stores childIdx+1)
+    private final int[] nodeStack;        // Node indices
+    private final float[] tMaxStack;      // tMax values for each level
+    private final byte[] typeStack;       // Tet types (0-5) at each level
+    private final byte[] entryFaceStack;  // Entry face (0-3) at each level
+    /** Sorted position (index into sorted order) for resuming after pop. Repurposed from siblingPos. */
+    private final byte[] siblingPosStack;
+    /**
+     * Packed sorted visit order per level. Bits 27–24: count (4 bits); bits 23–0: 8 × 3-bit childIdx slots
+     * (slot 0 in bits 23–21, slot 7 in bits 2–0). See class javadoc for the full layout.
+     */
+    private final int[] sortedOrderStack;
     // Parent vertices at each level (4 vertices * 3 coords = 12 floats per level)
     private final float[][] vertsStack; // [level][12] for v0.xyz, v1.xyz, v2.xyz, v3.xyz
 
@@ -56,6 +78,7 @@ public final class ESVTStack {
         this.typeStack = new byte[STACK_SIZE];
         this.entryFaceStack = new byte[STACK_SIZE];
         this.siblingPosStack = new byte[STACK_SIZE];
+        this.sortedOrderStack = new int[STACK_SIZE];
         this.vertsStack = new float[STACK_SIZE][12];
         reset();
     }
@@ -70,6 +93,7 @@ public final class ESVTStack {
             typeStack[i] = -1;
             entryFaceStack[i] = -1;
             siblingPosStack[i] = 0;
+            sortedOrderStack[i] = 0;
             java.util.Arrays.fill(vertsStack[i], 0.0f);
         }
     }
@@ -141,28 +165,97 @@ public final class ESVTStack {
     }
 
     /**
-     * Write sibling position to stack at given scale level.
+     * Write sorted position (resume index into sorted order) to stack at given scale level.
+     * Repurposed from the old "siblingPos = childIdx+1" semantics to "index in sorted order".
      *
-     * @param scale Scale level
-     * @param siblingPos Sibling position (0-8) to resume from after pop (stores childIdx+1 for children 0-7)
+     * @param scale      Scale level
+     * @param sortedPos  Position in sorted order to resume from (0-based)
      */
-    public void writeSiblingPos(int scale, byte siblingPos) {
+    public void writeSiblingPos(int scale, byte sortedPos) {
         if (scale >= 0 && scale < STACK_SIZE) {
-            siblingPosStack[scale] = siblingPos;
+            siblingPosStack[scale] = sortedPos;
         }
     }
 
     /**
-     * Read sibling position from stack at given scale level.
+     * Read sorted position (resume index into sorted order) from stack at given scale level.
      *
      * @param scale Scale level
-     * @return Sibling position (0-8), or 0 if invalid
+     * @return Sorted position, or 0 if invalid
      */
     public byte readSiblingPos(int scale) {
         if (scale >= 0 && scale < STACK_SIZE) {
             return siblingPosStack[scale];
         }
         return 0;
+    }
+
+    /**
+     * Write the packed sorted visit order for the given scale level.
+     *
+     * <p>Packing: bits 27–24 = count (4 bits, value 0–8); each of slots 0–7 occupies
+     * 3 bits starting from bit 23 downward (slot 0 at bits 23–21, slot 7 at bits 2–0).
+     *
+     * @param scale        Scale level
+     * @param packedOrder  Packed word encoding count + 8 sorted child indices
+     */
+    public void writeSortedOrder(int scale, int packedOrder) {
+        if (scale >= 0 && scale < STACK_SIZE) {
+            sortedOrderStack[scale] = packedOrder;
+        }
+    }
+
+    /**
+     * Read the packed sorted visit order from the given scale level.
+     *
+     * @param scale Scale level
+     * @return Packed sorted-order word, or 0 if invalid
+     */
+    public int readSortedOrder(int scale) {
+        if (scale >= 0 && scale < STACK_SIZE) {
+            return sortedOrderStack[scale];
+        }
+        return 0;
+    }
+
+    /**
+     * Extract the count of intersecting children from a packed sorted-order word.
+     * Count is stored in bits 27–24.
+     *
+     * @param packedOrder Packed sorted-order word
+     * @return Number of intersecting children (0–8)
+     */
+    public static int sortedCount(int packedOrder) {
+        return (packedOrder >> 24) & 0xF;
+    }
+
+    /**
+     * Extract the child index at position {@code pos} in the sorted order.
+     * Slot 0 is in bits 23–21, slot 1 in bits 20–18, …, slot 7 in bits 2–0.
+     *
+     * @param packedOrder Packed sorted-order word
+     * @param pos         Slot index (0–7)
+     * @return Child index (0–7) at that slot
+     */
+    public static int sortedChildAt(int packedOrder, int pos) {
+        int shift = 21 - pos * 3;
+        return (packedOrder >> shift) & 0x7;
+    }
+
+    /**
+     * Build a packed sorted-order word from a count and an array of sorted child indices.
+     *
+     * @param count        Number of valid entries in {@code sortedChildren}
+     * @param sortedChildren Array of child indices in sorted visit order (only first {@code count} used)
+     * @return Packed word
+     */
+    public static int packSortedOrder(int count, int[] sortedChildren) {
+        int packed = (count & 0xF) << 24;
+        for (int i = 0; i < count; i++) {
+            int shift = 21 - i * 3;
+            packed |= (sortedChildren[i] & 0x7) << shift;
+        }
+        return packed;
     }
 
     /**
@@ -233,6 +326,8 @@ public final class ESVTStack {
             tMaxStack[scale] = 0.0f;
             typeStack[scale] = -1;
             entryFaceStack[scale] = -1;
+            siblingPosStack[scale] = 0;
+            sortedOrderStack[scale] = 0;
         }
     }
 
@@ -250,12 +345,18 @@ public final class ESVTStack {
 
     /**
      * Copy stack state from another stack.
+     * Deep-copies all arrays including per-level vertex data (vertsStack).
      */
     public void copyFrom(ESVTStack other) {
         System.arraycopy(other.nodeStack, 0, this.nodeStack, 0, STACK_SIZE);
         System.arraycopy(other.tMaxStack, 0, this.tMaxStack, 0, STACK_SIZE);
         System.arraycopy(other.typeStack, 0, this.typeStack, 0, STACK_SIZE);
         System.arraycopy(other.entryFaceStack, 0, this.entryFaceStack, 0, STACK_SIZE);
+        System.arraycopy(other.siblingPosStack, 0, this.siblingPosStack, 0, STACK_SIZE);
+        System.arraycopy(other.sortedOrderStack, 0, this.sortedOrderStack, 0, STACK_SIZE);
+        for (int i = 0; i < STACK_SIZE; i++) {
+            System.arraycopy(other.vertsStack[i], 0, this.vertsStack[i], 0, 12);
+        }
     }
 
     @Override

--- a/render/src/main/java/com/hellblazer/luciferase/esvt/traversal/ESVTTraversal.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvt/traversal/ESVTTraversal.java
@@ -172,7 +172,6 @@ public final class ESVTTraversal {
         // entryFace is kept for child-descent context but no longer drives child selection:
         // the all-8 scan below iterates all Morton children regardless of entry face.
         int entryFace = 0;
-        float tMin = aabbResult.tEntry;
         float tMax = aabbResult.tExit;
         int scale = MAX_DEPTH - 1;
         int iterations = 0;
@@ -183,178 +182,347 @@ public final class ESVTTraversal {
         var bestResult = new ESVTResult();
         float bestT = Float.MAX_VALUE;
 
-        // Track position in the all-8 Morton child iteration (0-7)
-        int siblingPos = 0;
+        // front-to-back: sorted position (index into sorted order per level)
+        int sortedPos = 0;
+
+        // Scratch arrays for front-to-back child collection and insertion sort (max 8 children).
+        // Sorted in tandem: after the sort, slot i holds the i-th nearest child's (tEntry, childIdx).
+        final float[] candidateTEntry = new float[8];
+        final int[] candidateIdx = new int[8];
 
         while (scale < MAX_DEPTH && iterations < MAX_ITERATIONS) {
             iterations++;
 
-            var node = nodes[parentIdx];
-            if (!node.isValid()) {
-                // Invalid node - pop
-                if (!popStack(scale, result)) {
-                    break;
-                }
-                parentIdx = result.nodeIndex;
-                parentType = result.tetType;
-                entryFace = result.entryFace;
-                tMax = result.t;
+            // -----------------------------------------------------------------------
+            // Front-to-back: collect intersecting children, insertion-sort by tEntry,
+            // visit in sorted order, prune when next tEntry >= bestT.
+            //
+            // On first entry to this node: sortedPos == 0, collect all candidates.
+            // On resume (after pop): sortedPos > 0, re-derive the next child in order.
+            // -----------------------------------------------------------------------
+            var currentNode = nodes[parentIdx];
+            if (!currentNode.isValid()) {
+                // Invalid node — pop
+                if (scale >= MAX_DEPTH - 1) break;
                 scale++;
-                siblingPos = stack.readSiblingPos(scale); // Resume from next untested sibling
+                if (!stack.hasEntry(scale)) break;
+                parentIdx = stack.readNode(scale);
+                parentType = stack.readType(scale);
+                entryFace = stack.readEntryFace(scale);
+                tMax = stack.readTmax(scale);
+                sortedPos = stack.readSiblingPos(scale);
+                float[] restoredVerts = stack.readVerts(scale);
+                if (restoredVerts != null) {
+                    System.arraycopy(restoredVerts, 0, currentVerts, 0, 12);
+                }
                 continue;
             }
 
-            // All-8 Morton scan: iterate childIdx=siblingPos..7 directly as Morton index.
-            // No BEY_NUMBER_TO_INDEX conversion — childIdx IS the Morton bit in the
-            // childMask/leafMask (mirrors esvt_ray_traversal.cl:775-885).
             boolean descended = false;
-            for (int childIdx = siblingPos; childIdx < 8; childIdx++) {
 
-                // Check if child exists (Morton index directly into childMask)
-                if (!node.hasChild(childIdx)) {
-                    continue;
+            // Determine the packed sorted order for this level.
+            // If sortedPos == 0 we are entering this node fresh: collect + sort.
+            // If sortedPos > 0 we are resuming: use the stored packed order.
+            int packedOrder;
+            int childCount;
+
+            if (sortedPos == 0) {
+                // ----- COLLECT: scan all 8 Morton children, compute intersections -----
+                int nCandidates = 0;
+                for (int childIdx = 0; childIdx < 8; childIdx++) {
+                    if (!currentNode.hasChild(childIdx)) {
+                        continue;
+                    }
+                    // getChildVerticesFromParent: Morton→Bey internally (INDEX_TO_BEY_NUMBER)
+                    getChildVerticesFromParent(currentVerts, childIdx, parentType, scratchVerts);
+                    if (!intersector.intersectTetrahedron(rayOrigin, rayDir,
+                            scratchVerts[0], scratchVerts[1], scratchVerts[2], scratchVerts[3],
+                            tetResult)) {
+                        continue;
+                    }
+                    candidateTEntry[nCandidates] = tetResult.tEntry;
+                    candidateIdx[nCandidates] = childIdx;
+                    nCandidates++;
                 }
 
-                // Get child vertices using Morton index
-                // getChildVerticesFromParent() converts Morton to Bey internally for geometry
-                getChildVerticesFromParent(currentVerts, childIdx, parentType, scratchVerts);
-
-                // Test ray-child intersection
-                if (!intersector.intersectTetrahedron(rayOrigin, rayDir,
-                        scratchVerts[0], scratchVerts[1], scratchVerts[2], scratchVerts[3],
-                        tetResult)) {
-                    continue;
+                // ----- INSERTION SORT ascending by tEntry, tiebreak childIdx ascending -----
+                // Direct tandem sort of the two parallel arrays; max 8 elements.
+                // P3 mirrors this exact shape in .cl/.comp: same loop, same comparator.
+                for (int i = 1; i < nCandidates; i++) {
+                    float ti = candidateTEntry[i];
+                    int ci = candidateIdx[i];
+                    int j = i - 1;
+                    while (j >= 0 && (candidateTEntry[j] > ti
+                                      || (candidateTEntry[j] == ti && candidateIdx[j] > ci))) {
+                        candidateTEntry[j + 1] = candidateTEntry[j];
+                        candidateIdx[j + 1] = candidateIdx[j];
+                        j--;
+                    }
+                    candidateTEntry[j + 1] = ti;
+                    candidateIdx[j + 1] = ci;
                 }
 
-                // Child intersection found
-                float childTEntry = tetResult.tEntry;
-                int childEntryFace = tetResult.entryFace;
+                childCount = nCandidates;
+                // Pack the sorted childIdx order into the sorted-order word
+                packedOrder = ESVTStack.packSortedOrder(childCount, candidateIdx);
 
-                // Check if this is a leaf (using Morton index)
-                if (node.isChildLeaf(childIdx)) {
-                    // Get child node for contour data and type (relative pointer + current node index)
-                    int childNodeIdx = node.getChildIndex(childIdx, parentIdx, farPointers);
-                    var childNode = (childNodeIdx >= 0 && childNodeIdx < nodes.length)
-                        ? nodes[childNodeIdx] : null;
+                // ----- VISIT in sorted order, PRUNE when tEntry >= bestT -----
+                boolean descendedInner = false;
+                for (int si = 0; si < childCount; si++) {
+                    int childIdx = candidateIdx[si];
+                    float childTEntry = candidateTEntry[si];
 
-                    // Apply contour refinement if available
-                    float refinedT = childTEntry;
-                    Vector3f refinedNormal = null;
+                    // front-to-back: prune — next ordered child's tEntry >= bestT → BREAK
+                    // (sorted ⇒ all remaining also >= bestT, cannot improve result)
+                    if (childTEntry >= bestT) {
+                        break; // prune: next tEntry >= bestT, break
+                    }
 
-                    if (contours != null && childNode != null && childNode.hasContour()) {
-                        // Get contour for entry face
-                        int contourMask = childNode.getContourMask();
-                        if ((contourMask & (1 << childEntryFace)) != 0) {
-                            int contourPtr = childNode.getContourPtr();
-                            int contourOffset = Integer.bitCount(contourMask & ((1 << childEntryFace) - 1));
-                            int contourIdx = contourPtr + contourOffset;
+                    // Re-derive vertices and full intersection result for this child
+                    getChildVerticesFromParent(currentVerts, childIdx, parentType, scratchVerts);
+                    if (!intersector.intersectTetrahedron(rayOrigin, rayDir,
+                            scratchVerts[0], scratchVerts[1], scratchVerts[2], scratchVerts[3],
+                            tetResult)) {
+                        // No longer intersects (shouldn't happen since we collected above, but be safe)
+                        continue;
+                    }
+                    int childEntryFace = tetResult.entryFace;
 
-                            if (contourIdx >= 0 && contourIdx < contours.length) {
-                                int contour = contours[contourIdx];
+                    if (currentNode.isChildLeaf(childIdx)) {
+                        int childNodeIdx = currentNode.getChildIndex(childIdx, parentIdx, farPointers);
+                        var childNode = (childNodeIdx >= 0 && childNodeIdx < nodes.length)
+                            ? nodes[childNodeIdx] : null;
 
-                                // Compute tetrahedron scale from current level
-                                float tetScale = (float) Math.pow(0.5, MAX_DEPTH - 1 - scale);
+                        float refinedT = childTEntry;
+                        Vector3f refinedNormal = null;
 
-                                // Set up ray for contour intersection
-                                contourRayOrigin.set(rayOrigin.x, rayOrigin.y, rayOrigin.z);
-                                contourRayDir.set(rayDir.x, rayDir.y, rayDir.z);
+                        if (contours != null && childNode != null && childNode.hasContour()) {
+                            int contourMask = childNode.getContourMask();
+                            if ((contourMask & (1 << childEntryFace)) != 0) {
+                                int contourPtr = childNode.getContourPtr();
+                                int contourOffset = Integer.bitCount(contourMask & ((1 << childEntryFace) - 1));
+                                int contourIdx = contourPtr + contourOffset;
 
-                                // Intersect ray with contour
-                                float[] contourHit = ESVTContour.intersectRay(
-                                    contour, contourRayOrigin, contourRayDir, tetScale);
+                                if (contourIdx >= 0 && contourIdx < contours.length) {
+                                    int contour = contours[contourIdx];
+                                    float tetScale = (float) Math.pow(0.5, MAX_DEPTH - 1 - scale);
+                                    contourRayOrigin.set(rayOrigin.x, rayOrigin.y, rayOrigin.z);
+                                    contourRayDir.set(rayDir.x, rayDir.y, rayDir.z);
+                                    float[] contourHit = ESVTContour.intersectRay(
+                                        contour, contourRayOrigin, contourRayDir, tetScale);
 
-                                if (contourHit == null) {
-                                    // Contour-invalid: continue to next child (do NOT abort subtree)
-                                    continue;
-                                }
+                                    if (contourHit == null) {
+                                        // Contour-invalid: continue to next child (do NOT abort subtree)
+                                        continue;
+                                    }
 
-                                // Refine hit to contour surface
-                                var decoded = ESVTContour.decodeNormal(contour);
-                                float[] posThick = ESVTContour.decodePosThick(contour);
-                                float contourPos = posThick[0] * tetScale;
-
-                                // Calculate refined t at contour plane center
-                                float denom = decoded.x * rayDir.x + decoded.y * rayDir.y + decoded.z * rayDir.z;
-                                if (Math.abs(denom) > 1e-10f) {
-                                    float originDot = decoded.x * rayOrigin.x + decoded.y * rayOrigin.y + decoded.z * rayOrigin.z;
-                                    float newT = (contourPos - originDot) / denom;
-                                    if (newT >= childTEntry && newT <= tetResult.tExit) {
-                                        refinedT = newT;
-                                        refinedNormal = decoded;
-                                        refinedNormal.normalize();
-
-                                        // Ensure normal faces ray
-                                        if (refinedNormal.x * rayDir.x + refinedNormal.y * rayDir.y + refinedNormal.z * rayDir.z > 0) {
-                                            refinedNormal.negate();
+                                    var decoded = ESVTContour.decodeNormal(contour);
+                                    float[] posThick = ESVTContour.decodePosThick(contour);
+                                    float contourPos = posThick[0] * tetScale;
+                                    float denom = decoded.x * rayDir.x + decoded.y * rayDir.y + decoded.z * rayDir.z;
+                                    if (Math.abs(denom) > 1e-10f) {
+                                        float originDot = decoded.x * rayOrigin.x + decoded.y * rayOrigin.y + decoded.z * rayOrigin.z;
+                                        float newT = (contourPos - originDot) / denom;
+                                        if (newT >= childTEntry && newT <= tetResult.tExit) {
+                                            refinedT = newT;
+                                            refinedNormal = decoded;
+                                            refinedNormal.normalize();
+                                            if (refinedNormal.x * rayDir.x + refinedNormal.y * rayDir.y + refinedNormal.z * rayDir.z > 0) {
+                                                refinedNormal.negate();
+                                            }
                                         }
                                     }
                                 }
                             }
                         }
-                    }
 
-                    // Global min-t: only update bestResult if this hit is closer.
-                    // Do NOT return here — continue scanning all remaining children.
-                    if (refinedT < bestT) {
-                        bestT = refinedT;
-
-                        // Read child type from child node (reuse childNodeIdx from above)
-                        byte childType = childNode != null ? childNode.getTetType() : 0;
-                        bestResult.setHit(refinedT,
-                            rayOrigin.x + refinedT * rayDir.x,
-                            rayOrigin.y + refinedT * rayDir.y,
-                            rayOrigin.z + refinedT * rayDir.z,
-                            parentIdx, childIdx, childType,
-                            (byte) childEntryFace, scale);
-                        bestResult.exitFace = (byte) tetResult.exitFace;
-                        if (refinedNormal != null) {
-                            bestResult.normal = refinedNormal;
+                        // Global min-t: only update bestResult if this hit is closer.
+                        if (refinedT < bestT) {
+                            bestT = refinedT;
+                            byte childType = childNode != null ? childNode.getTetType() : 0;
+                            bestResult.setHit(refinedT,
+                                rayOrigin.x + refinedT * rayDir.x,
+                                rayOrigin.y + refinedT * rayDir.y,
+                                rayOrigin.z + refinedT * rayDir.z,
+                                parentIdx, childIdx, childType,
+                                (byte) childEntryFace, scale);
+                            bestResult.exitFace = (byte) tetResult.exitFace;
+                            if (refinedNormal != null) {
+                                bestResult.normal = refinedNormal;
+                            }
                         }
+                        // Continue to check other children at same level (may find closer hit)
+                        continue;
                     }
-                    // Continue to check other children at same level (may find closer hit)
-                    continue;
+
+                    // Non-leaf: fail loud on OOB before any state mutation
+                    int childNodeIdx = currentNode.getChildIndex(childIdx, parentIdx, farPointers);
+                    if (childNodeIdx < 0 || childNodeIdx >= nodes.length) {
+                        throw new IllegalStateException(
+                            "child pointer out of bounds: " + childNodeIdx
+                            + " (node " + parentIdx + ", child " + childIdx
+                            + ", nodes.length " + nodes.length + ")");
+                    }
+
+                    // Push current state; store packed sorted order + next resume position
+                    stack.write(scale, parentIdx, tMax, parentType, (byte) entryFace);
+                    // Resume position = si+1 (next slot in sorted order after this non-leaf descent)
+                    stack.writeSiblingPos(scale, (byte) (si + 1));
+                    stack.writeSortedOrder(scale, packedOrder);
+                    stack.writeVerts(scale,
+                        currentVerts[0], currentVerts[1], currentVerts[2],
+                        currentVerts[3], currentVerts[4], currentVerts[5],
+                        currentVerts[6], currentVerts[7], currentVerts[8],
+                        currentVerts[9], currentVerts[10], currentVerts[11]);
+
+                    // Descend
+                    currentVerts[0] = scratchVerts[0].x; currentVerts[1] = scratchVerts[0].y; currentVerts[2] = scratchVerts[0].z;
+                    currentVerts[3] = scratchVerts[1].x; currentVerts[4] = scratchVerts[1].y; currentVerts[5] = scratchVerts[1].z;
+                    currentVerts[6] = scratchVerts[2].x; currentVerts[7] = scratchVerts[2].y; currentVerts[8] = scratchVerts[2].z;
+                    currentVerts[9] = scratchVerts[3].x; currentVerts[10] = scratchVerts[3].y; currentVerts[11] = scratchVerts[3].z;
+
+                    parentIdx = childNodeIdx;
+                    parentType = nodes[childNodeIdx].getTetType();
+                    entryFace = childEntryFace >= 0 ? childEntryFace : 0;
+                    tMax = tetResult.tExit;
+                    scale--;
+                    sortedPos = 0;
+                    descendedInner = true;
+                    descended = true;
+                    break;
                 }
+                descended = descendedInner;
 
-                // Fetch child index FIRST — fail loud if out of bounds (malformed tree)
-                int childNodeIdx = node.getChildIndex(childIdx, parentIdx, farPointers);
-                if (childNodeIdx < 0 || childNodeIdx >= nodes.length) {
-                    throw new IllegalStateException(
-                        "child pointer out of bounds: " + childNodeIdx
-                        + " (node " + parentIdx + ", child " + childIdx
-                        + ", nodes.length " + nodes.length + ")");
+            } else {
+                // ----- RESUME: we popped back to this node; continue sorted-order visit -----
+                // Restore the packed sorted order (already read above during pop restore or passed through)
+                packedOrder = stack.readSortedOrder(scale);
+                childCount = ESVTStack.sortedCount(packedOrder);
+
+                boolean descendedResume = false;
+                for (int si = sortedPos; si < childCount; si++) {
+                    int childIdx = ESVTStack.sortedChildAt(packedOrder, si);
+
+                    // Re-derive vertices + re-intersect (per design: resume re-intersects, no stored tEntry)
+                    getChildVerticesFromParent(currentVerts, childIdx, parentType, scratchVerts);
+                    if (!intersector.intersectTetrahedron(rayOrigin, rayDir,
+                            scratchVerts[0], scratchVerts[1], scratchVerts[2], scratchVerts[3],
+                            tetResult)) {
+                        continue;
+                    }
+                    float childTEntry = tetResult.tEntry;
+                    int childEntryFace = tetResult.entryFace;
+
+                    // front-to-back: prune — next ordered child's tEntry >= bestT → BREAK
+                    if (childTEntry >= bestT) {
+                        break; // prune: next tEntry >= bestT, break
+                    }
+
+                    if (currentNode.isChildLeaf(childIdx)) {
+                        int childNodeIdx = currentNode.getChildIndex(childIdx, parentIdx, farPointers);
+                        var childNode = (childNodeIdx >= 0 && childNodeIdx < nodes.length)
+                            ? nodes[childNodeIdx] : null;
+
+                        float refinedT = childTEntry;
+                        Vector3f refinedNormal = null;
+
+                        if (contours != null && childNode != null && childNode.hasContour()) {
+                            int contourMask = childNode.getContourMask();
+                            if ((contourMask & (1 << childEntryFace)) != 0) {
+                                int contourPtr = childNode.getContourPtr();
+                                int contourOffset = Integer.bitCount(contourMask & ((1 << childEntryFace) - 1));
+                                int contourIdx = contourPtr + contourOffset;
+
+                                if (contourIdx >= 0 && contourIdx < contours.length) {
+                                    int contour = contours[contourIdx];
+                                    float tetScale = (float) Math.pow(0.5, MAX_DEPTH - 1 - scale);
+                                    contourRayOrigin.set(rayOrigin.x, rayOrigin.y, rayOrigin.z);
+                                    contourRayDir.set(rayDir.x, rayDir.y, rayDir.z);
+                                    float[] contourHit = ESVTContour.intersectRay(
+                                        contour, contourRayOrigin, contourRayDir, tetScale);
+
+                                    if (contourHit == null) {
+                                        // Contour-invalid: continue to next child (do NOT abort subtree)
+                                        continue;
+                                    }
+
+                                    var decoded = ESVTContour.decodeNormal(contour);
+                                    float[] posThick = ESVTContour.decodePosThick(contour);
+                                    float contourPos = posThick[0] * tetScale;
+                                    float denom = decoded.x * rayDir.x + decoded.y * rayDir.y + decoded.z * rayDir.z;
+                                    if (Math.abs(denom) > 1e-10f) {
+                                        float originDot = decoded.x * rayOrigin.x + decoded.y * rayOrigin.y + decoded.z * rayOrigin.z;
+                                        float newT = (contourPos - originDot) / denom;
+                                        if (newT >= childTEntry && newT <= tetResult.tExit) {
+                                            refinedT = newT;
+                                            refinedNormal = decoded;
+                                            refinedNormal.normalize();
+                                            if (refinedNormal.x * rayDir.x + refinedNormal.y * rayDir.y + refinedNormal.z * rayDir.z > 0) {
+                                                refinedNormal.negate();
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        if (refinedT < bestT) {
+                            bestT = refinedT;
+                            byte childType = childNode != null ? childNode.getTetType() : 0;
+                            bestResult.setHit(refinedT,
+                                rayOrigin.x + refinedT * rayDir.x,
+                                rayOrigin.y + refinedT * rayDir.y,
+                                rayOrigin.z + refinedT * rayDir.z,
+                                parentIdx, childIdx, childType,
+                                (byte) childEntryFace, scale);
+                            bestResult.exitFace = (byte) tetResult.exitFace;
+                            if (refinedNormal != null) {
+                                bestResult.normal = refinedNormal;
+                            }
+                        }
+                        continue;
+                    }
+
+                    // Non-leaf: fail loud on OOB before any state mutation
+                    int childNodeIdx = currentNode.getChildIndex(childIdx, parentIdx, farPointers);
+                    if (childNodeIdx < 0 || childNodeIdx >= nodes.length) {
+                        throw new IllegalStateException(
+                            "child pointer out of bounds: " + childNodeIdx
+                            + " (node " + parentIdx + ", child " + childIdx
+                            + ", nodes.length " + nodes.length + ")");
+                    }
+
+                    // Push: store resume at si+1
+                    stack.write(scale, parentIdx, tMax, parentType, (byte) entryFace);
+                    stack.writeSiblingPos(scale, (byte) (si + 1));
+                    stack.writeSortedOrder(scale, packedOrder);
+                    stack.writeVerts(scale,
+                        currentVerts[0], currentVerts[1], currentVerts[2],
+                        currentVerts[3], currentVerts[4], currentVerts[5],
+                        currentVerts[6], currentVerts[7], currentVerts[8],
+                        currentVerts[9], currentVerts[10], currentVerts[11]);
+
+                    currentVerts[0] = scratchVerts[0].x; currentVerts[1] = scratchVerts[0].y; currentVerts[2] = scratchVerts[0].z;
+                    currentVerts[3] = scratchVerts[1].x; currentVerts[4] = scratchVerts[1].y; currentVerts[5] = scratchVerts[1].z;
+                    currentVerts[6] = scratchVerts[2].x; currentVerts[7] = scratchVerts[2].y; currentVerts[8] = scratchVerts[2].z;
+                    currentVerts[9] = scratchVerts[3].x; currentVerts[10] = scratchVerts[3].y; currentVerts[11] = scratchVerts[3].z;
+
+                    parentIdx = childNodeIdx;
+                    parentType = nodes[childNodeIdx].getTetType();
+                    entryFace = childEntryFace >= 0 ? childEntryFace : 0;
+                    tMax = tetResult.tExit;
+                    scale--;
+                    sortedPos = 0;
+                    descendedResume = true;
+                    descended = true;
+                    break;
                 }
-
-                // Non-leaf - push current state including vertices and sibling position
-                stack.write(scale, parentIdx, tMax, parentType, (byte) entryFace);
-                stack.writeSiblingPos(scale, (byte) (childIdx + 1)); // Resume from next sibling after pop
-                stack.writeVerts(scale,
-                    currentVerts[0], currentVerts[1], currentVerts[2],
-                    currentVerts[3], currentVerts[4], currentVerts[5],
-                    currentVerts[6], currentVerts[7], currentVerts[8],
-                    currentVerts[9], currentVerts[10], currentVerts[11]);
-
-                // Update current vertices to child vertices
-                currentVerts[0] = scratchVerts[0].x; currentVerts[1] = scratchVerts[0].y; currentVerts[2] = scratchVerts[0].z;
-                currentVerts[3] = scratchVerts[1].x; currentVerts[4] = scratchVerts[1].y; currentVerts[5] = scratchVerts[1].z;
-                currentVerts[6] = scratchVerts[2].x; currentVerts[7] = scratchVerts[2].y; currentVerts[8] = scratchVerts[2].z;
-                currentVerts[9] = scratchVerts[3].x; currentVerts[10] = scratchVerts[3].y; currentVerts[11] = scratchVerts[3].z;
-
-                parentIdx = childNodeIdx;
-                // Read child type directly from the child node (types are propagated during build)
-                parentType = nodes[childNodeIdx].getTetType();
-                entryFace = childEntryFace >= 0 ? childEntryFace : 0;
-                tMin = childTEntry;
-                tMax = tetResult.tExit;
-                scale--;
-                siblingPos = 0;
-                descended = true;
-                break;
+                descended = descendedResume;
             }
 
             if (!descended) {
-                // No valid non-leaf child descended into — pop to parent
+                // No more children to visit — pop to parent
                 if (scale >= MAX_DEPTH - 1) {
-                    // At root level, traversal complete
                     break;
                 }
 
@@ -374,29 +542,14 @@ public final class ESVTTraversal {
                     System.arraycopy(restoredVerts, 0, currentVerts, 0, 12);
                 }
 
-                // Resume from next untested sibling
-                siblingPos = stack.readSiblingPos(scale);
+                // Resume at the stored sorted position for this level
+                sortedPos = stack.readSiblingPos(scale);
             }
         }
 
         // Return global best hit after stack exhaustion (bestT preserved across all pop/resume)
         bestResult.iterations = iterations;
         return bestResult;
-    }
-
-    /**
-     * Pop traversal state from stack.
-     */
-    private boolean popStack(int currentScale, ESVTResult tempResult) {
-        int parentScale = currentScale + 1;
-        if (!stack.hasEntry(parentScale)) {
-            return false;
-        }
-        tempResult.nodeIndex = stack.readNode(parentScale);
-        tempResult.tetType = stack.readType(parentScale);
-        tempResult.entryFace = stack.readEntryFace(parentScale);
-        tempResult.t = stack.readTmax(parentScale);
-        return true;
     }
 
     /**
@@ -500,95 +653,6 @@ public final class ESVTTraversal {
         }
     }
 
-    /**
-     * Get child tetrahedron vertices at given scale.
-     *
-     * <p>Uses Bey subdivision to compute child vertices from parent.
-     * At each level, the tetrahedra are scaled by 0.5.
-     */
-    private void getChildVertices(int parentType, int childIdx, int scale, Point3f[] verts) {
-        // Get parent vertices
-        Point3i[] parentStandard = Constants.SIMPLEX_STANDARD[parentType];
-        float[] pv0 = {parentStandard[0].x, parentStandard[0].y, parentStandard[0].z};
-        float[] pv1 = {parentStandard[1].x, parentStandard[1].y, parentStandard[1].z};
-        float[] pv2 = {parentStandard[2].x, parentStandard[2].y, parentStandard[2].z};
-        float[] pv3 = {parentStandard[3].x, parentStandard[3].y, parentStandard[3].z};
-
-        // Scale factor for this level (each level halves the size)
-        float levelScale = (float) Math.pow(0.5, MAX_DEPTH - 1 - scale);
-
-        // Edge midpoints
-        float[] m01 = midpoint(pv0, pv1);
-        float[] m02 = midpoint(pv0, pv2);
-        float[] m03 = midpoint(pv0, pv3);
-        float[] m12 = midpoint(pv1, pv2);
-        float[] m13 = midpoint(pv1, pv3);
-        float[] m23 = midpoint(pv2, pv3);
-
-        // Bey children vertices (from BeySubdivision)
-        switch (childIdx) {
-            case 0 -> { // Corner at v0
-                setVertex(verts[0], pv0, levelScale);
-                setVertex(verts[1], m01, levelScale);
-                setVertex(verts[2], m02, levelScale);
-                setVertex(verts[3], m03, levelScale);
-            }
-            case 1 -> { // Corner at v1
-                setVertex(verts[0], pv1, levelScale);
-                setVertex(verts[1], m01, levelScale);
-                setVertex(verts[2], m12, levelScale);
-                setVertex(verts[3], m13, levelScale);
-            }
-            case 2 -> { // Corner at v2
-                setVertex(verts[0], pv2, levelScale);
-                setVertex(verts[1], m02, levelScale);
-                setVertex(verts[2], m12, levelScale);
-                setVertex(verts[3], m23, levelScale);
-            }
-            case 3 -> { // Corner at v3
-                setVertex(verts[0], pv3, levelScale);
-                setVertex(verts[1], m03, levelScale);
-                setVertex(verts[2], m13, levelScale);
-                setVertex(verts[3], m23, levelScale);
-            }
-            case 4 -> { // Octahedral region
-                setVertex(verts[0], m01, levelScale);
-                setVertex(verts[1], m02, levelScale);
-                setVertex(verts[2], m03, levelScale);
-                setVertex(verts[3], m12, levelScale);
-            }
-            case 5 -> {
-                setVertex(verts[0], m01, levelScale);
-                setVertex(verts[1], m02, levelScale);
-                setVertex(verts[2], m12, levelScale);
-                setVertex(verts[3], m13, levelScale);
-            }
-            case 6 -> {
-                setVertex(verts[0], m02, levelScale);
-                setVertex(verts[1], m03, levelScale);
-                setVertex(verts[2], m12, levelScale);
-                setVertex(verts[3], m23, levelScale);
-            }
-            case 7 -> {
-                setVertex(verts[0], m03, levelScale);
-                setVertex(verts[1], m12, levelScale);
-                setVertex(verts[2], m13, levelScale);
-                setVertex(verts[3], m23, levelScale);
-            }
-        }
-    }
-
-    private static float[] midpoint(float[] a, float[] b) {
-        return new float[]{
-            (a[0] + b[0]) / 2,
-            (a[1] + b[1]) / 2,
-            (a[2] + b[2]) / 2
-        };
-    }
-
-    private static void setVertex(Point3f vert, float[] coords, float scale) {
-        vert.set(coords[0] * scale, coords[1] * scale, coords[2] * scale);
-    }
 
     /**
      * Cast multiple rays (batch processing).

--- a/render/src/main/resources/kernels/esvt_ray_traversal.cl
+++ b/render/src/main/resources/kernels/esvt_ray_traversal.cl
@@ -58,7 +58,8 @@ typedef struct {
     float tMax;
     int parentType;
     int entryFace;
-    int siblingPos;  // Next child index to try when we pop back to this level
+    int siblingPos;  // front-to-back: resume position (sortedPos) in this level's sorted visit order
+    int sortedOrder; // front-to-back: packed sorted order — count in bits 27-24, 3-bit Morton childIdx slots at bits 23-0
     // Store actual parent vertices for correct multi-level traversal
     float3 v0, v1, v2, v3;
 } StackEntry;
@@ -651,6 +652,7 @@ __kernel void traverseESVT(
     for (int i = 0; i < CAST_STACK_DEPTH; i++) {
         stack[i].nodeIdx = 0xFFFFFFFFu;
         stack[i].siblingPos = 0;
+        stack[i].sortedOrder = 0;
     }
 
     // Get root node
@@ -714,7 +716,8 @@ __kernel void traverseESVT(
         float tMaxLocal = rootHit_tExit;
         int scale = CAST_STACK_DEPTH - 1;
         float scaleExp2 = 1.0f;
-        int siblingPos = 0;
+        // front-to-back: sorted position (index into the sorted visit order per level)
+        int sortedPos = 0;
         int iter = 0;
 
         // Track best hit (using float flag to avoid conditional crash)
@@ -738,7 +741,7 @@ __kernel void traverseESVT(
                 tMaxLocal = stack[scale].tMax;
                 parentType = stack[scale].parentType;
                 entryFace = stack[scale].entryFace;
-                siblingPos = stack[scale].siblingPos;  // Resume from saved position
+                sortedPos = stack[scale].siblingPos;  // Resume from saved sorted position
                 pv0 = stack[scale].v0;
                 pv1 = stack[scale].v1;
                 pv2 = stack[scale].v2;
@@ -747,109 +750,275 @@ __kernel void traverseESVT(
                 continue;
             }
 
-            // Try each child starting from siblingPos (for resumption after pop)
-            // Bey subdivision has 8 children that completely fill the parent
+            // -----------------------------------------------------------------------
+            // Front-to-back: collect intersecting children, insertion-sort by tEntry,
+            // visit in sorted order, prune when next tEntry >= bestT.
+            //
+            // On first entry to this node: sortedPos == 0, collect all candidates.
+            // On resume (after pop): sortedPos > 0, use the stored packed order.
+            // Mirrors ESVTTraversal.java castRay exactly: same loop, same comparator.
+            // -----------------------------------------------------------------------
             bool descended = false;
-            for (int childIdx = siblingPos; childIdx < 8; childIdx++) {
 
-                if (!hasChild(node, childIdx)) {
-                    continue;
+            if (sortedPos == 0) {
+                // ----- COLLECT: scan all 8 Morton children, compute intersections -----
+                float candidateTEntry[8];
+                int candidateIdx[8];
+                int nCandidates = 0;
+                for (int childIdx = 0; childIdx < 8; childIdx++) {
+                    if (!hasChild(node, childIdx)) {
+                        continue;
+                    }
+                    // childIdx is in Morton order; getChildVerticesFromParent converts to Bey order
+                    float3 sv0, sv1, sv2, sv3;
+                    getChildVerticesFromParent(pv0, pv1, pv2, pv3, childIdx, parentType, &sv0, &sv1, &sv2, &sv3);
+                    bool scanHit_hit;
+                    float scanHit_tEntry, scanHit_tExit;
+                    int scanHit_entryFace, scanHit_exitFace;
+                    intersectTetrahedronInplace(rayOrigin, rayDir, sv0, sv1, sv2, sv3,
+                                                &scanHit_hit, &scanHit_tEntry, &scanHit_tExit,
+                                                &scanHit_entryFace, &scanHit_exitFace);
+                    if (!scanHit_hit) {
+                        continue;
+                    }
+                    candidateTEntry[nCandidates] = scanHit_tEntry;
+                    candidateIdx[nCandidates] = childIdx;
+                    nCandidates++;
                 }
 
-                // Get child vertices from ACTUAL parent vertices (not SIMPLEX_STANDARD)
-                // childIdx is in Morton order; getChildVerticesFromParent converts to Bey order
-                float3 cv0, cv1, cv2, cv3;
-                getChildVerticesFromParent(pv0, pv1, pv2, pv3, childIdx, parentType, &cv0, &cv1, &cv2, &cv3);
-
-                // Test intersection using inplace version (avoids struct return issues)
-                bool childHit_hit;
-                float childHit_tEntry, childHit_tExit;
-                int childHit_entryFace, childHit_exitFace;
-                intersectTetrahedronInplace(rayOrigin, rayDir, cv0, cv1, cv2, cv3,
-                                            &childHit_hit, &childHit_tEntry, &childHit_tExit,
-                                            &childHit_entryFace, &childHit_exitFace);
-                if (!childHit_hit) {
-                    continue;
+                // ----- INSERTION SORT ascending by tEntry, tiebreak childIdx ascending -----
+                // Direct tandem sort of the two parallel arrays; max 8 elements.
+                for (int i = 1; i < nCandidates; i++) {
+                    float ti = candidateTEntry[i];
+                    int ci = candidateIdx[i];
+                    int j = i - 1;
+                    while (j >= 0 && (candidateTEntry[j] > ti
+                                      || (candidateTEntry[j] == ti && candidateIdx[j] > ci))) {
+                        candidateTEntry[j + 1] = candidateTEntry[j];
+                        candidateIdx[j + 1] = candidateIdx[j];
+                        j--;
+                    }
+                    candidateTEntry[j + 1] = ti;
+                    candidateIdx[j + 1] = ci;
                 }
 
-                // Check if leaf
-                if (isChildLeaf(node, childIdx)) {
-                    uint childNodeIdx = getChildIndex(farPointers, node, childIdx, parentIdx);
-                    ESVTNode childNode = nodes[childNodeIdx];
-                    float childScale = scaleExp2 * 0.5f;
+                int childCount = nCandidates;
+                // Pack sorted childIdx order: count in bits 27-24, 3-bit slots at bits 23-0
+                int packedOrder = (childCount & 0xF) << 24;
+                for (int i = 0; i < childCount; i++) {
+                    packedOrder |= (candidateIdx[i] & 0x7) << (21 - i * 3);
+                }
 
-                    // Use inplace version to avoid struct return
-                    float contourT;
-                    float3 contourNormal;
-                    bool contourValid;
-                    refineHitWithContoursInplace(
-                        childNode, childHit_entryFace, childHit_tEntry, childHit_tExit,
-                        rayOrigin, rayDir, childScale, contours,
-                        &contourT, &contourNormal, &contourValid);
+                // ----- VISIT in sorted order, PRUNE when tEntry >= bestT -----
+                for (int si = 0; si < childCount; si++) {
+                    int childIdx = candidateIdx[si];
 
-                    if (!contourValid) {
+                    // front-to-back: prune — next ordered child's tEntry >= bestT → BREAK
+                    // (sorted ⇒ all remaining also >= bestT, cannot improve result)
+                    if (candidateTEntry[si] >= bestT) {
+                        break; // prune: next tEntry >= bestT, break
+                    }
+
+                    // Re-derive vertices and full intersection result for this child
+                    float3 cv0, cv1, cv2, cv3;
+                    getChildVerticesFromParent(pv0, pv1, pv2, pv3, childIdx, parentType, &cv0, &cv1, &cv2, &cv3);
+                    bool childHit_hit;
+                    float childHit_tEntry, childHit_tExit;
+                    int childHit_entryFace, childHit_exitFace;
+                    intersectTetrahedronInplace(rayOrigin, rayDir, cv0, cv1, cv2, cv3,
+                                                &childHit_hit, &childHit_tEntry, &childHit_tExit,
+                                                &childHit_entryFace, &childHit_exitFace);
+                    if (!childHit_hit) {
                         continue;
                     }
 
-                    // Found valid leaf hit - check if it's closer
-                    if (contourT < bestT) {
-                        bestT = contourT;
-                        bestHitPoint = rayOrigin + rayDir * contourT;
+                    // Check if leaf
+                    if (isChildLeaf(node, childIdx)) {
+                        uint childNodeIdx = getChildIndex(farPointers, node, childIdx, parentIdx);
+                        ESVTNode childNode = nodes[childNodeIdx];
+                        float childScale = scaleExp2 * 0.5f;
 
-                        // Calculate normal
-                        float normalLen = length(contourNormal);
-                        if (normalLen > 0.5f) {
-                            bestHitNormal = contourNormal;
-                        } else {
-                            // Compute face normal based on entry face
-                            float3 fv0, fv1, fv2;
-                            int ef = childHit_entryFace;
-                            // Use safe indexing to select face vertices
-                            if (ef == 0) { fv0 = cv1; fv1 = cv2; fv2 = cv3; }
-                            else if (ef == 1) { fv0 = cv0; fv1 = cv2; fv2 = cv3; }
-                            else if (ef == 2) { fv0 = cv0; fv1 = cv1; fv2 = cv3; }
-                            else { fv0 = cv0; fv1 = cv1; fv2 = cv2; }
+                        // Use inplace version to avoid struct return
+                        float contourT;
+                        float3 contourNormal;
+                        bool contourValid;
+                        refineHitWithContoursInplace(
+                            childNode, childHit_entryFace, childHit_tEntry, childHit_tExit,
+                            rayOrigin, rayDir, childScale, contours,
+                            &contourT, &contourNormal, &contourValid);
 
-                            bestHitNormal = normalize(cross(fv1 - fv0, fv2 - fv0));
-                            if (dot(bestHitNormal, rayDir) > 0) {
-                                bestHitNormal = -bestHitNormal;
-                            }
+                        if (!contourValid) {
+                            continue;
                         }
-                        foundLeafFlag = 1.0f;
+
+                        // Found valid leaf hit - check if it's closer
+                        if (contourT < bestT) {
+                            bestT = contourT;
+                            bestHitPoint = rayOrigin + rayDir * contourT;
+
+                            // Calculate normal
+                            float normalLen = length(contourNormal);
+                            if (normalLen > 0.5f) {
+                                bestHitNormal = contourNormal;
+                            } else {
+                                // Compute face normal based on entry face
+                                float3 fv0, fv1, fv2;
+                                int ef = childHit_entryFace;
+                                // Use safe indexing to select face vertices
+                                if (ef == 0) { fv0 = cv1; fv1 = cv2; fv2 = cv3; }
+                                else if (ef == 1) { fv0 = cv0; fv1 = cv2; fv2 = cv3; }
+                                else if (ef == 2) { fv0 = cv0; fv1 = cv1; fv2 = cv3; }
+                                else { fv0 = cv0; fv1 = cv1; fv2 = cv2; }
+
+                                bestHitNormal = normalize(cross(fv1 - fv0, fv2 - fv0));
+                                if (dot(bestHitNormal, rayDir) > 0) {
+                                    bestHitNormal = -bestHitNormal;
+                                }
+                            }
+                            foundLeafFlag = 1.0f;
+                        }
+                        // Continue to check other children at same level (may find closer hit)
+                        continue;
                     }
-                    // Continue to check other children at same level (may find closer hit)
-                    continue;
+
+                    // Non-leaf - push and descend
+                    // Save current state including parent vertices + packed sorted order
+                    stack[scale].nodeIdx = parentIdx;
+                    stack[scale].tMax = tMaxLocal;
+                    stack[scale].parentType = parentType;
+                    stack[scale].entryFace = entryFace;
+                    stack[scale].siblingPos = si + 1;  // Resume at next slot in sorted order
+                    stack[scale].sortedOrder = packedOrder;
+                    stack[scale].v0 = pv0;
+                    stack[scale].v1 = pv1;
+                    stack[scale].v2 = pv2;
+                    stack[scale].v3 = pv3;
+
+                    // Update state for child - child vertices become new parent vertices
+                    parentIdx = getChildIndex(farPointers, node, childIdx, parentIdx);
+                    // childIdx is Morton index; convert to Bey index for type lookup
+                    int beyIdx = INDEX_TO_BEY_NUMBER[parentType * 8 + childIdx];
+                    parentType = PARENT_TYPE_TO_CHILD_TYPE[parentType * 8 + beyIdx];
+                    entryFace = (childHit_entryFace >= 0) ? childHit_entryFace : 0;
+                    tMinLocal = childHit_tEntry;
+                    tMaxLocal = childHit_tExit;
+                    pv0 = cv0;
+                    pv1 = cv1;
+                    pv2 = cv2;
+                    pv3 = cv3;
+                    scale--;
+                    scaleExp2 *= 0.5f;
+                    sortedPos = 0;
+                    descended = true;
+                    break;
                 }
 
-                // Non-leaf - push and descend
-                // Save current state including parent vertices
-                stack[scale].nodeIdx = parentIdx;
-                stack[scale].tMax = tMaxLocal;
-                stack[scale].parentType = parentType;
-                stack[scale].entryFace = entryFace;
-                stack[scale].siblingPos = childIdx + 1;  // Resume from next sibling when we pop back
-                stack[scale].v0 = pv0;
-                stack[scale].v1 = pv1;
-                stack[scale].v2 = pv2;
-                stack[scale].v3 = pv3;
+            } else {
+                // ----- RESUME: popped back to this node; continue sorted-order visit -----
+                int packedOrder = stack[scale].sortedOrder;
+                int childCount = (packedOrder >> 24) & 0xF;
 
-                // Update state for child - child vertices become new parent vertices
-                parentIdx = getChildIndex(farPointers, node, childIdx, parentIdx);
-                // childIdx is Morton index; convert to Bey index for type lookup
-                int beyIdx = INDEX_TO_BEY_NUMBER[parentType * 8 + childIdx];
-                parentType = PARENT_TYPE_TO_CHILD_TYPE[parentType * 8 + beyIdx];
-                entryFace = (childHit_entryFace >= 0) ? childHit_entryFace : 0;
-                tMinLocal = childHit_tEntry;
-                tMaxLocal = childHit_tExit;
-                pv0 = cv0;
-                pv1 = cv1;
-                pv2 = cv2;
-                pv3 = cv3;
-                scale--;
-                scaleExp2 *= 0.5f;
-                siblingPos = 0;
-                descended = true;
-                break;
+                for (int si = sortedPos; si < childCount; si++) {
+                    int childIdx = (packedOrder >> (21 - si * 3)) & 0x7;
+
+                    // Re-derive vertices + re-intersect (resume re-intersects, no stored tEntry)
+                    float3 cv0, cv1, cv2, cv3;
+                    getChildVerticesFromParent(pv0, pv1, pv2, pv3, childIdx, parentType, &cv0, &cv1, &cv2, &cv3);
+                    bool childHit_hit;
+                    float childHit_tEntry, childHit_tExit;
+                    int childHit_entryFace, childHit_exitFace;
+                    intersectTetrahedronInplace(rayOrigin, rayDir, cv0, cv1, cv2, cv3,
+                                                &childHit_hit, &childHit_tEntry, &childHit_tExit,
+                                                &childHit_entryFace, &childHit_exitFace);
+                    if (!childHit_hit) {
+                        continue;
+                    }
+
+                    // front-to-back: prune — next ordered child's tEntry >= bestT → BREAK
+                    if (childHit_tEntry >= bestT) {
+                        break; // prune: next tEntry >= bestT, break
+                    }
+
+                    // Check if leaf
+                    if (isChildLeaf(node, childIdx)) {
+                        uint childNodeIdx = getChildIndex(farPointers, node, childIdx, parentIdx);
+                        ESVTNode childNode = nodes[childNodeIdx];
+                        float childScale = scaleExp2 * 0.5f;
+
+                        // Use inplace version to avoid struct return
+                        float contourT;
+                        float3 contourNormal;
+                        bool contourValid;
+                        refineHitWithContoursInplace(
+                            childNode, childHit_entryFace, childHit_tEntry, childHit_tExit,
+                            rayOrigin, rayDir, childScale, contours,
+                            &contourT, &contourNormal, &contourValid);
+
+                        if (!contourValid) {
+                            continue;
+                        }
+
+                        // Found valid leaf hit - check if it's closer
+                        if (contourT < bestT) {
+                            bestT = contourT;
+                            bestHitPoint = rayOrigin + rayDir * contourT;
+
+                            // Calculate normal
+                            float normalLen = length(contourNormal);
+                            if (normalLen > 0.5f) {
+                                bestHitNormal = contourNormal;
+                            } else {
+                                // Compute face normal based on entry face
+                                float3 fv0, fv1, fv2;
+                                int ef = childHit_entryFace;
+                                // Use safe indexing to select face vertices
+                                if (ef == 0) { fv0 = cv1; fv1 = cv2; fv2 = cv3; }
+                                else if (ef == 1) { fv0 = cv0; fv1 = cv2; fv2 = cv3; }
+                                else if (ef == 2) { fv0 = cv0; fv1 = cv1; fv2 = cv3; }
+                                else { fv0 = cv0; fv1 = cv1; fv2 = cv2; }
+
+                                bestHitNormal = normalize(cross(fv1 - fv0, fv2 - fv0));
+                                if (dot(bestHitNormal, rayDir) > 0) {
+                                    bestHitNormal = -bestHitNormal;
+                                }
+                            }
+                            foundLeafFlag = 1.0f;
+                        }
+                        // Continue to check other children at same level (may find closer hit)
+                        continue;
+                    }
+
+                    // Non-leaf - push and descend
+                    // Save current state including parent vertices + packed sorted order
+                    stack[scale].nodeIdx = parentIdx;
+                    stack[scale].tMax = tMaxLocal;
+                    stack[scale].parentType = parentType;
+                    stack[scale].entryFace = entryFace;
+                    stack[scale].siblingPos = si + 1;  // Resume at next slot in sorted order
+                    stack[scale].sortedOrder = packedOrder;
+                    stack[scale].v0 = pv0;
+                    stack[scale].v1 = pv1;
+                    stack[scale].v2 = pv2;
+                    stack[scale].v3 = pv3;
+
+                    // Update state for child - child vertices become new parent vertices
+                    parentIdx = getChildIndex(farPointers, node, childIdx, parentIdx);
+                    // childIdx is Morton index; convert to Bey index for type lookup
+                    int beyIdx = INDEX_TO_BEY_NUMBER[parentType * 8 + childIdx];
+                    parentType = PARENT_TYPE_TO_CHILD_TYPE[parentType * 8 + beyIdx];
+                    entryFace = (childHit_entryFace >= 0) ? childHit_entryFace : 0;
+                    tMinLocal = childHit_tEntry;
+                    tMaxLocal = childHit_tExit;
+                    pv0 = cv0;
+                    pv1 = cv1;
+                    pv2 = cv2;
+                    pv3 = cv3;
+                    scale--;
+                    scaleExp2 *= 0.5f;
+                    sortedPos = 0;
+                    descended = true;
+                    break;
+                }
             }
 
             if (!descended) {
@@ -869,7 +1038,7 @@ __kernel void traverseESVT(
                 tMaxLocal = stack[scale].tMax;
                 parentType = stack[scale].parentType;
                 entryFace = stack[scale].entryFace;
-                siblingPos = stack[scale].siblingPos;  // Resume from saved position
+                sortedPos = stack[scale].siblingPos;  // Resume from saved sorted position
                 pv0 = stack[scale].v0;
                 pv1 = stack[scale].v1;
                 pv2 = stack[scale].v2;

--- a/render/src/main/resources/shaders/raycast_esvt.comp
+++ b/render/src/main/resources/shaders/raycast_esvt.comp
@@ -73,10 +73,13 @@ const int INDEX_TO_BEY_NUMBER[6][8] = {
     { 0, 5, 4, 1, 6, 7, 2, 3 }   // Parent type 5
 };
 
-// All-8 Morton scan (Luciferase-g51tc / jk5tk P3): traversal iterates childIdx=0..7 in Morton order,
-// tracking a global bestT across all DFS branches. The old 4-child per-type entry-face
-// table has been removed: it only scanned 4 of 8 children and returned on the first hit rather than
-// the globally closest one. The .cl kernel reference always used all-8 Morton order; this shader now matches.
+// Front-to-back traversal (Luciferase-2s3jc, supersedes the all-8 exhaustive scan of g51tc/jk5tk):
+// on fresh node entry the COLLECT loop scans all 8 Morton children (hasChild + intersect), then a
+// tandem insertion sort orders candidates ascending by (tEntry, childIdx tiebreak), the visit loop
+// proceeds in sorted order, and prunes with BREAK when the next tEntry >= bestT (sorted order
+// guarantees no remaining child can improve the result). Global bestT across all DFS branches is
+// preserved; result returned only after stack exhaustion. Mirrors ESVTTraversal.java and
+// esvt_ray_traversal.cl exactly: same collect scan, same comparator, same prune condition.
 
 // ============================================================================
 // BUFFER BINDINGS
@@ -87,7 +90,10 @@ shared uint stack_nodes[64 * CAST_STACK_DEPTH];
 shared float stack_tmax[64 * CAST_STACK_DEPTH];
 shared int stack_type[64 * CAST_STACK_DEPTH];
 shared int stack_entryFace[64 * CAST_STACK_DEPTH];
-// siblingPos stores childIdx+1 (range 1-8, 0 = empty slot) so pop resumes after the child that triggered descent
+// Front-to-back packed slot (NO 6th shared array — 32 KiB shared-memory budget, Luciferase-y3l06):
+// bits 31-28 = sortedPos resume cursor (0-8), bits 27-24 = sorted child count (0-8),
+// bits 23-0  = eight 3-bit Morton childIdx slots in sorted visit order (slot i at shift 21 - i*3).
+// Exactly 32 bits; read/write via uint casts to avoid sign-extension on the high nibble.
 shared int stack_siblingPos[64 * CAST_STACK_DEPTH];
 
 // SSBO for ESVT nodes (8 bytes per node = 2 x uint)
@@ -708,7 +714,8 @@ void castRayESVT(inout Ray ray, out vec3 hitPoint, out vec3 hitNormal, out bool 
     float tMax = rootHit.tExit;
     int scale = CAST_STACK_DEPTH - 1;
     float scaleExp2 = 1.0;
-    int siblingPos = 0;
+    // front-to-back: sorted position (index into the sorted visit order per level)
+    int sortedPos = 0;
     int iter = 0;
 
     // Global min-t accumulators — updated at every LOD/leaf hit, returned after stack exhaustion
@@ -732,150 +739,352 @@ void castRayESVT(inout Ray ray, out vec3 hitPoint, out vec3 hitNormal, out bool 
             tMax = stack_tmax[stackBase + scale];
             parentType = stack_type[stackBase + scale];
             entryFace = stack_entryFace[stackBase + scale];
-            siblingPos = stack_siblingPos[stackBase + scale];
+            // Resume cursor lives in the high nibble of the packed siblingPos slot
+            sortedPos = int((uint(stack_siblingPos[stackBase + scale]) >> 28) & 0xFu);
             scaleExp2 *= 2.0;
             continue;
         }
 
-        // All-8 Morton scan: iterate childIdx=0..7, tracking global bestT (Luciferase-g51tc P3)
+        // -----------------------------------------------------------------------
+        // Front-to-back: collect intersecting children, insertion-sort by tEntry,
+        // visit in sorted order, prune when next tEntry >= bestT.
+        //
+        // On first entry to this node: sortedPos == 0, collect all candidates.
+        // On resume (after pop): sortedPos > 0, use the stored packed order.
+        // Mirrors ESVTTraversal.java and esvt_ray_traversal.cl exactly:
+        // same collect scan, same comparator, same prune condition.
+        // -----------------------------------------------------------------------
         bool descended = false;
-        for (int childIdx = siblingPos; childIdx < 8; childIdx++) {
 
-            // Check if child exists (childmask is Morton-ordered — use raw childIdx)
-            if (!hasChild(node, childIdx)) {
-                continue;
+        if (sortedPos == 0) {
+            // ----- COLLECT: scan all 8 Morton children, compute intersections -----
+            float candidateTEntry[8];
+            int candidateIdx[8];
+            int nCandidates = 0;
+            for (int childIdx = 0; childIdx < 8; childIdx++) {
+                // Check if child exists (childmask is Morton-ordered — use raw childIdx)
+                if (!hasChild(node, childIdx)) {
+                    continue;
+                }
+                // Convert Morton child index to Bey child index for geometry lookups.
+                int scanBeyIdx = INDEX_TO_BEY_NUMBER[parentType][childIdx];
+                vec3 sv0, sv1, sv2, sv3;
+                getChildVertices(parentType, scanBeyIdx, scaleExp2 * 0.5, sv0, sv1, sv2, sv3);
+                TetrahedronHit scanHit = intersectTetrahedron(ray.origin, ray.direction, sv0, sv1, sv2, sv3);
+                if (!scanHit.hit) {
+                    continue;
+                }
+                // Beam optimization: children entirely behind our tmin are not candidates
+                if (scanHit.tExit < ray.tmin) {
+                    continue;
+                }
+                candidateTEntry[nCandidates] = scanHit.tEntry;
+                candidateIdx[nCandidates] = childIdx;
+                nCandidates++;
             }
 
-            // Convert Morton child index to Bey child index for geometry/type lookups.
-            // hasChild/isChildLeaf/getChildIndex use the Morton-ordered bitset — keep childIdx there.
-            int beyIdx = INDEX_TO_BEY_NUMBER[parentType][childIdx];
-
-            // Get child vertices (Bey-indexed switch — must pass beyIdx)
-            vec3 cv0, cv1, cv2, cv3;
-            getChildVertices(parentType, beyIdx, scaleExp2 * 0.5, cv0, cv1, cv2, cv3);
-
-            // Test ray-child intersection
-            TetrahedronHit childHit = intersectTetrahedron(ray.origin, ray.direction, cv0, cv1, cv2, cv3);
-            if (!childHit.hit) {
-                continue;
+            // ----- INSERTION SORT ascending by tEntry, tiebreak childIdx ascending -----
+            // Direct tandem sort of the two parallel arrays; max 8 elements.
+            for (int i = 1; i < nCandidates; i++) {
+                float ti = candidateTEntry[i];
+                int ci = candidateIdx[i];
+                int j = i - 1;
+                while (j >= 0 && (candidateTEntry[j] > ti
+                                  || (candidateTEntry[j] == ti && candidateIdx[j] > ci))) {
+                    candidateTEntry[j + 1] = candidateTEntry[j];
+                    candidateIdx[j + 1] = candidateIdx[j];
+                    j--;
+                }
+                candidateTEntry[j + 1] = ti;
+                candidateIdx[j + 1] = ci;
             }
 
-            // Beam optimization: skip children entirely behind our tmin
-            if (childHit.tExit < ray.tmin) {
-                continue;
+            int childCount = nCandidates;
+            // Pack sorted childIdx order: count in bits 27-24, 3-bit slots at bits 23-0
+            int packedOrder = (childCount & 0xF) << 24;
+            for (int i = 0; i < childCount; i++) {
+                packedOrder |= (candidateIdx[i] & 0x7) << (21 - i * 3);
             }
 
-            // Check LOD termination
-            float raySize = childHit.tEntry * ray.dir_sz + ray.orig_sz;
-            if (raySize >= scaleExp2 * 0.5) {
-                // LOD termination - voxel small enough
-                // Get child node for contour data
-                uint childNodeIdx = getChildIndex(node, childIdx, parentIdx);
-                uvec2 childNode = esvt.nodes[childNodeIdx];
-                float childScale = scaleExp2 * 0.5;
+            // ----- VISIT in sorted order, PRUNE when tEntry >= bestT -----
+            for (int si = 0; si < childCount; si++) {
+                int childIdx = candidateIdx[si];
 
-                // Apply contour refinement if available
-                ContourRefinement contourRef = refineHitWithContours(
-                    childNode, childHit.entryFace, childHit.tEntry, childHit.tExit,
-                    ray.origin, ray.direction, childScale);
+                // front-to-back: prune — next ordered child's tEntry >= bestT → BREAK
+                // (sorted ⇒ all remaining also >= bestT, cannot improve result)
+                if (candidateTEntry[si] >= bestT) {
+                    break; // prune: next tEntry >= bestT, break
+                }
 
-                if (!contourRef.valid) {
-                    // Contour indicates no hit - continue searching
+                // Re-derive vertices and full intersection result for this child.
+                // hasChild/isChildLeaf/getChildIndex use the Morton-ordered bitset — keep childIdx there.
+                int beyIdx = INDEX_TO_BEY_NUMBER[parentType][childIdx];
+                vec3 cv0, cv1, cv2, cv3;
+                getChildVertices(parentType, beyIdx, scaleExp2 * 0.5, cv0, cv1, cv2, cv3);
+                TetrahedronHit childHit = intersectTetrahedron(ray.origin, ray.direction, cv0, cv1, cv2, cv3);
+                if (!childHit.hit) {
                     continue;
                 }
 
-                // Update global min-t rather than returning immediately — closer hits may follow
-                if (contourRef.t < bestT) {
-                    bestT = contourRef.t;
-                    bestDidHit = true;
-                    bestHitPoint = ray.origin + ray.direction * contourRef.t;
-
-                    // Use contour normal if available, otherwise calculate from face
-                    if (length(contourRef.normal) > 0.5) {
-                        bestHitNormal = contourRef.normal;
-                    } else {
-                        // Calculate normal from entry face
-                        vec3 fv0, fv1, fv2;
-                        int entryF = childHit.entryFace;
-
-                        if (entryF == 0) { fv0 = cv1; fv1 = cv2; fv2 = cv3; }
-                        else if (entryF == 1) { fv0 = cv0; fv1 = cv2; fv2 = cv3; }
-                        else if (entryF == 2) { fv0 = cv0; fv1 = cv1; fv2 = cv3; }
-                        else { fv0 = cv0; fv1 = cv1; fv2 = cv2; }
-
-                        bestHitNormal = normalize(cross(fv1 - fv0, fv2 - fv0));
-                        if (dot(bestHitNormal, ray.direction) > 0) {
-                            bestHitNormal = -bestHitNormal;
-                        }
-                    }
-                }
-                continue; // Keep scanning for closer hits
-            }
-
-            // Check if this is a leaf
-            if (isChildLeaf(node, childIdx)) {
-                // Leaf hit - get child node for contour data
-                uint childNodeIdx = getChildIndex(node, childIdx, parentIdx);
-                uvec2 childNode = esvt.nodes[childNodeIdx];
-                float childScale = scaleExp2 * 0.5;
-
-                // Apply contour refinement if available
-                ContourRefinement contourRef = refineHitWithContours(
-                    childNode, childHit.entryFace, childHit.tEntry, childHit.tExit,
-                    ray.origin, ray.direction, childScale);
-
-                if (!contourRef.valid) {
-                    // Contour indicates no hit - continue searching
+                // Beam optimization: skip children entirely behind our tmin
+                if (childHit.tExit < ray.tmin) {
                     continue;
                 }
 
-                // Update global min-t rather than returning immediately — closer hits may follow
-                if (contourRef.t < bestT) {
-                    bestT = contourRef.t;
-                    bestDidHit = true;
-                    bestHitPoint = ray.origin + ray.direction * contourRef.t;
+                // Check LOD termination
+                float raySize = childHit.tEntry * ray.dir_sz + ray.orig_sz;
+                if (raySize >= scaleExp2 * 0.5) {
+                    // LOD termination - voxel small enough
+                    // Get child node for contour data
+                    uint childNodeIdx = getChildIndex(node, childIdx, parentIdx);
+                    uvec2 childNode = esvt.nodes[childNodeIdx];
+                    float childScale = scaleExp2 * 0.5;
 
-                    // Use contour normal if available, otherwise calculate from face
-                    if (length(contourRef.normal) > 0.5) {
-                        bestHitNormal = contourRef.normal;
-                    } else {
-                        // Calculate normal from entry face
-                        vec3 fv0, fv1, fv2;
-                        int entryF = childHit.entryFace;
+                    // Apply contour refinement if available
+                    ContourRefinement contourRef = refineHitWithContours(
+                        childNode, childHit.entryFace, childHit.tEntry, childHit.tExit,
+                        ray.origin, ray.direction, childScale);
 
-                        if (entryF == 0) { fv0 = cv1; fv1 = cv2; fv2 = cv3; }
-                        else if (entryF == 1) { fv0 = cv0; fv1 = cv2; fv2 = cv3; }
-                        else if (entryF == 2) { fv0 = cv0; fv1 = cv1; fv2 = cv3; }
-                        else { fv0 = cv0; fv1 = cv1; fv2 = cv2; }
+                    if (!contourRef.valid) {
+                        // Contour indicates no hit - continue searching
+                        continue;
+                    }
 
-                        bestHitNormal = normalize(cross(fv1 - fv0, fv2 - fv0));
-                        if (dot(bestHitNormal, ray.direction) > 0) {
-                            bestHitNormal = -bestHitNormal;
+                    // Update global min-t rather than returning immediately — closer hits may follow
+                    if (contourRef.t < bestT) {
+                        bestT = contourRef.t;
+                        bestDidHit = true;
+                        bestHitPoint = ray.origin + ray.direction * contourRef.t;
+
+                        // Use contour normal if available, otherwise calculate from face
+                        if (length(contourRef.normal) > 0.5) {
+                            bestHitNormal = contourRef.normal;
+                        } else {
+                            // Calculate normal from entry face
+                            vec3 fv0, fv1, fv2;
+                            int entryF = childHit.entryFace;
+
+                            if (entryF == 0) { fv0 = cv1; fv1 = cv2; fv2 = cv3; }
+                            else if (entryF == 1) { fv0 = cv0; fv1 = cv2; fv2 = cv3; }
+                            else if (entryF == 2) { fv0 = cv0; fv1 = cv1; fv2 = cv3; }
+                            else { fv0 = cv0; fv1 = cv1; fv2 = cv2; }
+
+                            bestHitNormal = normalize(cross(fv1 - fv0, fv2 - fv0));
+                            if (dot(bestHitNormal, ray.direction) > 0) {
+                                bestHitNormal = -bestHitNormal;
+                            }
                         }
                     }
+                    continue; // Keep scanning for closer hits
                 }
-                continue; // Keep scanning for closer hits
+
+                // Check if this is a leaf
+                if (isChildLeaf(node, childIdx)) {
+                    // Leaf hit - get child node for contour data
+                    uint childNodeIdx = getChildIndex(node, childIdx, parentIdx);
+                    uvec2 childNode = esvt.nodes[childNodeIdx];
+                    float childScale = scaleExp2 * 0.5;
+
+                    // Apply contour refinement if available
+                    ContourRefinement contourRef = refineHitWithContours(
+                        childNode, childHit.entryFace, childHit.tEntry, childHit.tExit,
+                        ray.origin, ray.direction, childScale);
+
+                    if (!contourRef.valid) {
+                        // Contour indicates no hit - continue searching
+                        continue;
+                    }
+
+                    // Update global min-t rather than returning immediately — closer hits may follow
+                    if (contourRef.t < bestT) {
+                        bestT = contourRef.t;
+                        bestDidHit = true;
+                        bestHitPoint = ray.origin + ray.direction * contourRef.t;
+
+                        // Use contour normal if available, otherwise calculate from face
+                        if (length(contourRef.normal) > 0.5) {
+                            bestHitNormal = contourRef.normal;
+                        } else {
+                            // Calculate normal from entry face
+                            vec3 fv0, fv1, fv2;
+                            int entryF = childHit.entryFace;
+
+                            if (entryF == 0) { fv0 = cv1; fv1 = cv2; fv2 = cv3; }
+                            else if (entryF == 1) { fv0 = cv0; fv1 = cv2; fv2 = cv3; }
+                            else if (entryF == 2) { fv0 = cv0; fv1 = cv1; fv2 = cv3; }
+                            else { fv0 = cv0; fv1 = cv1; fv2 = cv2; }
+
+                            bestHitNormal = normalize(cross(fv1 - fv0, fv2 - fv0));
+                            if (dot(bestHitNormal, ray.direction) > 0) {
+                                bestHitNormal = -bestHitNormal;
+                            }
+                        }
+                    }
+                    continue; // Keep scanning for closer hits
+                }
+
+                // Non-leaf - push and descend
+                stack_nodes[stackBase + scale] = parentIdx;
+                stack_tmax[stackBase + scale] = tMax;
+                stack_type[stackBase + scale] = parentType;
+                stack_entryFace[stackBase + scale] = entryFace;
+                // Packed slot: resume cursor (si+1) in bits 31-28, sorted order in bits 27-0
+                stack_siblingPos[stackBase + scale] = int((uint(si + 1) << 28) | uint(packedOrder));
+
+                // Move to child (getChildIndex uses Morton-ordered bitset — use childIdx)
+                parentIdx = getChildIndex(node, childIdx, parentIdx);
+                // PARENT_TYPE_TO_CHILD_TYPE is Bey-indexed — use beyIdx, not childIdx
+                parentType = PARENT_TYPE_TO_CHILD_TYPE[parentType][beyIdx];
+                entryFace = childHit.entryFace >= 0 ? childHit.entryFace : 0;
+                tMin = childHit.tEntry;
+                tMax = childHit.tExit;
+                scale--;
+                scaleExp2 *= 0.5;
+                sortedPos = 0;
+                descended = true;
+                break;
             }
 
-            // Non-leaf - push and descend
-            stack_nodes[stackBase + scale] = parentIdx;
-            stack_tmax[stackBase + scale] = tMax;
-            stack_type[stackBase + scale] = parentType;
-            stack_entryFace[stackBase + scale] = entryFace;
-            stack_siblingPos[stackBase + scale] = childIdx + 1; // resume AFTER this child on pop
+        } else {
+            // ----- RESUME: popped back to this node; continue sorted-order visit -----
+            int packedOrder = int(uint(stack_siblingPos[stackBase + scale]) & 0x0FFFFFFFu);
+            int childCount = (packedOrder >> 24) & 0xF;
 
-            // Move to child (getChildIndex uses Morton-ordered bitset — use childIdx)
-            parentIdx = getChildIndex(node, childIdx, parentIdx);
-            // PARENT_TYPE_TO_CHILD_TYPE is Bey-indexed — use beyIdx, not childIdx
-            parentType = PARENT_TYPE_TO_CHILD_TYPE[parentType][beyIdx];
-            entryFace = childHit.entryFace >= 0 ? childHit.entryFace : 0;
-            tMin = childHit.tEntry;
-            tMax = childHit.tExit;
-            scale--;
-            scaleExp2 *= 0.5;
-            siblingPos = 0;
-            descended = true;
-            break;
+            for (int si = sortedPos; si < childCount; si++) {
+                int childIdx = (packedOrder >> (21 - si * 3)) & 0x7;
+
+                // Re-derive vertices + re-intersect (resume re-intersects, no stored tEntry)
+                int beyIdx = INDEX_TO_BEY_NUMBER[parentType][childIdx];
+                vec3 cv0, cv1, cv2, cv3;
+                getChildVertices(parentType, beyIdx, scaleExp2 * 0.5, cv0, cv1, cv2, cv3);
+                TetrahedronHit childHit = intersectTetrahedron(ray.origin, ray.direction, cv0, cv1, cv2, cv3);
+                if (!childHit.hit) {
+                    continue;
+                }
+
+                // front-to-back: prune — next ordered child's tEntry >= bestT → BREAK
+                if (childHit.tEntry >= bestT) {
+                    break; // prune: next tEntry >= bestT, break
+                }
+
+                // Beam optimization: skip children entirely behind our tmin
+                if (childHit.tExit < ray.tmin) {
+                    continue;
+                }
+
+                // Check LOD termination
+                float raySize = childHit.tEntry * ray.dir_sz + ray.orig_sz;
+                if (raySize >= scaleExp2 * 0.5) {
+                    // LOD termination - voxel small enough
+                    // Get child node for contour data
+                    uint childNodeIdx = getChildIndex(node, childIdx, parentIdx);
+                    uvec2 childNode = esvt.nodes[childNodeIdx];
+                    float childScale = scaleExp2 * 0.5;
+
+                    // Apply contour refinement if available
+                    ContourRefinement contourRef = refineHitWithContours(
+                        childNode, childHit.entryFace, childHit.tEntry, childHit.tExit,
+                        ray.origin, ray.direction, childScale);
+
+                    if (!contourRef.valid) {
+                        // Contour indicates no hit - continue searching
+                        continue;
+                    }
+
+                    // Update global min-t rather than returning immediately — closer hits may follow
+                    if (contourRef.t < bestT) {
+                        bestT = contourRef.t;
+                        bestDidHit = true;
+                        bestHitPoint = ray.origin + ray.direction * contourRef.t;
+
+                        // Use contour normal if available, otherwise calculate from face
+                        if (length(contourRef.normal) > 0.5) {
+                            bestHitNormal = contourRef.normal;
+                        } else {
+                            // Calculate normal from entry face
+                            vec3 fv0, fv1, fv2;
+                            int entryF = childHit.entryFace;
+
+                            if (entryF == 0) { fv0 = cv1; fv1 = cv2; fv2 = cv3; }
+                            else if (entryF == 1) { fv0 = cv0; fv1 = cv2; fv2 = cv3; }
+                            else if (entryF == 2) { fv0 = cv0; fv1 = cv1; fv2 = cv3; }
+                            else { fv0 = cv0; fv1 = cv1; fv2 = cv2; }
+
+                            bestHitNormal = normalize(cross(fv1 - fv0, fv2 - fv0));
+                            if (dot(bestHitNormal, ray.direction) > 0) {
+                                bestHitNormal = -bestHitNormal;
+                            }
+                        }
+                    }
+                    continue; // Keep scanning for closer hits
+                }
+
+                // Check if this is a leaf
+                if (isChildLeaf(node, childIdx)) {
+                    // Leaf hit - get child node for contour data
+                    uint childNodeIdx = getChildIndex(node, childIdx, parentIdx);
+                    uvec2 childNode = esvt.nodes[childNodeIdx];
+                    float childScale = scaleExp2 * 0.5;
+
+                    // Apply contour refinement if available
+                    ContourRefinement contourRef = refineHitWithContours(
+                        childNode, childHit.entryFace, childHit.tEntry, childHit.tExit,
+                        ray.origin, ray.direction, childScale);
+
+                    if (!contourRef.valid) {
+                        // Contour indicates no hit - continue searching
+                        continue;
+                    }
+
+                    // Update global min-t rather than returning immediately — closer hits may follow
+                    if (contourRef.t < bestT) {
+                        bestT = contourRef.t;
+                        bestDidHit = true;
+                        bestHitPoint = ray.origin + ray.direction * contourRef.t;
+
+                        // Use contour normal if available, otherwise calculate from face
+                        if (length(contourRef.normal) > 0.5) {
+                            bestHitNormal = contourRef.normal;
+                        } else {
+                            // Calculate normal from entry face
+                            vec3 fv0, fv1, fv2;
+                            int entryF = childHit.entryFace;
+
+                            if (entryF == 0) { fv0 = cv1; fv1 = cv2; fv2 = cv3; }
+                            else if (entryF == 1) { fv0 = cv0; fv1 = cv2; fv2 = cv3; }
+                            else if (entryF == 2) { fv0 = cv0; fv1 = cv1; fv2 = cv3; }
+                            else { fv0 = cv0; fv1 = cv1; fv2 = cv2; }
+
+                            bestHitNormal = normalize(cross(fv1 - fv0, fv2 - fv0));
+                            if (dot(bestHitNormal, ray.direction) > 0) {
+                                bestHitNormal = -bestHitNormal;
+                            }
+                        }
+                    }
+                    continue; // Keep scanning for closer hits
+                }
+
+                // Non-leaf - push and descend
+                stack_nodes[stackBase + scale] = parentIdx;
+                stack_tmax[stackBase + scale] = tMax;
+                stack_type[stackBase + scale] = parentType;
+                stack_entryFace[stackBase + scale] = entryFace;
+                // Packed slot: resume cursor (si+1) in bits 31-28, sorted order in bits 27-0
+                stack_siblingPos[stackBase + scale] = int((uint(si + 1) << 28) | uint(packedOrder));
+
+                // Move to child (getChildIndex uses Morton-ordered bitset — use childIdx)
+                parentIdx = getChildIndex(node, childIdx, parentIdx);
+                // PARENT_TYPE_TO_CHILD_TYPE is Bey-indexed — use beyIdx, not childIdx
+                parentType = PARENT_TYPE_TO_CHILD_TYPE[parentType][beyIdx];
+                entryFace = childHit.entryFace >= 0 ? childHit.entryFace : 0;
+                tMin = childHit.tEntry;
+                tMax = childHit.tExit;
+                scale--;
+                scaleExp2 *= 0.5;
+                sortedPos = 0;
+                descended = true;
+                break;
+            }
         }
 
         if (!descended) {
@@ -895,7 +1104,8 @@ void castRayESVT(inout Ray ray, out vec3 hitPoint, out vec3 hitNormal, out bool 
             tMax = stack_tmax[stackBase + scale];
             parentType = stack_type[stackBase + scale];
             entryFace = stack_entryFace[stackBase + scale];
-            siblingPos = stack_siblingPos[stackBase + scale]; // resume after child that triggered descent
+            // Resume cursor lives in the high nibble of the packed siblingPos slot
+            sortedPos = int((uint(stack_siblingPos[stackBase + scale]) >> 28) & 0xFu);
         }
     }
 

--- a/render/src/test/java/com/hellblazer/luciferase/esvt/gpu/ESVTOpenCLRendererFarPointerTest.java
+++ b/render/src/test/java/com/hellblazer/luciferase/esvt/gpu/ESVTOpenCLRendererFarPointerTest.java
@@ -328,9 +328,14 @@ class ESVTOpenCLRendererFarPointerTest {
                     hitCount++;
                 }
             }
-            assertTrue(hitCount > 0,
-                    "At least one ray must report a real leaf hit through the far pointer "
-                    + "(hitNormals.w > 0.5); zero hits means far resolution or leaf detection broke");
+            // Exact pin (Luciferase-ypbk9): 24 leaf-hit rays observed on hardware for this fixed
+            // 64x64 camera/tree, unchanged across the exhaustive-scan -> front-to-back rewrite
+            // (result invariance). A drift in either direction means traversal results changed:
+            // 0 = far resolution or leaf detection broke; other values = hit-set divergence.
+            assertEquals(24, hitCount,
+                    "Exactly 24 rays must report a real leaf hit through the far pointer "
+                    + "(hitNormals.w > 0.5) — measured on hardware pre- and post-front-to-back; "
+                    + "any drift means the traversal hit-set changed");
 
             System.out.println("GPU far-pointer render test: completed, " + hitCount + " leaf-hit rays ("
                                + data.nodeCount() + " nodes, "

--- a/render/src/test/java/com/hellblazer/luciferase/esvt/gpu/ESVTShaderSourcePinTest.java
+++ b/render/src/test/java/com/hellblazer/luciferase/esvt/gpu/ESVTShaderSourcePinTest.java
@@ -23,33 +23,27 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Source-pin tests for ESVT GPU shader and kernel correctness (P3 — Luciferase-g51tc).
+ * Source-pin tests for ESVT GPU shader and kernel correctness.
  *
- * <p>Eight headless tests pin the post-fix textual contracts for:
- * <ol>
- *   <li>{@code raycast_esvt.comp} — all-8 Morton loop: uses {@code childIdx < 8}, NOT the old {@code pos < 4}
- *       CHILD_ORDER positional loop (P3 Fix 1a)</li>
- *   <li>{@code raycast_esvt.comp} — CHILD_ORDER constant absent: the dead 4-child table has been removed
- *       (P3 Fix 1b)</li>
- *   <li>{@code raycast_esvt.comp} — siblingPos shared stack present: {@code stack_siblingPos} array added for
- *       correct resume-after-pop (P3 Fix 1c)</li>
- *   <li>{@code raycast_esvt.comp} — global min-t tracking: {@code bestT} variable declared, LOD and leaf hit
- *       sites update {@code bestT} and {@code continue} rather than returning immediately (P3 Fix 1d)</li>
- *   <li>{@code raycast_esvt.comp} — no first-hit early return inside the child loop: the pre-fix pattern
- *       {@code return;} inside the traversal while loop is gone (P3 Fix 1d)</li>
- *   <li>{@code esvt_ray_traversal.cl} — dead CHILD_ORDER[96] block absent: the unused constant was removed
- *       (P3 Fix 2)</li>
- *   <li>{@code esvt_ray_traversal.cl} — all-8 scan retained: {@code childIdx < 8} still present in kernel
- *       (regression guard)</li>
- *   <li>{@code esvt_ray_traversal.cl} — global min-t retained: {@code bestT} and {@code < bestT} still
- *       present in kernel (regression guard)</li>
- * </ol>
+ * <p>Headless tests pinning the textual contracts of {@code raycast_esvt.comp} and
+ * {@code esvt_ray_traversal.cl}, loaded via the same {@link ShaderResourceLoader} /
+ * resource path used at runtime (no GPU/OpenCL required).
  *
- * <p>All tests are headless (no GPU/OpenCL required); they pin the source text
- * loaded via the same {@link ShaderResourceLoader} / resource path used at runtime.
- * Tests 1–5 pin the compute shader; tests 6–8 pin the OpenCL kernel.
+ * <p>Two pin generations:
+ * <ul>
+ *   <li><b>jk5tk/g51tc parity pins</b> (Pins 1-11): all-8 Morton scan, CHILD_ORDER removal,
+ *       global min-t bestT, no first-hit return, Morton→Bey conversion, root-without-leaf MISS,
+ *       real leaf normals. Pins 1, 3, 5b, and 7 were revised in place by 2s3jc (see their javadoc)
+ *       — the all-8 loop survives as the front-to-back COLLECT scan, stack_siblingPos is
+ *       repurposed as the packed sorted-order slot, and the keep-scanning marker count doubled
+ *       (fresh + resume paths).</li>
+ *   <li><b>2s3jc front-to-back pins</b> (Pins 12-19): tandem insertion sort present in both
+ *       shaders with the exact CPU comparator, sortedOrder StackEntry field (.cl), packed
+ *       sorted-order slot + per-thread offset + no-6th-shared-array (.comp), and the prune-break
+ *       marker at both implementations' visit loops.</li>
+ * </ul>
  *
- * <p>Bead: Luciferase-g51tc (P3 RED phase, TDD). Branch: feature/jk5tk-esvt-parity.
+ * <p>Beads: Luciferase-g51tc (parity pins), Luciferase-y3l06 (front-to-back pin revision).
  */
 class ESVTShaderSourcePinTest {
 
@@ -74,16 +68,15 @@ class ESVTShaderSourcePinTest {
     // -------------------------------------------------------------------------
 
     /**
-     * Pin 1: traversal loop must iterate all 8 Morton children ({@code childIdx < 8}).
+     * Pin 1 (revised by 2s3jc): all-8 Morton scan must survive as the front-to-back COLLECT loop.
      *
-     * <p>The pre-fix shader iterated only 4 entry-face children via
+     * <p>The pre-jk5tk shader iterated only 4 entry-face children via
      * {@code for (int pos = siblingPos; pos < 4; pos++)} with an indirection through
-     * {@code CHILD_ORDER[parentType][entryFace][pos]}. This misses up to 4 children whose
-     * tetrahedral geometry does intersect the ray but are not in the entry-face set.
-     * Post-fix: {@code for (int childIdx = siblingPos; childIdx < 8; childIdx++)} in
-     * Morton order, matching the {@code esvt_ray_traversal.cl} pattern.
-     *
-     * <p>This test is RED before P3 Fix 1a.
+     * {@code CHILD_ORDER[parentType][entryFace][pos]}, missing up to 4 intersecting children.
+     * jk5tk replaced it with the all-8 Morton visit loop. 2s3jc restructured that loop into
+     * COLLECT ({@code for (int childIdx = 0; childIdx < 8; childIdx++)} gathering candidates)
+     * + sorted VISIT — the all-8 scan survives as the collection pass. The {@code pos < 4}
+     * pattern must never return.
      */
     @Test
     void comp_childLoop_iteratesAllEightChildren() {
@@ -114,16 +107,15 @@ class ESVTShaderSourcePinTest {
     }
 
     /**
-     * Pin 3: shared siblingPos stack must be present.
+     * Pin 3 (revised by 2s3jc): shared siblingPos stack must be present — now as the packed
+     * front-to-back slot.
      *
-     * <p>The pre-fix shader had {@code stack_nodes}, {@code stack_tmax}, {@code stack_type},
-     * and {@code stack_entryFace} but no {@code stack_siblingPos}. On pop, it always reset
-     * {@code siblingPos = 0}, restarting the child scan from Morton child 0 instead of resuming
-     * after the child that triggered the descent. Post-fix adds:
-     * {@code shared int stack_siblingPos[64 * CAST_STACK_DEPTH];} and saves
-     * {@code childIdx + 1} on push, restores on pop.
-     *
-     * <p>This test is RED before P3 Fix 1c.
+     * <p>jk5tk added {@code shared int stack_siblingPos[64 * CAST_STACK_DEPTH];} storing
+     * {@code childIdx + 1} for resume-after-pop. 2s3jc repurposed the slot (NO 6th shared
+     * array — 32 KiB shared-memory budget): bits 31-28 = sortedPos resume cursor, bits 27-24 =
+     * sorted child count, bits 23-0 = eight 3-bit Morton childIdx slots in sorted visit order.
+     * The array itself must remain — without it, pop restarts the child visit from slot 0,
+     * re-scanning already-visited children.
      */
     @Test
     void comp_siblingPosStack_present() {
@@ -215,14 +207,13 @@ class ESVTShaderSourcePinTest {
     }
 
     /**
-     * Pin 7 (regression): all-8 Morton scan must be retained in the kernel.
+     * Pin 7 (regression, revised by 2s3jc): all-8 Morton scan must be retained in the kernel
+     * — now as the front-to-back COLLECT loop.
      *
-     * <p>The correct {@code esvt_ray_traversal.cl} traversal already uses
-     * {@code for (int childIdx = siblingPos; childIdx < 8; childIdx++)} in Morton order.
-     * This regression guard ensures P3 Fix 2 (deletion of the dead CHILD_ORDER block)
-     * does not accidentally remove or corrupt the traversal loop.
-     *
-     * <p>This test is GREEN before P3 Fix 2 and must stay GREEN after.
+     * <p>The jk5tk kernel visited all 8 children via
+     * {@code for (int childIdx = siblingPos; childIdx < 8; childIdx++)}. 2s3jc restructured
+     * this into COLLECT ({@code for (int childIdx = 0; childIdx < 8; childIdx++)}) + sorted
+     * VISIT; the all-8 scan survives as the collection pass and must not be narrowed.
      */
     @Test
     void cl_allEightScan_retained() {
@@ -283,16 +274,17 @@ class ESVTShaderSourcePinTest {
     }
 
     /**
-     * Pin 5b (robustness): leaf-hit and LOD-hit sites must continue with stable marker comment,
-     * not return.
+     * Pin 5b (robustness, revised by 2s3jc): leaf-hit and LOD-hit sites must continue with the
+     * stable marker comment, not return — at all FOUR sites.
      *
      * <p>Pin 5 used a whitespace-exact negative assertion that could miss a reintroduced
-     * {@code return} with different surrounding whitespace. Post-fix: both hit sites explicitly
-     * annotate the continuation with {@code // keep scanning for closer hits} — a stable
-     * marker that is present if and only if the correct {@code continue} replaces the old
-     * {@code return}. This positive assertion is formatting-independent.
+     * {@code return} with different surrounding whitespace. The hit sites explicitly annotate
+     * the continuation with {@code // Keep scanning for closer hits} — a stable marker present
+     * if and only if the correct {@code continue} replaces the old first-hit {@code return}.
      *
-     * <p>This test is GREEN after P3 Fix 1d and must stay GREEN through all subsequent edits.
+     * <p>2s3jc duplicated the LOD-termination and leaf-hit bodies across the fresh (collect+sort)
+     * and resume visit paths, so the marker count doubled from 2 to 4: fresh-LOD, fresh-leaf,
+     * resume-LOD, resume-leaf.
      */
     @Test
     void comp_hitSites_continueWithMarker() {
@@ -303,10 +295,10 @@ class ESVTShaderSourcePinTest {
             count++;
             idx = compSource.indexOf(marker, idx + 1);
         }
-        assertEquals(2, count,
-                "raycast_esvt.comp must carry 'continue; // Keep scanning for closer hits' at BOTH "
-                + "the LOD-termination and leaf hit sites (found " + count + ") "
-                + "— a bare return; at either site is the pre-fix first-hit-only bug");
+        assertEquals(4, count,
+                "raycast_esvt.comp must carry 'continue; // Keep scanning for closer hits' at all FOUR "
+                + "hit sites — LOD + leaf in BOTH the fresh and resume visit paths (found " + count + ") "
+                + "— a bare return; at any site is the pre-fix first-hit-only bug");
     }
 
     // -------------------------------------------------------------------------
@@ -359,5 +351,166 @@ class ESVTShaderSourcePinTest {
         assertFalse(clSource.contains("leafNormal"),
                 "esvt_ray_traversal.cl must not contain the debug 'leafNormal' variable — "
                 + "post-fix writes bestHitNormal directly to hitNormals[gid]");
+    }
+
+    // -------------------------------------------------------------------------
+    // 2s3jc front-to-back pins (Luciferase-y3l06)
+    // -------------------------------------------------------------------------
+
+    /** The exact tandem-sort comparator shared by ESVTTraversal.java, .cl, and .comp. */
+    private static final String COMPARATOR =
+        "candidateTEntry[j] == ti && candidateIdx[j] > ci";
+
+    /** The exact prune-break marker shared by ESVTTraversal.java, .cl, and .comp. */
+    private static final String PRUNE_MARKER =
+        "break; // prune: next tEntry >= bestT, break";
+
+    /**
+     * Pin 12: tandem insertion sort must be present in the OpenCL kernel with the exact
+     * CPU comparator.
+     *
+     * <p>2s3jc front-to-back requires all three implementations (Java, .cl, .comp) to sort
+     * candidates with the identical comparator — ascending tEntry, childIdx-ascending tiebreak.
+     * Any divergence in the comparator is the jk5tk three-way-divergence bug class: results
+     * stay correct for most scenes but visit order (and therefore tie resolution and pruning)
+     * silently differs across implementations.
+     */
+    @Test
+    void cl_insertionSort_present() {
+        assertTrue(clSource.contains("INSERTION SORT ascending by tEntry, tiebreak childIdx ascending"),
+                "esvt_ray_traversal.cl must carry the front-to-back insertion-sort block — "
+                + "without it the kernel visits children in Morton order and cannot prune");
+        assertTrue(clSource.contains(COMPARATOR),
+                "esvt_ray_traversal.cl insertion sort must use the exact CPU comparator '"
+                + COMPARATOR + "' — any deviation diverges visit order from ESVTTraversal.java");
+    }
+
+    /**
+     * Pin 13: tandem insertion sort must be present in the compute shader with the exact
+     * CPU comparator. Same contract as Pin 12 for raycast_esvt.comp.
+     */
+    @Test
+    void comp_insertionSort_present() {
+        assertTrue(compSource.contains("INSERTION SORT ascending by tEntry, tiebreak childIdx ascending"),
+                "raycast_esvt.comp must carry the front-to-back insertion-sort block — "
+                + "without it the shader visits children in Morton order and cannot prune");
+        assertTrue(compSource.contains(COMPARATOR),
+                "raycast_esvt.comp insertion sort must use the exact CPU comparator '"
+                + COMPARATOR + "' — any deviation diverges visit order from ESVTTraversal.java");
+    }
+
+    /**
+     * Pin 14: the .cl StackEntry must carry the packed sortedOrder field.
+     *
+     * <p>The OpenCL stack is private per-work-item, so a dedicated struct field is the
+     * correct storage for the packed sorted order (count in bits 27-24, eight 3-bit Morton
+     * childIdx slots at bits 23-0). The resume path reads it via
+     * {@code stack[scale].sortedOrder}; without it, resume cannot reconstruct the sorted
+     * visit order and would fall back to Morton-order scanning.
+     */
+    @Test
+    void cl_sortedOrder_stackField() {
+        assertTrue(clSource.contains("int sortedOrder;"),
+                "esvt_ray_traversal.cl StackEntry must declare 'int sortedOrder;' — the packed "
+                + "sorted visit order the resume path replays after pop");
+        assertTrue(clSource.contains("stack[scale].sortedOrder"),
+                "esvt_ray_traversal.cl must read/write 'stack[scale].sortedOrder' on push and resume");
+    }
+
+    /**
+     * Pin 15: the .comp packed sorted-order slot must pack the resume cursor into the high
+     * nibble of the EXISTING stack_siblingPos slot.
+     *
+     * <p>Layout: bits 31-28 = sortedPos resume cursor (0-8), bits 27-24 = count, bits 23-0 =
+     * sorted childIdx slots. Exactly 32 bits — written with uint casts to avoid sign-extension
+     * on the high nibble. The write {@code int((uint(si + 1) << 28) | uint(packedOrder))} and
+     * the cursor read {@code >> 28) & 0xFu} are both required.
+     */
+    @Test
+    void comp_sortedOrder_packed() {
+        assertTrue(compSource.contains("int((uint(si + 1) << 28) | uint(packedOrder))"),
+                "raycast_esvt.comp push must pack the resume cursor (si+1) into bits 31-28 of the "
+                + "stack_siblingPos slot alongside the 28-bit packedOrder");
+        assertTrue(compSource.contains(">> 28) & 0xFu"),
+                "raycast_esvt.comp pop must extract the resume cursor from the high nibble via "
+                + "unsigned shift — signed shift would sign-extend when sortedPos == 8");
+    }
+
+    /**
+     * Pin 16: every .comp shared-stack access must use the per-thread offset.
+     *
+     * <p>The shared arrays are indexed {@code stackBase + scale} with
+     * {@code stackBase = threadIdx * CAST_STACK_DEPTH} — the 0bn1q race class: any access
+     * missing the per-thread base reads/writes another invocation's stack slice.
+     */
+    @Test
+    void comp_sortedOrder_perThreadOffset() {
+        assertTrue(compSource.contains("int stackBase = threadIdx * CAST_STACK_DEPTH;"),
+                "raycast_esvt.comp must compute the per-thread stack base — shared arrays are "
+                + "sliced per invocation (0bn1q race class)");
+        assertTrue(compSource.contains("stack_siblingPos[stackBase + scale]"),
+                "raycast_esvt.comp must index the packed sorted-order slot with 'stackBase + scale' — "
+                + "a bare [scale] access races against other invocations in the workgroup");
+        assertFalse(compSource.contains("stack_siblingPos[scale]"),
+                "raycast_esvt.comp must not index stack_siblingPos without the per-thread base");
+    }
+
+    /**
+     * Pin 17: the .comp shared-memory stack must remain exactly 5 arrays — NO 6th shared array.
+     *
+     * <p>The workgroup shared budget is 32 KiB; the 5 arrays (64 threads x CAST_STACK_DEPTH x
+     * 4 bytes each) total 28,160 bytes. Adding a 6th array (e.g. a dedicated sortedOrder array,
+     * +5,632 bytes = 33,792) exceeds the limit on common hardware. This is why the sorted order
+     * is packed into the existing stack_siblingPos slot rather than stored separately.
+     */
+    @Test
+    void comp_noSixthSharedArray() {
+        // Count declarations only (line-start "shared "), not prose mentions in comments
+        long count = compSource.lines().filter(l -> l.startsWith("shared ")).count();
+        assertEquals(5, count,
+                "raycast_esvt.comp must declare exactly 5 shared stack arrays (found " + count + ") — "
+                + "a 6th would push workgroup shared memory past the 32 KiB budget "
+                + "(28,160 B -> 33,792 B); pack new per-level state into existing slots instead");
+    }
+
+    /**
+     * Pin 18: the prune-break marker must be present in the OpenCL kernel — in BOTH the fresh
+     * and resume visit paths.
+     *
+     * <p>The prune is the entire point of front-to-back: once the next sorted child's tEntry
+     * is >= bestT, no remaining child can improve the result and the visit loop BREAKs.
+     * Replacing the break with continue (or removing the check) silently reverts to exhaustive
+     * scanning — results stay identical, performance regresses, and no result-pin catches it.
+     */
+    @Test
+    void cl_pruneBreak_marker() {
+        int count = 0;
+        int idx = clSource.indexOf(PRUNE_MARKER);
+        while (idx >= 0) {
+            count++;
+            idx = clSource.indexOf(PRUNE_MARKER, idx + 1);
+        }
+        assertEquals(2, count,
+                "esvt_ray_traversal.cl must carry '" + PRUNE_MARKER + "' in BOTH the fresh and "
+                + "resume visit paths (found " + count + ") — removing either silently reverts "
+                + "that path to exhaustive scanning");
+    }
+
+    /**
+     * Pin 19: the prune-break marker must be present in the compute shader — in BOTH the fresh
+     * and resume visit paths. Same contract as Pin 18 for raycast_esvt.comp.
+     */
+    @Test
+    void comp_pruneBreak_marker() {
+        int count = 0;
+        int idx = compSource.indexOf(PRUNE_MARKER);
+        while (idx >= 0) {
+            count++;
+            idx = compSource.indexOf(PRUNE_MARKER, idx + 1);
+        }
+        assertEquals(2, count,
+                "raycast_esvt.comp must carry '" + PRUNE_MARKER + "' in BOTH the fresh and "
+                + "resume visit paths (found " + count + ") — removing either silently reverts "
+                + "that path to exhaustive scanning");
     }
 }

--- a/render/src/test/java/com/hellblazer/luciferase/esvt/traversal/ESVTFrontToBackBenchmarkTest.java
+++ b/render/src/test/java/com/hellblazer/luciferase/esvt/traversal/ESVTFrontToBackBenchmarkTest.java
@@ -1,0 +1,434 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.esvt.traversal;
+
+import com.hellblazer.luciferase.esvt.builder.ESVTBuilder;
+import com.hellblazer.luciferase.esvt.core.ESVTData;
+import com.hellblazer.luciferase.lucien.Constants;
+import com.hellblazer.luciferase.lucien.entity.SequentialLongIDGenerator;
+import com.hellblazer.luciferase.lucien.tetree.Tetree;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import javax.vecmath.Matrix4f;
+import javax.vecmath.Point3f;
+import javax.vecmath.Vector3f;
+import javax.vecmath.Vector4f;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Benchmark test for the ESVT front-to-back traversal arc (2s3jc).
+ *
+ * <h2>Two test methods with distinct roles</h2>
+ *
+ * <h3>testBaselineIterations — depth-6 regression guard (1-hit scene)</h3>
+ * Runs on the seeded depth-6 sphere scene (Random(42), 4096 rays, camera (2,2,2)).
+ * This scene produces only 1 hitting ray; pruning never fires because bestT does not
+ * shrink before the single leaf is reached. {@code PRUNE_MARGIN = 1.01} is a
+ * non-regression bound (at most 1% overhead vs exhaustive), NOT a perf-evidence claim.
+ * {@code FRONTTOBACK_MEAN_ITERATIONS = 13.0} pins the deterministic result; any
+ * algorithm change that visits more nodes shows up as a test failure.
+ *
+ * <h3>testDenseScenePruning — depth-3 perf gate (multi-hit scene)</h3>
+ * Runs on the same scene at depth 3 (larger leaf tets → many more hits per 64×64 grid).
+ * This is the actual perf-evidence test: with many hits, bestT shrinks early and pruning
+ * fires for later siblings. {@code DENSE_PRUNE_MARGIN = 0.70} is the required reduction;
+ * observed ratio is pinned as {@code DENSE_FRONTTOBACK_MEAN_ITERATIONS}.
+ * {@code DENSE_HIT_COUNT_FLOOR >= 40} guards against scene degeneration (observed: 44 hits).
+ *
+ * <p>Both baselines were captured using {@code git stash} to revert to the exhaustive
+ * code, running the tests to observe the exhaustive numbers, then {@code git stash pop}
+ * to restore the P2 rewrite and observe the front-to-back numbers.
+ *
+ * @author hal.hildebrand
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ESVTFrontToBackBenchmarkTest {
+
+    /** Frame size (64×64 = 4096 rays), matching parity test. */
+    private static final int FRAME_SIZE = 64;
+
+    // -------------------------------------------------------------------------
+    // P1 baseline constant: exhaustive all-8 Morton child scan.
+    // Set by running the test once on unmodified exhaustive code; do NOT change
+    // this constant without a documented reason — it is the regression anchor.
+    // Value will be filled in after first run (see test output).
+    // -------------------------------------------------------------------------
+    /**
+     * Mean iterations per hitting ray with the exhaustive (pre-P2) traversal.
+     * Captured 2026-06-11: hitCount=1, totalIterations=13, mean=13.000000.
+     * Scene: Random(42), depth 6, 2000 sphere samples, radius 0.3.
+     * Rays: 64×64 grid, camera (2,2,2) lookAt (0.5,0.5,0.5) fov 60.
+     */
+    static final double BASELINE_MEAN_ITERATIONS_EXHAUSTIVE = 13.0;
+
+    // -------------------------------------------------------------------------
+    // P2 constants (captured 2026-06-11 after CPU rewrite):
+    //   FRONTTOBACK_MEAN_ITERATIONS: exact mean after P2 rewrite (pin, ±epsilon)
+    //   PRUNE_MARGIN: max fraction of baseline allowed
+    //
+    // NOTE on pruning benefit with this specific scene:
+    //   The sphere at depth 6 with camera (2,2,2) produces only 1 hitting ray from
+    //   the 64×64 grid. With a single hit, bestT never shrinks from a prior hit to
+    //   allow pruning of siblings — the prune-break fires AFTER the single leaf is
+    //   reached, at which point traversal is essentially complete. So the iteration
+    //   count is identical to the exhaustive baseline (13) for this scene.
+    //
+    //   The pruning benefit is real and would be visible on a denser scene where
+    //   many rays hit and bestT shrinks from earlier hits. This scene serves as a
+    //   regression guard: if the rewrite introduces extra work (iterations > baseline),
+    //   the PRUNE_MARGIN assertion catches it. PRUNE_MARGIN = 1.01 means "at most
+    //   1% overhead allowed; must not be worse than exhaustive". The exact-pin on
+    //   FRONTTOBACK_MEAN_ITERATIONS pins the deterministic result.
+    // -------------------------------------------------------------------------
+    /**
+     * Regression guard for the 1-hit depth-6 scene: at most 1% overhead vs exhaustive.
+     * Pruning never fires on this scene (single hit). The real perf gate is
+     * {@code DENSE_PRUNE_MARGIN} in {@code testDenseScenePruning}.
+     */
+    static final double PRUNE_MARGIN = 1.01;
+
+    /**
+     * Exact mean iterations per hit after P2 rewrite.
+     * Captured 2026-06-11: hitCount=1, totalIterations=13, mean=13.000000.
+     * Same as baseline — pruning does not trigger on a 1-hit scene.
+     */
+    static final double FRONTTOBACK_MEAN_ITERATIONS = 13.0;
+
+    // -------------------------------------------------------------------------
+    // Dense scene constants (depth-3 sphere, same Random(42), same camera).
+    // Captured via git stash (exhaustive) → run → record → git stash pop → run → record.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Minimum number of hitting rays in the depth-3 scene.
+     * Guards against silent scene degeneration to a near-zero-hit case.
+     * Observed (2026-06-11, exhaustive): hitCount=44 from a depth-3 sphere with 64×64 rays.
+     * Floor set to 40 (10% below observed) to catch scene degeneration while tolerating
+     * minor floating-point-path variation across JVMs.
+     */
+    static final int DENSE_HIT_COUNT_FLOOR = 40;
+
+    /**
+     * Mean iterations per hit in the depth-3 scene with the exhaustive traversal.
+     * Captured 2026-06-11 via git stash procedure (exhaustive code):
+     * hitCount=44, totalIterations=488, mean=11.090909.
+     * Scene: Random(42), depth 3, 2000 sphere samples, radius 0.3.
+     * Rays: 64×64 grid, camera (2,2,2) lookAt (0.5,0.5,0.5) fov 60.
+     */
+    static final double DENSE_BASELINE_MEAN_ITERATIONS_EXHAUSTIVE = 11.090909;
+
+    /**
+     * Required prune fraction for the dense scene. Front-to-back must visit at most
+     * 70% of the iterations the exhaustive scan does. If observed ratio is above 0.70,
+     * implementation must be re-examined before loosening this constant.
+     */
+    static final double DENSE_PRUNE_MARGIN = 0.70;
+
+    /**
+     * Exact mean iterations per hit after P2 rewrite on the dense (depth-3) scene.
+     * Captured 2026-06-11 via git stash pop procedure (front-to-back code):
+     * hitCount=44, totalIterations=296, mean=6.727273.
+     * Ratio vs exhaustive: 6.727273 / 11.090909 = 0.606 (beats DENSE_PRUNE_MARGIN=0.70).
+     */
+    static final double DENSE_FRONTTOBACK_MEAN_ITERATIONS = 6.727273;
+
+    /** Tolerance for double mean comparison (means of integers; effectively exact). */
+    private static final double MEAN_EPSILON = 1e-3;
+
+    private ESVTData testData;
+    private List<ESVTRay> rays;
+
+    @BeforeAll
+    void setup() {
+        testData = createTestSphere(6);
+        System.out.println("[ESVTFrontToBackBenchmarkTest] nodes=" + testData.nodes().length);
+
+        var cameraPos = new Vector3f(2.0f, 2.0f, 2.0f);
+        var lookAt = new Vector3f(0.5f, 0.5f, 0.5f);
+        rays = generateRays(cameraPos, lookAt, 60.0f, FRAME_SIZE, FRAME_SIZE);
+        System.out.println("[ESVTFrontToBackBenchmarkTest] rays=" + rays.size());
+    }
+
+    /**
+     * P1: Run the traversal on the seeded scene and print the deterministic baseline.
+     *
+     * <p>On current exhaustive code this test captures the mean and prints it. Once
+     * the constant {@code BASELINE_MEAN_ITERATIONS_EXHAUSTIVE} is filled in, the
+     * equality assertion activates and pins the baseline.
+     */
+    @Test
+    void testBaselineIterations() {
+        var traversal = new ESVTTraversal();
+        var nodes = testData.nodes();
+        var farPointers = testData.farPointers();
+
+        long totalIterations = 0;
+        int hitCount = 0;
+
+        for (var ray : rays) {
+            var result = traversal.castRay(ray, nodes, null, farPointers, 0);
+            if (result.hit) {
+                totalIterations += result.iterations;
+                hitCount++;
+            }
+        }
+
+        assertTrue(hitCount > 0, "Scene must produce at least one hit (non-vacuous)");
+
+        double mean = (double) totalIterations / hitCount;
+        System.out.printf("[P1-baseline] hitCount=%d, totalIterations=%d, meanIterations=%.6f%n",
+                          hitCount, totalIterations, mean);
+        System.out.printf("[P1-baseline] *** BASELINE_MEAN_ITERATIONS_EXHAUSTIVE = %.6f ***%n", mean);
+
+        if (BASELINE_MEAN_ITERATIONS_EXHAUSTIVE >= 0.0) {
+            // Baseline pinned: assert exact equality (deterministic CPU-side)
+            assertTrue(Math.abs(mean - BASELINE_MEAN_ITERATIONS_EXHAUSTIVE) < MEAN_EPSILON,
+                       String.format("Baseline changed! expected=%.6f actual=%.6f delta=%.6f",
+                                     BASELINE_MEAN_ITERATIONS_EXHAUSTIVE, mean,
+                                     Math.abs(mean - BASELINE_MEAN_ITERATIONS_EXHAUSTIVE)));
+        }
+        // else: first run — just print; caller reads console and sets the constant.
+
+        // P2 ratio assertion (active only after BASELINE is set and P2 rewrite is done)
+        if (BASELINE_MEAN_ITERATIONS_EXHAUSTIVE >= 0.0 && FRONTTOBACK_MEAN_ITERATIONS >= 0.0) {
+            // After P2: assert mean beat the baseline by the required margin
+            assertTrue(mean < BASELINE_MEAN_ITERATIONS_EXHAUSTIVE * PRUNE_MARGIN,
+                       String.format("Front-to-back did NOT beat baseline: mean=%.6f baseline=%.6f margin=%.2f required<%.6f",
+                                     mean, BASELINE_MEAN_ITERATIONS_EXHAUSTIVE, PRUNE_MARGIN,
+                                     BASELINE_MEAN_ITERATIONS_EXHAUSTIVE * PRUNE_MARGIN));
+
+            // And pin the new exact mean
+            assertTrue(Math.abs(mean - FRONTTOBACK_MEAN_ITERATIONS) < MEAN_EPSILON,
+                       String.format("Front-to-back mean changed! expected=%.6f actual=%.6f",
+                                     FRONTTOBACK_MEAN_ITERATIONS, mean));
+        }
+    }
+
+    /**
+     * Depth-3 dense scene perf gate (2s3jc P2).
+     *
+     * <p>At depth 3, leaf tetrahedra are 8× larger per linear dimension than depth 6.
+     * The 64×64 ray grid hits many more cells, bestT shrinks early from front-facing hits,
+     * and the prune-break fires for back-facing siblings — demonstrating the actual
+     * algorithmic win.
+     *
+     * <p>Assertions:
+     * <ul>
+     *   <li>Dense hitCount >= {@code DENSE_HIT_COUNT_FLOOR} (scene is not degenerate)</li>
+     *   <li>mean < {@code DENSE_BASELINE_MEAN_ITERATIONS_EXHAUSTIVE * DENSE_PRUNE_MARGIN}
+     *       (front-to-back beats exhaustive by ≥ 30%)</li>
+     *   <li>mean == {@code DENSE_FRONTTOBACK_MEAN_ITERATIONS} ± epsilon (exact pin)</li>
+     * </ul>
+     *
+     * <p>Constants captured via stash procedure: exhaustive baseline measured on
+     * unmodified code, then stash popped to measure front-to-back numbers.
+     */
+    @Test
+    void testDenseScenePruning() {
+        var denseData = createTestSphere(3);
+        System.out.printf("[dense] nodes=%d%n", denseData.nodes().length);
+
+        var cameraPos = new Vector3f(2.0f, 2.0f, 2.0f);
+        var lookAt = new Vector3f(0.5f, 0.5f, 0.5f);
+        var denseRays = generateRays(cameraPos, lookAt, 60.0f, FRAME_SIZE, FRAME_SIZE);
+
+        var traversal = new ESVTTraversal();
+        var nodes = denseData.nodes();
+        var farPointers = denseData.farPointers();
+
+        long totalIterations = 0;
+        int hitCount = 0;
+
+        for (var ray : denseRays) {
+            var result = traversal.castRay(ray, nodes, null, farPointers, 0);
+            if (result.hit) {
+                totalIterations += result.iterations;
+                hitCount++;
+            }
+        }
+
+        System.out.printf("[dense] hitCount=%d, totalIterations=%d%n", hitCount, totalIterations);
+        assertTrue(hitCount > 0, "Dense scene must produce at least one hit");
+
+        double mean = (double) totalIterations / hitCount;
+        System.out.printf("[dense] meanIterations=%.6f%n", mean);
+        System.out.printf("[dense] *** DENSE current mean = %.6f ***%n", mean);
+
+        // Non-vacuous scene guard
+        assertTrue(hitCount >= DENSE_HIT_COUNT_FLOOR,
+                   String.format("Dense scene hitCount=%d below floor=%d — scene may have degenerated",
+                                 hitCount, DENSE_HIT_COUNT_FLOOR));
+
+        // Both constants must be set (i.e., P2 rewrite active) before the perf gate fires.
+        // While DENSE_FRONTTOBACK_MEAN_ITERATIONS is -1 (sentinel), we are still capturing
+        // baselines; assertions are skipped so exhaustive code passes this test.
+        if (DENSE_BASELINE_MEAN_ITERATIONS_EXHAUSTIVE >= 0.0 && DENSE_FRONTTOBACK_MEAN_ITERATIONS >= 0.0) {
+            // Perf gate: front-to-back must beat exhaustive by DENSE_PRUNE_MARGIN
+            double required = DENSE_BASELINE_MEAN_ITERATIONS_EXHAUSTIVE * DENSE_PRUNE_MARGIN;
+            assertTrue(mean < required,
+                       String.format("Front-to-back did NOT beat dense baseline: mean=%.6f baseline=%.6f margin=%.2f required<%.6f (ratio=%.3f)",
+                                     mean, DENSE_BASELINE_MEAN_ITERATIONS_EXHAUSTIVE, DENSE_PRUNE_MARGIN, required,
+                                     mean / DENSE_BASELINE_MEAN_ITERATIONS_EXHAUSTIVE));
+
+            // Exact regression pin: any future change to traversal order shows up here
+            assertTrue(Math.abs(mean - DENSE_FRONTTOBACK_MEAN_ITERATIONS) < MEAN_EPSILON,
+                       String.format("Dense front-to-back mean changed! expected=%.6f actual=%.6f",
+                                     DENSE_FRONTTOBACK_MEAN_ITERATIONS, mean));
+
+            System.out.printf("[dense] *** ratio = %.3f (baseline=%.6f f2b=%.6f) ***%n",
+                              mean / DENSE_BASELINE_MEAN_ITERATIONS_EXHAUSTIVE,
+                              DENSE_BASELINE_MEAN_ITERATIONS_EXHAUSTIVE, mean);
+        } else {
+            // Baseline captured; front-to-back constant not yet filled — print for recording.
+            System.out.printf("[dense] *** DENSE_FRONTTOBACK_MEAN_ITERATIONS candidate = %.6f (fill this in after git stash pop) ***%n", mean);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Scene construction — verbatim from ESVTGPUCPUParityTest.createTestSphere
+    // (method is private there; duplicated here with Random(42) seed intact).
+    // Any drift from the original invalidates the baseline.
+    // -------------------------------------------------------------------------
+    private ESVTData createTestSphere(int depth) {
+        var random = new Random(42);
+        var tetree = new Tetree<>(new SequentialLongIDGenerator());
+        var builder = new ESVTBuilder();
+
+        float center = 0.5f;
+        float radius = 0.3f;
+        int samples = 2000;
+
+        for (int i = 0; i < samples; i++) {
+            float x = random.nextFloat();
+            float y = random.nextFloat();
+            float z = random.nextFloat();
+
+            float dx = x - center;
+            float dy = y - center;
+            float dz = z - center;
+            float dist = (float) Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+            if (dist <= radius) {
+                float scale = Constants.lengthAtLevel((byte) 0);
+                tetree.insert(new Point3f(x * scale, y * scale, z * scale), (byte) depth, "Entity" + i);
+            }
+        }
+
+        return builder.build(tetree);
+    }
+
+    // -------------------------------------------------------------------------
+    // Ray generation — verbatim from ESVTGPUCPUParityTest.generateRays
+    // -------------------------------------------------------------------------
+    private List<ESVTRay> generateRays(Vector3f cameraPos, Vector3f lookAt, float fov,
+                                      int width, int height) {
+        var rays = new ArrayList<ESVTRay>(width * height);
+
+        var viewMatrix = createViewMatrix(cameraPos, lookAt, new Vector3f(0, 1, 0));
+        float aspect = (float) width / height;
+        var projMatrix = createPerspectiveMatrix(fov, aspect, 0.1f, 100.0f);
+
+        var invView = new Matrix4f();
+        invView.invert(viewMatrix);
+        var invProj = new Matrix4f();
+        invProj.invert(projMatrix);
+
+        var cameraPosWorld = new Vector3f(invView.m03, invView.m13, invView.m23);
+        var cameraPosDataSpace = new Vector3f(cameraPosWorld);
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                float ndcX = (2.0f * x / width) - 1.0f;
+                float ndcY = 1.0f - (2.0f * y / height);
+
+                var clipPos = new Vector4f(ndcX, ndcY, -1.0f, 1.0f);
+                var viewPos = new Vector4f();
+                invProj.transform(clipPos, viewPos);
+                viewPos.scale(1.0f / viewPos.w);
+
+                var worldPos = new Vector4f();
+                invView.transform(viewPos, worldPos);
+
+                var rayDir = new Vector3f(
+                    worldPos.x - cameraPosDataSpace.x,
+                    worldPos.y - cameraPosDataSpace.y,
+                    worldPos.z - cameraPosDataSpace.z
+                );
+                rayDir.normalize();
+
+                var ray = new ESVTRay(
+                    cameraPosDataSpace.x, cameraPosDataSpace.y, cameraPosDataSpace.z,
+                    rayDir.x, rayDir.y, rayDir.z
+                );
+                ray.tMin = 0.001f;
+                ray.tMax = 1000.0f;
+
+                rays.add(ray);
+            }
+        }
+        return rays;
+    }
+
+    private Matrix4f createViewMatrix(Vector3f eye, Vector3f center, Vector3f up) {
+        var f = new Vector3f();
+        f.sub(center, eye);
+        f.normalize();
+
+        var actualUp = new Vector3f(up);
+        var s = new Vector3f();
+        s.cross(f, actualUp);
+        if (s.lengthSquared() < 1e-6f) {
+            actualUp.set(0, 0, 1);
+            s.cross(f, actualUp);
+            if (s.lengthSquared() < 1e-6f) {
+                actualUp.set(1, 0, 0);
+                s.cross(f, actualUp);
+            }
+        }
+        s.normalize();
+
+        var u = new Vector3f();
+        u.cross(s, f);
+
+        var view = new Matrix4f();
+        view.m00 = s.x;  view.m01 = s.y;  view.m02 = s.z;  view.m03 = -s.dot(eye);
+        view.m10 = u.x;  view.m11 = u.y;  view.m12 = u.z;  view.m13 = -u.dot(eye);
+        view.m20 = -f.x; view.m21 = -f.y; view.m22 = -f.z; view.m23 = f.dot(eye);
+        view.m30 = 0;    view.m31 = 0;    view.m32 = 0;    view.m33 = 1;
+        return view;
+    }
+
+    private Matrix4f createPerspectiveMatrix(float fovDegrees, float aspect, float near, float far) {
+        float fovRad = (float) Math.toRadians(fovDegrees);
+        float f = 1.0f / (float) Math.tan(fovRad / 2.0f);
+
+        var proj = new Matrix4f();
+        proj.m00 = f / aspect;
+        proj.m11 = f;
+        proj.m22 = (far + near) / (near - far);
+        proj.m23 = (2 * far * near) / (near - far);
+        proj.m32 = -1;
+        proj.m33 = 0;
+        return proj;
+    }
+}


### PR DESCRIPTION
## Summary

Implements front-to-back child traversal with early-exit pruning across all three ESVT implementations — `ESVTTraversal.java`, `esvt_ray_traversal.cl`, `raycast_esvt.comp` — replacing the exhaustive all-8 min-t scan shipped by the jk5tk parity arc (#234). Approved design (approach B): collect intersecting Morton children → tandem insertion sort ascending by (tEntry, childIdx tiebreak) → visit in sorted order → prune-BREAK when the next tEntry >= bestT (sorted order guarantees no remaining child can improve the result). The packed visit order lives on the stack per level; the resume path re-intersects (no per-child tEntry floats stored).

## Commits / phases

- **c1a56daf — P1+P2 CPU** (Luciferase-nmqk0, Luciferase-nr052): `ESVTStack` packed sorted-order word (count bits 27-24, eight 3-bit Morton childIdx slots bits 23-0) + `ESVTTraversal` collect/sort/visit/prune rewrite with zero allocations in the hot loop. Dead pre-jk5tk methods removed. New `ESVTFrontToBackBenchmarkTest` with measured (stash-captured) constants: dense scene exhaustive mean 11.09 → front-to-back 6.73 iterations, **ratio 0.607**; 1-hit no-regression gate at 1.01x.
- **551dd55c — P3 shaders** (Luciferase-y3l06): identical mirror into both shaders — same collect scan, same comparator, same prune condition. `.cl` adds an `int sortedOrder` StackEntry field (private per-work-item stack). `.comp` adds **no 6th shared array** (32 KiB workgroup budget): resume cursor + count + order packed into the existing `stack_siblingPos` slot (bits 31-28 / 27-24 / 23-0, uint-cast shifts against sign extension), all accesses via the `stackBase + scale` per-thread offset. `ESVTShaderSourcePinTest` revised 12 → 20 pins (Pins 1/3/7 javadoc-revised, Pin 5b marker count 2→4, new Pins 12-19 covering the sort/comparator, packed slot, per-thread offset, no-6th-shared-array, and prune-break markers).
- **f11593eb — P4 hardware gate** (Luciferase-ypbk9): the single pre-authorized assertion edit — `ESVTOpenCLRendererFarPointerTest` real-hit assertion strengthened from `hitCount > 0` to `assertEquals(24, hitCount)`. 24 was measured on M4 Max hardware both before and after the rewrite (result invariance); the test is `RUN_GPU_TESTS=true`-gated and the scene/camera are fully deterministic.

## Verification

- **Result invariance**: the jk5tk result-pin files `ESVTTraversalTest` (18) and `ESVTPerSlotDescendTest` (11) are untouched across the whole branch (`git log` per file: empty) and green.
- **Headless**: 51/51 (20 shader pins + 31 traversal/benchmark); full render suite 2221 tests / 0 failures (`DynamicKernelSelectionTest` excluded per Luciferase-vkl96).
- **Hardware (M4 Max, RUN_GPU_TESTS=true)**: `ESVTGPUCPUParityTest` 4/4 — 99.79% average / 99.68% minimum ray match (95% thresholds) with CPU and GPU both running front-to-back; `ESVTOpenCLRendererFarPointerTest` 9/9 including the ==24 exact pin.
- **Review**: stacked review (code-review-expert + substantive-critic) at every phase boundary; final pre-PR pass clean from both — 0 Critical / 0 Significant.

Locked jk5tk contracts preserved throughout: Morton childmask/leafmask (INDEX_TO_BEY_NUMBER only for vertex derivation/type propagation), global bestT across the DFS with return after stack exhaustion, contour-invalid = continue, root-without-leaf is MISS, fail-loud OOB child pointers.

Beads: Luciferase-2s3jc (epic), Luciferase-nmqk0, Luciferase-nr052, Luciferase-y3l06, Luciferase-ypbk9.