### PR TITLE
test(lucien): de-flake partition fault injection via awaitable Future (Luciferase-8brw9)

### DIFF
--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/P441IntegrationTestFixtureTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/P441IntegrationTestFixtureTest.java
@@ -57,17 +57,20 @@ class P441IntegrationTestFixtureTest {
     }
 
     @Test
-    void testPartitionFailureInjection() throws InterruptedException {
+    void testPartitionFailureInjection() throws Exception {
         // Given: Forest with 3 partitions and configured handler
         var forest = fixture.setupForestWithPartitions(3);
         fixture.configureFaultHandler();
         var partitionId = forest.getPartitionIds().iterator().next();
 
         // When: Inject partition failure with 100ms delay
-        fixture.injectPartitionFailure(partitionId, 100);
+        var injection = fixture.injectPartitionFailure(partitionId, 100);
 
-        // Then: Partition should fail after delay
-        Thread.sleep(150); // Wait for failure
+        // Then: once the (background) injection actually completes, the partition is unhealthy.
+        // Await the injection Future rather than sleeping a fixed margin over the delay — the
+        // injection runs on a background thread, so a fixed Thread.sleep(150) raced it under CI
+        // load and intermittently asserted before the partition was marked failed (Luciferase-8brw9).
+        injection.get(5, TimeUnit.SECONDS);
         assertFalse(
             forest.isPartitionHealthy(partitionId),
             "Partition should be marked unhealthy"

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/Phase43IntegrationTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/Phase43IntegrationTest.java
@@ -129,19 +129,22 @@ class Phase43IntegrationTest {
         fixture.injectPartitionFailure(partition1, 0);
         Thread.sleep(50);
 
-        // Fail partition 2 after 100ms
-        fixture.injectPartitionFailure(partition2, 100);
+        // Fail partition 2 after 100ms, partition 3 after 200ms (cascading). Capture the injection
+        // futures so each partition's failure is deterministically awaited before its recovery starts,
+        // rather than racing a fixed sleep margin over the background injection under CI load
+        // (Luciferase-8brw9, same latent flake fixed in P441IntegrationTestFixtureTest).
+        var fail2 = fixture.injectPartitionFailure(partition2, 100);
+        var fail3 = fixture.injectPartitionFailure(partition3, 200);
 
-        // Fail partition 3 after 200ms
-        fixture.injectPartitionFailure(partition3, 200);
-
-        // Start recoveries for all three
+        // Start recoveries for all three, each only after its partition has actually failed.
         var result1Future = recovery1.recover(partition1, handler);
-        Thread.sleep(100); // Wait for first to start
+        Thread.sleep(100); // Stagger: let the first recovery get underway
 
+        fail2.get(5, TimeUnit.SECONDS);
         var result2Future = recovery2.recover(partition2, handler);
-        Thread.sleep(100); // Wait for second to start
+        Thread.sleep(100); // Stagger: let the second recovery get underway
 
+        fail3.get(5, TimeUnit.SECONDS);
         var result3Future = recovery3.recover(partition3, handler);
 
         // Then: All recoveries should complete

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/testinfra/IntegrationTestFixture.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/testinfra/IntegrationTestFixture.java
@@ -130,9 +130,14 @@ public class IntegrationTestFixture {
      *
      * @param partitionId partition UUID to fail
      * @param delayMs delay before failure in milliseconds (0 for immediate)
+     * @return a {@link Future} that completes once the failure has actually been injected and the
+     *         partition marked failed. For {@code delayMs == 0} this is an already-completed future.
+     *         Callers testing the delayed path should block on this (e.g. {@code .get(timeout, ...)})
+     *         instead of sleeping a fixed wall-clock interval — the injection runs on a background
+     *         thread, so a fixed sleep races the injection under load (Luciferase-8brw9).
      * @throws IllegalStateException if forest or handler not configured
      */
-    public void injectPartitionFailure(UUID partitionId, int delayMs) {
+    public Future<?> injectPartitionFailure(UUID partitionId, int delayMs) {
         if (currentForest == null) {
             throw new IllegalStateException("Forest not configured - call setupForestWithPartitions first");
         }
@@ -144,9 +149,11 @@ public class IntegrationTestFixture {
             // Immediate failure
             currentHandler.injectFailure(partitionId);
             currentForest.markPartitionFailed(partitionId);
+            return CompletableFuture.completedFuture(null);
         } else {
-            // Delayed failure
-            executorService.submit(() -> {
+            // Delayed failure — the returned Future lets callers await the actual injection
+            // deterministically rather than guessing a wall-clock margin over delayMs.
+            return executorService.submit(() -> {
                 try {
                     Thread.sleep(delayMs);
                     currentHandler.injectFailure(partitionId);


### PR DESCRIPTION
## Summary

Fixes the flaky `P441IntegrationTestFixtureTest.testPartitionFailureInjection` (`'Partition should be marked unhealthy' expected false but was true` — timing-dependent in CI).

**Root cause**: `IntegrationTestFixture.injectPartitionFailure(id, delayMs)` submits a background task that does `Thread.sleep(delayMs)` then `markPartitionFailed`. The test injected with `delay=100` then did a fixed `Thread.sleep(150)` before asserting — a 50ms wall-clock margin that the background injection lost under CI load.

## Changes (test-only)

- `IntegrationTestFixture.injectPartitionFailure`: `void` → `Future<?>` — returns the `executorService.submit()` future for the delayed path, an already-completed future for the synchronous `delay=0` path. Callers testing the delayed path can now block on the actual injection instead of guessing a margin.
- `testPartitionFailureInjection`: `injection.get(5, TimeUnit.SECONDS)` replaces `Thread.sleep(150)`. A `FutureTask` completes only after the runnable body runs, so `markPartitionFailed` has executed before the assertion — a genuine happens-before, not a wider sleep.
- `Phase43IntegrationTest` (cascading-failure test): the same latent race — the delayed injections' futures are now captured and awaited before their recovery coordinators start.

## Compatibility

Backward-compatible: the 40+ `delay=0` callers ignore the return value (Java permits this), and the `delay=0` path stays fully synchronous with unchanged exception propagation. No new test dependency (the `Future` approach is cleaner than pulling Awaitility onto the lucien test classpath).

## Verification

- 21/21 green (P441 14 + Phase43 7); full lucien test-compile clean (all call sites).
- Stacked review (code-review-expert + substantive-critic), round-2 clean: **0 Critical / 0 Significant**. code-review-expert verified the `FutureTask` happens-before; substantive-critic's round-1 flagged the Phase43 sibling (fixed) and a P51 citation that turned out to be the separate `FaultInjector` class (out of scope).

## Follow-up

**Luciferase-uockh (P4)**: the separate `FaultInjector.injectPartitionFailure` delayed path has the same discard-future pattern (not yet observed flaking) — tracked for if/when it surfaces.