### PR TITLE
fix(portal): atomic two-map claim in SpatialIndexService.createIndex — close containsKey/put TOCTOU (Luciferase-6zs8q)

### DIFF
--- a/portal/src/main/java/com/hellblazer/luciferase/portal/web/service/SpatialIndexService.java
+++ b/portal/src/main/java/com/hellblazer/luciferase/portal/web/service/SpatialIndexService.java
@@ -17,6 +17,7 @@ import javax.vecmath.Point3f;
 import javax.vecmath.Vector3f;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Service for managing spatial indices via REST API.
@@ -31,6 +32,14 @@ import java.util.concurrent.ConcurrentHashMap;
  * to drift above the true entity count, leading to spurious 413 responses.  Do not relax the
  * single-session-serialization assumption without adding a per-session lock around the full
  * read-modify-write sequence.
+ *
+ * <p>Exception: {@link #createIndex} is safe against concurrent duplicate creates for the same
+ * session (atomic {@code putIfAbsent} claim — exactly one wins, the loser gets
+ * {@link IllegalStateException}). A create racing a {@link #deleteIndex} of the same session
+ * remains under the serialization assumption (the two-map removal in delete is not atomic):
+ * the new session can inherit the old session's non-zero counter, or — if the full create
+ * lands between delete's two removals — delete removes the new session's counter, leaving an
+ * index with no counter and silently disabling cap enforcement for that session.
  */
 public class SpatialIndexService {
 
@@ -43,10 +52,17 @@ public class SpatialIndexService {
     private final Map<String, SpatialIndexHolder> indices = new ConcurrentHashMap<>();
 
     /** Per-session live entity count, kept in sync with insert/remove. */
-    private final Map<String, java.util.concurrent.atomic.AtomicInteger> entityCounts =
-            new ConcurrentHashMap<>();
+    private final Map<String, AtomicInteger> entityCounts = new ConcurrentHashMap<>();
 
     private final int maxSessionEntities;
+
+    /**
+     * Test seam: runs between createIndex's exists-check and the atomic claim of the
+     * indices map, so the TOCTOU regression test can deterministically hold two threads
+     * in the race window. No-op in production.
+     */
+    Runnable preClaimHook = () -> {
+    };
 
     public SpatialIndexService() {
         this(DEFAULT_MAX_SESSION_ENTITIES);
@@ -68,8 +84,17 @@ public class SpatialIndexService {
         }
 
         var holder = createIndexHolder(request);
-        indices.put(sessionId, holder);
-        entityCounts.put(sessionId, new java.util.concurrent.atomic.AtomicInteger(0));
+        preClaimHook.run();
+        // Atomic claim: the containsKey check above is a cheap fast-fail only — a concurrent
+        // create for the same session can race past it. The counter is initialized BEFORE the
+        // claim (putIfAbsent, so a losing create cannot replace the winner's live counter):
+        // this keeps the invariant that any session visible in `indices` has its counter,
+        // with no window where an insert could observe the index but miss the counter.
+        entityCounts.putIfAbsent(sessionId, new AtomicInteger(0));
+        if (indices.putIfAbsent(sessionId, holder) != null) {
+            log.debug("Concurrent createIndex lost race for session {}; discarding", sessionId);
+            throw new IllegalStateException("Session already has a spatial index. Delete it first.");
+        }
 
         log.info("Created {} index for session {} with maxDepth={}, maxEntitiesPerNode={}",
                 request.indexType(), sessionId, request.maxDepth(), request.maxEntitiesPerNode());

--- a/portal/src/test/java/com/hellblazer/luciferase/portal/web/service/SpatialIndexServiceTest.java
+++ b/portal/src/test/java/com/hellblazer/luciferase/portal/web/service/SpatialIndexServiceTest.java
@@ -260,4 +260,109 @@ class SpatialIndexServiceTest {
         assertThrows(IllegalArgumentException.class, () -> service.rayQuery("s14", req),
                 "Ray origin with NaN coordinate must be rejected");
     }
+
+    // ===== createIndex TOCTOU (Luciferase-6zs8q) =====
+
+    /**
+     * Two concurrent createIndex calls for the same session must admit exactly one —
+     * the loser gets IllegalStateException and must not overwrite the winner's index
+     * or its live entity counter. The preClaimHook barrier guarantees both threads
+     * pass the exists-check before either claims the indices map.
+     */
+    @Test
+    void concurrentCreateIndexForSameSessionAdmitsExactlyOne() throws Exception {
+        var service = new SpatialIndexService();
+        var barrier = new java.util.concurrent.CyclicBarrier(2);
+        service.preClaimHook = () -> {
+            try {
+                barrier.await(5, java.util.concurrent.TimeUnit.SECONDS);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+        var request = new CreateIndexRequest(SpatialIndexService.IndexType.OCTREE, (byte) 10, 10);
+
+        var successes = new java.util.concurrent.atomic.AtomicInteger();
+        var conflicts = new java.util.concurrent.atomic.AtomicInteger();
+        Runnable create = () -> {
+            try {
+                service.createIndex("race-session", request);
+                successes.incrementAndGet();
+            } catch (IllegalStateException e) {
+                conflicts.incrementAndGet();
+            }
+        };
+        var t1 = new Thread(create);
+        var t2 = new Thread(create);
+        t1.start();
+        t2.start();
+        t1.join(10_000);
+        t2.join(10_000);
+        assertFalse(t1.isAlive(), "t1 must complete within join timeout");
+        assertFalse(t2.isAlive(), "t2 must complete within join timeout");
+
+        assertEquals(1, successes.get(), "Exactly one concurrent createIndex must win");
+        assertEquals(1, conflicts.get(), "The losing createIndex must get IllegalStateException");
+        assertTrue(service.hasIndex("race-session"));
+        // The entityCounts invariant must hold: counting works after the race
+        assertEquals(0, service.sessionEntityCount("race-session"),
+                "Entity counter must exist and be coherent after a racing create");
+        var inserted = service.insertEntity("race-session", new InsertEntityRequest(0.5f, 0.5f, 0.5f, null));
+        assertNotNull(inserted);
+        assertEquals(1, service.sessionEntityCount("race-session"),
+                "Counter must track inserts after a racing create");
+    }
+
+    /**
+     * A losing create must not reset a LIVE counter: the loser is held in the race window
+     * while the winner creates the session AND inserts an entity (counter = 1); when the
+     * loser proceeds, its counter write must not clobber the live count back to 0. Pins
+     * entityCounts.putIfAbsent — a plain put would reset the counter and fail this test.
+     */
+    @Test
+    void losingCreateMustNotResetLiveCounter() throws Exception {
+        var service = new SpatialIndexService();
+        var loserInWindow = new java.util.concurrent.CountDownLatch(1);
+        var releaseLoser = new java.util.concurrent.CountDownLatch(1);
+        var firstCaller = new java.util.concurrent.atomic.AtomicBoolean(true);
+        service.preClaimHook = () -> {
+            // Only the first caller (the loser thread) is held; the winner runs through
+            if (firstCaller.compareAndSet(true, false)) {
+                loserInWindow.countDown();
+                try {
+                    if (!releaseLoser.await(5, java.util.concurrent.TimeUnit.SECONDS)) {
+                        throw new RuntimeException("release timeout");
+                    }
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        var request = new CreateIndexRequest(SpatialIndexService.IndexType.OCTREE, (byte) 10, 10);
+
+        var conflicts = new java.util.concurrent.atomic.AtomicInteger();
+        var loser = new Thread(() -> {
+            try {
+                service.createIndex("live-session", request);
+            } catch (IllegalStateException e) {
+                conflicts.incrementAndGet();
+            }
+        });
+        loser.start();
+        assertTrue(loserInWindow.await(5, java.util.concurrent.TimeUnit.SECONDS),
+                "loser must reach the race window");
+
+        // Winner creates the session and inserts an entity — the counter is live at 1
+        service.createIndex("live-session", request);
+        service.insertEntity("live-session", new InsertEntityRequest(0.5f, 0.5f, 0.5f, null));
+        assertEquals(1, service.sessionEntityCount("live-session"));
+
+        releaseLoser.countDown();
+        loser.join(10_000);
+        assertFalse(loser.isAlive(), "loser must complete within join timeout");
+
+        assertEquals(1, conflicts.get(), "loser must get IllegalStateException");
+        assertEquals(1, service.sessionEntityCount("live-session"),
+                "losing create must not reset the live entity counter");
+    }
 }


### PR DESCRIPTION
## Summary

Closes **Luciferase-6zs8q** (sibling of #238, found in its review): `SpatialIndexService.createIndex` had the same containsKey→put TOCTOU as RenderService, compounded by a two-map (`indices`/`entityCounts`) non-atomic write sequence.

## Changes

- **Counter-first atomic claim** — deliberate deviation from the bead's sketch (indices-first, winner-only counter), which would have left a window where the index is visible but the counter missing (a concurrent insert would silently skip cap accounting). Instead: `entityCounts.putIfAbsent` first (a losing create cannot replace the winner's *live* counter), then `indices.putIfAbsent` as the claim; the loser throws the same `IllegalStateException` → 409 as the fast-fail. The counter-ahead window is unobservable — every external consumer gates through `getHolder()` on `indices`. Both reviewers confirmed the deviation is strictly sounder than the sketch.
- **Package-private `preClaimHook` test seam** (no-op in production) so the race window is deterministically testable.
- **Class javadoc**: documents that createIndex is now safe vs concurrent duplicate creates, and spells out the two residual delete/create interleaving failure modes (stale counter inheritance; counter removal silently disabling cap enforcement) that remain under the documented per-session-serialization assumption.

## Tests (both verified RED against the old code)

- `concurrentCreateIndexForSameSessionAdmitsExactlyOne`: barrier in the seam holds both threads past the exists-check; exactly one winner + one 409-conflict; counter coherent (0, then insert → 1). RED pre-fix: both creates won.
- `losingCreateMustNotResetLiveCounter`: the loser is held in the window while the winner creates the session and inserts (counter = 1); the loser's counter write must not reset it. Pins `putIfAbsent` vs `put` on `entityCounts` — added for the review finding that the first test alone wouldn't catch that regression.

SpatialIndexServiceTest 37/37, SpatialIndexServiceCounterTest 4/4, SpatialInspectorServerTest 22/22 locally.

## Review

Stacked review run (code-review-expert: approved, Medium javadoc gap fixed; substantive-critic: justified, the one Significant test-coverage gap closed with the second test). Remaining sibling: **Luciferase-5nwqd** (GpuService.enableGpu, native CL leak on loser).

Bead: Luciferase-6zs8q