### PR TITLE
feat(simulation): assemble-before-createBubble guard on Manager — close RDR-017 HIGH-2 pre-assembly Layer-0 window (Luciferase-n6jrh.1)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Manager.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/Manager.java
@@ -76,6 +76,12 @@ public class Manager {
     // bootstrap sets this to List.of("PersistenceManager") after registering the persistence adapter,
     // so bubbles register at Layer 1 and start only after persistence is up.
     private volatile List<String> bubbleDependencies = List.of();
+    // RDR-017 HIGH-2 (Luciferase-n6jrh.1): when true, createBubble is rejected until
+    // setBubbleDependencies has been given a non-empty list (the final step of
+    // NodeBootstrap.assemble). Armed at construction — the only race-free point — so a
+    // composed node cannot create a Layer-0 bubble in the window between Manager
+    // construction and assembly. Legacy/standalone managers default to false.
+    private final boolean requireAssembly;
 
     /**
      * Create a Manager with default configuration.
@@ -126,6 +132,33 @@ public class Manager {
      */
     public Manager(LocalServerTransport.Registry transportRegistry,
                       byte spatialLevel, long targetFrameMs, float aoiRadius, Clock clock) {
+        this(transportRegistry, spatialLevel, targetFrameMs, aoiRadius, clock, false);
+    }
+
+    /**
+     * Create a Manager for the composed-node path (RDR-017, Luciferase-n6jrh.1).
+     * <p>
+     * With {@code requireAssembly = true}, {@link #createBubble()} fails loud with
+     * {@link IllegalStateException} until {@link #setBubbleDependencies(List)} has been given a
+     * non-empty list — the final step of
+     * {@link com.hellblazer.luciferase.simulation.von.NodeBootstrap#assemble}. This closes the
+     * window between Manager construction and assembly in which a bubble would otherwise
+     * silently register at Layer 0, starting before persistence and bypassing recovery ordering.
+     * The live node entry point must construct its Manager with this flag; standalone/test
+     * managers use the other constructors ({@code requireAssembly = false}, pre-RDR-017
+     * behavior unchanged).
+     *
+     * @param transportRegistry Transport registry for P2P communication
+     * @param spatialLevel      Tetree refinement level for bubbles
+     * @param targetFrameMs     Target frame time for simulation
+     * @param aoiRadius         Area of Interest radius for neighbor detection
+     * @param clock             Clock for timestamps (use TestClock for testing)
+     * @param requireAssembly   when true, createBubble is rejected until assembly completes
+     */
+    public Manager(LocalServerTransport.Registry transportRegistry,
+                      byte spatialLevel, long targetFrameMs, float aoiRadius, Clock clock,
+                      boolean requireAssembly) {
+        this.requireAssembly = requireAssembly;
         this.transportRegistry = Objects.requireNonNull(transportRegistry, "transportRegistry cannot be null");
         this.clock = Objects.requireNonNull(clock, "clock cannot be null");
         this.factory = new MessageFactory(clock);
@@ -186,10 +219,31 @@ public class Manager {
      * only after persistence. Each named dependency must already be registered (or be registered
      * before the next {@code createBubble}) or {@code createBubble} will fail to register the bubble.
      *
+     * <p>
+     * On a {@code requireAssembly} manager (Luciferase-n6jrh.1) a non-empty list also opens the
+     * {@code createBubble} gate — this is the assembly-completion signal. The gate is monotonic:
+     * an armed manager rejects an empty list outright, so the gate can never re-close (and a
+     * concurrent {@code createBubble} cannot observe the gate flapping).
+     *
      * @param dependencies component names new bubbles depend on (defensively copied)
      */
     public void setBubbleDependencies(List<String> dependencies) {
-        this.bubbleDependencies = List.copyOf(Objects.requireNonNull(dependencies, "dependencies cannot be null"));
+        Objects.requireNonNull(dependencies, "dependencies cannot be null");
+        if (requireAssembly && dependencies.isEmpty()) {
+            throw new IllegalStateException(
+                "Cannot set empty bubble dependencies on a requireAssembly manager: the "
+                + "createBubble gate is monotonic — once NodeBootstrap.assemble() opens it, "
+                + "clearing dependencies would silently re-route new bubbles to Layer 0");
+        }
+        this.bubbleDependencies = List.copyOf(dependencies);
+    }
+
+    /**
+     * @return whether this manager was constructed in {@code requireAssembly} mode
+     * (Luciferase-n6jrh.1); package-private for {@code NodeBootstrap} and tests
+     */
+    boolean requiresAssembly() {
+        return requireAssembly;
     }
 
     /**
@@ -218,6 +272,7 @@ public class Manager {
      * @return The newly created Bubble
      */
     public Bubble createBubble() {
+        checkAssembled();
         var id = UUID.randomUUID();
         var transport = transportRegistry.register(id);
         var bubble = new Bubble(id, spatialLevel, targetFrameMs, transport);
@@ -244,6 +299,7 @@ public class Manager {
      * @return The newly created Bubble
      */
     public Bubble createBubble(UUID id) {
+        checkAssembled();
         var transport = transportRegistry.register(id);
         var bubble = new Bubble(id, spatialLevel, targetFrameMs, transport);
 
@@ -253,8 +309,26 @@ public class Manager {
         // Forward events to manager listeners
         bubble.addEventListener(this::dispatchEvent);
 
+        // Track like the no-arg overload — pre-existing omission (caught in n6jrh.1 review):
+        // an untracked bubble is invisible to size()/getBubble()/getAllBubbles()/close().
+        bubbles.put(id, bubble);
+
         registerBubbleAdapter(id, bubble);
         return bubble;
+    }
+
+    /**
+     * RDR-017 HIGH-2 (Luciferase-n6jrh.1): on a {@code requireAssembly} manager, reject bubble
+     * creation until assembly has set non-empty bubble dependencies. Checked before the transport
+     * registration so a rejected create leaks nothing.
+     */
+    private void checkAssembled() {
+        if (requireAssembly && bubbleDependencies.isEmpty()) {
+            throw new IllegalStateException(
+                "Manager requires assembly: NodeBootstrap.assemble(...) must complete before "
+                + "createBubble() — a bubble created now would register at Layer 0 and bypass "
+                + "persistence lifecycle ordering (RDR-017 HIGH-2)");
+        }
     }
 
     /**

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
@@ -137,11 +137,35 @@ public final class NodeBootstrap {
     }
 
     /**
+     * Construct a {@link Manager} armed for the composed-node path (RDR-017 HIGH-2,
+     * Luciferase-n6jrh.1): {@code createBubble} fails loud until {@link #assemble} completes, so
+     * a bubble cannot silently register at Layer 0 in the window between Manager construction
+     * and assembly. The live {@link #main} wiring MUST construct its manager through this
+     * factory; the plain {@link Manager} constructors are the legacy/standalone path with no
+     * such guard.
+     *
+     * @param transportRegistry Transport registry for P2P communication
+     * @param spatialLevel      Tetree refinement level for bubbles
+     * @param targetFrameMs     Target frame time for simulation
+     * @param aoiRadius         Area of Interest radius for neighbor detection
+     * @param clock             Clock for timestamps (use TestClock for testing)
+     * @return a Manager that rejects {@code createBubble} until assembled
+     */
+    public static Manager armedManager(LocalServerTransport.Registry transportRegistry,
+                                       byte spatialLevel, long targetFrameMs, float aoiRadius,
+                                       Clock clock) {
+        return new Manager(transportRegistry, spatialLevel, targetFrameMs, aoiRadius, clock, true);
+    }
+
+    /**
      * Wire the node lifecycle graph: register the connection-manager and persistence adapters at Layer 0
      * and configure bubbles (created subsequently via {@link Manager#createBubble()}) to depend on
      * {@code PersistenceManager} (Layer 1).
      * <p>
-     * Must be called before any {@code createBubble} so the bubble dependency resolves.
+     * Must be called before any {@code createBubble} so the bubble dependency resolves. Composed
+     * production nodes should pass a manager constructed via {@link #armedManager} so creates in
+     * the pre-assembly window fail loud instead of landing at Layer 0; an unarmed manager is
+     * accepted (test/standalone paths) but logged.
      *
      * @param manager    the VON manager owning the lifecycle coordinator
      * @param scmAdapter the connection-manager adapter (Layer 0)
@@ -153,6 +177,11 @@ public final class NodeBootstrap {
         Objects.requireNonNull(scmAdapter, "scmAdapter cannot be null");
         Objects.requireNonNull(pmAdapter, "pmAdapter cannot be null");
 
+        if (!manager.requiresAssembly()) {
+            log.warn("assemble() called on an unarmed Manager: bubbles created before this point "
+                     + "registered at Layer 0 with no guard. Composed production nodes must construct "
+                     + "via NodeBootstrap.armedManager (Luciferase-n6jrh.1).");
+        }
         manager.registerInfrastructure(scmAdapter);
         manager.registerInfrastructure(pmAdapter);
         manager.setBubbleDependencies(List.of(pmAdapter.name()));

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapTest.java
@@ -98,6 +98,106 @@ class NodeBootstrapTest {
     }
 
     @Test
+    void requireAssemblyManagerRejectsCreateBubbleBeforeAssemble() {
+        // RDR-017 HIGH-2 (Luciferase-n6jrh.1): a composed-node Manager constructed via
+        // NodeBootstrap.armedManager must reject createBubble until NodeBootstrap.assemble has
+        // set the bubble dependencies — otherwise a bubble created in the window between Manager
+        // construction and assemble() silently lands at Layer 0, bypassing persistence ordering.
+        var registry = LocalServerTransport.Registry.create();
+        var manager = NodeBootstrap.armedManager(registry, SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL, 16L,
+                                                 SpatialLevelHeuristic.DEFAULT_AOI_RADIUS,
+                                                 com.hellblazer.luciferase.common.time.Clock.system());
+        try {
+            var ex = assertThrows(IllegalStateException.class, manager::createBubble,
+                                  "createBubble before assemble must fail loud on a requireAssembly manager");
+            assertTrue(ex.getMessage().contains("assemble"),
+                       "guard message must point at NodeBootstrap.assemble, got: " + ex.getMessage());
+            assertEquals(0, manager.size(), "no bubble may leak from a rejected create");
+            assertEquals(0, registry.size(),
+                         "the guard must fire before transport registration — no transport may leak");
+
+            var ex2 = assertThrows(IllegalStateException.class, () -> manager.createBubble(UUID.randomUUID()),
+                                   "createBubble(UUID) must be guarded identically");
+            assertTrue(ex2.getMessage().contains("assemble"));
+            assertEquals(0, manager.size());
+            assertEquals(0, registry.size());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void requireAssemblyManagerCreatesBubblesAfterAssemble(@TempDir Path walDir) throws IOException {
+        // The guard must open exactly when assemble() completes: same flow as the unguarded
+        // assemble test, but on an armed manager — and assembly itself must be fully wired
+        // (deps configured, infrastructure RUNNING), not merely gate-opening.
+        var registry = LocalServerTransport.Registry.create();
+        var manager = NodeBootstrap.armedManager(registry, SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL, 16L,
+                                                 SpatialLevelHeuristic.DEFAULT_AOI_RADIUS,
+                                                 com.hellblazer.luciferase.common.time.Clock.system());
+        var scm = new SocketConnectionManager(ProcessAddress.localhost("n6jrh1-guard", 0), msg -> {});
+        var pm = new PersistenceManager(UUID.randomUUID(), walDir);
+        try {
+            NodeBootstrap.assemble(manager, new SocketConnectionManagerAdapter(scm),
+                                   new PersistenceManagerAdapter(pm));
+
+            assertEquals(java.util.List.of("PersistenceManager"), manager.getBubbleDependencies(),
+                         "assemble must configure bubbles to depend on PersistenceManager");
+            assertEquals(LifecycleState.RUNNING, manager.coordinator().getState("SocketConnectionManager"));
+            assertEquals(LifecycleState.RUNNING, manager.coordinator().getState("PersistenceManager"));
+
+            var bubble = manager.createBubble();
+            assertEquals(LifecycleState.RUNNING, manager.coordinator().getState("EnhancedBubble-" + bubble.id()),
+                         "after assemble, a requireAssembly manager must create bubbles normally (Layer 1)");
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void armedManagerGateIsMonotonic(@TempDir Path walDir) throws IOException {
+        // Once assemble() opens the gate, clearing the dependencies on an armed manager must be
+        // rejected — otherwise a post-assembly setBubbleDependencies(List.of()) would silently
+        // re-route new bubbles to Layer 0 (review finding on Luciferase-n6jrh.1).
+        var registry = LocalServerTransport.Registry.create();
+        var manager = NodeBootstrap.armedManager(registry, SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL, 16L,
+                                                 SpatialLevelHeuristic.DEFAULT_AOI_RADIUS,
+                                                 com.hellblazer.luciferase.common.time.Clock.system());
+        var scm = new SocketConnectionManager(ProcessAddress.localhost("n6jrh1-mono", 0), msg -> {});
+        var pm = new PersistenceManager(UUID.randomUUID(), walDir);
+        try {
+            NodeBootstrap.assemble(manager, new SocketConnectionManagerAdapter(scm),
+                                   new PersistenceManagerAdapter(pm));
+
+            assertThrows(IllegalStateException.class,
+                         () -> manager.setBubbleDependencies(java.util.List.of()),
+                         "armed manager must reject clearing dependencies after assembly");
+            // The gate must still be open
+            var bubble = manager.createBubble();
+            assertEquals(LifecycleState.RUNNING, manager.coordinator().getState("EnhancedBubble-" + bubble.id()));
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void createBubbleWithExplicitIdIsTrackedByManager() {
+        // Pre-existing omission caught in the n6jrh.1 review: createBubble(UUID) never put the
+        // bubble into the manager's map, making it invisible to size()/getBubble()/close().
+        var registry = LocalServerTransport.Registry.create();
+        var manager = new Manager(registry, SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL, 16L,
+                                  SpatialLevelHeuristic.DEFAULT_AOI_RADIUS);
+        try {
+            var id = UUID.randomUUID();
+            var bubble = manager.createBubble(id);
+            assertEquals(1, manager.size(), "explicit-id bubble must be tracked by the manager");
+            assertEquals(bubble, manager.getBubble(id), "getBubble(id) must resolve the explicit-id bubble");
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
     void createBubbleHasNoPersistenceDependencyByDefault() {
         // No regression: a Manager not wired for persistence creates bubbles with no
         // lifecycle dependencies (registers at Layer 0, exactly as before RDR-017).


### PR DESCRIPTION
## Summary

Closes **Luciferase-n6jrh.1**, an RDR-017 `main()`-precondition (P0 review HIGH-2, confirmed by P1 review Sig-1): before the live `NodeBootstrap.main()` is wired, a bubble created in the window between `Manager` construction and `NodeBootstrap.assemble()` would silently register at **Layer 0** — starting before persistence and bypassing recovery ordering. P0 already made the *non-empty-deps* misordering fail loud; this closes the remaining *empty-deps* window.

## Changes

- **`Manager` `requireAssembly` mode** (new 6-arg ctor; 5-arg delegates `false`, all existing users unchanged): `checkAssembled()` is the first statement of both `createBubble` overloads — before transport registration, so a rejected create leaks nothing — throwing `IllegalStateException` naming `NodeBootstrap.assemble` while `bubbleDependencies` is empty. Armed at construction, the only race-free point; the gate signal is the volatile `bubbleDependencies` going non-empty (assemble's final step).
- **Monotonic gate** (review finding): an armed manager rejects `setBubbleDependencies(empty)`, so the gate can never re-close post-assembly — which also eliminates the check-then-act window between the guard read and bubble registration.
- **`NodeBootstrap.armedManager(...)` factory + unarmed-manager warning in `assemble()`** (review finding: an opt-in guard nobody opts into is documentation, not enforcement). The future `main()` wiring finds the armed path in NodeBootstrap itself; test/standalone paths stay valid (warn only — zero blast radius on the existing NodeBootstrap integration tests).
- **Pre-existing bug fixed**: `createBubble(UUID)` never did `bubbles.put` — the bubble was invisible to `size()`/`getBubble()`/`close()`. Surfaced because it made the new guard test's `size()==0` assertion vacuous; no production caller existed.

## Tests

- Armed reject: both overloads throw pre-assembly; **no bubble and no transport-registry entry leaks** (registry `size()` asserted — guard placement pinned).
- Armed create-after-real-assemble: full `assemble()` flow with deps + SCM/PM `RUNNING` assertions, bubble reaches `RUNNING` at Layer 1.
- Monotonic-gate rejection post-assembly (gate stays open after the rejected clear).
- Explicit-id tracking regression for the `bubbles.put` fix.
- Local: NodeBootstrap*/Manager*/lifecycle slice **136/136** (incl. durability round-trip, shutdown ordering, persistence wiring, fault tolerance on unarmed managers).

## Review

Stacked review run; all findings applied (armedManager factory, monotonic gate, transport-leak assertion, infra-state assertions, `bubbles.put` fix). 

Bead: Luciferase-n6jrh.1 (RDR-017)