### PR TITLE
fix(render): recreate far-pointer SSBO on size change — keep ResourceManager accounting honest (Luciferase-z2ysz)

### DIFF
--- a/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/ComputeShaderRenderer.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/ComputeShaderRenderer.java
@@ -132,7 +132,13 @@ public final class ComputeShaderRenderer {
         int[] fps = data.getFarPointers();
         int byteCount = (fps != null && fps.length > 0) ? fps.length * Integer.BYTES : Integer.BYTES;
 
-        if (farPointerSSBO == null) {
+        // Recreate the tracked resource when the size changes (Luciferase-z2ysz): the glBufferData
+        // below re-orphans the GL allocation at the new size, but the UnifiedResourceManager-tracked
+        // BufferResource keeps its original sizeBytes unless recreated, drifting the accounting.
+        if (farPointerSSBO == null || farPointerSSBO.getSizeBytes() != byteCount) {
+            if (farPointerSSBO != null) {
+                farPointerSSBO.close();
+            }
             farPointerSSBO = resourceManager.createStorageBuffer(byteCount, "ESVOFarPointerSSBO");
         }
 

--- a/render/src/main/java/com/hellblazer/luciferase/esvt/gpu/ESVTComputeRenderer.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvt/gpu/ESVTComputeRenderer.java
@@ -171,7 +171,13 @@ public final class ESVTComputeRenderer {
         int[] fps = data.hasFarPointers() ? data.farPointers() : null;
         int byteCount = (fps != null && fps.length > 0) ? fps.length * Integer.BYTES : Integer.BYTES;
 
-        if (farPointerSSBO == null) {
+        // Recreate the tracked resource when the size changes (Luciferase-z2ysz): the glBufferData
+        // below re-orphans the GL allocation at the new size, but the UnifiedResourceManager-tracked
+        // BufferResource keeps its original sizeBytes unless recreated, drifting the accounting.
+        if (farPointerSSBO == null || farPointerSSBO.getSizeBytes() != byteCount) {
+            if (farPointerSSBO != null) {
+                farPointerSSBO.close();
+            }
             farPointerSSBO = resourceManager.createStorageBuffer(byteCount, "ESVTFarPointerSSBO");
         }
 


### PR DESCRIPTION
## Summary

`ComputeShaderRenderer.uploadData` and `ESVTComputeRenderer.uploadData` created the far-pointer SSBO once at the first call's `byteCount` via `UnifiedResourceManager.createStorageBuffer`. A subsequent `uploadData` with a different-sized far-pointer table re-orphans the GL allocation via `glBufferData` (correct on the GL side) but the tracked `BufferResource` keeps its original `sizeBytes`, so `UnifiedResourceManager`'s per-type byte accounting **drifts** (no data corruption — accounting only). Found in the `7stji` / `0bn1q` review (code-review-expert M2).

## Fix

`BufferResource.sizeBytes` is `final` and there is no resize API (`updateData` uses `glBufferSubData`, which cannot grow), so the metadata-honest fix is to **recreate the tracked resource on size change**:

```java
if (farPointerSSBO == null || farPointerSSBO.getSizeBytes() != byteCount) {
    if (farPointerSSBO != null) farPointerSSBO.close();   // single-fire CAS, deregisters old sizeBytes
    farPointerSSBO = resourceManager.createStorageBuffer(byteCount, "...");  // registers new size
}
```

Applied identically in both renderers. `close()`+recreate is safe here: the far-pointer SSBO path is single-GL-thread with no concurrent readers at `uploadData`, and `dispose()` also `close()`s+nulls the field idempotently (CAS prevents double-free).

## Verification

- **Compile + stacked review only.** These are OpenGL **4.3** compute-shader renderers; this dev machine (Apple Silicon) caps at OpenGL **4.1** (confirmed: `ESVTGPUIntegrationTest` skips with *"macOS only supports OpenGL 4.1 - compute shaders require 4.3"*) and CI has no GPU — they cannot be executed here. Both reviewers agreed against adding a regression test that runs nowhere in our infra for a P4 accounting fix that is correct by inspection.
- Stacked review clean: code-review-expert **APPROVED**, substantive-critic **justified (0 Critical / 0 Significant)** after round-2.

## Scope

The identical drift in `OctreeGPUMemory` / `ESVTGPUMemory` `nodeSSBO` (more impactful — node buffers grow with real data) is tracked separately as **Luciferase-8pcrt** — split out because those mutate `nodeSSBO` under a **read lock** (`dispose()` nulls under the write lock), so `close()`+recreate there is a use-after-free hazard that needs its own review.