### PR TITLE
feat(simulation): mTLS + peer-identity for GrpcBubbleNetworkChannel migration RPCs (Luciferase-l9dny)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/network/GrpcBubbleNetworkChannel.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/distributed/network/GrpcBubbleNetworkChannel.java
@@ -13,6 +13,7 @@ import com.hellblazer.luciferase.lucien.distributed.migration.proto.MigrationRes
 
 // Domain event classes
 import com.hellblazer.luciferase.simulation.causality.EntityMigrationState;
+import com.hellblazer.luciferase.common.grpc.GrpcCredentialFactory;
 import com.hellblazer.luciferase.common.grpc.GrpcServerHardening;
 import com.hellblazer.luciferase.common.time.Clock;
 import com.hellblazer.luciferase.simulation.events.EntityDepartureEvent;
@@ -20,8 +21,11 @@ import com.hellblazer.luciferase.simulation.events.EntityRollbackEvent;
 import com.hellblazer.luciferase.simulation.events.ViewSynchronyAck;
 
 // gRPC
+import io.grpc.ChannelCredentials;
+import io.grpc.Grpc;
 import io.grpc.ManagedChannel;
 import io.grpc.Server;
+import io.grpc.ServerBuilder;
 import io.grpc.Status;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
@@ -93,6 +97,13 @@ public class GrpcBubbleNetworkChannel implements BubbleNetworkChannel, AutoClose
      */
     private volatile boolean allowPlaintext = false;
 
+    // mTLS + peer-identity binding (Luciferase-l9dny, RDR-023). When serverAuth / channelCredentials are set
+    // (via setCredentials), the channel uses mutual-TLS with a PeerAuthInterceptor instead of plaintext, and
+    // the allowPlaintext opt-in is bypassed on that side (credentials take precedence). Both sides should be
+    // configured together for a working mTLS node. Null = mTLS not configured for that side.
+    private volatile GrpcCredentialFactory.ServerAuth serverAuth;
+    private volatile ChannelCredentials channelCredentials;
+
     private volatile EntityDepartureListener departureListener;
     private volatile ViewSynchronyAckListener ackListener;
     private volatile EntityRollbackListener rollbackListener;
@@ -132,6 +143,42 @@ public class GrpcBubbleNetworkChannel implements BubbleNetworkChannel, AutoClose
     }
 
     /**
+     * Configure mutual-TLS with peer-identity binding for migration RPCs (Luciferase-l9dny, RDR-023).
+     * <p>
+     * Must be called BEFORE {@link #initialize} (server) and before the first outbound send (client). When
+     * set, the server installs the {@link GrpcCredentialFactory.ServerAuth}'s (trust-any) mTLS credentials
+     * together with its {@code PeerAuthInterceptor} (which cryptographically verifies each peer's certificate
+     * identity via the injected {@code PeerVerifier} against the KERL), and outbound channels use the given
+     * mutual-TLS {@link ChannelCredentials}. mTLS takes precedence: the plaintext opt-in
+     * ({@link #setAllowPlaintext}) is bypassed on whichever side has credentials configured. Both sides
+     * should be set together for a working mTLS node.
+     * <p>
+     * Prefer {@link GrpcCredentialFactory#serverAuth(java.security.PrivateKey, java.security.cert.X509Certificate, com.hellblazer.luciferase.common.grpc.PeerVerifier)}
+     * to build {@code serverAuth} — it pairs the trust-any credentials with a verifying interceptor so bare
+     * credentials cannot be installed without authentication.
+     *
+     * @param serverAuth         server credentials + peer-auth interceptor, or {@code null} to leave the
+     *                           server on the plaintext-opt-in path
+     * @param channelCredentials outbound mutual-TLS channel credentials, or {@code null} to leave the client
+     *                           on the plaintext-opt-in path
+     */
+    public void setCredentials(GrpcCredentialFactory.ServerAuth serverAuth, ChannelCredentials channelCredentials) {
+        // Asymmetric config (exactly one side set) is a footgun: the node still fails LOUD — an mTLS server
+        // rejects a plaintext client, an mTLS client can't complete a handshake to a plaintext server — but
+        // the failure surfaces as a confusing transport-layer UNAVAILABLE far from here. Warn at config time
+        // so the misconfiguration is traceable. (No security weakening; both halves fail loud regardless.)
+        if ((serverAuth == null) != (channelCredentials == null)) {
+            log.warn("setCredentials: only one of serverAuth/channelCredentials is set (serverAuth={}, "
+                     + "channelCredentials={}) — asymmetric mTLS config; the unconfigured side will fall back "
+                     + "to the plaintext-opt-in gate and inbound/outbound RPCs will fail at the TLS layer. "
+                     + "Set both together for a working mTLS node.",
+                     serverAuth != null, channelCredentials != null);
+        }
+        this.serverAuth = serverAuth;
+        this.channelCredentials = channelCredentials;
+    }
+
+    /**
      * Set the clock for deterministic testing.
      *
      * @param clock Clock instance to use
@@ -144,28 +191,36 @@ public class GrpcBubbleNetworkChannel implements BubbleNetworkChannel, AutoClose
     public void initialize(UUID nodeId, String nodeAddress) {
         this.localNodeId = nodeId;
 
-        // Server-side plaintext gate (Luciferase-7wzml.200 I1).
-        // Mirror the client-side gate in getOrCreateChannel(): both directions must opt in.
-        //
-        // NOTE: TLS does not yet exist — this gate is a construction-time reminder that plaintext
-        // is the only transport, NOT runtime security enforcement. Real mTLS (with peer-identity
-        // binding) is tracked in Luciferase-l9dny. Do not interpret passing this gate as a
-        // security guarantee; it is an explicit acknowledgement that plaintext is intentional.
-        if (!allowPlaintext) {
-            throw new IllegalStateException(
-                "Server: plaintext transport requires explicit opt-in via setAllowPlaintext(true). "
-                + "Full mTLS with peer-identity binding is tracked in Luciferase-l9dny "
-                + "(coordinates with RDR-005/RDR-013 cert plumbing).");
-        }
-
         try {
             // Parse port from address (format: "host:port")
             var port = parsePort(nodeAddress);
 
-            // Build and start gRPC server on specified port (0 = dynamic)
-            var bubbleServerBuilder = NettyServerBuilder.forPort(port)
-                .addService(new BubbleMigrationServiceImpl())
-                .executor(executorService);
+            // Build and start the gRPC server. mTLS takes precedence over the plaintext opt-in: when a
+            // ServerAuth is configured (Luciferase-l9dny / RDR-023), install its (trust-any) mTLS credentials
+            // together with the PeerAuthInterceptor that cryptographically authenticates each peer's
+            // certificate identity. Otherwise fall back to the explicit plaintext opt-in.
+            ServerBuilder<?> bubbleServerBuilder;
+            var auth = this.serverAuth;
+            if (auth != null) {
+                bubbleServerBuilder = Grpc.newServerBuilderForPort(port, auth.credentials())
+                    .addService(new BubbleMigrationServiceImpl())
+                    .executor(executorService)
+                    .intercept(auth.interceptor());
+            } else {
+                // Server-side plaintext gate (Luciferase-7wzml.200 I1). Mirror the client-side gate in
+                // getOrCreateChannel(): both directions must opt in. Passing this gate is an explicit
+                // acknowledgement that plaintext is intentional, NOT a security guarantee — configure mTLS
+                // via setCredentials(...) for authenticated transport (Luciferase-l9dny).
+                if (!allowPlaintext) {
+                    throw new IllegalStateException(
+                        "Server: transport requires either mTLS (setCredentials(...)) or an explicit "
+                        + "plaintext opt-in via setAllowPlaintext(true). Full mTLS with peer-identity "
+                        + "binding is Luciferase-l9dny (RDR-023/RDR-005 cert plumbing).");
+                }
+                bubbleServerBuilder = NettyServerBuilder.forPort(port)
+                    .addService(new BubbleMigrationServiceImpl())
+                    .executor(executorService);
+            }
             // RDR-013 / Luciferase-06ujn: explicit inbound size + metadata bounds (DoS surface) — this is the
             // third production gRPC server (alongside Ghost), enumerated in RDR-005's inventory.
             GrpcServerHardening.applyInboundLimits(bubbleServerBuilder);
@@ -489,27 +544,32 @@ public class GrpcBubbleNetworkChannel implements BubbleNetworkChannel, AutoClose
                 throw new IllegalStateException("No address registered for node: " + nodeId);
             }
 
-            // Client-side plaintext gate (Luciferase-7wzml.200).
-            //
-            // NOTE: TLS does not yet exist — this gate is a construction-time reminder that
-            // plaintext is the only transport, NOT runtime security enforcement. Real mTLS
-            // (with peer-identity binding) is tracked in Luciferase-l9dny. Passing this gate
-            // is an explicit acknowledgement that plaintext is intentional, not a security
-            // guarantee.
-            if (!allowPlaintext) {
-                throw new IllegalStateException(
-                    "plaintext transport requires explicit opt-in: call setAllowPlaintext(true) "
-                    + "or use GrpcBubbleNetworkChannel(true). "
-                    + "Full mTLS with peer-identity binding is tracked in Luciferase-l9dny "
-                    + "(coordinates with RDR-005/RDR-013 cert plumbing).");
-            }
-
             var parts = address.split(":");
             var host = parts[0];
             var port = Integer.parseInt(parts[1]);
 
-            log.debug("Creating plaintext gRPC channel to {}:{} (opt-in; see Luciferase-l9dny for TLS roadmap)",
-                      host, port);
+            // mTLS takes precedence over the plaintext opt-in (Luciferase-l9dny / RDR-023): when outbound
+            // channel credentials are configured, build a mutual-TLS channel; the server's
+            // PeerAuthInterceptor then authenticates this client's certificate identity.
+            var creds = this.channelCredentials;
+            if (creds != null) {
+                log.debug("Creating mTLS gRPC channel to {}:{}", host, port);
+                return Grpc.newChannelBuilderForAddress(host, port, creds)
+                    .executor(executorService)
+                    .build();
+            }
+
+            // Client-side plaintext gate (Luciferase-7wzml.200). Passing this gate is an explicit
+            // acknowledgement that plaintext is intentional, NOT a security guarantee — configure mTLS via
+            // setCredentials(...) for authenticated transport (Luciferase-l9dny).
+            if (!allowPlaintext) {
+                throw new IllegalStateException(
+                    "transport requires either mTLS (setCredentials(...)) or an explicit plaintext "
+                    + "opt-in: call setAllowPlaintext(true) or use GrpcBubbleNetworkChannel(true). "
+                    + "Full mTLS with peer-identity binding is Luciferase-l9dny (RDR-023/RDR-005 cert plumbing).");
+            }
+
+            log.debug("Creating plaintext gRPC channel to {}:{} (opt-in)", host, port);
             return NettyChannelBuilder.forAddress(host, port)
                 .usePlaintext()
                 .executor(executorService)

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/network/GrpcBubbleNetworkChannelMtlsTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/distributed/network/GrpcBubbleNetworkChannelMtlsTest.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase Simulation Framework.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.hellblazer.luciferase.simulation.distributed.network;
+
+import com.hellblazer.luciferase.common.grpc.GrpcCredentialFactory;
+import com.hellblazer.luciferase.common.grpc.PeerVerifier;
+import com.hellblazer.luciferase.lucien.distributed.migration.proto.BubbleMigrationServiceGrpc;
+import com.hellblazer.luciferase.lucien.distributed.migration.proto.HealthCheckRequest;
+import com.hellblazer.luciferase.simulation.causality.EntityMigrationState;
+import com.hellblazer.luciferase.simulation.events.EntityDepartureEvent;
+import io.grpc.Grpc;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * mTLS + peer-identity binding for GrpcBubbleNetworkChannel migration RPCs (Luciferase-l9dny, RDR-023).
+ *
+ * <p>Verifies the wiring added by l9dny on the now-proven mTLS transport (RDR-023): when credentials are
+ * configured via {@link GrpcBubbleNetworkChannel#setCredentials}, the server installs the {@code ServerAuth}
+ * mTLS credentials + the {@code PeerAuthInterceptor}, and outbound channels use mutual-TLS — so (a) an
+ * authorized peer's migration RPC round-trips end-to-end and (b) a peer whose certificate identity the
+ * {@link PeerVerifier} rejects is denied with {@code UNAUTHENTICATED}.
+ *
+ * <p>No {@code overrideAuthority} workaround is needed: the RDR-023 trust-manager fix disables client TLS
+ * hostname verification (the cert CN is not a trust principal in the KERI model), so the handshake completes
+ * even though the dialed address (e.g. {@code localhost}) ≠ the cert CN. The {@link PeerVerifier} double here
+ * exercises the transport+interceptor wiring; the real KERI verifier's correctness is covered by
+ * {@code FirefliesPeerVerifierTest}.
+ *
+ * @author hal.hildebrand
+ */
+class GrpcBubbleNetworkChannelMtlsTest {
+
+    private static final String CERT_PEM = """
+        -----BEGIN CERTIFICATE-----
+        MIIBxTCCAWugAwIBAgIUSJNl7QU354hZbcNYf3iUuWi26HswCgYIKoZIzj0EAwIw
+        NzEYMBYGA1UEAwwPbHVjaWZlcmFzZS10ZXN0MRswGQYKCZImiZPyLGQBAQwLdGVz
+        dC1tZW1iZXIwIBcNMjYwNTI1MTU0MTU5WhgPMjEyNjA1MDExNTQxNTlaMDcxGDAW
+        BgNVBAMMD2x1Y2lmZXJhc2UtdGVzdDEbMBkGCgmSJomT8ixkAQEMC3Rlc3QtbWVt
+        YmVyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElsNuMitnEFzulXZDXJhkHqbC
+        kWDr/hcDRLvPtXrXSYpJOmEKB7YDBzTtZsiWxlAKP281bMzDRixltHkGNm/w7KNT
+        MFEwHQYDVR0OBBYEFENQByxeLJtrYTtNlKKWrIBhg5HkMB8GA1UdIwQYMBaAFENQ
+        ByxeLJtrYTtNlKKWrIBhg5HkMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwID
+        SAAwRQIhALpV3QSUouQ6F5vNtCF5H7jEGwHFzmVeXQpBIfYdoFulAiAMkz16j7tV
+        rrMLPIOdjMe2d4NGkUSfnwX/S9EW1TQntw==
+        -----END CERTIFICATE-----
+        """;
+    private static final String KEY_B64 =
+        "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgsAplYmfGNfNKlgBP"
+        + "7Mo+lZNJFSrI0ydYoGs3NYyvpKmhRANCAASWw24yK2cQXO6VdkNcmGQepsKRYOv+"
+        + "FwNEu8+1etdJikk6YQoHtgMHNO1myJbGUAo/bzVszMNGLGW0eQY2b/Ds";
+
+    private static X509Certificate cert() throws Exception {
+        return (X509Certificate) CertificateFactory.getInstance("X.509")
+            .generateCertificate(new ByteArrayInputStream(CERT_PEM.getBytes(StandardCharsets.UTF_8)));
+    }
+    private static PrivateKey key() throws Exception {
+        return KeyFactory.getInstance("EC").generatePrivate(
+            new PKCS8EncodedKeySpec(Base64.getDecoder().decode(KEY_B64)));
+    }
+
+    @Test
+    void authorizedPeerCompletesMtlsMigrationRpc() throws Exception {
+        var key = key();
+        var cert = cert();
+        PeerVerifier accept = peerCert -> Optional.of("authorized-peer");
+
+        var sourceId = UUID.randomUUID();
+        var targetId = UUID.randomUUID();
+        var source = new GrpcBubbleNetworkChannel();
+        var target = new GrpcBubbleNetworkChannel();
+        // Both sides on mTLS (no plaintext opt-in): server installs creds + PeerAuthInterceptor, client uses
+        // mutual-TLS channel credentials. No overrideAuthority — the RDR-023 fix makes the handshake work.
+        source.setCredentials(GrpcCredentialFactory.serverAuth(key, cert, accept),
+                              GrpcCredentialFactory.mtlsChannel(key, cert));
+        target.setCredentials(GrpcCredentialFactory.serverAuth(key, cert, accept),
+                              GrpcCredentialFactory.mtlsChannel(key, cert));
+        try {
+            source.initialize(sourceId, "localhost:0");
+            target.initialize(targetId, "localhost:0");
+            source.registerNode(targetId, target.getLocalAddress());
+            target.registerNode(sourceId, source.getLocalAddress());
+
+            var received = new CountDownLatch(1);
+            var receivedSourceId = new AtomicReference<UUID>();
+            target.setEntityDepartureListener((sid, ev) -> {
+                receivedSourceId.set(sid);
+                received.countDown();
+            });
+
+            var event = new EntityDepartureEvent(UUID.randomUUID(), sourceId, targetId,
+                                                 EntityMigrationState.MIGRATING_OUT, 1_000L);
+            assertTrue(source.sendEntityDeparture(targetId, event), "send must dispatch over mTLS");
+            assertTrue(received.await(5, TimeUnit.SECONDS),
+                       "an authorized mTLS peer's migration RPC must be delivered to the target listener");
+            assertEquals(sourceId, receivedSourceId.get(), "delivered event must carry the source node id");
+        } finally {
+            source.close();
+            target.close();
+        }
+    }
+
+    @Test
+    void unauthorizedPeerIsRejectedWithUnauthenticated() throws Exception {
+        var key = key();
+        var cert = cert();
+        // Verifier rejects every peer — the PeerAuthInterceptor must deny the call before the service runs.
+        PeerVerifier reject = peerCert -> Optional.empty();
+
+        var target = new GrpcBubbleNetworkChannel();
+        target.setCredentials(GrpcCredentialFactory.serverAuth(key, cert, reject), null);
+        ManagedChannel clientChannel = null;
+        try {
+            target.initialize(UUID.randomUUID(), "localhost:0");
+            var parts = target.getLocalAddress().split(":");
+            var host = parts[0];
+            var port = Integer.parseInt(parts[1]);
+
+            // Direct mTLS blocking stub: deterministic — the interceptor rejects pre-handler for ANY method,
+            // and we observe the status synchronously (the channel's async send would swallow it into a log).
+            clientChannel = Grpc.newChannelBuilderForAddress(host, port,
+                                                             GrpcCredentialFactory.mtlsChannel(key, cert)).build();
+            var stub = BubbleMigrationServiceGrpc.newBlockingStub(clientChannel)
+                .withDeadlineAfter(10, TimeUnit.SECONDS);
+            var ex = assertThrows(StatusRuntimeException.class,
+                                  () -> stub.healthCheck(HealthCheckRequest.newBuilder().build()),
+                                  "a peer rejected by the PeerVerifier must be denied, not served");
+            assertEquals(Status.Code.UNAUTHENTICATED, ex.getStatus().getCode(),
+                         "the handshake completes and rejection surfaces as UNAUTHENTICATED from the interceptor");
+        } finally {
+            if (clientChannel != null) {
+                clientChannel.shutdownNow();
+                clientChannel.awaitTermination(2, TimeUnit.SECONDS);
+            }
+            target.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Wires `GrpcBubbleNetworkChannel` onto the now-proven mTLS transport (RDR-023). Completes the mTLS story for the third production gRPC server (alongside Ghost/Balance).

## Change

- New `setCredentials(ServerAuth, ChannelCredentials)`. When set: the server installs the (trust-any) mTLS credentials **with** the `PeerAuthInterceptor` (cryptographic peer-identity auth against the KERL), and outbound channels use mutual-TLS.
- mTLS takes precedence over the plaintext opt-in **per side**; the existing `allowPlaintext` path is retained for examples/in-process tests.
- Default (no creds, no opt-in) still **fails loud** on both server (`initialize`) and client (`getOrCreateChannel`) — a production node cannot accidentally run plaintext.
- DoS inbound limits apply on **both** branches; the `ServerAuth` record keeps creds+interceptor inseparable; `setCredentials` **warns on an asymmetric** (one-side-only) config.

## Verification

- New `GrpcBubbleNetworkChannelMtlsTest`: an authorized peer's migration RPC round-trips over a **real mTLS handshake** via the channel's own send + listener (no `overrideAuthority` — the RDR-023 fix disables hostname verification), and a `PeerVerifier`-rejected peer gets `UNAUTHENTICATED`. 18/18 (2 new + 16 existing plaintext-path tests unaffected).
- Stacked review (both sonnet, security-sensitive): code-review-expert **APPROVED**, substantive-critic **justified** (0 Critical). The critic traced all four credential combinations and confirmed **no combination silently weakens security** — all misconfigurations fail loud. Round-1 Significant (asymmetric-config footgun) fixed with a config-time warning.

## Scope

Proves **client→server** auth (the load-bearing direction). Client-side **server** authentication remains a pre-existing, out-of-scope RDR-005 gap.