### PR TITLE
feat(simulation): lifecycle-integrate BubbleMigrator — drain before WAL close, clean-shutdown gate on truncation (Luciferase-n6jrh.2)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/BubbleMigratorAdapter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/BubbleMigratorAdapter.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2025, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.lifecycle;
+
+import com.hellblazer.luciferase.simulation.tumbler.BubbleMigrator;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Lifecycle adapter for {@link BubbleMigrator} (RDR-017, Luciferase-n6jrh.2).
+ * <p>
+ * Dependency Layer: 1 — depends on {@code PersistenceManager}, so reverse-order shutdown
+ * drains the migrator BEFORE the coordinator stops the persistence layer and closes the WAL.
+ * Without this ordering, an in-flight migration can call {@code logMigrationCommit()} against
+ * a closed WAL: the commit fails, leaving a durable {@code ENTITY_DEPARTURE} with no
+ * {@code MIGRATION_COMMIT} — the RDR-016 R2 split-brain precondition.
+ * <p>
+ * {@link #doStop()} drains via {@link BubbleMigrator#shutdownGracefully(Duration)}: in-flight
+ * migrations run to completion (bounded by the migrator's per-migration timeout, the default
+ * drain grace) and new ones are rejected with a clean failed result. The migrator's executor
+ * cannot be revived after drain — a restart attempt fails loud rather than producing a zombie
+ * adapter whose migrations are silently rejected.
+ * <p>
+ * <b>Over-budget drains.</b> The coordinator divides {@code Manager.close()}'s total stop
+ * timeout across all components and does NOT cancel a drain that exceeds its share — it
+ * proceeds to the persistence layer with the drain still running. That residual case is made
+ * safe by the {@code PersistenceManagerAdapter} clean-shutdown gate (wired by the 4-arg
+ * {@code NodeBootstrap.assemble} to {@link BubbleMigrator#isTerminated()}): the WAL is
+ * checkpoint-truncated only when the migration executor has fully terminated; otherwise it is
+ * closed crash-safe and retained, so a half-bracket recovers as MIGRATING_OUT instead of being
+ * truncated away.
+ *
+ * @author hal.hildebrand
+ */
+public class BubbleMigratorAdapter extends AbstractLifecycleAdapter {
+
+    public static final String NAME = "BubbleMigrator";
+
+    private final BubbleMigrator migrator;
+    private final Duration drainGrace;
+
+    /**
+     * Create an adapter draining with the migrator's own per-migration timeout as grace —
+     * in-flight work is bounded by that timeout, so it is the natural drain budget.
+     *
+     * @param migrator the migrator to lifecycle-manage
+     */
+    public BubbleMigratorAdapter(BubbleMigrator migrator) {
+        this(migrator, Objects.requireNonNull(migrator, "migrator must not be null").migrationTimeout());
+    }
+
+    /**
+     * Create an adapter with an explicit drain grace.
+     * <p>
+     * Note the coordinator budgets {@code Manager.close()}'s total shutdown timeout across all
+     * components; a grace exceeding the per-component share is cut short by the coordinator's
+     * stop timeout (logged, shutdown continues).
+     *
+     * @param migrator   the migrator to lifecycle-manage
+     * @param drainGrace how long {@link #doStop()} waits for in-flight migrations
+     */
+    public BubbleMigratorAdapter(BubbleMigrator migrator, Duration drainGrace) {
+        this.migrator = Objects.requireNonNull(migrator, "migrator must not be null");
+        this.drainGrace = Objects.requireNonNull(drainGrace, "drainGrace must not be null");
+    }
+
+    @Override
+    protected String getComponentName() {
+        return NAME;
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        // The migrator's executor is live from construction — nothing to start. But it cannot
+        // be revived after a drain: fail loud instead of running as a zombie whose migrations
+        // are all silently rejected.
+        if (migrator.isShutdown()) {
+            throw new IllegalStateException(
+                "BubbleMigrator cannot restart after drain — construct a new migrator");
+        }
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        // shutdownGracefully logs a warning itself when the grace elapses and falls back to
+        // interrupting; an interrupted migration aborts pre-commit (recoverable MIGRATING_OUT
+        // half-bracket), never half-commits.
+        migrator.shutdownGracefully(drainGrace);
+        // shutdownGracefully re-asserts the interrupt flag if awaitTermination was interrupted;
+        // doStop runs on a shared pool worker (ForkJoinPool does not clear the flag between
+        // tasks), so swallow it here — the adapter's contract is "drain complete or timed out,
+        // either way stop is done".
+        Thread.interrupted();
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public List<String> dependencies() {
+        // Layer 1: started after, and stopped before, the persistence layer — the entire point
+        // of this adapter (see class javadoc).
+        return List.of("PersistenceManager");
+    }
+
+    /**
+     * @return the wrapped migrator
+     */
+    public BubbleMigrator getMigrator() {
+        return migrator;
+    }
+}

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapter.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/lifecycle/PersistenceManagerAdapter.java
@@ -36,7 +36,30 @@ import java.util.Objects;
  */
 public class PersistenceManagerAdapter extends AbstractLifecycleAdapter {
 
+    private static final org.slf4j.Logger log =
+        org.slf4j.LoggerFactory.getLogger(PersistenceManagerAdapter.class);
+
     private final PersistenceManager persistenceManager;
+
+    /**
+     * Clean-shutdown gate (Luciferase-n6jrh.2). When set (by the 4-arg
+     * {@code NodeBootstrap.assemble} to {@code migrator::isTerminated}), {@link #doStop()} only
+     * performs the checkpoint-and-truncate {@code closeClean()} when the gate holds — i.e. the
+     * migration executor has fully terminated and no in-flight migration can ever write to the
+     * WAL again. If the gate fails (the coordinator's per-component stop budget expired before
+     * the migrator finished draining, or a forced interrupt left a half-bracket), the WAL is
+     * closed crash-safe instead, RETAINING it: recovery then reconstructs MIGRATING_OUT from
+     * the retained ENTITY_DEPARTURE rather than truncation silently erasing it. Null (3-arg
+     * assemble / standalone) means no migrator exists and clean shutdown is unconditional.
+     */
+    private volatile java.util.function.BooleanSupplier cleanShutdownGate;
+
+    /**
+     * Wire the clean-shutdown gate; see field javadoc. Call before shutdown begins.
+     */
+    public void setCleanShutdownGate(java.util.function.BooleanSupplier gate) {
+        this.cleanShutdownGate = gate;
+    }
 
     /**
      * Create an adapter for PersistenceManager.
@@ -85,7 +108,18 @@ public class PersistenceManagerAdapter extends AbstractLifecycleAdapter {
         // RDR-017 P3 (gate O1): a lifecycle stop is a CLEAN shutdown — checkpoint + truncate the WAL
         // (compaction) so the next start recovers nothing. The crash path (abort in doStart) calls
         // close() directly, retaining the WAL for recovery.
-        persistenceManager.closeClean();
+        // Luciferase-n6jrh.2: clean shutdown additionally requires the migration executor to have
+        // fully terminated — otherwise an in-flight migration's ENTITY_DEPARTURE half-bracket
+        // would be truncated away (silent entity loss) or a late commit would hit a closed WAL.
+        // When the gate fails, degrade to the crash-safe close, retaining the WAL for recovery.
+        var gate = cleanShutdownGate;
+        if (gate == null || gate.getAsBoolean()) {
+            persistenceManager.closeClean();
+        } else {
+            log.warn("Clean-shutdown gate failed (migrator not fully drained) — closing WAL "
+                     + "crash-safe and retaining it for recovery instead of truncating");
+            persistenceManager.close();
+        }
     }
 
     @Override

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/tumbler/BubbleMigrator.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/tumbler/BubbleMigrator.java
@@ -100,11 +100,65 @@ public class BubbleMigrator {
     }
 
     /**
-     * Shut down the dedicated migration executor. Call when the migrator is no longer needed to
-     * release its threads.
+     * Shut down the dedicated migration executor immediately, interrupting in-flight migrations.
+     * Test/abrupt cleanup path — production shutdown goes through
+     * {@link #shutdownGracefully(Duration)} via the lifecycle adapter so in-flight WAL brackets
+     * complete before the WAL closes (Luciferase-n6jrh.2).
      */
     public void shutdown() {
         migrationExecutor.shutdownNow();
+    }
+
+    /**
+     * Drain in-flight migrations, then shut down the executor (Luciferase-n6jrh.2). New
+     * migrations are rejected immediately; in-flight ones run to completion so their WAL
+     * bracket (ENTITY_DEPARTURE … MIGRATION_COMMIT) lands on an open WAL. Falls back to
+     * {@code shutdownNow()} when the grace period elapses — an interrupted migration aborts
+     * pre-commit (the recoverable MIGRATING_OUT half-bracket), it never half-commits.
+     *
+     * @param grace how long to wait for in-flight migrations; in-flight work is bounded by
+     *              {@code migrationTimeout}, so that is the natural grace value
+     * @return true if all in-flight migrations drained within the grace period
+     */
+    public boolean shutdownGracefully(Duration grace) {
+        var inFlightAtDrain = inFlightMigrations.size();
+        migrationExecutor.shutdown();
+        try {
+            if (migrationExecutor.awaitTermination(grace.toMillis(), TimeUnit.MILLISECONDS)) {
+                return true;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        log.warn("BubbleMigrator drain incomplete after {}ms; interrupting (had {} in-flight at drain start)",
+                 grace.toMillis(), inFlightAtDrain);
+        migrationExecutor.shutdownNow();
+        return false;
+    }
+
+    /**
+     * @return whether the migration executor has been shut down (gracefully or not)
+     */
+    public boolean isShutdown() {
+        return migrationExecutor.isShutdown();
+    }
+
+    /**
+     * @return whether the migration executor has fully terminated — shut down AND every
+     * in-flight task completed. Once true it is true forever: no migration can ever write to
+     * the WAL again. {@code PersistenceManagerAdapter} uses this as the clean-shutdown gate
+     * (Luciferase-n6jrh.2): the WAL may only be checkpoint-truncated when this holds.
+     */
+    public boolean isTerminated() {
+        return migrationExecutor.isTerminated();
+    }
+
+    /**
+     * @return the configured per-migration timeout (bounds in-flight work; the lifecycle
+     * adapter uses it as the default drain grace)
+     */
+    public Duration migrationTimeout() {
+        return migrationTimeout;
     }
 
     /**
@@ -197,15 +251,25 @@ public class BubbleMigrator {
             );
         }
 
-        return CompletableFuture.supplyAsync(() -> {
-            try {
-                return executeMigration(bubble, sourceServerId, targetServerId, startTime);
-            } finally {
-                // Luciferase-0frcy.38: value-conditional removal so we only clear OUR reservation,
-                // never a subsequent re-reservation of the same bubbleId by another thread.
-                inFlightMigrations.remove(bubbleId, state);
-            }
-        }, migrationExecutor) // dedicated pool — never block ForkJoinPool.commonPool (0frcy.116)
+        CompletableFuture<MigrationResult> submitted;
+        try {
+            submitted = CompletableFuture.supplyAsync(() -> {
+                try {
+                    return executeMigration(bubble, sourceServerId, targetServerId, startTime);
+                } finally {
+                    // Luciferase-0frcy.38: value-conditional removal so we only clear OUR reservation,
+                    // never a subsequent re-reservation of the same bubbleId by another thread.
+                    inFlightMigrations.remove(bubbleId, state);
+                }
+            }, migrationExecutor); // dedicated pool — never block ForkJoinPool.commonPool (0frcy.116)
+        } catch (java.util.concurrent.RejectedExecutionException ree) {
+            // Migrator drained/shut down (Luciferase-n6jrh.2): reject as a clean failed result
+            // rather than throwing at the caller mid-shutdown.
+            inFlightMigrations.remove(bubbleId, state);
+            return CompletableFuture.completedFuture(
+                new MigrationResult(bubbleId, targetServerId, false, "Migrator is shut down", 0));
+        }
+        return submitted
           .orTimeout(migrationTimeout.toMillis(), TimeUnit.MILLISECONDS)
           .exceptionally(ex -> {
               // The supplyAsync body's finally already removed our entry on normal completion; this

--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/von/NodeBootstrap.java
@@ -20,6 +20,7 @@ import com.hellblazer.luciferase.simulation.consensus.ownership.BubbleOwnershipR
 import com.hellblazer.luciferase.simulation.consensus.ownership.FirefliesBubbleOwnershipResolver;
 import com.hellblazer.luciferase.simulation.consensus.ownership.RendezvousOwnershipFunction;
 import com.hellblazer.luciferase.simulation.delos.MembershipView;
+import com.hellblazer.luciferase.simulation.lifecycle.BubbleMigratorAdapter;
 import com.hellblazer.luciferase.simulation.lifecycle.PersistenceManagerAdapter;
 import com.hellblazer.luciferase.simulation.lifecycle.RecoveryIntegrationAdapter;
 import com.hellblazer.luciferase.simulation.lifecycle.SocketConnectionManagerAdapter;
@@ -199,14 +200,14 @@ public final class NodeBootstrap {
      * and started (the coordinator started in the {@link Manager} constructor starts components on
      * registration), so the migrator never logs against an unrecovered/unstarted WAL.
      * <p>
-     * <b>Shutdown ordering contract.</b> The migrator is wired to the persistence manager but is NOT
-     * registered as a lifecycle component, so {@code Manager.close()} does not stop it. The caller MUST
-     * call {@code migrator.shutdown()} (draining in-flight migrations) <b>before</b> {@code Manager.close()}
-     * closes the WAL — otherwise an in-flight migration can call {@code logMigrationCommit()} after the
-     * WAL is closed, failing the commit and leaving an {@code ENTITY_DEPARTURE}-without-{@code COMMIT}
-     * split-brain precondition (the exact hazard RDR-016 R2 guards). Lifecycle-integrating the migrator
-     * (a {@code BubbleMigratorAdapter} stopped ahead of the persistence layer) is tracked for the live
-     * {@link #main} wiring — until then {@code main} throws, so the race is unreachable in production.
+     * <b>Shutdown ordering (Luciferase-n6jrh.2).</b> The migrator is lifecycle-registered as a
+     * {@link BubbleMigratorAdapter} at Layer 1 (dependency: {@code PersistenceManager}), so
+     * {@code Manager.close()} drains it — in-flight migrations run to completion, new ones are
+     * rejected — <b>before</b> the coordinator stops the persistence layer and closes the WAL.
+     * An in-flight migration therefore can never call {@code logMigrationCommit()} against a
+     * closed WAL (the {@code ENTITY_DEPARTURE}-without-{@code COMMIT} split-brain precondition
+     * RDR-016 R2 guards). Callers no longer need to stop the migrator manually; after
+     * {@code Manager.close()} the migrator is drained and cannot be restarted.
      *
      * @param manager    the VON manager owning the lifecycle coordinator
      * @param scmAdapter the connection-manager adapter (Layer 0)
@@ -220,7 +221,18 @@ public final class NodeBootstrap {
         // After coordinator.start()/registration: the persistence adapter is RUNNING (recovered,
         // schedulers up), so the migration WAL bracket can durably log against it.
         migrator.setPersistenceManager(pmAdapter.getPersistenceManager());
-        log.info("Migration durability wired: BubbleMigrator → {}", pmAdapter.name());
+        // Lifecycle-integrate the migrator ABOVE the persistence layer so reverse-order shutdown
+        // drains in-flight migrations before the WAL closes (Luciferase-n6jrh.2).
+        manager.registerInfrastructure(new BubbleMigratorAdapter(migrator));
+        // Defense for the over-budget case: the coordinator's per-component stop timeout does not
+        // cancel a still-running drain, so the persistence layer may be reached while migrations
+        // are alive. The gate makes that safe — the WAL is checkpoint-truncated ONLY when the
+        // migration executor has fully terminated; otherwise it is closed crash-safe and retained,
+        // so an interrupted migration's half-bracket recovers as MIGRATING_OUT instead of being
+        // silently truncated away.
+        pmAdapter.setCleanShutdownGate(migrator::isTerminated);
+        log.info("Migration durability wired: BubbleMigrator → {} (lifecycle Layer 1, clean-shutdown gated)",
+                 pmAdapter.name());
     }
 
     /**

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapDurabilityRoundTripTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapDurabilityRoundTripTest.java
@@ -99,8 +99,11 @@ class NodeBootstrapDurabilityRoundTripTest {
             pmAdapter1.getPersistenceManager().close();
         } finally {
             target.close();        // releases the target Bubble's retry-scheduler daemon thread
-            migrator.shutdown();    // releases the migration executor pool
-            mgr1.close();           // doStop → closeClean is a no-op (PM already closed); stops the SCM
+            // Since n6jrh.2 the lifecycle drains the migrator in mgr1.close(); this abrupt
+            // shutdown is redundant (no-op on an already-drained executor) but kept as
+            // belt-and-braces for the early-throw paths above assemble().
+            migrator.shutdown();
+            mgr1.close();           // drains migrator (L1), then PM doStop; closeClean no-op (PM already closed)
         }
 
         // ───────── WAL-identity pinning (gate C1): the reopened node derives the SAME dir ─────────

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapMigratorLifecycleTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/von/NodeBootstrapMigratorLifecycleTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2025, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.von;
+
+import com.hellblazer.delos.cryptography.DigestAlgorithm;
+import com.hellblazer.luciferase.simulation.bubble.SpatialLevelHeuristic;
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationState;
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationStateMachine;
+import com.hellblazer.luciferase.simulation.causality.FirefliesViewMonitor;
+import com.hellblazer.luciferase.simulation.delos.mock.MockFirefliesView;
+import com.hellblazer.luciferase.simulation.lifecycle.BubbleMigratorAdapter;
+import com.hellblazer.luciferase.simulation.lifecycle.LifecycleState;
+import com.hellblazer.luciferase.simulation.lifecycle.SocketConnectionManagerAdapter;
+import com.hellblazer.luciferase.simulation.tumbler.BubbleMigrator;
+import com.hellblazer.luciferase.simulation.tumbler.SpatialTumbler;
+import com.hellblazer.luciferase.simulation.von.transport.ProcessAddress;
+import com.hellblazer.luciferase.simulation.von.transport.SocketConnectionManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.vecmath.Point3f;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * RDR-017 (Luciferase-n6jrh.2) — BubbleMigrator lifecycle integration: the migrator must be
+ * drained BEFORE the coordinator closes the WAL on shutdown, so an in-flight migration can
+ * never call {@code logMigrationCommit()} against a closed WAL (the RDR-016 R2
+ * ENTITY_DEPARTURE-without-COMMIT split-brain precondition).
+ */
+class NodeBootstrapMigratorLifecycleTest {
+
+    private static EntityMigrationStateMachine freshFsm() {
+        return new EntityMigrationStateMachine(new FirefliesViewMonitor(new MockFirefliesView<>(), 3));
+    }
+
+    private static Manager manager() {
+        return new Manager(LocalServerTransport.Registry.create(),
+                           SpatialLevelHeuristic.DEFAULT_SPATIAL_LEVEL, 16L,
+                           SpatialLevelHeuristic.DEFAULT_AOI_RADIUS);
+    }
+
+    @Test
+    void fourArgAssembleLifecycleRegistersMigrator(@TempDir Path base) throws Exception {
+        var memberId = DigestAlgorithm.DEFAULT.random();
+        var nodeId = NodeBootstrap.resolveNodeId(memberId);
+        var pmAdapter = NodeBootstrap.persistenceAdapter(nodeId, NodeBootstrap.walDir(base, nodeId), freshFsm());
+        var scm = new SocketConnectionManager(ProcessAddress.localhost("n6jrh2-reg", 0), msg -> {});
+        var mgr = manager();
+        var migrator = new BubbleMigrator(new SpatialTumbler((byte) 5, 16L),
+                                          Duration.ofSeconds(1), Duration.ofMillis(100), 5);
+        try {
+            NodeBootstrap.assemble(mgr, new SocketConnectionManagerAdapter(scm), pmAdapter, migrator);
+
+            assertEquals(LifecycleState.RUNNING, mgr.coordinator().getState(BubbleMigratorAdapter.NAME),
+                         "4-arg assemble must lifecycle-register the migrator (RUNNING)");
+        } finally {
+            mgr.close();
+        }
+        assertEquals(LifecycleState.STOPPED, mgr.coordinator().getState(BubbleMigratorAdapter.NAME),
+                     "Manager.close() must stop the migrator adapter");
+        assertTrue(migrator.isShutdown(), "lifecycle stop must drain/shut down the migrator executor");
+    }
+
+    /**
+     * THE hazard (P2 review Sig-2): an in-flight migration at shutdown must complete its WAL
+     * bracket before the coordinator closes the WAL. The transfer factory blocks the migration
+     * in-flight (before any WAL write); Manager.close() starts on another thread; the migration
+     * is then released. Because the migrator adapter sits at Layer 1 (above PersistenceManager
+     * at Layer 0), reverse-order shutdown drains the migration FIRST — the WAL bracket
+     * (ENTITY_DEPARTURE + MIGRATION_COMMIT) lands on an open WAL and the migration succeeds.
+     * Without the adapter, close() returns without draining and the WAL closes under the
+     * in-flight migration, which then fails its bracket.
+     */
+    @Test
+    void inFlightMigrationDrainsBeforeWalCloseOnShutdown(@TempDir Path base) throws Exception {
+        var memberId = DigestAlgorithm.DEFAULT.random();
+        var nodeId = NodeBootstrap.resolveNodeId(memberId);
+        var pmAdapter = NodeBootstrap.persistenceAdapter(nodeId, NodeBootstrap.walDir(base, nodeId), freshFsm());
+        var scm = new SocketConnectionManager(ProcessAddress.localhost("n6jrh2-drain", 0), msg -> {});
+        var mgr = manager();
+        // migrationTimeout (= default drain grace) must fit the coordinator's per-component stop
+        // budget (5000ms / 3 components here) or the coordinator races ahead of the drain and the
+        // test exercises the gate fallback instead of the drain.
+        var migrator = new BubbleMigrator(new SpatialTumbler((byte) 5, 16L),
+                                          Duration.ofMillis(1500), Duration.ofMillis(100), 5);
+
+        var entityId = UUID.randomUUID();
+        var source = new Bubble(UUID.randomUUID(), (byte) 5, 16L, mock(Transport.class));
+        var target = new Bubble(UUID.randomUUID(), (byte) 5, 16L, mock(Transport.class));
+        var migrationEntered = new CountDownLatch(1);
+        var releaseMigration = new CountDownLatch(1);
+        try {
+            NodeBootstrap.assemble(mgr, new SocketConnectionManagerAdapter(scm), pmAdapter, migrator);
+
+            source.addEntity(entityId.toString(), new Point3f(1f, 0f, 0f), "payload");
+            // The factory runs on the migration executor BEFORE any WAL write — blocking here
+            // holds the migration genuinely in-flight across the start of shutdown.
+            migrator.setBubbleTransferFactory((tgtServer, src) -> {
+                migrationEntered.countDown();
+                try {
+                    if (!releaseMigration.await(5, TimeUnit.SECONDS)) {
+                        throw new RuntimeException("release latch timeout");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+                return target;
+            });
+
+            var resultFuture = migrator.migrate(source, UUID.randomUUID(), UUID.randomUUID());
+            assertTrue(migrationEntered.await(5, TimeUnit.SECONDS), "migration must be in-flight");
+
+            // Begin shutdown while the migration is in-flight. The release is withheld until the
+            // drain has demonstrably BEGUN (migrator.isShutdown() flips when doStop calls
+            // executor.shutdown()), so the test cannot pass trivially by the migration finishing
+            // before the coordinator reaches Layer 1 — the drain genuinely overlaps the migration.
+            var closer = new Thread(mgr::close, "test-closer");
+            closer.start();
+            var drainDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+            while (!migrator.isShutdown()) {
+                assertTrue(System.nanoTime() < drainDeadline, "drain must begin within 10s");
+                Thread.onSpinWait();
+            }
+            releaseMigration.countDown();
+            closer.join(15_000);
+            assertFalse(closer.isAlive(), "Manager.close() must complete");
+
+            var result = resultFuture.get(5, TimeUnit.SECONDS);
+            assertTrue(result.success(),
+                       "in-flight migration must complete its WAL bracket before the WAL closes, got: "
+                       + result.message());
+            assertEquals(LifecycleState.STOPPED, mgr.coordinator().getState(BubbleMigratorAdapter.NAME));
+            assertEquals(LifecycleState.STOPPED, mgr.coordinator().getState("PersistenceManager"));
+        } finally {
+            target.close();
+            migrator.shutdown();
+            mgr.close();
+        }
+    }
+
+    @Test
+    void migrateAfterShutdownReturnsCleanFailure(@TempDir Path base) throws Exception {
+        var memberId = DigestAlgorithm.DEFAULT.random();
+        var nodeId = NodeBootstrap.resolveNodeId(memberId);
+        var pmAdapter = NodeBootstrap.persistenceAdapter(nodeId, NodeBootstrap.walDir(base, nodeId), freshFsm());
+        var scm = new SocketConnectionManager(ProcessAddress.localhost("n6jrh2-post", 0), msg -> {});
+        var mgr = manager();
+        var migrator = new BubbleMigrator(new SpatialTumbler((byte) 5, 16L),
+                                          Duration.ofSeconds(1), Duration.ofMillis(100), 5);
+        var source = new Bubble(UUID.randomUUID(), (byte) 5, 16L, mock(Transport.class));
+        try {
+            NodeBootstrap.assemble(mgr, new SocketConnectionManagerAdapter(scm), pmAdapter, migrator);
+            source.addEntity(UUID.randomUUID().toString(), new Point3f(1f, 0f, 0f), "payload");
+        } finally {
+            mgr.close();
+        }
+
+        // After lifecycle shutdown the migrator executor is gone: migrate() must return a clean
+        // failed result, not throw RejectedExecutionException at the caller.
+        var result = migrator.migrate(source, UUID.randomUUID(), UUID.randomUUID())
+                             .get(5, TimeUnit.SECONDS);
+        assertFalse(result.success(), "migrate after shutdown must fail");
+        assertTrue(result.message().toLowerCase().contains("shut"),
+                   "failure must say the migrator is shut down, got: " + result.message());
+    }
+
+    /**
+     * The over-budget defense (review Critical on n6jrh.2): the coordinator's per-component
+     * stop timeout does not cancel a still-running drain, so the persistence layer can be
+     * stopped while the migrator has not fully terminated. In that case the WAL must be closed
+     * crash-safe and RETAINED — a checkpoint-truncate would silently erase the in-flight
+     * migration's ENTITY_DEPARTURE half-bracket, losing the MIGRATING_OUT recovery evidence.
+     */
+    @Test
+    void dirtyShutdownGateRetainsWalForRecovery(@TempDir Path base) throws Exception {
+        var memberId = DigestAlgorithm.DEFAULT.random();
+        var nodeId = NodeBootstrap.resolveNodeId(memberId);
+        var walDir = NodeBootstrap.walDir(base, nodeId);
+        var inFlight = UUID.randomUUID();
+
+        var pmAdapter = NodeBootstrap.persistenceAdapter(nodeId, walDir, freshFsm());
+        pmAdapter.start().join();
+        pmAdapter.getPersistenceManager().logEntityDeparture(inFlight, UUID.randomUUID(), UUID.randomUUID());
+
+        // Simulate the over-budget case: the migration executor has NOT fully terminated when
+        // the persistence layer stops.
+        pmAdapter.setCleanShutdownGate(() -> false);
+        pmAdapter.stop().join();
+
+        // The reopened node must reconstruct MIGRATING_OUT — truncation would have erased it.
+        var fsm2 = freshFsm();
+        var pmAdapter2 = NodeBootstrap.persistenceAdapter(nodeId, walDir, fsm2);
+        pmAdapter2.start().join();
+        try {
+            assertEquals(EntityMigrationState.MIGRATING_OUT, fsm2.getState(inFlight.toString()),
+                         "retained WAL must recover the in-flight half-bracket as MIGRATING_OUT");
+        } finally {
+            pmAdapter2.stop().join();
+        }
+    }
+
+    /**
+     * Inversion: with the gate holding (migrator fully terminated), clean shutdown keeps the
+     * P3 gate-O1 semantics — checkpoint + truncate, nothing to recover.
+     */
+    @Test
+    void cleanShutdownGateStillTruncates(@TempDir Path base) throws Exception {
+        var memberId = DigestAlgorithm.DEFAULT.random();
+        var nodeId = NodeBootstrap.resolveNodeId(memberId);
+        var walDir = NodeBootstrap.walDir(base, nodeId);
+        var inFlight = UUID.randomUUID();
+
+        var pmAdapter = NodeBootstrap.persistenceAdapter(nodeId, walDir, freshFsm());
+        pmAdapter.start().join();
+        pmAdapter.getPersistenceManager().logEntityDeparture(inFlight, UUID.randomUUID(), UUID.randomUUID());
+
+        pmAdapter.setCleanShutdownGate(() -> true);
+        pmAdapter.stop().join();
+
+        var fsm2 = freshFsm();
+        var pmAdapter2 = NodeBootstrap.persistenceAdapter(nodeId, walDir, fsm2);
+        pmAdapter2.start().join();
+        try {
+            assertNotEquals(EntityMigrationState.MIGRATING_OUT, fsm2.getState(inFlight.toString()),
+                            "clean shutdown must checkpoint-truncate (gate O1 semantics preserved)");
+        } finally {
+            pmAdapter2.stop().join();
+        }
+    }
+
+    @Test
+    void migratorAdapterDoesNotRestartAfterDrain() {
+        var migrator = new BubbleMigrator(new SpatialTumbler((byte) 5, 16L),
+                                          Duration.ofSeconds(1), Duration.ofMillis(100), 5);
+        var adapter = new BubbleMigratorAdapter(migrator);
+        assertEquals(java.util.List.of("PersistenceManager"), adapter.dependencies(),
+                     "migrator must sit above PersistenceManager so it is stopped first");
+
+        adapter.start().join();
+        adapter.stop().join();
+        assertTrue(migrator.isShutdown());
+
+        // The migration executor cannot be revived: a restart must fail loud, not produce a
+        // zombie adapter whose migrations are silently rejected.
+        var ex = assertThrows(Exception.class, () -> adapter.start().join(),
+                              "restart after drain must fail loud");
+        var found = false;
+        for (Throwable cause = ex; cause != null; cause = cause.getCause()) {
+            if (cause.getMessage() != null && cause.getMessage().contains("restart")) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue(found, "failure chain must explain the no-restart contract, got: " + ex);
+    }
+}


### PR DESCRIPTION
## Summary

Closes **Luciferase-n6jrh.2**, the second RDR-017 `main()`-precondition (P2 review Sig-2): the 4-arg `NodeBootstrap.assemble` wired the migrator's WAL bracket but never lifecycle-registered the migrator, so `Manager.close()` closed the WAL with no knowledge of in-flight migrations — a late `logMigrationCommit()` against the closed WAL leaves a durable `ENTITY_DEPARTURE` without `COMMIT`, the **RDR-016 R2 split-brain precondition**. Until now this was only a documented caller contract.

## Changes

- **`BubbleMigratorAdapter`** (new, Layer 1 — depends on `PersistenceManager`): reverse-order shutdown drains the migrator before the WAL closes. `doStop` uses the new `BubbleMigrator.shutdownGracefully(grace)` — no new tasks, in-flight migrations run to completion, interrupt fallback after the grace (an interrupted migration aborts pre-commit; it never half-commits). No restart after drain: fails loud instead of running as a zombie.
- **Clean-shutdown gate** — the load-bearing fix for the review's Critical: the coordinator's per-component stop timeout does **not** cancel a still-running drain (`orTimeout` doesn't interrupt the `runAsync` thread), so the persistence layer can be reached with migrations alive, and `closeClean()`'s checkpoint+**truncate** would silently erase an interrupted migration's half-bracket. `PersistenceManagerAdapter` now gates `closeClean` on `migrator::isTerminated` (wired by 4-arg assemble; race-free — a terminated executor can never write again). Gate fails → crash-safe `close()` **retaining** the WAL, so the half-bracket recovers as `MIGRATING_OUT`. 3-arg/standalone paths (gate null) unchanged.
- `migrate()` post-drain returns a clean failed result instead of throwing `RejectedExecutionException`.

## Tests (6 new, in `NodeBootstrapMigratorLifecycleTest`)

- **Hazard test**: a latch-blocked migration is held in-flight across `Manager.close()`; the release is withheld until the drain has *demonstrably begun* (`migrator.isShutdown()` spin gate with deadline) so the drain genuinely overlaps the migration — the WAL bracket must land on an open WAL and the migration must succeed. (Round-1 review caught that the original test could pass by timing luck; fixed.)
- **Dirty-gate retention round-trip**: gate=false → WAL retained → reopened node recovers `MIGRATING_OUT` (truncation would have erased it). **Clean-gate inversion**: P3 gate-O1 truncation semantics preserved.
- Lifecycle registration/shutdown, post-shutdown migrate clean failure, no-restart-after-drain.
- Local slice 135/135 (NodeBootstrap*, Manager*, BubbleMigrator*, PersistenceManagerAdapter*, LifecycleCoordinator).

## Review

Stacked review, two rounds. Round 1: 2 Critical + 1 Significant (coordinator races ahead of over-budget drains; test timing luck; truncation erasing the half-bracket) — all fixed via the gate + test redesign. Round 2: **0 Critical / 0 Significant**, all round-1 findings explicitly discharged; the FJP interrupt-flag observation also applied. The coordinator-wide stop-budget collapse at scale is tracked separately as **Luciferase-43bat**.

Bead: Luciferase-n6jrh.2 (RDR-017). Remaining `main()`-precondition: n6jrh.3 (WAL checkpoint data-loss, P1).