### PR TITLE
fix(portal): RenderService routes ESVO/ESVT builds through BuildResult success-guard (Luciferase-x5zcl)

### DIFF
--- a/portal/src/main/java/com/hellblazer/luciferase/portal/esvo/bridge/ESVOBridge.java
+++ b/portal/src/main/java/com/hellblazer/luciferase/portal/esvo/bridge/ESVOBridge.java
@@ -82,7 +82,8 @@ public class ESVOBridge implements SpatialBridge<ESVOOctreeData> {
             currentMaxDepth = maxDepth;
             
             var buildTime = (System.nanoTime() - startTime) / 1_000_000.0; // Convert to ms
-            log.debug("Octree built in {:.2f}ms with {} nodes", buildTime, currentOctree.getNodeCount());
+            log.debug("Octree built in {}ms with {} nodes", String.format("%.2f", buildTime),
+                      currentOctree.getNodeCount());
             
             return currentOctree;
         } catch (Exception e) {

--- a/portal/src/main/java/com/hellblazer/luciferase/portal/esvt/bridge/ESVTBridge.java
+++ b/portal/src/main/java/com/hellblazer/luciferase/portal/esvt/bridge/ESVTBridge.java
@@ -327,6 +327,14 @@ public class ESVTBridge implements SpatialBridge<ESVTData> {
         long startMs = System.currentTimeMillis();
         int voxelCount = voxels != null ? voxels.size() : 0;
         try {
+            if (voxels == null) {
+                throw new IllegalArgumentException("Voxels list cannot be null");
+            }
+            // Tetree supports 21 levels; ESVTTraversal.MAX_DEPTH (22) is the scale domain,
+            // so the deepest buildable tree is 21.
+            if (maxDepth < 1 || maxDepth > 21) {
+                throw new IllegalArgumentException("Max depth must be between 1 and 21, got: " + maxDepth);
+            }
             long startNs = System.nanoTime();
             this.data = builder.buildFromVoxels(voxels, maxDepth, gridResolution);
             this.lastBuildTimeNs = System.nanoTime() - startNs;

--- a/portal/src/main/java/com/hellblazer/luciferase/portal/web/SpatialInspectorServer.java
+++ b/portal/src/main/java/com/hellblazer/luciferase/portal/web/SpatialInspectorServer.java
@@ -5,6 +5,7 @@ import com.hellblazer.luciferase.esvo.io.VOLLoader;
 import com.hellblazer.luciferase.portal.web.dto.*;
 import com.hellblazer.luciferase.portal.web.service.EntityCapExceededException;
 import com.hellblazer.luciferase.portal.web.service.GpuService;
+import com.hellblazer.luciferase.portal.web.service.RenderBuildException;
 import com.hellblazer.luciferase.portal.web.service.RenderService;
 import com.hellblazer.luciferase.portal.web.service.SpatialIndexService;
 import io.javalin.Javalin;
@@ -164,6 +165,14 @@ public class SpatialInspectorServer {
             ctx.status(409).json(Map.of(
                 "error", e.getMessage(),
                 "type", "Conflict",
+                "timestamp", Instant.now().toString()
+            ));
+        });
+
+        javalin.exception(RenderBuildException.class, (e, ctx) -> {
+            ctx.status(422).json(Map.of(
+                "error", e.getMessage(),
+                "type", "BuildFailed",
                 "timestamp", Instant.now().toString()
             ));
         });

--- a/portal/src/main/java/com/hellblazer/luciferase/portal/web/service/RenderBuildException.java
+++ b/portal/src/main/java/com/hellblazer/luciferase/portal/web/service/RenderBuildException.java
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+package com.hellblazer.luciferase.portal.web.service;
+
+/**
+ * Thrown when building a render structure (ESVO/ESVT) fails. Carries the failure
+ * message from the {@code SpatialBridge.BuildResult} guard. Maps to HTTP 422
+ * Unprocessable Entity.
+ */
+public class RenderBuildException extends RuntimeException {
+
+    public RenderBuildException(String message) {
+        super(message);
+    }
+}

--- a/portal/src/main/java/com/hellblazer/luciferase/portal/web/service/RenderService.java
+++ b/portal/src/main/java/com/hellblazer/luciferase/portal/web/service/RenderService.java
@@ -1,8 +1,6 @@
 package com.hellblazer.luciferase.portal.web.service;
 
-import com.hellblazer.luciferase.esvo.core.OctreeBuilder;
 import com.hellblazer.luciferase.esvo.core.ESVOOctreeData;
-import com.hellblazer.luciferase.esvt.builder.ESVTBuilder;
 import com.hellblazer.luciferase.esvt.core.ESVTData;
 import com.hellblazer.luciferase.esvt.traversal.ESVTRay;
 import com.hellblazer.luciferase.esvt.traversal.ESVTTraversal;
@@ -10,6 +8,9 @@ import com.hellblazer.luciferase.geometry.Point3i;
 import com.hellblazer.luciferase.lucien.entity.UUIDEntityID;
 import com.hellblazer.luciferase.lucien.octree.Octree;
 import com.hellblazer.luciferase.lucien.tetree.Tetree;
+import com.hellblazer.luciferase.portal.esvo.bridge.ESVOBridge;
+import com.hellblazer.luciferase.portal.esvt.bridge.ESVTBridge;
+import com.hellblazer.luciferase.portal.inspector.SpatialBridge;
 import com.hellblazer.luciferase.portal.web.dto.*;
 import com.hellblazer.luciferase.portal.web.dto.CreateRenderRequest.RenderType;
 import org.slf4j.Logger;
@@ -19,6 +20,7 @@ import javax.vecmath.Point3f;
 import javax.vecmath.Vector3f;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 /**
  * Service for managing ESVO/ESVT render structures via REST API.
@@ -32,6 +34,24 @@ public class RenderService {
 
     private final Map<String, RenderHolder> renders = new ConcurrentHashMap<>();
     private final Map<String, CameraState> cameras = new ConcurrentHashMap<>();
+
+    private final Supplier<SpatialBridge<ESVTData>> esvtBridgeFactory;
+    private final Supplier<SpatialBridge<ESVOOctreeData>> esvoBridgeFactory;
+
+    public RenderService() {
+        this(ESVTBridge::new, ESVOBridge::new);
+    }
+
+    /**
+     * Constructor-injected bridge factories. Builds go through the {@link SpatialBridge}
+     * wrappers so the {@code BuildResult.isSuccess()} guard is the single success signal
+     * (.220); a fresh bridge is created per build because bridges are stateful.
+     */
+    public RenderService(Supplier<SpatialBridge<ESVTData>> esvtBridgeFactory,
+                         Supplier<SpatialBridge<ESVOOctreeData>> esvoBridgeFactory) {
+        this.esvtBridgeFactory = esvtBridgeFactory;
+        this.esvoBridgeFactory = esvoBridgeFactory;
+    }
 
     /**
      * Create a render structure from the spatial index data.
@@ -220,8 +240,12 @@ public class RenderService {
             }
         }
 
-        var builder = new ESVTBuilder();
-        var data = builder.buildFromVoxels(voxels, maxDepth, gridResolution);
+        var result = esvtBridgeFactory.get().buildFromVoxels(voxels, maxDepth, gridResolution);
+        if (!result.isSuccess()) {
+            log.warn("createESVT: build failed: {}", result.message());
+            throw new RenderBuildException("ESVT: " + result.message());
+        }
+        var data = result.getData();
 
         log.info("createESVT: built ESVT with {} nodes, {} leaves, {} internal",
                 data.nodes().length, data.leafCount(), data.internalCount());
@@ -257,22 +281,25 @@ public class RenderService {
             voxels.add(new Point3i(x, y, z));
         }
 
-        try (var builder = new OctreeBuilder(maxDepth)) {
-            var octreeData = builder.buildFromVoxels(voxels, maxDepth);
-
-            return new RenderHolder(
-                    RenderType.ESVO,
-                    octreeData,
-                    null,
-                    octreeData.nodeCount(),
-                    octreeData.leafCount(),
-                    octreeData.internalCount(),
-                    octreeData.maxDepth(),
-                    gridResolution,
-                    octreeData.sizeInBytes(),
-                    octreeData.getFarPointers().length
-            );
+        var result = esvoBridgeFactory.get().buildFromVoxels(voxels, maxDepth, gridResolution);
+        if (!result.isSuccess()) {
+            log.warn("createESVO: build failed: {}", result.message());
+            throw new RenderBuildException("ESVO: " + result.message());
         }
+        var octreeData = result.getData();
+
+        return new RenderHolder(
+                RenderType.ESVO,
+                octreeData,
+                null,
+                octreeData.nodeCount(),
+                octreeData.leafCount(),
+                octreeData.internalCount(),
+                octreeData.maxDepth(),
+                gridResolution,
+                octreeData.sizeInBytes(),
+                octreeData.getFarPointers().length
+        );
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/portal/src/test/java/com/hellblazer/luciferase/portal/web/SpatialInspectorServerTest.java
+++ b/portal/src/test/java/com/hellblazer/luciferase/portal/web/SpatialInspectorServerTest.java
@@ -483,6 +483,63 @@ class SpatialInspectorServerTest {
         });
     }
 
+    // ========== x5zcl: Render Build Failure Tests ==========
+
+    /**
+     * A render build failure must map to a clean 422 BuildFailed response, not an
+     * uncaught builder exception surfacing as a generic 500. maxDepth=99 is rejected
+     * inside ESVOBridge's BuildResult guard (valid range 1..15), giving a deterministic
+     * failure trigger through the full HTTP path.
+     */
+    @Test
+    void renderBuildFailureReturns422BuildFailed() {
+        var server = new SpatialInspectorServer(0);
+        JavalinTest.test(server.app(), (javalin, client) -> {
+            var sessionId = extractSessionId(client.post("/api/session/create").body().string());
+            postJson(client, "/api/spatial/create?sessionId=" + sessionId, CREATE_OCTREE_BODY);
+
+            // Give the index an entity so the render path has positions to voxelize
+            postJson(client, "/api/spatial/entities/insert?sessionId=" + sessionId,
+                     "{\"x\":0.5,\"y\":0.5,\"z\":0.5}");
+
+            var resp = postJson(client, "/api/render/create?sessionId=" + sessionId,
+                                "{\"type\":\"ESVO\",\"maxDepth\":99,\"gridResolution\":16}");
+            assertEquals(422, resp.code(), "Build failure must return 422, not 500");
+            var body = resp.body().string();
+            assertTrue(body.contains("BuildFailed"), "Body must carry BuildFailed type: " + body);
+
+            // Failed build must not leave render state — a valid retry must succeed
+            assertFalse(server.renderService().hasRender(sessionId),
+                        "Failed build must not leave a render holder");
+            var retry = postJson(client, "/api/render/create?sessionId=" + sessionId,
+                                 "{\"type\":\"ESVO\",\"maxDepth\":10,\"gridResolution\":16}");
+            assertEquals(201, retry.code(), "Valid retry after failed build must succeed");
+        });
+    }
+
+    /**
+     * ESVT mirror of the 422 test: ESVTBridge validates maxDepth 1..21 inside its
+     * BuildResult guard, so maxDepth=99 on a TETREE index must surface as 422 BuildFailed
+     * through the live bridge — not just the stub-bridge unit tests.
+     */
+    @Test
+    void esvtRenderBuildFailureReturns422BuildFailed() {
+        var server = new SpatialInspectorServer(0);
+        JavalinTest.test(server.app(), (javalin, client) -> {
+            var sessionId = extractSessionId(client.post("/api/session/create").body().string());
+            postJson(client, "/api/spatial/create?sessionId=" + sessionId,
+                     "{\"indexType\":\"TETREE\",\"maxDepth\":10,\"maxEntitiesPerNode\":10}");
+            postJson(client, "/api/spatial/entities/insert?sessionId=" + sessionId,
+                     "{\"x\":0.5,\"y\":0.5,\"z\":0.5}");
+
+            var resp = postJson(client, "/api/render/create?sessionId=" + sessionId,
+                                "{\"type\":\"ESVT\",\"maxDepth\":99,\"gridResolution\":16}");
+            assertEquals(422, resp.code(), "ESVT build failure must return 422, not 500");
+            assertTrue(resp.body().string().contains("BuildFailed"));
+            assertFalse(server.renderService().hasRender(sessionId));
+        });
+    }
+
     /**
      * Build a JSON array of n minimal InsertEntityRequest objects with distinct positions.
      */

--- a/portal/src/test/java/com/hellblazer/luciferase/portal/web/service/RenderServiceTest.java
+++ b/portal/src/test/java/com/hellblazer/luciferase/portal/web/service/RenderServiceTest.java
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+package com.hellblazer.luciferase.portal.web.service;
+
+import com.hellblazer.luciferase.esvo.core.ESVOOctreeData;
+import com.hellblazer.luciferase.esvt.core.ESVTData;
+import com.hellblazer.luciferase.geometry.Point3i;
+import com.hellblazer.luciferase.lucien.entity.UUIDEntityID;
+import com.hellblazer.luciferase.lucien.octree.Octree;
+import com.hellblazer.luciferase.lucien.tetree.Tetree;
+import com.hellblazer.luciferase.portal.esvt.bridge.ESVTBridge;
+import com.hellblazer.luciferase.portal.inspector.SpatialBridge;
+import com.hellblazer.luciferase.portal.web.dto.CreateRenderRequest;
+import com.hellblazer.luciferase.portal.web.dto.CreateRenderRequest.RenderType;
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3f;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for RenderService build paths, in particular the BuildResult success-guard
+ * (Luciferase-x5zcl): a build failure must surface as a clean {@link RenderBuildException},
+ * not an uncaught builder exception, and must not leave partial render state behind.
+ */
+class RenderServiceTest {
+
+    private static final String SESSION = "test-session";
+
+    private static Octree<UUIDEntityID, Object> octreeWithEntities() {
+        var octree = new Octree<UUIDEntityID, Object>(UUIDEntityID::new, 10, (byte) 10);
+        octree.insert(new Point3f(0.25f, 0.25f, 0.25f), (byte) 10, Map.of());
+        octree.insert(new Point3f(0.5f, 0.5f, 0.5f), (byte) 10, Map.of());
+        octree.insert(new Point3f(0.75f, 0.75f, 0.75f), (byte) 10, Map.of());
+        return octree;
+    }
+
+    private static Tetree<UUIDEntityID, Object> tetreeWithEntities() {
+        var tetree = new Tetree<UUIDEntityID, Object>(UUIDEntityID::new, 10, (byte) 10);
+        tetree.insert(new Point3f(0.25f, 0.25f, 0.25f), (byte) 10, Map.of());
+        tetree.insert(new Point3f(0.5f, 0.5f, 0.5f), (byte) 10, Map.of());
+        tetree.insert(new Point3f(0.75f, 0.75f, 0.75f), (byte) 10, Map.of());
+        return tetree;
+    }
+
+    /** Bridge stub whose build always fails with a BuildResult failure (never throws). */
+    private static <D extends com.hellblazer.luciferase.render.inspector.SpatialData> SpatialBridge<D> failingBridge(
+            String typeName) {
+        return new SpatialBridge<>() {
+            @Override
+            public BuildResult<D> buildFromVoxels(List<Point3i> voxels, int maxDepth, int gridResolution) {
+                return BuildResult.failure(1, voxels != null ? voxels.size() : 0, "injected failure");
+            }
+
+            @Override
+            public String getStructureTypeName() {
+                return typeName;
+            }
+        };
+    }
+
+    private static RenderService withFailingBridges() {
+        Supplier<SpatialBridge<ESVTData>> esvt = () -> failingBridge("ESVT");
+        Supplier<SpatialBridge<ESVOOctreeData>> esvo = () -> failingBridge("Octree");
+        return new RenderService(esvt, esvo);
+    }
+
+    // ===== Failure path (the .220 scope gap) =====
+
+    @Test
+    void esvtBuildFailureThrowsRenderBuildExceptionNotRawThrow() {
+        var service = withFailingBridges();
+        var request = new CreateRenderRequest(RenderType.ESVT, 5, 16);
+
+        var ex = assertThrows(RenderBuildException.class,
+                              () -> service.createRender(SESSION, tetreeWithEntities(), request));
+        assertTrue(ex.getMessage().contains("injected failure"),
+                   "Failure message from BuildResult must be propagated, got: " + ex.getMessage());
+    }
+
+    @Test
+    void esvoBuildFailureThrowsRenderBuildExceptionNotRawThrow() {
+        var service = withFailingBridges();
+        var request = new CreateRenderRequest(RenderType.ESVO, 5, 16);
+
+        var ex = assertThrows(RenderBuildException.class,
+                              () -> service.createRender(SESSION, octreeWithEntities(), request));
+        assertTrue(ex.getMessage().contains("injected failure"),
+                   "Failure message from BuildResult must be propagated, got: " + ex.getMessage());
+    }
+
+    /**
+     * Same-instance recovery: a transient build failure must not poison the service —
+     * the SAME RenderService must accept a retry for the same session once the build
+     * can complete. The flaky bridge fails the first build, then delegates to a real
+     * ESVTBridge.
+     */
+    @Test
+    void buildFailureLeavesNoRenderStateAndSameServiceCanRetry() {
+        var failedOnce = new AtomicBoolean(false);
+        Supplier<SpatialBridge<ESVTData>> flaky = () -> new SpatialBridge<>() {
+            @Override
+            public BuildResult<ESVTData> buildFromVoxels(List<Point3i> voxels, int maxDepth, int gridResolution) {
+                if (failedOnce.compareAndSet(false, true)) {
+                    return BuildResult.failure(1, voxels != null ? voxels.size() : 0, "injected failure");
+                }
+                return new ESVTBridge().buildFromVoxels(voxels, maxDepth, gridResolution);
+            }
+
+            @Override
+            public String getStructureTypeName() {
+                return "ESVT";
+            }
+        };
+        var service = new RenderService(flaky, () -> failingBridge("Octree"));
+        var request = new CreateRenderRequest(RenderType.ESVT, 5, 16);
+
+        assertThrows(RenderBuildException.class,
+                     () -> service.createRender(SESSION, tetreeWithEntities(), request));
+        assertFalse(service.hasRender(SESSION),
+                    "Failed build must not leave a render holder for the session");
+
+        // Same service, same session: retry must succeed once the build can complete
+        var info = service.createRender(SESSION, tetreeWithEntities(), request);
+        assertNotNull(info);
+        assertTrue(service.hasRender(SESSION));
+    }
+
+    /**
+     * Real-path regression: ESVOBridge validates maxDepth 1..15 inside the guard, so an
+     * out-of-range depth must surface as RenderBuildException — previously the raw
+     * OctreeBuilder path threw an unguarded exception through to the HTTP handler.
+     */
+    @Test
+    void realEsvoBridgeRejectsOutOfRangeDepthAsBuildFailure() {
+        var service = new RenderService();
+        var request = new CreateRenderRequest(RenderType.ESVO, 99, 16);
+
+        assertThrows(RenderBuildException.class,
+                     () -> service.createRender(SESSION, octreeWithEntities(), request));
+        assertFalse(service.hasRender(SESSION));
+    }
+
+    /**
+     * Real-path regression for ESVT: ESVTBridge validates maxDepth 1..21 inside the
+     * guard (Tetree supports 21 levels; ESVTTraversal.MAX_DEPTH=22 is the scale domain),
+     * so an out-of-range depth must surface as RenderBuildException.
+     */
+    @Test
+    void realEsvtBridgeRejectsOutOfRangeDepthAsBuildFailure() {
+        var service = new RenderService();
+        var request = new CreateRenderRequest(RenderType.ESVT, 99, 16);
+
+        assertThrows(RenderBuildException.class,
+                     () -> service.createRender(SESSION, tetreeWithEntities(), request));
+        assertFalse(service.hasRender(SESSION));
+    }
+
+    // ===== Success path must be unchanged through the bridges =====
+
+    @Test
+    void esvoSuccessPathBuildsThroughBridge() {
+        var service = new RenderService();
+        var request = new CreateRenderRequest(RenderType.ESVO, 5, 16);
+
+        var info = service.createRender(SESSION, octreeWithEntities(), request);
+        assertEquals("esvo", info.type());
+        assertTrue(info.nodeCount() > 0, "ESVO build must produce nodes");
+        assertTrue(service.hasRender(SESSION));
+    }
+
+    @Test
+    void esvtSuccessPathBuildsThroughBridge() {
+        var service = new RenderService();
+        var request = new CreateRenderRequest(RenderType.ESVT, 5, 16);
+
+        var info = service.createRender(SESSION, tetreeWithEntities(), request);
+        assertEquals("esvt", info.type());
+        assertTrue(info.nodeCount() > 0, "ESVT build must produce nodes");
+        assertTrue(service.hasRender(SESSION));
+        assertNotNull(service.getESVTData(SESSION), "ESVT data must be available for GPU rendering");
+    }
+}


### PR DESCRIPTION
## Summary

Closes the Wave-15 `.220` scope gap (bead **Luciferase-x5zcl**): `RenderService.createESVT`/`createESVO` called the raw `ESVTBuilder`/`OctreeBuilder.buildFromVoxels` directly, bypassing the `SpatialBridge` wrapper hardened in .220 with the unambiguous `BuildResult.ok` success signal. A build failure on this production render path threw uncaught through to the Javalin handler as a generic 500 with raw exception internals.

## Changes

- **RenderService**: both build paths now route through `ESVTBridge`/`ESVOBridge.buildFromVoxels` and gate on `BuildResult.isSuccess()`; failures throw the new typed `RenderBuildException`. Bridge factories are constructor-injected (`Supplier<SpatialBridge<…>>`) with production defaults, so the failure path is deterministically testable. The removed try-with-resources on `OctreeBuilder` is preserved inside `ESVOBridge.buildOctree` — no resource leak.
- **SpatialInspectorServer**: maps `RenderBuildException` → **422** `BuildFailed`, following the existing exception-mapper convention (404/400/409/413).
- **ESVTBridge**: `buildFromVoxels` now validates null voxels and `maxDepth` 1..21 (Tetree 21-level support; `ESVTTraversal.MAX_DEPTH=22` is the scale domain) — real-bridge failure parity with ESVOBridge's 1..15 guard.
- **ESVOBridge**: fixed pre-existing SLF4J `{:.2f}` format bug in `buildOctree`, now on the live build path.
- Failed builds leave no render holder; the same service/session can retry (pinned by tests).

## Tests

- New `RenderServiceTest` (7): stub-bridge failure paths for ESVT+ESVO, same-instance fail-once recovery, real-bridge depth-99 failure for both types, success paths for both types.
- `SpatialInspectorServerTest` +2: HTTP-level 422 `BuildFailed` for ESVO and ESVT (maxDepth=99 through the live bridges), no residual state, valid retry returns 201.
- Targeted suites green locally: RenderServiceTest 7/7, SpatialInspectorServerTest 22/22, ESVOBridgeTest 21/21.

## Notes

- Local full-portal-suite runs show `GPUMemoryPaneTest` `FX thread execution timeout` errors; reproduced identically on clean main (passes 5/5 standalone on both main and this branch) — pre-existing local suite-environment issue, tracked as **Luciferase-tugep**.
- Pre-existing TOCTOU on the `renders` map (`containsKey`→`put` non-atomic) noted by review; out of scope here.

Bead: Luciferase-x5zcl