### PR TITLE
fix(portal): start-once / never-exit JavaFX toolkit in tests — stop suite-context FX wedge (Luciferase-tugep)

### DIFF
--- a/portal/src/test/java/com/hellblazer/luciferase/portal/JavaFXTestBase.java
+++ b/portal/src/test/java/com/hellblazer/luciferase/portal/JavaFXTestBase.java
@@ -16,10 +16,7 @@
  */
 package com.hellblazer.luciferase.portal;
 
-import javafx.application.Application;
 import javafx.application.Platform;
-import javafx.stage.Stage;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 
@@ -54,84 +51,69 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public abstract class JavaFXTestBase {
 
     private static final AtomicBoolean initialized = new AtomicBoolean(false);
-    private static final CountDownLatch initLatch = new CountDownLatch(1);
 
     /**
-     * Launcher application for JavaFX initialization.
-     * This is required to properly start the JavaFX toolkit.
+     * Initialize the JavaFX toolkit before any tests run, exactly once per JVM (surefire fork).
+     *
+     * <p>The toolkit is started via {@link Platform#startup(Runnable)} and {@code implicitExit} is
+     * disabled so it stays alive for the ENTIRE fork. It is deliberately <b>never</b> torn down with
+     * {@link Platform#exit()} (Luciferase-tugep): JavaFX cannot be restarted within a JVM once
+     * exited, so a per-class {@code @AfterAll Platform.exit()} would kill the toolkit for every
+     * later FX test class in the same fork — a subsequent re-init (e.g. {@code new JFXPanel()} or
+     * {@code Platform.startup}) then deadlocks in {@code QuantumRenderer.createResourceFactory},
+     * wedging the fork at 0% CPU. The daemon FX thread dies with the JVM at fork exit instead.</p>
+     *
+     * <p>{@code IllegalStateException} from {@code startup()} (toolkit already started by another
+     * FX test in this fork) is benign — we adopt the running toolkit. Skipped in CI where the
+     * {@code javafx} tag is excluded and no display is available.</p>
      */
-    public static class TestApplication extends Application {
-        @Override
-        public void start(Stage primaryStage) {
-            // Don't show the stage
-            initLatch.countDown();
-        }
+    @BeforeAll
+    public static void initializeJavaFX() {
+        ensureStarted();
     }
 
     /**
-     * Initialize JavaFX toolkit before any tests run.
-     * This is called once per test class.
-     *
-     * Note: Skipped in CI environments where xvfb may not provide sufficient display support.
+     * Idempotently start the shared JavaFX toolkit for this fork. Safe to call from any FX test
+     * class's {@code @BeforeAll}; the single shared start-and-never-exit lifecycle is the fix for
+     * the suite-context FX wedge (Luciferase-tugep). Public so non-{@code JavaFXTestBase} FX tests
+     * can route through the same path instead of their own divergent init/exit idioms.
      */
-    @BeforeAll
-    public static void initializeJavaFX() throws Exception {
-        // Skip JavaFX initialization in CI (xvfb may timeout on Application.launch)
+    public static void ensureStarted() {
+        // Skip JavaFX initialization in CI (the javafx tag is excluded there; no display available).
         if ("true".equals(System.getenv("CI"))) {
-            System.out.println("Skipping JavaFX initialization in CI environment");
             initialized.set(true);
             return;
         }
-
-        if (initialized.compareAndSet(false, true)) {
-            // Check if we're running in headless mode
-            if (Boolean.getBoolean("testfx.headless")) {
-                System.setProperty("java.awt.headless", "true");
-                System.setProperty("testfx.robot", "glass");
-                System.setProperty("testfx.headless", "true");
-                System.setProperty("prism.order", "sw");
-                System.setProperty("prism.text", "t2k");
-                System.setProperty("glass.platform", "Monocle");
-                System.setProperty("monocle.platform", "Headless");
-            }
-
-            // Launch JavaFX toolkit on a separate thread with timeout protection
-            Thread fxThread = new Thread(() -> {
-                try {
-                    Application.launch(TestApplication.class);
-                } catch (Exception e) {
-                    System.err.println("Failed to launch JavaFX: " + e.getMessage());
-                    e.printStackTrace();
-                    // Signal initialization complete even on failure
-                    initLatch.countDown();
-                }
-            });
-            fxThread.setDaemon(true);
-            fxThread.start();
-
-            // Wait for initialization with shorter timeout (5s)
-            if (!initLatch.await(5, TimeUnit.SECONDS)) {
-                System.err.println("JavaFX initialization timeout - tests may fail or be skipped");
-                // Don't throw - let tests handle the failure gracefully
-            }
-
-            // Give the toolkit a moment to fully initialize
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
+        if (!initialized.compareAndSet(false, true)) {
+            return;
         }
-    }
-
-    /**
-     * Shutdown JavaFX toolkit after all tests complete.
-     * Note: This may not be called in all test scenarios due to JUnit lifecycle.
-     */
-    @AfterAll
-    public static void shutdownJavaFX() {
-        if (initialized.get()) {
-            Platform.exit();
+        if (Boolean.getBoolean("testfx.headless")) {
+            System.setProperty("java.awt.headless", "true");
+            System.setProperty("testfx.robot", "glass");
+            System.setProperty("testfx.headless", "true");
+            System.setProperty("prism.order", "sw");
+            System.setProperty("prism.text", "t2k");
+            System.setProperty("glass.platform", "Monocle");
+            System.setProperty("monocle.platform", "Headless");
+        }
+        // Never auto-exit: keep the toolkit alive for the whole fork (see method javadoc). Set
+        // BEFORE startup so the policy is in force the instant the toolkit comes up — the startup
+        // runnable fires on the FX thread asynchronously and could otherwise observe the default
+        // implicitExit=true (stageless toolkit) before we flip it.
+        Platform.setImplicitExit(false);
+        var latch = new CountDownLatch(1);
+        try {
+            Platform.startup(latch::countDown);
+        } catch (IllegalStateException alreadyRunning) {
+            // Toolkit already started by another FX test in this fork — adopt it.
+            latch.countDown();
+        }
+        try {
+            if (!latch.await(5, TimeUnit.SECONDS)) {
+                System.err.println("JavaFX initialization timeout - tests may fail or be skipped");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/portal/src/test/java/com/hellblazer/luciferase/portal/esvt/ESVTRenderPipelineTest.java
+++ b/portal/src/test/java/com/hellblazer/luciferase/portal/esvt/ESVTRenderPipelineTest.java
@@ -4,10 +4,9 @@
 package com.hellblazer.luciferase.portal.esvt;
 
 import com.hellblazer.luciferase.geometry.Point3i;
+import com.hellblazer.luciferase.portal.JavaFXTestBase;
 import com.hellblazer.luciferase.portal.esvt.bridge.ESVTBridge;
 import com.hellblazer.luciferase.portal.esvt.renderer.ESVTNodeMeshRenderer;
-import javafx.application.Platform;
-import javafx.embed.swing.JFXPanel;
 import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.shape.MeshView;
@@ -16,8 +15,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -30,21 +27,13 @@ import static org.junit.jupiter.api.Assertions.*;
 class ESVTRenderPipelineTest {
 
     @BeforeAll
-    static void initJavaFX() throws InterruptedException {
-        // Skip JavaFX initialization in CI (xvfb may hang on JFXPanel initialization)
-        if ("true".equals(System.getenv("CI"))) {
-            System.out.println("Skipping JavaFX initialization in CI environment");
-            return;
-        }
-
-        CountDownLatch latch = new CountDownLatch(1);
-        try {
-            new JFXPanel();
-            Platform.runLater(latch::countDown);
-            latch.await(5, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            System.out.println("JavaFX init: " + e.getMessage());
-        }
+    static void initJavaFX() {
+        // Route through the shared, start-once / never-exit FX bootstrap (Luciferase-tugep). The
+        // previous `new JFXPanel()` re-initialized the toolkit independently; in a full-suite fork
+        // where another FX test had already run Platform.exit(), that restart deadlocked the FX
+        // thread in QuantumRenderer.createResourceFactory and wedged the fork. ensureStarted()
+        // adopts the living toolkit and never tears it down. (Also skips in CI internally.)
+        JavaFXTestBase.ensureStarted();
     }
 
     @Test


### PR DESCRIPTION
## Summary

The portal full-suite local run hung at **0% CPU** with `FX thread execution timeout` errors (the bug reports 5 in `GPUMemoryPaneTest`; repro hit `FrameTimePaneTest`). A thread dump of the wedged fork pinned it:
- **JavaFX Application Thread** parked forever in `QuantumRenderer.createResourceFactory` during `QuantumToolkit.startup`.
- **main** parked in `ESVTRenderPipelineTest`'s `new JFXPanel()` constructor.

## Root cause — JavaFX toolkit-restart deadlock

`JavaFXTestBase.@AfterAll` called the terminal `Platform.exit()` per test class. **JavaFX cannot be restarted within a JVM once exited.** When a later FX test class in the same surefire fork re-initialized the toolkit (`ESVTRenderPipelineTest` via `new JFXPanel()`, or another class via `Platform.startup`), the Prism pipeline deadlocked creating its resource factory and wedged the entire fork.

`GPUMemoryPaneTest` was a **victim, not the cause** — the all-timeout failure lands on whichever FX overlay class runs after the toolkit dies. This is exactly the *"a blind quarantine just moves the wedge to the next FX test"* hazard the bead called out.

## Fix — shared start-once / never-exit FX lifecycle

- **`JavaFXTestBase`**: replace `Application.launch` + per-class `@AfterAll Platform.exit()` with an idempotent `Platform.startup` (catching `IllegalStateException` to adopt an already-running toolkit) and `Platform.setImplicitExit(false)` **set before** `startup`. The `@AfterAll Platform.exit()` is removed entirely — the daemon FX thread dies with the JVM at fork exit. Exposed `public static ensureStarted()` so non-`JavaFXTestBase` FX tests share one init path.
- **`ESVTRenderPipelineTest`**: route through `JavaFXTestBase.ensureStarted()` instead of `new JFXPanel()`.
- `CellViewsTest` / `VoxelRendererTest` already use `Platform.startup` + catch-ISE and never exit, so they adopt the living toolkit unchanged.

## Verification (macOS arm64)

- Full portal suite (`mvn -pl portal test`) now **COMPLETES — 350 tests, 0 failures, 0 errors, 31 skipped** (was a 0%-CPU hang). Confirmed across two full runs.
- CI unaffected: portal excludes the `javafx` tag in CI (why this was local-only).
- Stacked review clean: code-review-expert + substantive-critic, round-2 **justified (0 Critical / 0 Significant)**. Both independently flagged the `setImplicitExit` ordering, now fixed.

## Scope note

Surfaced (not introduced): `MetricsIntegrationTest.testNoPerformanceRegression` has a brittle `<1ms` absolute-timing assertion that flakes under full-suite CPU contention and passes in isolation — filed **Luciferase-r389w**, out of scope.