### PR TITLE
test(simulation): fix Phase5IntegrationTest p99 latency flake with avg-based bounds (Luciferase-d5afj)

### DIFF
--- a/TEST_FRAMEWORK_GUIDE.md
+++ b/TEST_FRAMEWORK_GUIDE.md
@@ -200,6 +200,36 @@ assertTrue(p999Ms < 50.0, "P99.9 must be <50ms");
 - If CI finishes early: Verify system resources and consider stricter thresholds
 - After Phase 7B.5 optimization: Re-enable testLatencyDistribution with <25ms threshold
 
+#### 4. Phase5IntegrationTest (simulation module)
+
+**Location**: `simulation/src/test/java/.../metrics/Phase5IntegrationTest.java`
+
+**Test: testLatencyTrackingEndToEnd** (10 samples — p99 IS the max sample)
+```java
+assertThat(stats.avgLatencyMs()).isLessThan(10.0);   // Regression guard: avg dilutes one hiccup ~10x
+assertThat(stats.p99LatencyMs()).isLessThan(100.0);  // System target only (was <10ms p99, flaked)
+```
+
+**Test: testGhostLatencyUnder100ms** (100 samples — p99 = rank 99, ~2 bad samples to fail)
+```java
+assertThat(stats.p99LatencyMs()).isLessThan(100.0);  // Target: <100ms
+assertThat(stats.avgLatencyMs()).isLessThan(5.0);    // Replaces former <1ms p99 (flake-prone tail)
+```
+
+**Recent Fix** (Luciferase-d5afj):
+- Problem: `<10ms` p99 assertion on an InMemoryGhostChannel flaked at 28.16ms in CI batch-1 under runner contention (run 27443289525, on a portal-only PR — no simulation code changed, confirming contention not regression)
+- Solution: **average-based regression bounds** instead of tight p99 bounds. A single scheduler hiccup dominates a small-sample p99 (with 10 samples, p99 = max), but is diluted ~N× in the average — so the avg bound stays stable under CI contention while still failing on a uniform hot-path regression (e.g. accidental blocking call in `InstrumentedGhostChannel.sendBatch` or `LatencyTracker.record`). p99 assertions retain only the declared 100ms system target (`SimulationConfig.latencyAlertThresholdMs` default).
+- Same contention class as MultiBubbleLoadTest P99 (above), different remedy: avg bounds run everywhere (no CI-disabled strict variant needed) because the smoothed statistic is robust at these sample counts.
+
+**Threshold Values**:
+- testLatencyTrackingEndToEnd: avg <10ms, p99 <100ms (flake event would have passed: one 28ms spike over 10 samples → avg ≈ 2.8ms)
+- testGhostLatencyUnder100ms: avg <5ms, p99 <100ms (one 28ms spike over 100 samples → avg contribution ≈ 0.28ms)
+
+**When to Adjust**:
+- Not CI-disabled — tracking coverage and the avg regression guard run everywhere
+- If avg bounds ever flake in CI (would require sustained contention across most samples, not a single hiccup): re-diagnose before relaxing — that pattern looks like a real regression
+- Root-cause alternative: Clock injection (`InstrumentedGhostChannel.setClock`) would make latency deterministic; covered by the Clock-injection sweep (Luciferase-mt7hi)
+
 ---
 
 ## Flaky Test Handling

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/grid/GridMultiBubbleSimulationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/grid/GridMultiBubbleSimulationTest.java
@@ -14,9 +14,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import javax.vecmath.Point3f;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -128,17 +130,21 @@ class GridMultiBubbleSimulationTest {
     }
 
     @Test
-    void testTickProgression() throws InterruptedException {
+    void testTickProgression() {
         var config = GridConfiguration.square(2, 100f);
         var sim = new GridMultiBubbleSimulation(config, 50, WorldBounds.DEFAULT);
 
         sim.start();
-        Thread.sleep(100); // Let a few ticks happen
-
-        assertTrue(sim.getTickCount() > 0, "Tick count should increase");
-
-        sim.stop();
-        sim.close();
+        try {
+            // Await instead of a fixed 100ms sleep: under CI runner contention the tick
+            // thread can miss the whole window (Luciferase-ez6ej — failed 3 of 4 batch-3 runs)
+            await().alias("tick count should increase")
+                   .atMost(Duration.ofSeconds(10))
+                   .until(() -> sim.getTickCount() > 0);
+        } finally {
+            sim.stop();
+            sim.close();
+        }
     }
 
     @Test
@@ -227,7 +233,7 @@ class GridMultiBubbleSimulationTest {
     }
 
     @Test
-    void testEntityCountStability() throws InterruptedException {
+    void testEntityCountStability() {
         var config = GridConfiguration.square(2, 100f);
         var sim = new GridMultiBubbleSimulation(config, 100, WorldBounds.DEFAULT);
 
@@ -235,8 +241,15 @@ class GridMultiBubbleSimulationTest {
         assertEquals(100, initialCount);
 
         sim.start();
-        Thread.sleep(200);
-        sim.stop();
+        try {
+            // Await real ticks rather than sleeping a fixed 200ms: a starved window would
+            // pass vacuously with zero ticks executed (Luciferase-ez6ej)
+            await().alias("at least 5 ticks should run")
+                   .atMost(Duration.ofSeconds(10))
+                   .until(() -> sim.getTickCount() >= 5);
+        } finally {
+            sim.stop();
+        }
 
         int finalCount = sim.getRealEntities().size();  // Count only real entities (no ghosts)
         assertEquals(initialCount, finalCount, "Entity count should remain stable");

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/metrics/Phase5IntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/metrics/Phase5IntegrationTest.java
@@ -131,8 +131,12 @@ class Phase5IntegrationTest {
         assertThat(stats.avgLatencyNs()).isGreaterThan(0);
         assertThat(stats.p99LatencyNs()).isGreaterThan(0);
 
-        // For in-memory channel, latency should be minimal (<10ms)
-        assertThat(stats.p99LatencyMs()).isLessThan(10.0);
+        // With only 10 samples, p99 IS the max sample, so a single CI scheduler hiccup lands
+        // in the tail — a <10ms p99 bound flaked at 28.16ms under runner contention
+        // (Luciferase-d5afj). The average dilutes one hiccup ~10x (28ms -> ~3ms) but still
+        // fails on a uniform hot-path regression; p99 keeps only the 100ms system target.
+        assertThat(stats.avgLatencyMs()).isLessThan(10.0);
+        assertThat(stats.p99LatencyMs()).isLessThan(100.0);
 
         // Verify metric recorded
         var snapshot = metrics.getSnapshot();
@@ -245,9 +249,11 @@ class Phase5IntegrationTest {
         // Verify P99 latency is within expected range
         var stats = instrumentedChannel.getLatencyStats();
         assertThat(stats.p99LatencyMs()).isLessThan(100.0);  // Target: <100ms
-
-        // For in-memory, expect very low latency (<1ms)
-        assertThat(stats.p99LatencyMs()).isLessThan(1.0);
+        // Average bound replaces the former <1ms p99 assertion: with 100 samples, two CI
+        // scheduler hiccups push rank-99 p99 over a sub-ms bound (same class as
+        // Luciferase-d5afj), while the average dilutes them ~100x yet still catches a
+        // per-call regression in the sendBatch hot path.
+        assertThat(stats.avgLatencyMs()).isLessThan(5.0);
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes the CI batch-1 timing flake in `Phase5IntegrationTest.testLatencyTrackingEndToEnd` (28.16ms vs `p99 < 10ms`, first seen on portal-only PR #239 run 27443289525 — no simulation code changed, confirming runner contention). Bead: Luciferase-d5afj.

## Root cause

With only 10 latency samples, nearest-rank p99 **is** the max sample, so a single scheduler hiccup lands directly in the assertion. `testGhostLatencyUnder100ms`'s extra `p99 < 1ms` assertion was the same flake class in waiting.

## Remedy: avg-based regression bounds

Reviewer-shaped (substantive-critic round 1 found relax-only made the tests unable to catch a uniform 50ms regression). Instead of tight p99 bounds or the MultiBubbleLoadTest CI-disabled split:

| Test | Before | After |
|------|--------|-------|
| testLatencyTrackingEndToEnd (N=10) | p99 < 10ms | **avg < 10ms** + p99 < 100ms |
| testGhostLatencyUnder100ms (N=100) | p99 < 100ms, p99 < 1ms | p99 < 100ms + **avg < 5ms** |

The average dilutes a single hiccup ~N× (the actual flake event: 28ms spike over 10 samples → avg ≈ 2.8ms, passes) while a uniform hot-path regression in `InstrumentedGhostChannel.sendBatch`/`LatencyTracker.record` still fails. p99 keeps only the declared 100ms system target (`SimulationConfig.latencyAlertThresholdMs` default). Both tests keep running in CI — no coverage lost to `@DisabledIfEnvironmentVariable`.

TEST_FRAMEWORK_GUIDE gains entry #4 documenting thresholds, rationale, the deliberate divergence from the MultiBubbleLoadTest split pattern, and the root-cause pointer (Clock injection, Luciferase-mt7hi sweep).

## Review

Stacked review (code-review-expert + substantive-critic), two rounds; round 2 explicitly clean (0 Critical, 0 Significant). The critic verified the flake and regression scenarios numerically.

## Verification

- `Phase5IntegrationTest` all green locally (no-retry run)
- Flake event replay: passes new bounds; 50ms/5ms uniform regressions: fail