### PR TITLE
feat(simulation): surface BuildQueue build-failure count (Luciferase-8pygn)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/viz/render/BuildQueue.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/viz/render/BuildQueue.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Deduplicating build dispatcher. At most one in-flight build per SpatialKey<?>.
@@ -60,6 +61,15 @@ public final class BuildQueue {
      */
     private final ConcurrentHashMap<SpatialKey<?>, RegionBuilder.BuiltKeyedRegion> pending =
         new ConcurrentHashMap<>();
+    /**
+     * Lifetime count of builds that completed exceptionally (Luciferase-8pygn). A failed build is
+     * swallowed — it produces no {@code pending} entry, so {@code deliverPending} never updates the
+     * cache for that key and the region stays stale until a later resubmit succeeds. Without a surfaced
+     * count, a persistently-failing region (e.g. an {@code IOException} in ESVO serialization under
+     * memory pressure) would silently never receive cache updates. Exposed via
+     * {@link #getTotalBuildFailures()} so callers/monitors can detect the condition.
+     */
+    private final AtomicLong totalBuildFailures = new AtomicLong(0);
 
     public BuildQueue(SpatialIndexFacade facade, DirtyTracker dirtyTracker,
                       RegionBuilder builder, BuildCompleteCallback callback) {
@@ -88,7 +98,12 @@ public final class BuildQueue {
                               if (result != null) {
                                   pending.put(k, result);
                               } else if (err != null) {
-                                  log.warn("Build failed for key {}: {}", k, err.getMessage());
+                                  // Swallowed failure: no pending entry → cache stays stale for this key
+                                  // until a later resubmit succeeds. Count it and log at error so the
+                                  // otherwise-silent staleness is observable (Luciferase-8pygn).
+                                  long failureCount = totalBuildFailures.incrementAndGet();
+                                  log.error("Build failed for key {} (cache left stale, lifetime failures={}): {}",
+                                            k, failureCount, err.getMessage(), err);
                               }
                               inFlight.remove(k);
                           })
@@ -128,6 +143,17 @@ public final class BuildQueue {
      */
     public boolean isInFlight(SpatialKey<?> key) {
         return inFlight.containsKey(key);
+    }
+
+    /**
+     * Lifetime count of builds that completed exceptionally (Luciferase-8pygn). A non-zero, growing
+     * value means region builds are failing and their cache entries are going stale — a monitor/supervisor
+     * can alarm on this rather than discovering the silent staleness only via missing visual updates.
+     *
+     * @return the number of failed builds since this queue was created
+     */
+    public long getTotalBuildFailures() {
+        return totalBuildFailures.get();
     }
 
     /**

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/viz/render/BuildQueueTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/viz/render/BuildQueueTest.java
@@ -75,4 +75,48 @@ class BuildQueueTest {
         }
         assertEquals(0, completedCount.get(), "stale build must be discarded");
     }
+
+    /**
+     * A failed build (the future completes exceptionally) must be counted via
+     * {@link BuildQueue#getTotalBuildFailures()} and must NOT update the cache — the region is left stale
+     * for a later resubmit, but the failure is now observable rather than silently swallowed
+     * (Luciferase-8pygn).
+     */
+    @Test
+    void failedBuildIsCountedAndLeavesCacheStale() throws Exception {
+        var facade = new OctreeSpatialIndexFacade(4, 8);
+        facade.put(1L, new Point3f(100, 100, 100));
+        var key = facade.keysContaining(new Point3f(100, 100, 100), 4, 4).iterator().next();
+
+        var tracker = new DirtyTracker();
+        tracker.bump(key);
+
+        var cacheUpdates = new AtomicInteger(0);
+        try (var builder = new FailingRegionBuilder()) {
+            var queue = new BuildQueue(facade, tracker, builder, (k, v, data) -> cacheUpdates.incrementAndGet());
+
+            queue.submit(key, RegionBuilder.KeyedBuildRequest.Priority.VISIBLE);
+            queue.awaitBuilds().get(5, TimeUnit.SECONDS);
+
+            assertEquals(1, queue.getTotalBuildFailures(),
+                         "a build that completes exceptionally must be counted, not silently swallowed");
+            assertEquals(0, cacheUpdates.get(),
+                         "a failed build must NOT update the cache (the region is left stale for resubmit)");
+        }
+    }
+
+    /** RegionBuilder whose every keyed build completes exceptionally — exercises the failure path. */
+    private static final class FailingRegionBuilder extends RegionBuilder {
+        FailingRegionBuilder() {
+            super(1, 10, 8, 64);
+        }
+
+        @Override
+        public java.util.concurrent.CompletableFuture<BuiltKeyedRegion> buildKeyed(
+                com.hellblazer.luciferase.lucien.SpatialKey<?> key,
+                SpatialIndexFacade facade, long buildVersion) {
+            return java.util.concurrent.CompletableFuture.failedFuture(
+                new java.io.IOException("test-injected build failure"));
+        }
+    }
 }


### PR DESCRIPTION
## Summary

A build that completed exceptionally was logged at `warn` and **swallowed**: no `pending` entry, so `deliverPending` never updated the cache for that key — the region stayed stale until a later resubmit succeeded, with no counter, metric, or alarm path. This is the production observability gap behind the 5ezt5 streaming flake.

Approach A (observe-only, user-approved).

## Changes

- Add a lifetime `totalBuildFailures` `AtomicLong`, incremented in `submit()`'s `whenComplete` error branch, exposed via `getTotalBuildFailures()` — a monitor can alarm on growing failures instead of discovering staleness via missing visual updates.
- Elevate the swallowed-failure log `warn → error` (a stale cache is a real degradation), logging the captured failure count.

No retry/policy change: `StreamingCycle` already re-submits on a stale cache, so transient failures self-heal. Per-key health + retry/backoff are **deferred** (observe-only is the minimum viable surface; this counter is the prerequisite hook).

## Verification

- New test `failedBuildIsCountedAndLeavesCacheStale`: a `FailingRegionBuilder` (`buildKeyed` returns a failed future) increments the counter to 1 and leaves the cache un-updated (callback not invoked). `BuildQueueTest` 3/3 green.
- Stacked review (code-review-expert + substantive-critic), round-2 clean: **0 Critical / 0 Significant**. Round-1 caught a racy log count (read `.get()` after discarding `incrementAndGet()`'s return) — fixed by capturing the atomic return.