### PR TITLE
fix(simulation): surface tick failures + circuit-break GridMultiBubbleSimulation (Luciferase-a57pj)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/grid/GridMultiBubbleSimulation.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/grid/GridMultiBubbleSimulation.java
@@ -75,14 +75,32 @@ public class GridMultiBubbleSimulation implements AutoCloseable {
     // observation (Luciferase-jar).
     private final Object snapshotLock = new Object();
 
+    /**
+     * Number of <em>consecutive</em> failing ticks after which the simulation circuit-breaks: it logs a
+     * fatal, cancels the scheduled tick task, and transitions to a terminal {@code failed} state instead of
+     * silently hot-looping a deterministically-broken tick every {@link #DEFAULT_TICK_INTERVAL_MS} ms
+     * forever (Luciferase-a57pj). A transient failure self-heals — a single successful tick resets the
+     * consecutive counter, so only a sustained streak trips the breaker.
+     */
+    static final int MAX_CONSECUTIVE_TICK_FAILURES = 10;
+
     private final ScheduledExecutorService scheduler;
     private final AtomicBoolean running = new AtomicBoolean(false);
     private final AtomicLong tickCount = new AtomicLong(0);
     private final AtomicLong currentBucket = new AtomicLong(0);
+    // Tick-failure observability + circuit-break state (Luciferase-a57pj). tickFailureCount is a lifetime
+    // counter (cumulative across restarts); consecutiveTickFailures resets to 0 on any successful tick and
+    // drives the circuit-breaker; failed is the terminal state set when the breaker trips.
+    private final AtomicLong tickFailureCount = new AtomicLong(0);
+    private final AtomicLong consecutiveTickFailures = new AtomicLong(0);
+    private volatile boolean failed = false;
     private final SimulationMetrics metrics = new SimulationMetrics();
     private volatile Clock clock = Clock.system();
 
-    private ScheduledFuture<?> tickTask;
+    // volatile: written by the caller thread in start()/stop(), read by the scheduler thread in tick()'s
+    // circuit-break path. Without it the first tick (initialDelay=0) could read a stale null and skip the
+    // cancel, leaving the task hot-looping despite the breaker tripping (Luciferase-a57pj review).
+    private volatile ScheduledFuture<?> tickTask;
 
     /**
      * Create a multi-bubble simulation with default behavior.
@@ -154,6 +172,9 @@ public class GridMultiBubbleSimulation implements AutoCloseable {
      */
     public void start() {
         if (running.compareAndSet(false, true)) {
+            // Clear circuit-break state so a restart begins healthy (lifetime tickFailureCount is retained).
+            failed = false;
+            consecutiveTickFailures.set(0);
             initializeVelocities();
 
             tickTask = scheduler.scheduleAtFixedRate(
@@ -207,10 +228,49 @@ public class GridMultiBubbleSimulation implements AutoCloseable {
     }
 
     /**
-     * Get tick count.
+     * Get the number of <em>successful</em> ticks completed.
+     * <p>
+     * This counts ticks that ran to completion, NOT scheduler invocations: a tick that throws is counted by
+     * {@link #getTickFailureCount()} instead, so under failures this value diverges (downward) from the
+     * number of times the scheduler fired (Luciferase-a57pj).
      */
     public long getTickCount() {
         return tickCount.get();
+    }
+
+    /**
+     * Get the lifetime count of failing ticks (cumulative across restarts). A failing tick is one whose
+     * body threw; the exception is swallowed to keep the scheduled task alive, but counted here so the
+     * failure is observable. See {@link #getConsecutiveTickFailures()} and {@link #isFailed()}.
+     */
+    public long getTickFailureCount() {
+        return tickFailureCount.get();
+    }
+
+    /**
+     * Get the current run of consecutive failing ticks. Reset to 0 by any successful tick (so transient
+     * failures self-heal); reaching {@link #MAX_CONSECUTIVE_TICK_FAILURES} trips the circuit-breaker
+     * ({@link #isFailed()}).
+     */
+    public long getConsecutiveTickFailures() {
+        return consecutiveTickFailures.get();
+    }
+
+    /**
+     * Whether the simulation has circuit-broken: {@link #MAX_CONSECUTIVE_TICK_FAILURES} consecutive ticks
+     * failed, so the scheduled task was cancelled and the simulation halted in a terminal FAILED state.
+     * A subsequent {@link #start()} clears this.
+     */
+    public boolean isFailed() {
+        return failed;
+    }
+
+    /**
+     * Whether the simulation is running and has not circuit-broken. A supervisor wanting a finer signal can
+     * additionally inspect {@link #getConsecutiveTickFailures()} (running with a non-zero streak = degraded).
+     */
+    public boolean isHealthy() {
+        return running.get() && !failed;
     }
 
     /**
@@ -418,6 +478,8 @@ public class GridMultiBubbleSimulation implements AutoCloseable {
 
             tickCount.incrementAndGet();
             currentBucket.incrementAndGet();
+            // Successful tick — clear any in-progress failure streak so transient failures self-heal.
+            consecutiveTickFailures.set(0);
 
             // Log periodically
             long currentTick = tickCount.get();
@@ -428,7 +490,28 @@ public class GridMultiBubbleSimulation implements AutoCloseable {
             }
 
         } catch (Exception e) {
-            log.error("Error in simulation tick: {}", e.getMessage(), e);
+            // RDR / Luciferase-a57pj: scheduleAtFixedRate keeps the task alive only because we swallow here;
+            // without a failure surface a deterministically-broken tick would hot-loop every 16ms forever and
+            // tickCount (a success counter) would silently diverge from scheduler invocations. Count the
+            // failure, and circuit-break after a sustained streak so the breakage is loud and bounded.
+            long total = tickFailureCount.incrementAndGet();
+            long consecutive = consecutiveTickFailures.incrementAndGet();
+            log.error("Error in simulation tick (lifetime failures={}, consecutive={}/{}): {}",
+                      total, consecutive, MAX_CONSECUTIVE_TICK_FAILURES, e.getMessage(), e);
+
+            if (consecutive >= MAX_CONSECUTIVE_TICK_FAILURES) {
+                // Order matters for observers polling both flags: clear running first, then set failed, so a
+                // reader never sees the inconsistent (running && failed) pair — only ever (running && !failed),
+                // (!running && !failed) transiently, or the terminal (!running && failed).
+                running.set(false);
+                failed = true;
+                var task = tickTask;
+                if (task != null) {
+                    task.cancel(false);  // safe from the scheduler thread; false = don't self-interrupt
+                }
+                log.error("GridMultiBubbleSimulation circuit-break: {} consecutive tick failures — halting "
+                          + "(terminal FAILED state). Last error: {}", consecutive, e.getMessage());
+            }
         }
     }
 

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/grid/GridMultiBubbleSimulationTickFailureTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/grid/GridMultiBubbleSimulationTickFailureTest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase Simulation Framework.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.distributed.grid;
+
+import com.hellblazer.luciferase.simulation.behavior.FlockingBehavior;
+import com.hellblazer.luciferase.simulation.config.WorldBounds;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tick-failure observability + circuit-break behavior (Luciferase-a57pj).
+ *
+ * <p>{@code tick()} runs on a {@code scheduleAtFixedRate} task and swallows exceptions to keep that task
+ * alive. Before this fix a deterministically-failing tick was silently retried every 16ms forever with no
+ * failure surface beyond a log line, and {@code tickCount} (a success counter) diverged silently from
+ * scheduler invocations. These tests pin the fix: failures are counted, a sustained streak circuit-breaks
+ * to a terminal FAILED state (cancelling the task), and a sub-threshold transient self-heals.
+ *
+ * <p>The failure is injected at {@code tick()}'s outer-try seam — {@code FlockingBehavior.swapVelocityBuffers()},
+ * which (unlike the per-entity {@code computeVelocity} path) is NOT wrapped in an inner catch, so a throw
+ * there propagates to the tick-level handler under test.
+ *
+ * @author hal.hildebrand
+ */
+class GridMultiBubbleSimulationTickFailureTest {
+
+    /** FlockingBehavior whose per-tick buffer swap always throws — every tick fails deterministically. */
+    private static final class AlwaysThrowingFlocking extends FlockingBehavior {
+        @Override
+        public void swapVelocityBuffers() {
+            throw new IllegalStateException("test-injected deterministic tick failure");
+        }
+    }
+
+    /** FlockingBehavior that throws on its first {@code failTimes} ticks, then behaves normally. */
+    private static final class FlakyFlocking extends FlockingBehavior {
+        private final int failTimes;
+        private int calls = 0;  // touched only on the single scheduler thread
+
+        FlakyFlocking(int failTimes) {
+            this.failTimes = failTimes;
+        }
+
+        @Override
+        public void swapVelocityBuffers() {
+            if (calls++ < failTimes) {
+                throw new IllegalStateException("test-injected transient tick failure #" + calls);
+            }
+            super.swapVelocityBuffers();
+        }
+    }
+
+    @Test
+    void sustainedTickFailuresCircuitBreakToTerminalFailedState() {
+        var config = GridConfiguration.DEFAULT_2X2;
+        try (var sim = new GridMultiBubbleSimulation(config, 50, WorldBounds.DEFAULT, new AlwaysThrowingFlocking())) {
+            sim.start();
+
+            // Every tick throws → after MAX_CONSECUTIVE_TICK_FAILURES the breaker trips and halts the sim.
+            await("circuit-break to FAILED")
+                .atMost(Duration.ofSeconds(10))
+                .until(sim::isFailed);
+
+            assertFalse(sim.isRunning(), "circuit-break must halt the simulation (running=false)");
+            assertFalse(sim.isHealthy(), "a circuit-broken simulation is not healthy");
+            assertEquals(0L, sim.getTickCount(),
+                    "no tick ever succeeded, so the success counter must stay 0 (it must NOT track invocations)");
+            assertTrue(sim.getConsecutiveTickFailures() >= GridMultiBubbleSimulation.MAX_CONSECUTIVE_TICK_FAILURES,
+                    "the breaker trips only after MAX_CONSECUTIVE_TICK_FAILURES consecutive failures");
+            assertTrue(sim.getTickFailureCount() >= GridMultiBubbleSimulation.MAX_CONSECUTIVE_TICK_FAILURES,
+                    "every failing tick must be counted as a lifetime failure");
+
+            // The task was cancelled, so the failure counters stop advancing — confirm it really halted and
+            // is not still hot-looping (the silent-retry defect this bead fixes).
+            long failuresAtBreak = sim.getTickFailureCount();
+            await("no further ticks fire after the breaker trips")
+                .during(Duration.ofMillis(200))
+                .atMost(Duration.ofSeconds(2))
+                .until(() -> sim.getTickFailureCount() == failuresAtBreak);
+        }
+    }
+
+    @Test
+    void subThresholdTransientFailuresSelfHealWithoutCircuitBreaking() {
+        var transientFailures = GridMultiBubbleSimulation.MAX_CONSECUTIVE_TICK_FAILURES - 1;
+        var config = GridConfiguration.DEFAULT_2X2;
+        try (var sim = new GridMultiBubbleSimulation(config, 50, WorldBounds.DEFAULT,
+                                                     new FlakyFlocking(transientFailures))) {
+            sim.start();
+
+            // After the transient streak the next tick succeeds; a success must reset the consecutive counter
+            // so the breaker never trips.
+            await("a tick eventually succeeds after the transient failures")
+                .atMost(Duration.ofSeconds(10))
+                .until(() -> sim.getTickCount() > 0);
+
+            assertFalse(sim.isFailed(), "a sub-threshold transient must NOT circuit-break the simulation");
+            assertTrue(sim.isHealthy(), "the simulation must remain healthy after self-healing");
+            assertEquals(0L, sim.getConsecutiveTickFailures(),
+                    "a successful tick must reset the consecutive-failure streak to 0");
+            // Exact count is robust here (not flaky): the scheduler is single-threaded and FlakyFlocking.calls
+            // is monotone, so every tick after the transient streak succeeds — no further failures can be
+            // counted, and tickFailureCount is pinned at exactly transientFailures regardless of how many more
+            // successful ticks fire before this assertion runs.
+            assertEquals(transientFailures, sim.getTickFailureCount(),
+                    "exactly the injected transient failures must be counted (no more, no fewer)");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a silent-failure bug in `GridMultiBubbleSimulation.tick()` (found by substantive-critic during the ez6ej review). `tick()` runs on a `scheduleAtFixedRate` task and swallows exceptions to keep that task alive — but before this fix a **deterministically-failing tick was silently retried every 16ms forever**, with no failure surface beyond a log line, and `tickCount` (a success counter) silently diverged from scheduler invocations.

Approach **C — observe + circuit-break** (user-approved via brainstorming gate).

## Changes

- **Observe**: `tickFailureCount` (lifetime) + `consecutiveTickFailures` (resets to 0 on any successful tick, so transient failures self-heal).
- **Circuit-break**: after `MAX_CONSECUTIVE_TICK_FAILURES` (10) consecutive failures, log fatal, cancel the tick task, and enter a terminal **FAILED** state (`running=false`) instead of hot-looping a broken tick forever.
- **Surface**: `getTickFailureCount()` / `getConsecutiveTickFailures()` / `isFailed()` / `isHealthy()`; `getTickCount()` javadoc now documents its success-counter semantics (the previously-undocumented attempts-vs-successes ambiguity the bead asked to resolve).
- **Restart**: `start()` clears `failed` + consecutive so a restart begins healthy (lifetime failure count retained).

## Test

`GridMultiBubbleSimulationTickFailureTest`:
- `sustainedTickFailuresCircuitBreakToTerminalFailedState` — every tick throws → breaker trips → halted, `tickCount==0`, counters ≥ threshold, plus a `.during(...)` check that **no further ticks fire** after the break (proving the silent-retry hot-loop is actually stopped).
- `subThresholdTransientFailuresSelfHealWithoutCircuitBreaking` — 9 transient failures then success → never breaks, stays healthy, consecutive resets to 0.

Failures are injected at `tick()`'s outer-try seam (`FlockingBehavior.swapVelocityBuffers`), distinct from the per-entity inner catch.

## Verification

- 18/18 (2 new + 16 existing `GridMultiBubbleSimulationTest`) green.
- Stacked review (code-review-expert + substantive-critic), round-2 clean: **0 Critical / 0 Significant**. Round-1 caught two real concurrency issues, both fixed: `tickTask` made `volatile` (first-tick null-cancel race between the caller-thread write and scheduler-thread read), and the breaker writes `running=false` before `failed=true` so observers never see an inconsistent `(running && failed)`.

## Scope note

The sibling per-entity swallow in `updateBubbleEntities` (`computeVelocity` wrapped in its own inner catch) is a **distinct** defect at a different granularity — intentionally out of scope here.