### PR TITLE
fix(portal): atomic session claim in GpuService.enableGpu — close containsKey/put TOCTOU with native-renderer disposal (Luciferase-5nwqd)

### DIFF
--- a/portal/src/main/java/com/hellblazer/luciferase/portal/web/service/GpuService.java
+++ b/portal/src/main/java/com/hellblazer/luciferase/portal/web/service/GpuService.java
@@ -17,8 +17,10 @@ import java.nio.LongBuffer;
 import java.util.Base64;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 
 import static org.lwjgl.opencl.CL10.*;
 import static org.lwjgl.system.MemoryUtil.*;
@@ -26,6 +28,12 @@ import static org.lwjgl.system.MemoryUtil.*;
 /**
  * Service for GPU OpenCL operations via REST API.
  * Provides GPU info, rendering, and benchmarking capabilities.
+ *
+ * <p><b>Concurrency:</b> {@link #enableGpu} is safe against concurrent duplicate enables for
+ * the same session — the session slot is claimed atomically ({@code putIfAbsent}); exactly one
+ * caller wins and the loser's renderer (a live native OpenCL resource) is disposed before the
+ * loser is rejected with {@link IllegalStateException}. {@link #disableGpu} uses an atomic
+ * remove. Other per-session operations assume the REST layer's per-session serialization.
  */
 public class GpuService {
 
@@ -33,6 +41,17 @@ public class GpuService {
 
     // Session ID -> GPU session state
     private final Map<String, GpuSessionState> sessions = new ConcurrentHashMap<>();
+
+    /**
+     * Test seam: how a renderer is disposed when its enableGpu call loses the session-claim
+     * race. Production default is {@link #safeDispose}; headless tests substitute a recorder
+     * since a real ESVTOpenCLRenderer cannot be constructed without OpenCL natives (the
+     * enableGpu → claimSession routing itself is exercised by the RUN_GPU_TESTS-gated
+     * GpuEndpointTest integration suite, not headless tests — the availability probe exits
+     * enableGpu before the claim on headless hosts). Inject before any concurrent use;
+     * volatile so a setup-thread write is visible to claiming threads.
+     */
+    volatile Consumer<ESVTOpenCLRenderer> loserDisposer = GpuService::safeDispose;
 
     // Cached GPU info (device doesn't change during runtime)
     private volatile GpuInfo cachedGpuInfo;
@@ -107,16 +126,11 @@ public class GpuService {
         }
 
         var renderer = new ESVTOpenCLRenderer(width, height);
+        GpuSessionState state;
         try {
             renderer.initialize();
             renderer.uploadData(esvtData);
-
-            var state = new GpuSessionState(renderer, width, height);
-            sessions.put(sessionId, state);
-
-            log.info("Enabled GPU for session {} at {}x{}", sessionId, width, height);
-            return getStats(sessionId);
-
+            state = new GpuSessionState(renderer, width, height);
         } catch (Throwable t) {
             // Catch Throwable: native GPU init can fail with Error (UnsatisfiedLinkError etc.)
             // on runners where the OpenCL ICD reports available but no usable device exists.
@@ -124,13 +138,35 @@ public class GpuService {
             safeDispose(renderer);
             throw new IllegalStateException("GPU could not be initialized on this system: " + t.getMessage());
         }
+
+        claimSession(sessionId, state);
+
+        log.info("Enabled GPU for session {} at {}x{}", sessionId, width, height);
+        return getStats(sessionId);
+    }
+
+    /**
+     * Atomically claim the session slot. The containsKey fast-fail in {@link #enableGpu} is a
+     * cheap pre-init short-circuit only — a concurrent enable for the same session can race
+     * past it during native init. Exactly one caller wins; the loser's renderer is disposed
+     * before rejecting so a lost race cannot leak native CL objects (the map entry is the
+     * winner's renderer, never the loser's). Package-private for deterministic headless
+     * regression testing.
+     */
+    void claimSession(String sessionId, GpuSessionState state) {
+        Objects.requireNonNull(loserDisposer, "loserDisposer");
+        if (sessions.putIfAbsent(sessionId, state) != null) {
+            log.debug("Concurrent GPU enable lost race for session {}; disposing loser's renderer", sessionId);
+            loserDisposer.accept(state.renderer);
+            throw new IllegalStateException("GPU already enabled for session. Disable first.");
+        }
     }
 
     private static void safeDispose(ESVTOpenCLRenderer renderer) {
         try {
             renderer.dispose();
         } catch (Throwable t) {
-            log.debug("Renderer dispose during failed GPU enable threw: {}", t.toString());
+            log.warn("Renderer dispose threw: {}", t.toString());
         }
     }
 
@@ -143,7 +179,9 @@ public class GpuService {
             throw new NoSuchElementException("GPU not enabled for session: " + sessionId);
         }
 
-        state.renderer.dispose();
+        // Throwable-fenced like every other dispose path: a native Error escaping here would
+        // abort reaper/session-delete cleanup loops with the session already removed.
+        safeDispose(state.renderer);
         log.info("Disabled GPU for session {}", sessionId);
     }
 
@@ -403,8 +441,9 @@ public class GpuService {
 
     /**
      * Internal state for a GPU-enabled session.
+     * Package-private so headless tests can exercise {@link #claimSession} directly.
      */
-    private static class GpuSessionState {
+    static class GpuSessionState {
         final ESVTOpenCLRenderer renderer;
         final int width;
         final int height;

--- a/portal/src/test/java/com/hellblazer/luciferase/portal/web/service/GpuServiceTest.java
+++ b/portal/src/test/java/com/hellblazer/luciferase/portal/web/service/GpuServiceTest.java
@@ -75,4 +75,58 @@ class GpuServiceTest {
         assertEquals(700_000_000L, clock.nanoTime());
         assertEquals(700L, clock.currentTimeMillis());
     }
+
+    // ===== enableGpu session-claim TOCTOU (Luciferase-5nwqd) =====
+    //
+    // A real threaded enableGpu race cannot run headlessly (ESVTOpenCLRenderer is final and
+    // its construction requires OpenCL natives), so these tests pin claimSession — the atomic
+    // claim extracted from enableGpu — directly. The renderer in GpuSessionState is null here;
+    // the loserDisposer seam records disposal instead of touching native resources.
+
+    /**
+     * The claim must admit exactly one state per session: a second claim for the same session
+     * must throw IllegalStateException, dispose the LOSER's renderer exactly once, and leave
+     * the winner's state in place. Pins putIfAbsent — a regression to plain put would admit
+     * both (no throw), dispose nothing, and overwrite the winner.
+     */
+    @Test
+    void claimSessionAdmitsExactlyOneAndDisposesLoser() {
+        var service = new GpuService();
+        var disposals = new java.util.concurrent.atomic.AtomicInteger();
+        service.loserDisposer = renderer -> disposals.incrementAndGet();
+
+        var winner = new GpuService.GpuSessionState(null, 64, 64);
+        var loser = new GpuService.GpuSessionState(null, 128, 128);
+
+        service.claimSession("race-session", winner);
+        assertTrue(service.isGpuEnabled("race-session"));
+        assertEquals(0, disposals.get(), "winning claim must not dispose anything");
+
+        var ex = assertThrows(IllegalStateException.class,
+                              () -> service.claimSession("race-session", loser));
+        assertTrue(ex.getMessage().contains("already enabled"), ex.getMessage());
+        assertEquals(1, disposals.get(), "loser's renderer must be disposed exactly once");
+
+        // The winner's state must be untouched: stats reflect the winner's dimensions
+        var stats = service.getStats("race-session");
+        assertEquals(64, stats.frameWidth(), "losing claim must not replace the winner's state");
+        assertEquals(64, stats.frameHeight());
+    }
+
+    /**
+     * Distinct sessions must claim independently — the atomic claim is keyed per session,
+     * not global.
+     */
+    @Test
+    void claimSessionIsPerSession() {
+        var service = new GpuService();
+        var disposals = new java.util.concurrent.atomic.AtomicInteger();
+        service.loserDisposer = renderer -> disposals.incrementAndGet();
+
+        service.claimSession("s-a", new GpuService.GpuSessionState(null, 64, 64));
+        assertDoesNotThrow(() -> service.claimSession("s-b", new GpuService.GpuSessionState(null, 32, 32)));
+        assertTrue(service.isGpuEnabled("s-a"));
+        assertTrue(service.isGpuEnabled("s-b"));
+        assertEquals(0, disposals.get(), "independent sessions must not dispose anything");
+    }
 }


### PR DESCRIPTION
## Summary

Closes **Luciferase-5nwqd**, the last of the three sibling portal TOCTOU fixes (RenderService #238, SpatialIndexService #239). `GpuService.enableGpu` had the same containsKey→put race, but with the worst consequence: the loser's `put` overwrote the winner's `GpuSessionState`, leaving the winner's live `ESVTOpenCLRenderer` (CL command queue + memory objects) unreachable and never disposed — a native leak the GC cannot reclaim. (Review analysis corrected the bead text: the *winner's* renderer was the leaked one under the old overwrite semantics.)

## Changes

- **`claimSession`** (extracted, package-private): `sessions.putIfAbsent` atomic claim, called *after* the init try/catch so a lost-claim ISE isn't double-wrapped by the init-failure handler. The loser disposes its **own** renderer (local state — the map always holds the winner's) before rejecting with the same `IllegalStateException` → 409 as the fast-fail. The two disposal paths (init-failure / lost-claim) are mutually exclusive by control flow, and `AbstractOpenCLRenderer.dispose()` is idempotent — no double-dispose interleaving exists (critic-verified).
- **`disableGpu`**: dispose now Throwable-fenced via `safeDispose` like every other dispose path — previously a native `Error` could escape mid-cleanup and abort reaper/session-delete loops with the session already removed (review finding).
- **`loserDisposer` seam** (volatile, null-guarded, default `safeDispose`): `ESVTOpenCLRenderer` is final and requires OpenCL natives, so headless tests inject a recorder. Class javadoc documents the concurrency contract and that the `enableGpu→claimSession` routing is validated by the `RUN_GPU_TESTS`-gated integration suite (headless hosts exit at the availability probe before reaching the claim).

## Tests

- Headless: `claimSessionAdmitsExactlyOneAndDisposesLoser` (one winner, loser disposed exactly once, winner's dimensions preserved via `getStats`), `claimSessionIsPerSession`. GpuServiceTest 7/7, SpatialInspectorServerTest 22/22.
- **GPU hardware** (M4 Max, `RUN_GPU_TESTS=true`): GpuEndpointTest **13/13** — live `enableGpu` path intact through the refactor.

## Review

Stacked review run; all findings applied (disableGpu Throwable fence, volatile + null-guard on the seam, routing-gate documentation). 

Bead: Luciferase-5nwqd