### PR TITLE
fix(render): detectGPUCapabilities queries the renderer's actual device, not the global first GPU (Luciferase-ie6v8)

### DIFF
--- a/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/DAGOpenCLRenderer.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/DAGOpenCLRenderer.java
@@ -844,17 +844,38 @@ public class DAGOpenCLRenderer extends AbstractOpenCLRenderer<ESVONodeUnified, D
      * If no device is available (headless / no-GPU environment) returns an
      * honest generic fallback with UNKNOWN vendor — never a hardcoded NVIDIA stub.
      *
-     * <p><b>KNOWN LIMITATION (Luciferase-ie6v8):</b> {@link GPUVendorDetector#getInstance()}
-     * is a JVM singleton that queries the <em>first</em> GPU/platform found globally, not
-     * necessarily this renderer's actual device.  On multi-GPU or multi-platform systems the
-     * detected vendor, wavefront size, compute units, and local memory may not match the
-     * device used at {@code initialize()}, resulting in incorrect workgroup tuning.
-     * The single-GPU common case is correct; the UNKNOWN fallback when no device is present
-     * is honest.  Full fix requires passing this renderer's {@code cl_device_id} to a
-     * non-singleton query path — deferred to Luciferase-ie6v8.
+     * <p><b>Device selection (Luciferase-ie6v8):</b> when this renderer's {@link #context} is
+     * initialized, capabilities are queried for the renderer's <em>actual</em> device
+     * ({@code context.getDevice()} — the {@code cl_device_id} its {@code OpenCLContext} selected and
+     * runs kernels on) via {@link GPUVendorDetector#getCapabilitiesForDevice(long)}, so tuning
+     * matches the real device on multi-GPU / multi-platform hosts rather than
+     * {@link GPUVendorDetector#getInstance()}'s global first-GPU scan. Before the context is
+     * initialized (e.g. {@code optimizeForDevice()} called pre-{@code initialize()}) it falls back to
+     * the global scan (correct on a single-GPU host, but best-effort on multi-GPU — it may not match
+     * the device this renderer will run on; detect AFTER initialize() for device-accurate tuning),
+     * and to the honest UNKNOWN generic fallback when no device is present — never a hardcoded NVIDIA
+     * stub.
      */
     private com.hellblazer.luciferase.sparse.gpu.GPUCapabilities detectGPUCapabilities() {
-        var detected = GPUVendorDetector.getInstance().getCapabilities();
+        // Prefer this renderer's actual device over the global first-GPU scan (Luciferase-ie6v8).
+        var detected = GPUCapabilities.none();
+        if (context != null && context.isInitialized()) {
+            try {
+                detected = GPUVendorDetector.getInstance().getCapabilitiesForDevice(context.getDevice());
+            } catch (IllegalStateException e) {
+                // isInitialized() does not assert device != 0; getDevice() throws if the context is
+                // only partially initialized. Treat as "no device" and fall through to the scan.
+                log.debug("Context device unavailable despite isInitialized(); falling back to scan: {}",
+                          e.getMessage());
+            }
+        }
+        if (!detected.isValid()) {
+            // No initialized context/device for this renderer yet (e.g. optimizeForDevice() called
+            // before initialize()). Fall back to the global first-GPU scan: correct on a single-GPU
+            // host, but best-effort on multi-GPU — it may not match the device this renderer will
+            // run on. Callers needing device-accurate tuning must detect AFTER initialize().
+            detected = GPUVendorDetector.getInstance().getCapabilities();
+        }
         if (detected.isValid()) {
             // Map esvo.gpu.GPUVendor to sparse.gpu.GPUVendor via the vendor string.
             var sparseVendor = GPUVendor.fromVendorString(detected.vendorString());

--- a/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/GPUVendorDetector.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/GPUVendorDetector.java
@@ -108,6 +108,24 @@ public class GPUVendorDetector {
     }
 
     /**
+     * Query capabilities for a specific OpenCL device id, instead of the global first-GPU scan
+     * that {@link #getCapabilities()} caches at construction. Callers that already hold their
+     * actual {@code cl_device_id} (e.g. a renderer's {@code OpenCLContext.getDevice()}) use this so
+     * the detected vendor / compute-units / memory match the device they truly run on, not an
+     * unrelated first-found GPU on a multi-GPU or multi-platform host (Luciferase-ie6v8).
+     *
+     * @param device a valid OpenCL {@code cl_device_id}; {@code 0} yields {@link GPUCapabilities#none()}
+     * @return capabilities for that device, or {@link GPUCapabilities#none()} if {@code device == 0}
+     *         or the query fails
+     */
+    public GPUCapabilities getCapabilitiesForDevice(long device) {
+        if (device == 0L) {
+            return GPUCapabilities.none();
+        }
+        return queryDeviceCapabilities(device);
+    }
+
+    /**
      * Detect GPU vendor and capabilities from OpenCL
      */
     private GPUCapabilities detectGPU() {

--- a/render/src/test/java/com/hellblazer/luciferase/esvo/gpu/DAGOpenCLRendererTest.java
+++ b/render/src/test/java/com/hellblazer/luciferase/esvo/gpu/DAGOpenCLRendererTest.java
@@ -297,6 +297,59 @@ class DAGOpenCLRendererTest {
         // If a real GPU is present, any valid vendor value is acceptable.
     }
 
+    // ==================== ie6v8: actual-device capability query ====================
+
+    /**
+     * ie6v8: once the renderer's OpenCLContext is initialized, detectGPUCapabilities() must query
+     * the renderer's ACTUAL device (context.getDevice()) — not GPUVendorDetector's global first-GPU
+     * scan. Asserts the returned caps equal getCapabilitiesForDevice(actualDevice) and that a real
+     * device yields valid (not UNKNOWN) caps. GPU-gated: requires a live cl_device_id.
+     *
+     * <p><b>Verification limit (honest disclosure):</b> on a single-GPU / unified-memory host
+     * (e.g. Apple Silicon, the only hardware this is run on) the global first-GPU scan and
+     * context.getDevice() resolve to the SAME physical device, so this test validates the
+     * return-value contract but CANNOT distinguish the per-device path from the reverted global-scan
+     * path — both would pass here. The per-device-vs-global divergence is only observable on a
+     * genuine multi-GPU / multi-platform host, which is not available in CI or on the dev machine.
+     * The device==0 guard ({@code GPUVendorDetectorTest#testGetCapabilitiesForDeviceZeroGuard}) is
+     * the CI-runnable structural check of the new API.
+     */
+    @Test
+    @EnabledIfEnvironmentVariable(named = "RUN_GPU_TESTS", matches = "true")
+    @DisplayName("ie6v8: detectGPUCapabilities queries the renderer's actual device, not the global first GPU")
+    void testDetectGPUCapabilitiesUsesActualDevice() throws Exception {
+        // NB: like the other GPU tests in this class, we do NOT dispose() — the OpenCLContext is a
+        // refcounted process singleton these tests share; disposing it to refcount 0 would tear it
+        // down for sibling tests that upload without re-acquiring.
+        renderer.initialize();
+
+        // Read the renderer's actual OpenCL device id from the base context field.
+        Field contextField = renderer.getClass().getSuperclass().getDeclaredField("context");
+        contextField.setAccessible(true);
+        var context = contextField.get(renderer);
+        var getDevice = context.getClass().getMethod("getDevice");
+        long actualDevice = (long) getDevice.invoke(context);
+        assertNotEquals(0L, actualDevice, "an initialized context must expose a real cl_device_id");
+
+        Method detect = renderer.getClass().getDeclaredMethod("detectGPUCapabilities");
+        detect.setAccessible(true);
+        var caps = (com.hellblazer.luciferase.sparse.gpu.GPUCapabilities) detect.invoke(renderer);
+        assertNotEquals(GPUVendor.UNKNOWN, caps.vendor(),
+            "ie6v8: with a live device the renderer must report valid (non-UNKNOWN) capabilities");
+
+        // The returned caps must be the ones derived from the renderer's ACTUAL device, proving
+        // the per-device path is taken rather than the global getCapabilities() scan.
+        var actualDeviceCaps = GPUVendorDetector.getInstance().getCapabilitiesForDevice(actualDevice);
+        assertTrue(actualDeviceCaps.isValid(), "the actual device must itself report valid caps");
+        var expectedVendor = GPUVendor.fromVendorString(actualDeviceCaps.vendorString());
+        assertEquals(expectedVendor, caps.vendor(),
+            "ie6v8: detected vendor must match the renderer's actual device, not the first global GPU");
+        assertEquals(actualDeviceCaps.deviceName(), caps.model(),
+            "ie6v8: detected device name must match the renderer's actual device");
+        assertEquals(actualDeviceCaps.computeUnits(), caps.computeUnits(),
+            "ie6v8: detected compute units must come from the renderer's actual device");
+    }
+
     // ==================== Helper Methods ====================
 
     private ESVOOctreeData createTestOctree() {

--- a/render/src/test/java/com/hellblazer/luciferase/esvo/gpu/GPUVendorDetectorTest.java
+++ b/render/src/test/java/com/hellblazer/luciferase/esvo/gpu/GPUVendorDetectorTest.java
@@ -74,6 +74,18 @@ class GPUVendorDetectorTest {
         assertNotNull(capabilities.deviceName(), "Device name in capabilities should not be null");
     }
 
+    @Test
+    @DisplayName("ie6v8: getCapabilitiesForDevice(0) returns none() without touching OpenCL")
+    void testGetCapabilitiesForDeviceZeroGuard() {
+        // CI-runnable (no GPU): the per-device entry point must short-circuit an invalid (0)
+        // cl_device_id to none(), never attempting a live OpenCL query. Locks the guard that
+        // protects detectGPUCapabilities' actual-device path (Luciferase-ie6v8).
+        var detector = GPUVendorDetector.getInstance();
+        var caps = detector.getCapabilitiesForDevice(0L);
+        assertNotNull(caps, "getCapabilitiesForDevice must never return null");
+        assertFalse(caps.isValid(), "device id 0 must yield invalid (none) capabilities");
+    }
+
     // ==================== GPU Hardware Tests (Conditional) ====================
 
     @EnabledIfEnvironmentVariable(named = "RUN_GPU_TESTS", matches = "true")


### PR DESCRIPTION
## Summary

`DAGOpenCLRenderer.detectGPUCapabilities()` called `GPUVendorDetector.getInstance().getCapabilities()` — a JVM singleton that scans for and queries the **first** GPU/platform found globally. On multi-GPU / multi-platform hosts the detected vendor, compute-units, local-memory, and wavefront size could belong to a **different device** than the one the renderer's `OpenCLContext` actually selected and runs kernels on → incorrect workgroup tuning.

## Fix

Query the renderer's **actual** device:
- New public `GPUVendorDetector.getCapabilitiesForDevice(long device)` wrapping the existing per-device query path (`device == 0` → `none()`).
- `detectGPUCapabilities()` prefers `context.getDevice()` when `context.isInitialized()`, falling back to the global scan only **before** the context is initialized (e.g. `optimizeForDevice()` called pre-`initialize()` — best-effort on multi-GPU, correct on single-GPU), then to the honest `UNKNOWN` generic fallback.
- `context.getDevice()` guarded against `IllegalStateException` (`isInitialized()` does not assert `device != 0`).

## Verification (Apple Silicon, `RUN_GPU_TESTS=true`)

- GPU-gated `testDetectGPUCapabilitiesUsesActualDevice` passes: returned caps' vendor/name/compute-units match `context.getDevice()`.
- **Honest verification limit** (disclosed in the test javadoc): on single-GPU / unified-memory hardware the global scan and `context.getDevice()` resolve to the **same** device, so the per-device-vs-global divergence is only observable on a genuine multi-GPU host — unavailable in CI or on the dev machine. The CI-runnable `GPUVendorDetectorTest#testGetCapabilitiesForDeviceZeroGuard` locks the new API's `device == 0` guard without GPU hardware.
- Non-GPU CI path green (GPU tests skipped, guard test runs).
- Stacked review clean: code-review-expert **APPROVED**, substantive-critic **justified (0 Critical / 0 Significant)** after round-2.

## Scope notes

- Pre-init multi-GPU path remains best-effort (global scan); documented + disclosed as accepted residual on the bead (degrading it to `UNKNOWN` would regress the single-GPU common case).
- Surfaced (not introduced) two pre-existing broken GPU tests in `DAGOpenCLRendererTest` (`testUploadDAGDataToGPU`, `testRejectNonDAGData` call `uploadDataBuffers` without `initialize()`) — fail on clean main under `RUN_GPU_TESTS`, pass in CI only because it's unset. Filed **Luciferase-7f77k**, out of scope.