### PR TITLE
fix(portal): atomic putIfAbsent claim in RenderService.createRender — close containsKey/put TOCTOU (Luciferase-lc06v)

### DIFF
--- a/portal/src/main/java/com/hellblazer/luciferase/portal/web/service/RenderService.java
+++ b/portal/src/main/java/com/hellblazer/luciferase/portal/web/service/RenderService.java
@@ -83,7 +83,13 @@ public class RenderService {
             holder = createESVO(spatialIndex, maxDepth, gridResolution);
         }
 
-        renders.put(sessionId, holder);
+        // Atomic claim: the containsKey check above is a cheap fast-fail only — a
+        // concurrent create for the same session can race past it during the build,
+        // so the loser must be rejected here rather than overwrite the winner.
+        if (renders.putIfAbsent(sessionId, holder) != null) {
+            log.debug("Concurrent create lost race for session {}; discarding build result", sessionId);
+            throw new IllegalStateException("Session already has a render structure. Delete it first.");
+        }
         log.info("Created {} render for session {} with maxDepth={}, gridRes={}",
                 type, sessionId, maxDepth, gridResolution);
 

--- a/portal/src/test/java/com/hellblazer/luciferase/portal/web/service/RenderServiceTest.java
+++ b/portal/src/test/java/com/hellblazer/luciferase/portal/web/service/RenderServiceTest.java
@@ -16,7 +16,10 @@ import org.junit.jupiter.api.Test;
 import javax.vecmath.Point3f;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -157,6 +160,61 @@ class RenderServiceTest {
         assertThrows(RenderBuildException.class,
                      () -> service.createRender(SESSION, tetreeWithEntities(), request));
         assertFalse(service.hasRender(SESSION));
+    }
+
+    /**
+     * TOCTOU regression (Luciferase-lc06v): two concurrent createRender calls for the
+     * same session must admit exactly one — the loser gets IllegalStateException and
+     * must not overwrite the winner's holder. The barrier inside the bridge guarantees
+     * both threads pass the exists-check before either stores its result.
+     */
+    @Test
+    void concurrentCreateForSameSessionAdmitsExactlyOne() throws Exception {
+        // Both threads' bridge instances share this one barrier via closure — that's the
+        // intent: neither may store its result until both are past the exists-check.
+        var barrier = new CyclicBarrier(2);
+        Supplier<SpatialBridge<ESVTData>> blocking = () -> new SpatialBridge<>() {
+            @Override
+            public BuildResult<ESVTData> buildFromVoxels(List<Point3i> voxels, int maxDepth, int gridResolution) {
+                try {
+                    barrier.await(5, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                return new ESVTBridge().buildFromVoxels(voxels, maxDepth, gridResolution);
+            }
+
+            @Override
+            public String getStructureTypeName() {
+                return "ESVT";
+            }
+        };
+        var service = new RenderService(blocking, () -> failingBridge("Octree"));
+        var request = new CreateRenderRequest(RenderType.ESVT, 5, 16);
+        var tetree = tetreeWithEntities();
+
+        var successes = new AtomicInteger();
+        var conflicts = new AtomicInteger();
+        Runnable create = () -> {
+            try {
+                service.createRender(SESSION, tetree, request);
+                successes.incrementAndGet();
+            } catch (IllegalStateException e) {
+                conflicts.incrementAndGet();
+            }
+        };
+        var t1 = new Thread(create);
+        var t2 = new Thread(create);
+        t1.start();
+        t2.start();
+        t1.join(10_000);
+        t2.join(10_000);
+        assertFalse(t1.isAlive(), "t1 must complete within join timeout — barrier or build may be hung");
+        assertFalse(t2.isAlive(), "t2 must complete within join timeout — barrier or build may be hung");
+
+        assertEquals(1, successes.get(), "Exactly one concurrent create must win");
+        assertEquals(1, conflicts.get(), "The losing create must get IllegalStateException");
+        assertTrue(service.hasRender(SESSION));
     }
 
     // ===== Success path must be unchanged through the bridges =====


### PR DESCRIPTION
## Summary

Closes **Luciferase-lc06v** (found by review during #237): `RenderService.createRender` checked `renders.containsKey(sessionId)`, ran the expensive build, then unconditionally `put` — two concurrent creates for the same session could both pass the exists-check and the second would silently overwrite the first holder.

## Changes

- The `containsKey` stays as a cheap fast-fail; the store is now `putIfAbsent`. The losing create gets the same `IllegalStateException` (→ 409 Conflict via the existing mapper) as the fast-fail path, with a debug log of the discarded build. No lock is held during the build; the discarded `RenderHolder` is GC-clean (`ESVTData`/`ESVOOctreeData` are heap-only, no `Closeable`/native memory — verified in review).
- New deterministic regression test `concurrentCreateForSameSessionAdmitsExactlyOne`: a shared `CyclicBarrier(2)` inside the injected bridge guarantees both threads are past the exists-check before either stores; asserts exactly one winner + one conflict + post-join liveness guards. **Verified RED pre-fix** (both creates won), GREEN post-fix.

## Review follow-ups (tracked, out of scope)

Stacked review (code-review-expert + substantive-critic) found the same TOCTOU shape in two sibling services, filed as beads rather than scope-crept here:
- **Luciferase-5nwqd** (P3): `GpuService.enableGpu` — same race with native OpenCL init in the window; the losing renderer is never `safeDispose`'d (native leak).
- **Luciferase-6zs8q** (P4): `SpatialIndexService.createIndex` — same race plus a two-map (`indices`/`entityCounts`) atomicity window.

## Tests

RenderServiceTest 8/8, SpatialInspectorServerTest 22/22 locally.

Bead: Luciferase-lc06v