### PR TITLE
fix(render): untrack DAG cl_mem handles on release — stop dispose double-free (Luciferase-qe8p0)

### DIFF
--- a/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/DAGOpenCLRenderer.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/DAGOpenCLRenderer.java
@@ -454,12 +454,18 @@ public class DAGOpenCLRenderer extends AbstractOpenCLRenderer<ESVONodeUnified, D
             throw new IllegalArgumentException("DAG must use absolute addressing");
         }
 
-        // Release old buffers if exist
+        // Release old buffers if exist (re-upload). Untrack + reset to 0 to match the dispose path: the old
+        // handle was tracked by createRawBuffer; releasing without untracking would leave a freed handle in
+        // trackedRawHandles for dispose() to double-free (Luciferase-qe8p0).
         if (clNodeBuffer != 0) {
             clReleaseMemObject(clNodeBuffer);
+            untrackRawHandle(clNodeBuffer);
+            clNodeBuffer = 0;
         }
         if (clDummyChildPointersBuffer != 0) {
             clReleaseMemObject(clDummyChildPointersBuffer);
+            untrackRawHandle(clDummyChildPointersBuffer);
+            clDummyChildPointersBuffer = 0;
         }
 
         // Store node count for kernel arguments (Phase 4.2.2a)
@@ -691,16 +697,27 @@ public class DAGOpenCLRenderer extends AbstractOpenCLRenderer<ESVONodeUnified, D
         return (colorValue << 24) | (colorValue << 16) | (colorValue << 8) | 0xFF;
     }
 
+    /** Test-only (Luciferase-qe8p0): tracked raw cl_mem handle count, for double-free regression assertions. */
+    int trackedRawHandleCountForTest() {
+        return trackedRawHandleCount();
+    }
+
     @Override
     protected void disposeTypeSpecificBuffers() {
+        // These buffers are allocated via createRawBuffer (uploadDataBuffers), which TRACKS them in the
+        // base class's trackedRawHandles. Releasing here without untrackRawHandle leaves the handle tracked,
+        // so dispose()'s defensive release loop frees it AGAIN — a double-free that aborts the native OpenCL
+        // driver (Luciferase-qe8p0: exit 133 on init+upload+dispose). Untrack immediately after release.
         if (clNodeBuffer != 0) {
             clReleaseMemObject(clNodeBuffer);
+            untrackRawHandle(clNodeBuffer);
             clNodeBuffer = 0;
         }
 
         // Phase 4.2.2a: Release dummy childPointers buffer
         if (clDummyChildPointersBuffer != 0) {
             clReleaseMemObject(clDummyChildPointersBuffer);
+            untrackRawHandle(clDummyChildPointersBuffer);
             clDummyChildPointersBuffer = 0;
         }
 

--- a/render/src/main/java/com/hellblazer/luciferase/sparse/gpu/AbstractOpenCLRenderer.java
+++ b/render/src/main/java/com/hellblazer/luciferase/sparse/gpu/AbstractOpenCLRenderer.java
@@ -156,9 +156,10 @@ public abstract class AbstractOpenCLRenderer<N extends SparseVoxelNode, D extend
 
     /**
      * Returns the number of raw cl_mem handles currently tracked by the base class.
-     * Package-private — for unit-test assertions only.
+     * {@code protected} — for test assertions, including subclass tests in other packages that need to
+     * verify their release paths untrack handles (Luciferase-qe8p0 double-free regression guard).
      */
-    int trackedRawHandleCount() {
+    protected int trackedRawHandleCount() {
         return trackedRawHandles.size();
     }
 

--- a/render/src/test/java/com/hellblazer/luciferase/esvo/gpu/DynamicKernelSelectionTest.java
+++ b/render/src/test/java/com/hellblazer/luciferase/esvo/gpu/DynamicKernelSelectionTest.java
@@ -210,6 +210,34 @@ class DynamicKernelSelectionTest {
     }
 
     /**
+     * Re-upload then dispose must not double-free the node/childPointers buffers (Luciferase-qe8p0).
+     * uploadDataBuffers releases the previous tracked buffers on a re-upload; it must also untrack them, or
+     * dispose()'s defensive release loop frees the stale handle again — a native OpenCL abort (exit 133).
+     */
+    @Test
+    @DisplayName("Re-upload then dispose does not double-free (qe8p0)")
+    void testReuploadThenDisposeDoesNotDoubleFree() {
+        renderer.initialize();
+        renderer.uploadData(testDAG);
+        // node + dummy-childPointers buffers tracked.
+        assertEquals(2, renderer.trackedRawHandleCountForTest(),
+                     "upload tracks the node + dummy-childPointers buffers");
+
+        assertDoesNotThrow(() -> renderer.uploadData(testDAG), "re-upload must release+untrack the old buffers");
+        // Structural invariant: re-upload must untrack the OLD pair (count stays 2, not 4) — otherwise the
+        // stale freed handles remain tracked for dispose() to double-free.
+        assertEquals(2, renderer.trackedRawHandleCountForTest(),
+                     "re-upload must untrack old buffers (count stays 2, not 4) — else dispose double-frees");
+
+        assertDoesNotThrow(() -> renderer.dispose(),
+                          "dispose after re-upload must not double-free tracked buffers");
+        // dispose must leave NO tracked handles (each released exactly once).
+        assertEquals(0, renderer.trackedRawHandleCountForTest(),
+                     "dispose must untrack every released buffer (no handle left for a second free)");
+        assertFalse(renderer.isInitialized(), "renderer must be disposed");
+    }
+
+    /**
      * Test batch kernel initialization failure handling
      */
     @Test


### PR DESCRIPTION
## Summary

**Classifies and fixes** the `exit-133` crash that vkl96 quarantined: it is a **production-reachable double-free**, not a test-harness artifact (the open question qe8p0 was filed to answer).

`DAGOpenCLRenderer.uploadDataBuffers` allocates `clNodeBuffer`/`clDummyChildPointersBuffer` via `createRawBuffer()`, which **tracks** them in `AbstractOpenCLRenderer.trackedRawHandles`. `disposeTypeSpecificBuffers` released them with `clReleaseMemObject` but never called `untrackRawHandle`, so `dispose()`'s defensive release loop freed the **same handles again** → native OpenCL `abort()` (exit 133, no `hs_err`) on a normal `initialize() + uploadData() + dispose()` shutdown. The sibling `ESVTOpenCLRenderer` already does the untrack (its "G4" comment); `DAGOpenCLRenderer` was the outlier.

## Fix

`untrackRawHandle(handle)` after each `clReleaseMemObject` in `disposeTypeSpecificBuffers` **and** the `uploadDataBuffers` re-upload path (resetting handles to 0).

## Verification (Apple Silicon, `RUN_GPU_TESTS=true`)

- Isolation probes: upload-alone OK, dispose-without-upload OK, **upload+dispose CRASH**, **double-upload CRASH** → conclusively the release-without-untrack double-free.
- After fix: all pass; full `DynamicKernelSelectionTest` **9/9 green** (was a JVM fork crash).
- New `testReuploadThenDisposeDoesNotDoubleFree` asserts the **structural invariant** via a tracked-handle count (2 after upload, **2 after re-upload** proving untrack, 0 after dispose) — catches a silent untrack regression a liveness-only test would miss. `trackedRawHandleCount()` widened to `protected` + a DAG package-private test accessor.
- Stacked review (both sonnet): code-review-expert **APPROVED**, substantive-critic **justified** (0 Critical). Confirmed fix complete (DAG's two handles both covered, siblings already correct) and ordering safe (release→untrack→zero).

## Notes

- Test stays `RUN_GPU_TESTS`-gated (CI has no GPU; the separate device-probe-on-`initialize()` fork crash is why vkl96's quarantine **remains correct**). This PR removes the underlying double-free; the generic untrack mechanism is CI-unit-tested in `AbstractOpenCLRendererTrackingTest`.