### PR TITLE
docs(rdr): accept RDR-023 — gRPC mTLS hostname-verification fix (Luciferase-7m9kh)

### DIFF
--- a/docs/rdr/RDR-023-grpc-mtls-handshake-shaded-netty.md
+++ b/docs/rdr/RDR-023-grpc-mtls-handshake-shaded-netty.md
@@ -1,8 +1,10 @@
 ---
 id: RDR-023
 title: Real gRPC mTLS Handshake over Shaded-Only Netty — Verify and Fix the Unproven TLS Transport
-status: draft
+status: accepted
 date: 2026-06-13
+accepted_date: 2026-06-13
+reviewed-by: self
 supersedes: []
 related: [RDR-005, RDR-013, RDR-007]
 beads: [Luciferase-7m9kh, Luciferase-l9dny]

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -33,6 +33,7 @@ See the [RDR process documentation](https://github.com/cwensel/rdr) for the full
 | [RDR-020](RDR-020-bubble-to-fireflies-member-digest-resolution.md) | Bubble→Fireflies Member Digest Resolution for Migration Consensus | implemented | Bug Fix | high |
 | [RDR-021](RDR-021-wire-partition-fault-tolerance-node-bootstrap.md) | Wire Partition Fault Tolerance into the Production Node Bootstrap | implemented | Architecture | medium |
 | [RDR-022](RDR-022-wire-bubble-ownership-resolver-node-bootstrap.md) | Wire Bubble Ownership Resolution into the Production Node Bootstrap | implemented | Architecture | medium |
+| [RDR-023](RDR-023-grpc-mtls-handshake-shaded-netty.md) | Real gRPC mTLS Handshake over Shaded-Only Netty — Verify and Fix the Unproven TLS Transport | accepted | Bug Fix | P2 |
 
 ## Post-Mortems
 


### PR DESCRIPTION
Gate PASSED (0 Critical, 3 Significant closed). RDR-023 status draft→accepted, reviewed-by self, README index updated.

Decision locked — **Strategy C**: make `GrpcCredentialFactory.ACCEPT_ANY_CERT` an `X509ExtendedTrustManager` with no-op endpoint-identification overloads (disable client hostname verification; correct for the RDR-005 no-CA/KERI model — identity via `PeerVerifier` against the KERL, not the cert CN). No dependency change.

Ready for implementation: the trust-manager fix + a real-handshake test (client→server: authorized OK + `PeerVerifier`-rejected → `UNAUTHENTICATED`) in `common`, then unblock l9dny.