### PR TITLE
test(simulation): de-flake StreamingE2ETest via retry-driven streaming cycle (Luciferase-5ezt5)

### DIFF
--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/viz/render/StreamingE2ETest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/viz/render/StreamingE2ETest.java
@@ -109,21 +109,34 @@ class StreamingE2ETest {
         var movedKeys = facade.keysContaining(new Point3f(501, 501, 501), 4, 4);
         dirtyTracker.bumpAll(movedKeys);
 
-        // Submit and await the build so cache reflects the new version.
-        // StreamingCycle only pushes RegionUpdate when cache.version() == currentVersion;
-        // without awaiting the build, the cycle would submit a build but not push.
+        // Submit a build so the cache reflects the new version: StreamingCycle only pushes a
+        // RegionUpdate once cache.version() == currentVersion; otherwise a tick (re)submits a build
+        // but pushes nothing.
         for (var k : movedKeys) {
             buildQueue.submit(k, RegionBuilder.KeyedBuildRequest.Priority.VISIBLE);
         }
-        buildQueue.awaitBuilds().get(5, TimeUnit.SECONDS);
 
-        // Run streaming cycle with frozen clock so deadline never expires under CI load
+        // Run streaming cycle with frozen clock so the per-tick deadline never expires under CI load.
         var frozenClock = new TestClock(1_000_000_000L);
         var cycle = new StreamingCycle(facade, dirtyTracker, cache, buildQueue, subscriptions, frozenClock);
         subscriptions.updateViewport("e2e-sess", TestFrustums.fullScene(), 4);
-        cycle.tick(200_000_000L);
 
-        var updateMsg = client.nextServerMessage(500, TimeUnit.MILLISECONDS);
+        // Drive the build→cache→push pipeline to completion rather than asserting on a single shot.
+        // A build can fail transiently under heavy CI load — buildKeyed runs on RegionBuilder's
+        // buildPool and doBuild/ESVO serialization can throw IOException (e.g. under memory pressure).
+        // BuildQueue.awaitBuilds() shields that exception (.exceptionally(e->null)), so the cache stays
+        // stale and the tick re-submits instead of pushing. The production design is retry-based — a
+        // later tick re-submits and a later awaitBuilds delivers — so re-await + re-tick a bounded
+        // number of times here so a transient build failure self-heals (Luciferase-5ezt5). Once a
+        // RegionUpdate is pushed, the subscription's known version advances, so an extra tick will not
+        // double-push. (Note: the per-region circuit breaker is on RegionBuilder.build(BuildRequest),
+        // NOT this buildKeyed path, so it is not a failure mode here.)
+        ServerMessage updateMsg = null;
+        for (int attempt = 0; attempt < 10 && !(updateMsg instanceof ServerMessage.RegionUpdate); attempt++) {
+            buildQueue.awaitBuilds().get(5, TimeUnit.SECONDS); // deliver any (re)submitted build into cache
+            cycle.tick(200_000_000L);
+            updateMsg = client.nextServerMessage(200, TimeUnit.MILLISECONDS);
+        }
         assertInstanceOf(ServerMessage.RegionUpdate.class, updateMsg,
             "moved entity should trigger REGION_UPDATE via streaming cycle");
     }


### PR DESCRIPTION
## Summary

Fixes the intermittent `StreamingE2ETest.phaseCAndBFullFlow` (got `null` at the `REGION_UPDATE` assertion in CI batch-1).

**Diagnosis** (common causes ruled out by reading): `InProcessTransport` is fully synchronous (the 500ms read timeout was never the issue); `TestClock(1e9)` freezes `nanoTime()` so the per-tick deadline never fires; `awaitBuilds().get()` establishes cache visibility. The only async element is the build executor: `buildKeyed` runs on `RegionBuilder`'s `buildPool` and `doBuild`/ESVO serialization can throw `IOException` transiently under load. `BuildQueue.awaitBuilds()` **shields that exception** (`.exceptionally(e -> null)`), so the cache stays stale and `StreamingCycle.tick` re-submits a build instead of pushing → `null`.

The production delivery model is **retry-based** (the cache updates only via `awaitBuilds → deliverPending`; a cache-stale tick re-submits for a later tick to deliver), so the single-shot test did not model it.

## Change (test-only)

Replace the one-shot `awaitBuilds + tick + nextServerMessage(500ms) + assert` with a **bounded loop** (≤10 attempts) that re-awaits builds and re-ticks until the `RegionUpdate` is delivered. A transient build failure self-heals. Non-vacuous: if no `RegionUpdate` ever arrives, the final `assertInstanceOf` fails on `null`. No double-push — the subscription's known version advances on push, so an extra tick is a no-op.

## Verification

- Green locally; 12/12 + 5/5 stable under 16-stressor CPU contention (the original flake never reproduced locally — a rare CI-load hiccup).
- Stacked review (code-review-expert + substantive-critic), round-2 clean: **0 Critical / 0 Significant**. Round-1 caught that my comment mis-named the per-region circuit breaker as the cause — it's only on `RegionBuilder.build(BuildRequest)`, **not** the `buildKeyed` path `BuildQueue.submit` uses; corrected to the real `IOException` mode.

## Follow-up

**Luciferase-8pygn (P3)**: the production observability gap — `BuildQueue.awaitBuilds` silently swallows build failures, leaving the cache permanently stale with no alarm/metric path (only a single `log.warn`). Distinct from this test fix.