### PR TITLE
docs(rdr): close RDR-023 (implemented) + post-mortem

### DIFF
--- a/docs/rdr/RDR-023-grpc-mtls-handshake-shaded-netty.md
+++ b/docs/rdr/RDR-023-grpc-mtls-handshake-shaded-netty.md
@@ -1,9 +1,12 @@
 ---
 id: RDR-023
 title: Real gRPC mTLS Handshake over Shaded-Only Netty — Verify and Fix the Unproven TLS Transport
-status: accepted
+status: implemented
 date: 2026-06-13
 accepted_date: 2026-06-13
+closed_date: 2026-06-13
+close_reason: implemented
+post_mortem: docs/rdr/post-mortem/023-grpc-mtls-handshake-shaded-netty.md
 reviewed-by: self
 supersedes: []
 related: [RDR-005, RDR-013, RDR-007]

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -33,7 +33,7 @@ See the [RDR process documentation](https://github.com/cwensel/rdr) for the full
 | [RDR-020](RDR-020-bubble-to-fireflies-member-digest-resolution.md) | Bubble→Fireflies Member Digest Resolution for Migration Consensus | implemented | Bug Fix | high |
 | [RDR-021](RDR-021-wire-partition-fault-tolerance-node-bootstrap.md) | Wire Partition Fault Tolerance into the Production Node Bootstrap | implemented | Architecture | medium |
 | [RDR-022](RDR-022-wire-bubble-ownership-resolver-node-bootstrap.md) | Wire Bubble Ownership Resolution into the Production Node Bootstrap | implemented | Architecture | medium |
-| [RDR-023](RDR-023-grpc-mtls-handshake-shaded-netty.md) | Real gRPC mTLS Handshake over Shaded-Only Netty — Verify and Fix the Unproven TLS Transport | accepted | Bug Fix | P2 |
+| [RDR-023](RDR-023-grpc-mtls-handshake-shaded-netty.md) | Real gRPC mTLS Handshake over Shaded-Only Netty — Verify and Fix the Unproven TLS Transport | implemented | Bug Fix | P2 |
 
 ## Post-Mortems
 
@@ -57,3 +57,4 @@ Closed/implemented RDRs carry a post-mortem under [`post-mortem/`](post-mortem/)
 | RDR-020 | [post-mortem/020-bubble-to-fireflies-member-digest-resolution.md](post-mortem/020-bubble-to-fireflies-member-digest-resolution.md) |
 | RDR-021 | [post-mortem/021-wire-partition-fault-tolerance-node-bootstrap.md](post-mortem/021-wire-partition-fault-tolerance-node-bootstrap.md) |
 | RDR-022 | [post-mortem/022-wire-bubble-ownership-resolver-node-bootstrap.md](post-mortem/022-wire-bubble-ownership-resolver-node-bootstrap.md) |
+| RDR-023 | [post-mortem/023-grpc-mtls-handshake-shaded-netty.md](post-mortem/023-grpc-mtls-handshake-shaded-netty.md) |

--- a/docs/rdr/post-mortem/023-grpc-mtls-handshake-shaded-netty.md
+++ b/docs/rdr/post-mortem/023-grpc-mtls-handshake-shaded-netty.md
@@ -1,0 +1,45 @@
+# Post-Mortem: RDR-023 — Real gRPC mTLS Handshake over Shaded-Only Netty
+
+**Closed:** 2026-06-13 (implemented) · **Beads:** Luciferase-7m9kh (transport fix), Luciferase-l9dny (bubble-channel consumer) — both closed.
+
+## Outcome
+
+The repo's gRPC mTLS — wired (`GrpcCredentialFactory` + `PeerAuthInterceptor` + `FirefliesPeerVerifier`)
+but **never exercised with a real handshake** — now completes a real TLS handshake and authenticates peers,
+proven by a regression test. Fixed in one type change; consumed by the bubble channel; Ghost/Balance inherit
+it automatically (same `GrpcCredentialFactory`).
+
+## Predicted vs Realized
+
+| | Predicted (at create) | Realized |
+|---|---|---|
+| Root cause | Suspected shaded-vs-non-shaded netty provider / ALPN / credential-translation defect | **Client TLS hostname verification** — cert CN ≠ dialed authority (`No name matching localhost`). Not a netty defect at all; native tcnative/OpenSslEngine handshakes fine. |
+| Fix scope | Possibly add non-shaded `grpc-netty` + tcnative (Strategy B) or shaded `GrpcSslContexts` (Strategy A) — feared a dependency/architecture change | **Strategy C**: `ACCEPT_ANY_CERT` plain `X509TrustManager` → `X509ExtendedTrustManager` with no-op endpoint-identification overloads. One type change, **no dependency change**. |
+| Effort | RDR-scale; feared multi-session netty surgery | Research diagnostic (3 probes) cracked it; fix + test + consumer wiring all landed same day. |
+
+The research phase (a throwaway 3-probe diagnostic capturing the real exception chain) was decisive: it
+turned a feared netty re-architecture into a configuration fix. **Lesson: capture the actual exception
+before theorizing about the transport stack** — the `UNAVAILABLE` surfaced with no cause at the gRPC layer
+and misdirected the initial l9dny attempt toward "shaded netty is broken."
+
+## Divergences from the RDR
+
+- **Real-handshake test location.** The RDR said "test in `common` (the credential-factory home)."
+  Realized: `common` is grpc-api-only (no netty/service to stand up a real server), so the test lives in
+  `simulation` (`GrpcCredentialFactoryHandshakeTest`, using `BubbleMigrationServiceGrpc`). Documented at
+  implementation; no impact on what is proven.
+- **Four extended overloads, not two.** The RDR Decision named the two `checkServerTrusted` overloads;
+  `X509ExtendedTrustManager` requires all four (client + server × Socket + SSLEngine). All four are no-ops —
+  bytecode review confirmed the server-side client-cert handling is unchanged (the tcnative server callback
+  dispatches the 2-arg `checkClientTrusted`, already a no-op).
+
+## Security posture (as accepted)
+
+Disabling client hostname verification is safe in the RDR-005 no-CA/KERI model: the cert CN is not a trust
+anchor; the **server authenticates the client** via the KERL-backed `PeerVerifier`. The real-handshake test
+proves that direction (authorized → OK, rejected → `UNAUTHENTICATED`). **Client-side *server* authentication
+remains a pre-existing, out-of-scope RDR-005 gap** — neither improved nor regressed by this work.
+
+## Follow-ups
+
+- None opened by this RDR. The server→client auth gap is RDR-005's; credential rotation is RDR-005 / `ah3`.


### PR DESCRIPTION
## RDR-023 closed — implemented

Both beads closed: **7m9kh** (transport fix) + **l9dny** (bubble-channel consumer); Ghost/Balance inherit the fixed `GrpcCredentialFactory`. Full lifecycle this session: create (#259) → research (#260) → gate PASSED (#261) → accept (#262) → implement (#263) → consumer (#264) → close (this PR).

- `status: accepted → implemented`; post-mortem added; README index + post-mortem table updated.

## Post-mortem highlights

- **Predicted vs realized**: feared a netty re-architecture (strategies A/B, possible dependency change); realized a **one-type trust-manager fix** (Strategy C, no dep change). The research diagnostic that captured the real exception was decisive — root cause was client TLS **hostname verification**, not shaded netty.
- **Divergences**: real-handshake test landed in `simulation` (not `common` — grpc-api-only); four extended trust-manager overloads, not two (server-side handling unchanged, bytecode-verified).
- **Scope**: client→server auth proven; client-side server auth remains a pre-existing RDR-005 gap.
- **Lesson**: capture the actual exception before theorizing about the transport stack.