### PR TITLE
Fix HierarchicalZBuffer z-sign no-op — DSOC occlusion culling dead when enabled (Luciferase-01w6v)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/occlusion/HierarchicalZBuffer.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/occlusion/HierarchicalZBuffer.java
@@ -107,9 +107,14 @@ public class HierarchicalZBuffer {
     }
     
     /**
-     * Updates camera matrices
+     * Updates camera matrices.
+     *
+     * <p>Both matrices are 4x4 in ROW-MAJOR layout ({@code m[row*4+col]}) with
+     * GL-style clip semantics: in-frustum geometry projects to clip {@code w > 0}
+     * and NDC z in [-1, 1] (near plane → -1, far plane → +1). Column-major (OpenGL
+     * memory-layout) matrices must be transposed before being passed in.
      */
-    public void updateCamera(float[] viewMatrix, float[] projectionMatrix, 
+    public void updateCamera(float[] viewMatrix, float[] projectionMatrix,
                            float nearPlane, float farPlane) {
         lock.writeLock().lock();
         try {
@@ -223,6 +228,10 @@ public class HierarchicalZBuffer {
                     int srcX = x * 2;
                     int srcY = y * 2;
                     
+                    // Seed 0.0 acts as -infinity here: depths are viewport depths in [0,1],
+                    // so the max over the (always >= 1) in-bounds samples is unaffected.
+                    // Out-of-bounds samples on odd-dimension levels are simply absent —
+                    // the cell's value is the max of its existing samples only.
                     float maxDepth = 0.0f;
                     for (int dy = 0; dy < 2 && srcY + dy < srcHeight; dy++) {
                         for (int dx = 0; dx < 2 && srcX + dx < srcWidth; dx++) {
@@ -277,14 +286,23 @@ public class HierarchicalZBuffer {
         corners[6] = new Point3f(min.x, max.y, max.z);
         corners[7] = new Point3f(max.x, max.y, max.z);
         
-        // Project each corner
+        // Project each corner. A corner contributes only when it is usable:
+        //  - clip w > 0  — in front of the camera (a negative w means the corner is
+        //    behind the camera; the sign-flipping perspective divide would otherwise
+        //    produce NDC z > 1 that beats an EMPTY buffer and reports phantom occlusion)
+        //  - depth01 in [0,1] (NDC z in [-1,1]) — within the near/far depth range;
+        //    the lower bound is the behind test for orthographic projections (w == 1
+        //    always), the upper bound rejects beyond-far corners whose depth would
+        //    otherwise tie the buffer's far-plane init and report phantom occlusion
+        // Depths are GL viewport depths in [0,1]: 0 = near plane, 1 = far plane —
+        // matching the buffer convention (init 1.0, min-write, '< buffer' visibility).
         float minX = Float.MAX_VALUE, minY = Float.MAX_VALUE, minZ = Float.MAX_VALUE;
         float maxX = -Float.MAX_VALUE, maxY = -Float.MAX_VALUE, maxZ = -Float.MAX_VALUE;
-        
+
         boolean anyInFront = false;
         for (Point3f corner : corners) {
             float[] projected = projectPoint(corner);
-            if (projected[2] > 0) {
+            if (projected[3] > 0 && projected[2] >= 0 && projected[2] <= 1.0f) {
                 anyInFront = true;
                 minX = Math.min(minX, projected[0]);
                 minY = Math.min(minY, projected[1]);
@@ -294,22 +312,32 @@ public class HierarchicalZBuffer {
                 maxZ = Math.max(maxZ, projected[2]);
             }
         }
-        
+
         if (!anyInFront) {
-            return null; // All corners behind camera
+            return null; // All corners behind camera or outside the near/far depth range
         }
-        
+
         // Convert to pixel coordinates
         int pixelMinX = Math.max(0, (int)(minX * width));
         int pixelMinY = Math.max(0, (int)(minY * height));
         int pixelMaxX = Math.min(width - 1, (int)(maxX * width));
         int pixelMaxY = Math.min(height - 1, (int)(maxY * height));
-        
+
         return new ScreenSpaceBounds(pixelMinX, pixelMinY, pixelMaxX, pixelMaxY, minZ);
     }
-    
+
     /**
-     * Projects a 3D point to normalized device coordinates
+     * Projects a 3D point through the view-projection matrix.
+     *
+     * <p>Matrices are ROW-MAJOR ({@code m[row*4+col]}) with GL-style clip semantics:
+     * visible eye-space geometry has clip {@code w > 0} and NDC z in [-1, 1]
+     * (near plane → -1, far plane → +1).
+     *
+     * @return {@code [x01, y01, depth01, clipW]} where x01/y01 are screen coordinates
+     *         in [0,1], depth01 is the GL viewport depth {@code (ndcZ + 1) / 2}
+     *         (0 = near, 1 = far), and clipW is the pre-divide clip-space w used by
+     *         callers to reject behind-camera corners. When {@code clipW <= 0} the
+     *         divided components are meaningless and must not be used.
      */
     private float[] projectPoint(Point3f point) {
         float[] homogeneous = new float[4];
@@ -317,23 +345,26 @@ public class HierarchicalZBuffer {
         homogeneous[1] = point.y;
         homogeneous[2] = point.z;
         homogeneous[3] = 1.0f;
-        
+
         float[] transformed = new float[4];
         multiplyMatrixVector(viewProjectionMatrix, homogeneous, transformed);
-        
+
+        float clipW = transformed[3];
+
         // Perspective divide
-        if (transformed[3] != 0) {
-            transformed[0] /= transformed[3];
-            transformed[1] /= transformed[3];
-            transformed[2] /= transformed[3];
+        if (clipW != 0) {
+            transformed[0] /= clipW;
+            transformed[1] /= clipW;
+            transformed[2] /= clipW;
         }
-        
-        // Convert to [0,1] range
-        float[] result = new float[3];
+
+        // Convert to [0,1] range (x/y screen coords and GL viewport depth)
+        float[] result = new float[4];
         result[0] = (transformed[0] + 1.0f) * 0.5f;
         result[1] = (transformed[1] + 1.0f) * 0.5f;
-        result[2] = transformed[2]; // Keep Z in NDC space
-        
+        result[2] = (transformed[2] + 1.0f) * 0.5f; // depth01: 0 = near plane, 1 = far plane
+        result[3] = clipW;
+
         return result;
     }
     

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/occlusion/HierarchicalZBufferTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/occlusion/HierarchicalZBufferTest.java
@@ -84,9 +84,9 @@ public class HierarchicalZBufferTest {
     @Test
     void testRenderOccluder() {
         float[] viewMatrix = createIdentityMatrix();
-        float[] projMatrix = createOrthographicMatrix(-100, 100, -100, 100, 0.1f, 1000);
+        float[] projMatrix = createRowMajorOrthographic(-100, 100, -100, 100, 0.1f, 1000);
         zBuffer.updateCamera(viewMatrix, projMatrix, 0.1f, 1000);
-        var occluderBounds = new EntityBounds(new Point3f(0, 0, 10), new Point3f(50, 50, 20));
+        var occluderBounds = new EntityBounds(new Point3f(0, 0, -20), new Point3f(50, 50, -10));
         zBuffer.renderOccluder(occluderBounds);
         zBuffer.updateHierarchy();
         // Smoke test only - actual occlusion depends on projection implementation
@@ -94,9 +94,9 @@ public class HierarchicalZBufferTest {
 
     @Test
     void testHierarchyUpdate() {
-        var bounds = new EntityBounds(new Point3f(0, 0, 10), new Point3f(10, 10, 20));
+        var bounds = new EntityBounds(new Point3f(0, 0, -20), new Point3f(10, 10, -10));
         float[] viewMatrix = createIdentityMatrix();
-        float[] projMatrix = createOrthographicMatrix(-100, 100, -100, 100, 0.1f, 1000);
+        float[] projMatrix = createRowMajorOrthographic(-100, 100, -100, 100, 0.1f, 1000);
         zBuffer.updateCamera(viewMatrix, projMatrix, 0.1f, 1000);
         zBuffer.renderOccluder(bounds);
         assertDoesNotThrow(zBuffer::updateHierarchy);
@@ -105,7 +105,7 @@ public class HierarchicalZBufferTest {
     @Test
     void testBoundsOutsideFrustum() {
         float[] viewMatrix = createIdentityMatrix();
-        float[] projMatrix = createOrthographicMatrix(-10, 10, -10, 10, 0.1f, 100);
+        float[] projMatrix = createRowMajorOrthographic(-10, 10, -10, 10, 0.1f, 100);
         zBuffer.updateCamera(viewMatrix, projMatrix, 0.1f, 100);
         var bounds = new EntityBounds(new Point3f(1000, 1000, 1000), new Point3f(1100, 1100, 1100));
         assertFalse(zBuffer.isOccluded(bounds));
@@ -129,7 +129,7 @@ public class HierarchicalZBufferTest {
     @Test
     void testThreadSafety() throws InterruptedException {
         float[] viewMatrix = createIdentityMatrix();
-        float[] projMatrix = createOrthographicMatrix(-100, 100, -100, 100, 0.1f, 1000);
+        float[] projMatrix = createRowMajorOrthographic(-100, 100, -100, 100, 0.1f, 1000);
         zBuffer.updateCamera(viewMatrix, projMatrix, 0.1f, 1000);
         int numThreads = 10;
         Thread[] threads = new Thread[numThreads];
@@ -138,7 +138,7 @@ public class HierarchicalZBufferTest {
             threads[i] = new Thread(() -> {
                 for (int j = 0; j < 100; j++) {
                     float offset = threadId * 20;
-                    var b = new EntityBounds(new Point3f(offset, offset, 10), new Point3f(offset + 10, offset + 10, 20));
+                    var b = new EntityBounds(new Point3f(offset, offset, -20), new Point3f(offset + 10, offset + 10, -10));
                     zBuffer.renderOccluder(b);
                 }
             });
@@ -158,7 +158,7 @@ public class HierarchicalZBufferTest {
     @Test
     void testConcurrentRenderAndUpdateHierarchyNoTornPyramid() throws InterruptedException {
         float[] viewMatrix = createIdentityMatrix();
-        float[] projMatrix = createOrthographicMatrix(-100, 100, -100, 100, 0.1f, 1000);
+        float[] projMatrix = createRowMajorOrthographic(-100, 100, -100, 100, 0.1f, 1000);
         zBuffer.updateCamera(viewMatrix, projMatrix, 0.1f, 1000);
 
         AtomicBoolean failed = new AtomicBoolean(false);
@@ -170,8 +170,8 @@ public class HierarchicalZBufferTest {
             Thread t = new Thread(() -> {
                 try {
                     while (!stop.get()) {
-                        var b = new EntityBounds(new Point3f(offset, offset, 5f),
-                                                 new Point3f(offset + 10f, offset + 10f, 15f));
+                        var b = new EntityBounds(new Point3f(offset, offset, -15f),
+                                                 new Point3f(offset + 10f, offset + 10f, -5f));
                         zBuffer.renderOccluder(b);
                     }
                 } catch (Exception e) {
@@ -336,9 +336,9 @@ public class HierarchicalZBufferTest {
         // No-throw smoke: renderOccluder + isOccluded on boundary bounds must not throw
         // ArrayIndexOutOfBoundsException regardless of projection outcome.
         float[] view = createIdentityMatrix();
-        float[] proj = createOrthographicMatrix(-50, 50, -50, 50, 0.1f, 1000);
+        float[] proj = createRowMajorOrthographic(-50, 50, -50, 50, 0.1f, 1000);
         buf.updateCamera(view, proj, 0.1f, 1000f);
-        var boundary = new EntityBounds(new Point3f(0, 0, 10), new Point3f(50, 50, 20));
+        var boundary = new EntityBounds(new Point3f(0, 0, -20), new Point3f(50, 50, -10));
         assertDoesNotThrow(() -> buf.renderOccluder(boundary),
             "renderOccluder on non-power-of-two buffer must not throw OOB");
         buf.updateHierarchy();
@@ -346,25 +346,207 @@ public class HierarchicalZBufferTest {
             "isOccluded on non-power-of-two buffer must not throw OOB");
     }
 
+    // -------------------------------------------------------------------------
+    // Behavioral occlusion tests (Luciferase-01w6v): renderOccluder must actually
+    // write depth and isOccluded must report objects behind a rendered occluder.
+    //
+    // Matrices below are ROW-MAJOR (m[row*4+col]) — the convention used by
+    // HierarchicalZBuffer.multiplyMatrixVector. Column-major (OpenGL memory-layout)
+    // matrices must be transposed before being passed to updateCamera.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Near-half perspective occluder (Luciferase-01w6v RED case 1).
+     *
+     * <p>With near=1, far=10, geometry nearer than 2fn/(f+n) ≈ 1.82 eye units has
+     * NEGATIVE GL NDC z. The pre-fix guard {@code projected[2] > 0} rejected every
+     * corner of such an occluder, projectBounds returned null, renderOccluder
+     * silently no-oped, and nothing was ever occluded — the DSOC dead-when-enabled
+     * defect. Camera at z=5.4 looking down -z; occluder at z∈[3.7,4.2] is entirely
+     * in the near half (eye z ∈ [-1.2,-1.7], NDC z ∈ [-0.63,-0.09]).
+     */
+    @Test
+    void testNearHalfPerspectiveOccluderOccludesBehindObject() {
+        float[] view = createRowMajorTranslationView(5.4f);
+        float[] proj = createRowMajorPerspective(60f, 1f, 1f, 10f);
+        zBuffer.updateCamera(view, proj, 1f, 10f);
+
+        // Large occluder entirely in the NEAR half of the frustum (negative NDC z)
+        var occluder = new EntityBounds(new Point3f(-2, -2, 3.7f), new Point3f(2, 2, 4.2f));
+        // Small box well behind it (eye z ∈ [-4.5,-4.8]), screen-covered by the occluder
+        var behind = new EntityBounds(new Point3f(-0.2f, -0.2f, 0.6f), new Point3f(0.2f, 0.2f, 0.9f));
+
+        assertFalse(zBuffer.isOccluded(behind), "empty Z-buffer must not occlude anything");
+
+        zBuffer.renderOccluder(occluder);
+
+        assertTrue(zBuffer.isOccluded(behind),
+                "box fully behind a near-half occluder must be occluded — pre-fix the z-sign "
+                + "guard rejected all negative-NDC-z corners and renderOccluder silently no-oped");
+    }
+
+    /**
+     * Far-half perspective regression guard + in-front discrimination.
+     *
+     * <p>Far-half geometry (positive GL NDC z) accidentally worked pre-fix; this pins
+     * that it keeps working, and that an object IN FRONT of the occluder is never
+     * reported occluded (depth ordering, not just coverage).
+     */
+    @Test
+    void testFarHalfPerspectiveOcclusionAndInFrontDiscrimination() {
+        float[] view = createRowMajorTranslationView(100f);
+        float[] proj = createRowMajorPerspective(60f, 1f, 0.1f, 1000f);
+        zBuffer.updateCamera(view, proj, 0.1f, 1000f);
+
+        var occluder = new EntityBounds(new Point3f(-30, -30, 40), new Point3f(30, 30, 50));
+        var behind   = new EntityBounds(new Point3f(-5, -5, -20), new Point3f(5, 5, -10));
+        var inFront  = new EntityBounds(new Point3f(-5, -5, 70), new Point3f(5, 5, 80));
+
+        assertFalse(zBuffer.isOccluded(behind), "empty Z-buffer must not occlude anything");
+
+        zBuffer.renderOccluder(occluder);
+
+        assertTrue(zBuffer.isOccluded(behind),
+                "box behind the occluder (farther from camera) must be occluded");
+        assertFalse(zBuffer.isOccluded(inFront),
+                "box between camera and occluder must NOT be occluded");
+    }
+
+    /**
+     * Near-region orthographic occluder (Luciferase-01w6v RED case 2).
+     *
+     * <p>Standard GL ortho maps the near half of [near,far] to negative NDC z; the
+     * pre-fix guard rejected those corners. Identity view (camera at origin looking
+     * down -z), ortho ±100, near=0.1, far=100. Occluder at z∈[-20,-10] has NDC
+     * z ∈ [-0.80,-0.60] — fully rejected pre-fix.
+     */
+    @Test
+    void testOrthographicNearRegionOccluderOccludesBehindObject() {
+        float[] view = createIdentityMatrix();
+        float[] proj = createRowMajorOrthographic(-100, 100, -100, 100, 0.1f, 100f);
+        zBuffer.updateCamera(view, proj, 0.1f, 100f);
+
+        var occluder = new EntityBounds(new Point3f(-50, -50, -20), new Point3f(50, 50, -10));
+        var behind   = new EntityBounds(new Point3f(-5, -5, -60), new Point3f(5, 5, -50));
+
+        assertFalse(zBuffer.isOccluded(behind), "empty Z-buffer must not occlude anything");
+
+        zBuffer.renderOccluder(occluder);
+
+        assertTrue(zBuffer.isOccluded(behind),
+                "box behind a near-region ortho occluder must be occluded — pre-fix the "
+                + "z-sign guard rejected all negative-NDC-z corners");
+    }
+
+    /**
+     * Behind-camera bounds (Luciferase-01w6v RED case 3).
+     *
+     * <p>A box behind the camera has clip w &lt; 0; the perspective divide flips signs
+     * and produces NDC z &gt; 1, which PASSED the pre-fix {@code > 0} guard. Its
+     * nearZ (&gt; 1) then failed {@code nearZ < buffer} at every pixel of an EMPTY
+     * buffer, so isOccluded reported true for an object behind the camera with
+     * nothing rendered at all. Post-fix the w-guard rejects it: not occluded, and
+     * rendering it as an occluder is a clean no-op.
+     */
+    @Test
+    void testBehindCameraBoundsNeverOccluded() {
+        float[] view = createRowMajorTranslationView(5.4f);
+        float[] proj = createRowMajorPerspective(60f, 1f, 1f, 10f);
+        zBuffer.updateCamera(view, proj, 1f, 10f);
+
+        // Camera at z=5.4 looking down -z: world z > 5.4 is behind the camera
+        var behindCamera = new EntityBounds(new Point3f(-1, -1, 6f), new Point3f(1, 1, 7f));
+
+        assertFalse(zBuffer.isOccluded(behindCamera),
+                "a box behind the camera must never be reported occluded — pre-fix the "
+                + "sign-flipped divide produced NDC z > 1 which passed the guard and beat "
+                + "an empty buffer");
+
+        assertDoesNotThrow(() -> zBuffer.renderOccluder(behindCamera),
+                "rendering a behind-camera occluder must be a clean no-op");
+
+        // The no-op must not have corrupted the buffer: an in-frustum box is still visible
+        var inFrustum = new EntityBounds(new Point3f(-0.5f, -0.5f, 2f), new Point3f(0.5f, 0.5f, 2.5f));
+        assertFalse(zBuffer.isOccluded(inFrustum),
+                "after a behind-camera no-op render, in-frustum geometry must remain unoccluded");
+    }
+
+    /**
+     * Beyond-far-plane bounds must not report occluded against an empty buffer.
+     *
+     * <p>A box entirely past the far plane projects to depth01 &gt; 1 at every corner.
+     * Without the admission upper bound, its clamped nearZ (1.0) ties the buffer's
+     * far-plane initialization and {@code nearZ < buffer} fails at every pixel —
+     * phantom occlusion with nothing rendered. The depth-range admission guard
+     * rejects such corners; projectBounds returns null and the box stays visible.
+     */
+    @Test
+    void testBeyondFarPlaneBoundsNotOccluded() {
+        float[] view = createRowMajorTranslationView(100f);
+        float[] proj = createRowMajorPerspective(60f, 1f, 0.1f, 50f); // far plane at 50
+        zBuffer.updateCamera(view, proj, 0.1f, 50f);
+
+        // Eye z ∈ [-160,-150] — entirely beyond the far plane (50)
+        var beyondFar = new EntityBounds(new Point3f(-5, -5, -60), new Point3f(5, 5, -50));
+
+        assertFalse(zBuffer.isOccluded(beyondFar),
+                "a box entirely beyond the far plane must not report occluded against an "
+                + "empty buffer — its depth01 > 1 corners must be rejected, not clamped to "
+                + "the far-plane init value");
+
+        assertDoesNotThrow(() -> zBuffer.renderOccluder(beyondFar),
+                "rendering a beyond-far occluder must be a clean no-op");
+    }
+
     // Helper methods
+
+    /**
+     * Row-major view matrix for a camera at (0, 0, cameraZ) looking down -Z with +Y up:
+     * eye = world - (0,0,cameraZ).
+     */
+    private float[] createRowMajorTranslationView(float cameraZ) {
+        float[] m = createIdentityMatrix();
+        m[11] = -cameraZ; // row 2, col 3
+        return m;
+    }
+
+    /**
+     * Row-major GL-style perspective projection (visible eye z ∈ [-near,-far] maps to
+     * NDC z ∈ [-1,1], clip w = -z_eye).
+     */
+    private float[] createRowMajorPerspective(float fovYDegrees, float aspect, float near, float far) {
+        float f = (float) (1.0 / Math.tan(Math.toRadians(fovYDegrees) / 2.0));
+        float[] m = new float[16];
+        m[0]  = f / aspect;
+        m[5]  = f;
+        m[10] = (far + near) / (near - far);
+        m[11] = 2f * far * near / (near - far);
+        m[14] = -1f;
+        return m;
+    }
+
+    /**
+     * Row-major GL-style orthographic projection (visible eye z ∈ [-near,-far] maps to
+     * NDC z ∈ [-1,1], clip w = 1).
+     */
+    private float[] createRowMajorOrthographic(float left, float right, float bottom, float top,
+                                               float near, float far) {
+        float[] m = new float[16];
+        m[0]  = 2f / (right - left);
+        m[3]  = -(right + left) / (right - left);
+        m[5]  = 2f / (top - bottom);
+        m[7]  = -(top + bottom) / (top - bottom);
+        m[10] = -2f / (far - near);
+        m[11] = -(far + near) / (far - near);
+        m[15] = 1f;
+        return m;
+    }
 
     private float[] createIdentityMatrix() {
         float[] matrix = new float[16];
         for (int i = 0; i < 16; i++) {
             matrix[i] = (i % 5 == 0) ? 1.0f : 0.0f;
         }
-        return matrix;
-    }
-
-    private float[] createOrthographicMatrix(float left, float right, float bottom, float top, float near, float far) {
-        float[] matrix = new float[16];
-        matrix[0] = 2.0f / (right - left);
-        matrix[5] = 2.0f / (top - bottom);
-        matrix[10] = -2.0f / (far - near);
-        matrix[12] = -(right + left) / (right - left);
-        matrix[13] = -(top + bottom) / (top - bottom);
-        matrix[14] = -(far + near) / (far - near);
-        matrix[15] = 1.0f;
         return matrix;
     }
 }


### PR DESCRIPTION
## Summary

Fixes the looks-works-does-nothing defect found by the Wave-17 substantive critique: `HierarchicalZBuffer.renderOccluder` silently no-oped under standard camera matrices, leaving DSOC occlusion culling dead whenever it was enabled.

**Root cause** (three interlocking problems):
1. `projectBounds` admitted corners only when raw NDC z > 0 — but under standard GL projections, geometry in the *near half* of the frustum has negative NDC z, so near-half occluders were rejected wholesale → `projectBounds` null → `renderOccluder` no-op → Z-buffer never written → `isOccluded` always false.
2. `projectPoint` stored raw NDC z ∈ [-1,1] against a buffer whose convention is [0,1] (init 1.0 = far, min-write, `nearZ < buffer` visibility test).
3. Behind-camera boxes (clip w < 0) produced NDC z > 1 through the sign-flipping perspective divide, **passed** the `> 0` guard, and were reported occluded against an *empty* buffer — phantom occlusion.

**Fix** (43aa62e9):
- `projectPoint` now returns `[x01, y01, depth01, clipW]` with `depth01 = (ndcZ+1)/2` — the GL viewport depth (0 = near, 1 = far), consistent with the buffer convention end-to-end.
- Corner admission: `clipW > 0` (behind-camera test, perspective) AND `depth01 ∈ [0,1]` (near/far range; the lower bound is the behind test for orthographic where w ≡ 1, the upper bound rejects beyond-far corners that would tie the far-plane init and phantom-occlude).
- The previously undocumented ROW-MAJOR `float[16]` matrix convention is now documented on `updateCamera`/`projectPoint`; the legacy column-major test helper (which made the old tests structurally unable to assert projection behavior) is deleted and all call sites converted.

## Tests (TDD — three were RED pre-fix)

- Near-half perspective occluder occludes a behind-object (the no-op case)
- Orthographic near-region occluder occludes a behind-object
- Behind-camera bounds never occluded + clean no-op render (the phantom case)
- Beyond-far bounds never occluded against an empty buffer
- Far-half + in-front discrimination regression guard (pins depth ordering)
- Smoke/concurrency tests converted to row-major matrices with in-range geometry so their renders actually rasterize

## Verification

- `HierarchicalZBufferTest` 18/18; all occlusion/DSOC suites 174/0 (no assertions flipped now that occlusion actually works); full lucien module 3187/0.
- Stacked review clean over two rounds (code-review-expert APPROVED, substantive-critic 0 Critical / 0 Significant). One reviewer suggestion (downsample-seed change) was rejected with proof and retracted by the reviewer — seed 0.0 is −∞ for the [0,1] depth domain.

Bead: Luciferase-01w6v.