### PR TITLE
test(render): guard DynamicKernelSelectionTest behind RUN_GPU_TESTS (Luciferase-vkl96)

### DIFF
--- a/render/src/test/java/com/hellblazer/luciferase/esvo/gpu/DynamicKernelSelectionTest.java
+++ b/render/src/test/java/com/hellblazer/luciferase/esvo/gpu/DynamicKernelSelectionTest.java
@@ -23,7 +23,7 @@ import com.hellblazer.luciferase.esvo.dag.DAGOctreeData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -40,8 +40,16 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author hal.hildebrand
  */
 @DisplayName("Phase 4.2.2b: Dynamic Kernel Selection")
-@DisabledIfEnvironmentVariable(named = "CI", matches = "true",
-        disabledReason = "Requires GPU hardware not available in CI")
+// GPU device-probing test: every case constructs a DAGOpenCLRenderer and calls initialize() (OpenCL
+// kernel compilation + device selection). On macOS/GraalVM the device probe can crash the surefire fork
+// (exit 133, "terminated without properly saying goodbye"), aborting the whole render module run when not
+// excluded (Luciferase-vkl96). Guard it as opt-in like the other device-touching GPU tests
+// (DAGOpenCLRendererVendorTest, ESVOOpenCLRendererFarPointerTest): it runs only when RUN_GPU_TESTS=true,
+// so normal local + CI runs skip it (RUN_GPU_TESTS unset) instead of crashing. This subsumes the prior
+// CI-only disable — RUN_GPU_TESTS is unset in CI too.
+@EnabledIfEnvironmentVariable(named = "RUN_GPU_TESTS", matches = "true",
+        disabledReason = "GPU device probing crashes the surefire fork on macOS/GraalVM (Luciferase-vkl96); "
+                + "opt-in via RUN_GPU_TESTS=true on a machine with working OpenCL")
 class DynamicKernelSelectionTest {
 
     private DAGOpenCLRenderer renderer;


### PR DESCRIPTION
## Summary

`DynamicKernelSelectionTest` crashed the surefire fork (exit 133, "terminated without properly saying goodbye") during OpenCL device probing on local macOS/GraalVM runs, aborting the **entire render module** when not excluded. It was only guarded by `@DisabledIfEnvironmentVariable(CI)`, so it ran — and crashed — on every local run.

## Change (test-only)

Every test constructs a `DAGOpenCLRenderer` and calls `initialize()` (kernel compilation + device selection), so the whole class is device-touching. Guard it as **opt-in** like the other device-touching GPU tests (`DAGOpenCLRendererVendorTest` Tier 2, `ESVOOpenCLRendererFarPointerTest`):

`@EnabledIfEnvironmentVariable(named = "RUN_GPU_TESTS", matches = "true")` at class level — it runs only when `RUN_GPU_TESTS=true` on a machine with working OpenCL; normal local + CI runs skip it (`RUN_GPU_TESTS` unset). This **subsumes** the prior CI-only disable.

## Verification

- Without `RUN_GPU_TESTS`: `DynamicKernelSelectionTest` reports **Skipped:8, BUILD SUCCESS** — no fork crash (previously exit 133).
- Zero reliable coverage lost: the class only ever crashed the fork before; it now becomes actually executable on GPU hardware via the opt-in.
- Stacked review (code-review-expert + substantive-critic): **0 Critical / 0 Significant** blocking. Class-level guard confirmed correct (no device-free tests to split, unlike `DAGOpenCLRendererVendorTest`'s Tier 1).

## Follow-up

**Luciferase-qe8p0 (P3)**: investigate whether the exit-133 crash is a surefire/`-XstartOnFirstThread` fork-isolation artifact or a production-reachable native crash in `DAGOpenCLRenderer.initialize()` / `VendorKernelConfig` device probing (classify via `hs_err` + standalone repro). The quarantine is the correct interim disposition; root-causing the native crash is separate.