### PR TITLE
feat(simulation): surface per-entity update-failure count (Luciferase-nqk13)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/grid/GridMultiBubbleSimulation.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/grid/GridMultiBubbleSimulation.java
@@ -93,6 +93,13 @@ public class GridMultiBubbleSimulation implements AutoCloseable {
     // drives the circuit-breaker; failed is the terminal state set when the breaker trips.
     private final AtomicLong tickFailureCount = new AtomicLong(0);
     private final AtomicLong consecutiveTickFailures = new AtomicLong(0);
+    // Per-entity update-failure observability (Luciferase-nqk13). updateBubbleEntities isolates a
+    // throwing entity (logs + continues to the next) so one bad entity never aborts a whole bubble's
+    // tick — but that swallow was otherwise invisible. This counts failure EVENTS, not distinct entities:
+    // one increment per failing entity per tick, so a single persistently-failing entity contributes one
+    // count every tick (~60/s at 60 Hz). The aggregate flags THAT failures are happening; the per-failure
+    // error log carries entity.id() to identify WHICH entity is stuck.
+    private final AtomicLong entityUpdateFailureCount = new AtomicLong(0);
     private volatile boolean failed = false;
     private final SimulationMetrics metrics = new SimulationMetrics();
     private volatile Clock clock = Clock.system();
@@ -245,6 +252,21 @@ public class GridMultiBubbleSimulation implements AutoCloseable {
      */
     public long getTickFailureCount() {
         return tickFailureCount.get();
+    }
+
+    /**
+     * Get the lifetime count of per-entity update-failure <em>events</em> (Luciferase-nqk13).
+     * {@code updateBubbleEntities} isolates a throwing entity (skips it and continues) so one bad entity
+     * cannot abort a bubble's tick; each such skip is counted here.
+     * <p>
+     * <b>This counts events, not distinct entities.</b> A single persistently-failing entity adds one count
+     * per tick (e.g. ~60/s at 60 Hz), so a large value may be one stuck entity over time, not many entities.
+     * Use it to detect THAT per-entity failures are occurring; consult the error log (which includes the
+     * failing {@code entity.id()}) to identify WHICH entity is stuck. Distinct from a whole-tick failure
+     * ({@link #getTickFailureCount()}), which the per-entity catch prevents from propagating.
+     */
+    public long getEntityUpdateFailureCount() {
+        return entityUpdateFailureCount.get();
     }
 
     /**
@@ -548,7 +570,12 @@ public class GridMultiBubbleSimulation implements AutoCloseable {
 
                 bubble.updateEntityPosition(entity.id(), newPosition);
             } catch (Exception e) {
-                log.error("Failed to update entity {}: {}", entity.id(), e.getMessage());
+                // Per-entity isolation (intentional): a throwing entity is skipped so it cannot abort the
+                // whole bubble's tick. Count it (Luciferase-nqk13) so the otherwise-silent swallow is
+                // observable via getEntityUpdateFailureCount().
+                long failures = entityUpdateFailureCount.incrementAndGet();
+                log.error("Failed to update entity {} (lifetime entity-update failures={}): {}",
+                          entity.id(), failures, e.getMessage(), e);
             }
         }
     }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/grid/GridMultiBubbleSimulationEntityFailureTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/grid/GridMultiBubbleSimulationEntityFailureTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2025, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.simulation.distributed.grid;
+
+import com.hellblazer.luciferase.simulation.behavior.FlockingBehavior;
+import com.hellblazer.luciferase.simulation.config.WorldBounds;
+import org.junit.jupiter.api.Test;
+
+import javax.vecmath.Point3f;
+import javax.vecmath.Vector3f;
+import java.time.Duration;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Per-entity update-failure observability (Luciferase-nqk13).
+ *
+ * <p>{@code updateBubbleEntities} isolates a throwing entity — it logs and continues to the next entity so
+ * one bad entity cannot abort a whole bubble's tick. That swallow was previously invisible. These tests pin
+ * the fix: per-entity failures are counted ({@link GridMultiBubbleSimulation#getEntityUpdateFailureCount()})
+ * AND the isolation holds (the tick still succeeds, the simulation stays healthy, and tickCount advances —
+ * a per-entity failure does NOT trip the tick-level circuit-breaker).
+ *
+ * @author hal.hildebrand
+ */
+class GridMultiBubbleSimulationEntityFailureTest {
+
+    /** FlockingBehavior whose per-entity velocity computation always throws — every entity update fails. */
+    private static final class ThrowingComputeVelocity extends FlockingBehavior {
+        @Override
+        public Vector3f computeVelocity(String entityId, Point3f position, Vector3f velocity,
+                                        com.hellblazer.luciferase.simulation.bubble.EnhancedBubble bubble,
+                                        float deltaTime) {
+            throw new IllegalStateException("test-injected per-entity update failure for " + entityId);
+        }
+    }
+
+    @Test
+    void perEntityUpdateFailuresAreCountedAndIsolated() {
+        var config = GridConfiguration.DEFAULT_2X2;
+        try (var sim = new GridMultiBubbleSimulation(config, 20, WorldBounds.DEFAULT, new ThrowingComputeVelocity())) {
+            sim.start();
+
+            // Every entity's computeVelocity throws → the per-entity catch counts each and continues.
+            await("per-entity failures are surfaced")
+                .atMost(Duration.ofSeconds(10))
+                .until(() -> sim.getEntityUpdateFailureCount() > 0);
+
+            // Isolation held: a per-entity failure must NOT trip the tick-level breaker — the tick itself
+            // completes (the catch is inside the per-entity loop), so the sim stays healthy and ticks advance.
+            assertFalse(sim.isFailed(),
+                        "a per-entity update failure must be isolated — it must NOT circuit-break the tick");
+            assertTrue(sim.isHealthy(), "the simulation must remain healthy despite per-entity failures");
+            await("ticks keep advancing despite per-entity failures")
+                .atMost(Duration.ofSeconds(10))
+                .until(() -> sim.getTickCount() > 0);
+            assertEquals(0L, sim.getTickFailureCount(),
+                         "per-entity failures must not be counted as tick failures (distinct surfaces)");
+        }
+    }
+
+    @Test
+    void healthyEntitiesProduceNoUpdateFailures() {
+        var config = GridConfiguration.DEFAULT_2X2;
+        // Default FlockingBehavior — no injected failures.
+        try (var sim = new GridMultiBubbleSimulation(config, 20, WorldBounds.DEFAULT)) {
+            sim.start();
+            await("simulation ticks").atMost(Duration.ofSeconds(10)).until(() -> sim.getTickCount() > 2);
+            assertEquals(0L, sim.getEntityUpdateFailureCount(),
+                         "a healthy simulation must report zero per-entity update failures");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`GridMultiBubbleSimulation.updateBubbleEntities` isolates a throwing entity (logs + continues to the next) so one bad entity cannot abort a whole bubble's tick — intentional, but the swallow was invisible (no counter/metric). Sibling of the tick-level a57pj fix.

Observe-only (isolation unchanged):

- Add a lifetime `entityUpdateFailureCount` `AtomicLong` incremented in the per-entity catch + `getEntityUpdateFailureCount()` getter; the error log now carries the count and the exception.
- It counts failure **events**, not distinct entities: one increment per failing entity per tick (~60/s at 60 Hz for a single stuck entity). The aggregate flags THAT failures occur; the error log's `entity.id()` identifies WHICH — documented on the getter to prevent magnitude misreads (the round-1 review point).

## Verification

- New `GridMultiBubbleSimulationEntityFailureTest`: a `FlockingBehavior` whose `computeVelocity` always throws drives the per-entity catch — the counter grows AND isolation holds (sim stays healthy, `tickCount` advances, `getTickFailureCount()==0`: the per-entity throw never reaches the tick-level catch). Plus a healthy-case zero-failures regression guard. 20 grid tests green.
- Stacked review (code-review-expert + substantive-critic), round-2 clean: **0 Critical / 0 Significant**. Round-1 flagged the event-vs-entity counter semantics (a stuck entity inflates the count) — fixed with explicit javadoc + the two-surface (counter detects / log identifies) framing.