### PR TITLE
test(lucien): make FaultInjector delayed injection awaitable (Luciferase-uockh)

### DIFF
--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/P51IntegrationTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/P51IntegrationTest.java
@@ -191,9 +191,12 @@ class P51IntegrationTest {
 
         // When: Inject concurrent failures
         injector.injectPartitionFailure(partition1, 0);
-        injector.injectPartitionFailure(partition3, 50); // Slight stagger
+        var fault3 = injector.injectPartitionFailure(partition3, 50); // Slight stagger
 
         var future1 = recovery1.recover(partition1, faultHandler);
+        // Deterministically wait for the staggered (background) failure of partition3 before recovering it,
+        // rather than racing a fixed margin over the 50ms delay (Luciferase-uockh).
+        injector.awaitCompletion(fault3).get(5, TimeUnit.SECONDS);
         var future3 = recovery3.recover(partition3, faultHandler);
 
         var result1 = future1.get(10, TimeUnit.SECONDS);
@@ -260,8 +263,9 @@ class P51IntegrationTest {
         );
         var faults = injector.injectCascadingFailures(failingPartitions, 200);
 
-        // Wait for cascade to complete
-        Thread.sleep(1000);
+        // Deterministically wait for the staggered cascade to actually complete, rather than a fixed
+        // 1s margin over the 200ms-stagger background injections (Luciferase-uockh).
+        injector.awaitAll(faults).get(10, TimeUnit.SECONDS);
 
         // Then: Validate system recovered
         var activePartitions = new HashSet<>(partitionIds);

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/testinfra/FaultInjector.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/testinfra/FaultInjector.java
@@ -48,6 +48,11 @@ public class FaultInjector {
     private final ExecutorService executor;
     private final Map<String, Consumer<UUID>> partitionFailureHandlers;
     private final AtomicInteger faultCounter;
+    // Completion handle per fault (keyed by faultId) so callers can deterministically await a DELAYED
+    // injection instead of racing a fixed sleep over the background executor (Luciferase-uockh; same
+    // class of fix as the IntegrationTestFixture Future return in Luciferase-8brw9). Immediate (delay=0)
+    // faults complete synchronously; their entry is an already-completed future.
+    private final Map<Integer, CompletableFuture<Void>> faultCompletions = new ConcurrentHashMap<>();
 
     // Network fault state
     private volatile double packetLossRate = 0.0;
@@ -118,21 +123,57 @@ public class FaultInjector {
         injectedFaults.add(fault);
 
         if (delayMs == 0) {
-            // Immediate failure
+            // Immediate failure — completes synchronously on the caller thread.
             invokePartitionFailureHandlers(partitionId);
+            faultCompletions.put(faultId, CompletableFuture.completedFuture(null));
         } else {
-            // Delayed failure
-            executor.submit(() -> {
+            // Delayed failure — track the completion so callers can await the actual injection
+            // (awaitCompletion) rather than racing a fixed sleep over this background task (Luciferase-uockh).
+            var completion = CompletableFuture.runAsync(() -> {
                 try {
                     Thread.sleep(delayMs);
-                    invokePartitionFailureHandlers(partitionId);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
+                    throw new CompletionException(e);
                 }
-            });
+                invokePartitionFailureHandlers(partitionId);
+            }, executor);
+            faultCompletions.put(faultId, completion);
         }
 
         return fault;
+    }
+
+    /**
+     * Completion handle for a previously-injected fault (Luciferase-uockh). For a DELAYED partition
+     * failure the actual handler invocation runs on a background executor; this lets a caller/test await
+     * that the failure has actually been applied — deterministically — instead of guessing a wall-clock
+     * margin over the delay (the background-race class fixed for IntegrationTestFixture in 8brw9).
+     * <p>
+     * For an immediate ({@code delayMs == 0}) fault the returned future is already complete. An unknown
+     * fault (not produced by this injector) yields an already-complete future rather than throwing.
+     *
+     * @param fault a fault returned by {@link #injectPartitionFailure}
+     * @return a future that completes once the fault's handlers have been invoked
+     */
+    public CompletableFuture<Void> awaitCompletion(InjectedFault fault) {
+        Objects.requireNonNull(fault, "fault cannot be null");
+        return faultCompletions.getOrDefault(fault.faultId(), CompletableFuture.completedFuture(null));
+    }
+
+    /**
+     * Completion handle for a batch of faults (e.g. the result of {@link #injectCascadingFailures} or
+     * {@link #injectBurstFailures}) — completes once every fault's handlers have been invoked. Lets a
+     * caller await a staggered/cascading set deterministically instead of sleeping a fixed margin over the
+     * total delay (Luciferase-uockh).
+     *
+     * @param faults faults returned by an inject* method
+     * @return a future that completes when all the given faults have completed
+     */
+    public CompletableFuture<Void> awaitAll(List<InjectedFault> faults) {
+        Objects.requireNonNull(faults, "faults cannot be null");
+        return CompletableFuture.allOf(
+            faults.stream().map(this::awaitCompletion).toArray(CompletableFuture[]::new));
     }
 
     /**
@@ -488,6 +529,9 @@ public class FaultInjector {
         clockDrifting = false;
         driftRateMs = 0;
         faultCounter.set(0);
+        // Must clear alongside faultCounter.set(0): otherwise the next fault reuses faultId=1 and
+        // awaitCompletion would alias a stale (already-done) future from the pre-reset run (Luciferase-uockh).
+        faultCompletions.clear();
     }
 
     /**

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/testinfra/FaultInjectorTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/testinfra/FaultInjectorTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2025, Hal Hildebrand. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ */
+package com.hellblazer.luciferase.lucien.balancing.fault.testinfra;
+
+import com.hellblazer.luciferase.simulation.distributed.integration.TestClock;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link FaultInjector#awaitCompletion} deterministic delayed-injection completion (Luciferase-uockh).
+ *
+ * <p>A delayed partition failure runs its handler invocation on a background executor; before this fix the
+ * {@code executor.submit(...)} future was discarded, so a caller could only race a fixed sleep over the
+ * delay (the background-race class fixed for IntegrationTestFixture in 8brw9). These tests pin that the
+ * completion is now awaitable.
+ *
+ * @author hal.hildebrand
+ */
+class FaultInjectorTest {
+
+    @Test
+    void delayedInjectionCompletionIsAwaitable() throws Exception {
+        var injector = new FaultInjector(new TestClock(1_000L));
+        var failed = new AtomicReference<UUID>();
+        injector.registerPartitionFailureHandler("recorder", failed::set);
+
+        var partitionId = UUID.randomUUID();
+        var fault = injector.injectPartitionFailure(partitionId, 50);
+
+        // Await the actual (background) injection rather than sleeping a margin over the 50ms delay.
+        injector.awaitCompletion(fault).get(5, TimeUnit.SECONDS);
+
+        assertEquals(partitionId, failed.get(),
+                     "after awaitCompletion, the delayed partition-failure handler must have run");
+    }
+
+    @Test
+    void immediateInjectionCompletesSynchronously() throws Exception {
+        var injector = new FaultInjector(new TestClock(1_000L));
+        var failed = new AtomicReference<UUID>();
+        injector.registerPartitionFailureHandler("recorder", failed::set);
+
+        var partitionId = UUID.randomUUID();
+        var fault = injector.injectPartitionFailure(partitionId, 0);
+
+        // Immediate failure ran synchronously on this thread; its completion is already done.
+        assertTrue(injector.awaitCompletion(fault).isDone(),
+                   "an immediate (delay=0) injection's completion must already be complete");
+        assertEquals(partitionId, failed.get(),
+                     "an immediate partition-failure handler must run synchronously");
+        injector.awaitCompletion(fault).get(1, TimeUnit.SECONDS); // never blocks
+    }
+}


### PR DESCRIPTION
## Summary

`FaultInjector.injectPartitionFailure` ran a delayed partition failure on a background executor and **discarded the future**, so callers could only race a fixed sleep over the delay — the same background-race class fixed for `IntegrationTestFixture` in Luciferase-8brw9 (this is the sibling that was filed).

## Changes (test-infra)

- Track a `CompletableFuture<Void>` per fault (`faultCompletions`, keyed by `faultId`): `delay=0` → an already-complete future after the synchronous handler invoke; delayed → `CompletableFuture.runAsync(sleep+invoke, executor)` (an interrupt completes it exceptionally via `CompletionException`, so `awaitCompletion().get()` throws rather than hanging).
- Add `awaitCompletion(InjectedFault)` and `awaitAll(List<InjectedFault>)` so callers await the actual injection deterministically.
- `reset()` now clears `faultCompletions` alongside `faultCounter.set(0)` (otherwise a reused injector aliases stale completed futures onto reused faultIds).
- Use it at the two delayed `P51IntegrationTest` call sites (`partition3`/50ms and the 200ms-stagger cascade) in place of fixed sleeps.

## Verification

- New `FaultInjectorTest` proves the delayed completion is awaitable and the immediate path completes synchronously. 19 fault tests green (`FaultInjectorTest` 2, `P51IntegrationTest` 10, `Phase43IntegrationTest` 7); P51 runs faster without the fixed 1s sleep.
- Backward-compatible: existing callers ignore the new methods.
- Stacked review (code-review-expert + substantive-critic), round-2 clean: **0 Critical / 0 Significant**. Round-1 caught two real issues — `reset()` not clearing the completion map (stale-future aliasing) and the cascading P51 site still using a fixed sleep — both fixed.