### PR TITLE
test(render): CI-verify GL compute renderers under Mesa software GL (Luciferase-ai9tw)

### DIFF
--- a/.github/workflows/gpu-shader-validation.yml
+++ b/.github/workflows/gpu-shader-validation.yml
@@ -163,7 +163,9 @@ jobs:
           # instead of shipping review-only (Luciferase-ai9tw). Under Mesa's software GL 4.5 the
           # tests run; if the software context cannot be created they self-skip via Assumptions
           # (GLComputeTestSupport), so a missing context is a skip, not a false failure.
-          RUN_GPU_TESTS=true ./mvnw test -pl render -Dgroups=gl-software
+          # -am builds the in-reactor upstream modules (common, lucien, ...): this is a standalone
+          # job with no prior install step, so without -am render's SNAPSHOT deps fail to resolve.
+          RUN_GPU_TESTS=true ./mvnw test -pl render -am -Dgroups=gl-software
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -175,6 +177,6 @@ jobs:
 
           # Heavier rendering-parity test kept best-effort (|| true): software-GL pixel output can
           # vary, so it stays informational rather than gating.
-          RUN_GPU_TESTS=true ./mvnw test -pl render -Dtest=ESVTGPUIntegrationTest -q || true
+          RUN_GPU_TESTS=true ./mvnw test -pl render -am -Dtest=ESVTGPUIntegrationTest -q || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gpu-shader-validation.yml
+++ b/.github/workflows/gpu-shader-validation.yml
@@ -8,6 +8,9 @@ on:
       # GL compute renderers + their tests run under the Mesa software-GL job (Luciferase-ai9tw),
       # so Java changes to the GPU paths must trigger this workflow too — not just shader edits.
       - 'render/src/main/java/**/gpu/**'
+      # Data layers the GL tests drive (ESVOOctreeData.getFarPointers, ESVTData.farPointers, nodes).
+      - 'render/src/main/java/**/esvo/core/**'
+      - 'render/src/main/java/**/esvt/core/**'
       - 'render/src/test/java/**/gpu/**'
       - '.github/workflows/gpu-shader-validation.yml'
   pull_request:
@@ -15,6 +18,8 @@ on:
     paths:
       - 'render/src/main/resources/shaders/**'
       - 'render/src/main/java/**/gpu/**'
+      - 'render/src/main/java/**/esvo/core/**'
+      - 'render/src/main/java/**/esvt/core/**'
       - 'render/src/test/java/**/gpu/**'
       - '.github/workflows/gpu-shader-validation.yml'
 
@@ -154,25 +159,42 @@ jobs:
       - name: Run GL compute tests under Mesa (gl-software — GATING)
         run: |
           export DISPLAY=:99.0
-          Xvfb :99 -screen 0 1024x768x24 &
+          if ! pgrep -x Xvfb >/dev/null; then Xvfb :99 -screen 0 1024x768x24 & fi
           sleep 2
 
           # Deterministic GL compute tests (SSBO size-accounting, etc.) tagged @Tag("gl-software").
           # These exercise the real glBufferData / compute paths the dev hardware (Apple GL 4.1)
           # cannot run, so they GATE here: a GL regression in the compute renderers fails CI
-          # instead of shipping review-only (Luciferase-ai9tw). Under Mesa's software GL 4.5 the
-          # tests run; if the software context cannot be created they self-skip via Assumptions
-          # (GLComputeTestSupport), so a missing context is a skip, not a false failure.
+          # instead of shipping review-only (Luciferase-ai9tw).
           # -am builds the in-reactor upstream modules (common, lucien, ...): this is a standalone
           # job with no prior install step, so without -am render's SNAPSHOT deps fail to resolve.
           RUN_GPU_TESTS=true ./mvnw test -pl render -am -Dgroups=gl-software
+
+          # Gate-integrity guard (Luciferase-ai9tw): Surefire returns BUILD SUCCESS for 0 tests
+          # (no @Tag match) AND counts an Assumptions-skip as run-but-skipped, so a missing Mesa
+          # context or a lost gl-software tag would let this "gate" pass without verifying anything.
+          # A gate that silently self-disables is worse than honest best-effort — fail unless at
+          # least one gl-software test ACTUALLY executed (tests - skipped >= 1).
+          tests=0; skipped=0
+          shopt -s nullglob
+          for f in render/target/surefire-reports/TEST-*.xml; do
+            t=$(grep -oP 'tests="\K[0-9]+' "$f" | head -1)
+            s=$(grep -oP 'skipped="\K[0-9]+' "$f" | head -1)
+            tests=$((tests + ${t:-0})); skipped=$((skipped + ${s:-0}))
+          done
+          executed=$((tests - skipped))
+          echo "gl-software gate: tests=$tests skipped=$skipped executed=$executed"
+          if [ "$executed" -lt 1 ]; then
+            echo "::error::gl-software gate verified nothing (executed=0) — Mesa GL context missing or @Tag('gl-software') lost. Failing instead of silently passing."
+            exit 1
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run ESVT GPU rendering test with Mesa (best-effort)
         run: |
           export DISPLAY=:99.0
-          Xvfb :99 -screen 0 1024x768x24 &
+          if ! pgrep -x Xvfb >/dev/null; then Xvfb :99 -screen 0 1024x768x24 & fi
           sleep 2
 
           # Heavier rendering-parity test kept best-effort (|| true): software-GL pixel output can

--- a/.github/workflows/gpu-shader-validation.yml
+++ b/.github/workflows/gpu-shader-validation.yml
@@ -5,11 +5,17 @@ on:
     branches: [main, 'feature/**']
     paths:
       - 'render/src/main/resources/shaders/**'
+      # GL compute renderers + their tests run under the Mesa software-GL job (Luciferase-ai9tw),
+      # so Java changes to the GPU paths must trigger this workflow too — not just shader edits.
+      - 'render/src/main/java/**/gpu/**'
+      - 'render/src/test/java/**/gpu/**'
       - '.github/workflows/gpu-shader-validation.yml'
   pull_request:
     branches: [main]
     paths:
       - 'render/src/main/resources/shaders/**'
+      - 'render/src/main/java/**/gpu/**'
+      - 'render/src/test/java/**/gpu/**'
       - '.github/workflows/gpu-shader-validation.yml'
 
 jobs:
@@ -145,13 +151,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run ESVT GPU tests with Mesa
+      - name: Run GL compute tests under Mesa (gl-software — GATING)
         run: |
           export DISPLAY=:99.0
           Xvfb :99 -screen 0 1024x768x24 &
           sleep 2
 
-          # Try running GPU tests - they may skip if compute shaders unavailable
+          # Deterministic GL compute tests (SSBO size-accounting, etc.) tagged @Tag("gl-software").
+          # These exercise the real glBufferData / compute paths the dev hardware (Apple GL 4.1)
+          # cannot run, so they GATE here: a GL regression in the compute renderers fails CI
+          # instead of shipping review-only (Luciferase-ai9tw). Under Mesa's software GL 4.5 the
+          # tests run; if the software context cannot be created they self-skip via Assumptions
+          # (GLComputeTestSupport), so a missing context is a skip, not a false failure.
+          RUN_GPU_TESTS=true ./mvnw test -pl render -Dgroups=gl-software
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run ESVT GPU rendering test with Mesa (best-effort)
+        run: |
+          export DISPLAY=:99.0
+          Xvfb :99 -screen 0 1024x768x24 &
+          sleep 2
+
+          # Heavier rendering-parity test kept best-effort (|| true): software-GL pixel output can
+          # vary, so it stays informational rather than gating.
           RUN_GPU_TESTS=true ./mvnw test -pl render -Dtest=ESVTGPUIntegrationTest -q || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/render/src/test/java/com/hellblazer/luciferase/gpu/GLComputeTestSupport.java
+++ b/render/src/test/java/com/hellblazer/luciferase/gpu/GLComputeTestSupport.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.gpu;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.lwjgl.glfw.GLFWErrorCallback;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.system.Platform;
+
+import static org.lwjgl.glfw.GLFW.*;
+import static org.lwjgl.opengl.GL11.GL_RENDERER;
+import static org.lwjgl.opengl.GL11.GL_VENDOR;
+import static org.lwjgl.opengl.GL11.GL_VERSION;
+import static org.lwjgl.opengl.GL11.glGetString;
+import static org.lwjgl.system.MemoryUtil.NULL;
+
+/**
+ * Base for headless OpenGL 4.3 compute tests that run under a real GL context.
+ *
+ * <p><b>Why this exists (Luciferase-ai9tw):</b> the GL compute renderers (ComputeShaderRenderer,
+ * ESVTComputeRenderer, OctreeGPUMemory, ESVTGPUMemory) need an OpenGL 4.3 context (compute shaders +
+ * SSBOs) that this project's dev machines (Apple Silicon, capped at OpenGL 4.1) cannot provide. CI's
+ * {@code mesa-software-test} job (gpu-shader-validation.yml) provides a software GL 4.5 context via
+ * Mesa llvmpipe ({@code LIBGL_ALWAYS_SOFTWARE=1}, {@code MESA_GL_VERSION_OVERRIDE=4.5}, xvfb), so
+ * these tests are the way to actually CI-verify the GL compute paths instead of shipping them
+ * review-only.</p>
+ *
+ * <p>Tests extend this class and run their GL work inside {@link #runWithGLContext(GLTestBody)},
+ * which creates a hidden GL 4.3 window, makes its context current on the calling thread, runs the
+ * body, and tears everything down — all on one thread, mirroring the proven single-method pattern in
+ * {@code ESVTGPUIntegrationTest} (a cross-method static context risks running on a different JUnit
+ * thread than the one it was made current on). If no GL 4.3 context can be created (macOS 4.1 cap, no
+ * display, software GL absent) the body is skipped via {@link Assumptions}, never failed.</p>
+ *
+ * <p>The class is {@code @Tag("gl-software")} so the mesa job can select it with
+ * {@code -Dgroups=gl-software}, and {@code @EnabledIfEnvironmentVariable(RUN_GPU_TESTS=true)} so it
+ * stays inert in normal local / CI runs (no GL context there). Both are inherited by subclasses.</p>
+ *
+ * @author hal.hildebrand
+ */
+@Tag("gl-software")
+@EnabledIfEnvironmentVariable(named = "RUN_GPU_TESTS", matches = "true",
+        disabledReason = "GL 4.3 compute context required — run under the mesa-software-test CI job "
+                + "(LIBGL_ALWAYS_SOFTWARE=1, MESA_GL_VERSION_OVERRIDE=4.5) or RUN_GPU_TESTS=true on GL-4.3 hardware")
+public abstract class GLComputeTestSupport {
+
+    /** A unit of test work that runs with a current OpenGL 4.3 context. */
+    @FunctionalInterface
+    protected interface GLTestBody {
+        void run() throws Exception;
+    }
+
+    /**
+     * Create a hidden OpenGL 4.3 context, run {@code body} with it current on this thread, then
+     * destroy it. Skips (does not fail) when a GL 4.3 context is unavailable.
+     */
+    protected void runWithGLContext(GLTestBody body) throws Exception {
+        GLFWErrorCallback errorCallback = GLFWErrorCallback.createPrint(System.err);
+        glfwSetErrorCallback(errorCallback);
+
+        boolean glfwInitialized = false;
+        long window = NULL;
+        try {
+            if (!glfwInit()) {
+                Assumptions.assumeTrue(false, "GLFW initialization failed — no GL context available");
+                return;
+            }
+            glfwInitialized = true;
+
+            glfwDefaultWindowHints();
+            glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+            glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+            glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+            if (Platform.get() == Platform.MACOSX) {
+                glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+            }
+
+            window = glfwCreateWindow(64, 64, "gl-compute-test", NULL, NULL);
+            if (window == NULL) {
+                // macOS caps at GL 4.1; compute shaders need 4.3. Skip rather than fail.
+                Assumptions.assumeTrue(false,
+                        "Could not create a GL 4.3 context (macOS caps at 4.1; needs Mesa software GL or GL-4.3 hardware)");
+                return;
+            }
+
+            glfwMakeContextCurrent(window);
+            GL.createCapabilities();
+            System.out.printf("GL context: vendor=%s renderer=%s version=%s%n",
+                    glGetString(GL_VENDOR), glGetString(GL_RENDERER), glGetString(GL_VERSION));
+
+            body.run();
+        } finally {
+            if (window != NULL) {
+                glfwMakeContextCurrent(NULL);
+                glfwDestroyWindow(window);
+            }
+            if (glfwInitialized) {
+                glfwTerminate();
+            }
+            glfwSetErrorCallback(null);
+            if (errorCallback != null) {
+                errorCallback.free();
+            }
+        }
+    }
+}

--- a/render/src/test/java/com/hellblazer/luciferase/gpu/SSBOAccountingGLTest.java
+++ b/render/src/test/java/com/hellblazer/luciferase/gpu/SSBOAccountingGLTest.java
@@ -18,6 +18,9 @@ package com.hellblazer.luciferase.gpu;
 
 import com.hellblazer.luciferase.esvo.core.ESVOOctreeData;
 import com.hellblazer.luciferase.esvo.gpu.ComputeShaderRenderer;
+import com.hellblazer.luciferase.esvt.core.ESVTData;
+import com.hellblazer.luciferase.esvt.core.ESVTNodeUnified;
+import com.hellblazer.luciferase.esvt.gpu.ESVTComputeRenderer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -76,9 +79,45 @@ class SSBOAccountingGLTest extends GLComputeTestSupport {
         });
     }
 
-    /** Read the renderer's private far-pointer SSBO tracked size via reflection. */
-    private static long trackedFarPointerBytes(ComputeShaderRenderer renderer) throws Exception {
-        Field field = ComputeShaderRenderer.class.getDeclaredField("farPointerSSBO");
+    /**
+     * z2ysz: ESVTComputeRenderer (the sibling of ComputeShaderRenderer) carries the identical
+     * far-pointer SSBO recreate-on-size-change fix; verify it under software GL too so a regression
+     * in either parallel implementation fails the gate.
+     */
+    @Test
+    @DisplayName("z2ysz: far-pointer SSBO tracked size follows re-upload resize (ESVTComputeRenderer)")
+    void esvtFarPointerSsboTrackedSizeFollowsResize() throws Exception {
+        runWithGLContext(() -> {
+            var renderer = new ESVTComputeRenderer(64, 64);
+            try {
+                renderer.initialize();
+
+                renderer.uploadData(esvtWithFarPointers(4));     // 16 bytes
+                assertEquals(16L, trackedFarPointerBytes(renderer),
+                        "tracked size must match the first upload's far-pointer byte count");
+
+                renderer.uploadData(esvtWithFarPointers(64));    // 256 bytes
+                assertEquals(256L, trackedFarPointerBytes(renderer),
+                        "z2ysz: tracked size must follow the re-upload GROW (ESVTComputeRenderer)");
+
+                renderer.uploadData(esvtWithFarPointers(1));     // 4 bytes
+                assertEquals(4L, trackedFarPointerBytes(renderer),
+                        "z2ysz: tracked size must follow the re-upload SHRINK (ESVTComputeRenderer)");
+            } finally {
+                renderer.dispose();
+            }
+        });
+    }
+
+    /** Minimal ESVTData carrying a far-pointer table of {@code count} entries. */
+    private static ESVTData esvtWithFarPointers(int count) {
+        var nodes = new ESVTNodeUnified[] { new ESVTNodeUnified() };
+        return new ESVTData(nodes, new int[0], new int[count], 0, 3, 1, 0);
+    }
+
+    /** Read the renderer's private {@code farPointerSSBO} tracked size via reflection. */
+    private static long trackedFarPointerBytes(Object renderer) throws Exception {
+        Field field = renderer.getClass().getDeclaredField("farPointerSSBO");
         field.setAccessible(true);
         var ssbo = field.get(renderer);
         assertNotNull(ssbo, "farPointerSSBO must be allocated after uploadData");

--- a/render/src/test/java/com/hellblazer/luciferase/gpu/SSBOAccountingGLTest.java
+++ b/render/src/test/java/com/hellblazer/luciferase/gpu/SSBOAccountingGLTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.gpu;
+
+import com.hellblazer.luciferase.esvo.core.ESVOOctreeData;
+import com.hellblazer.luciferase.esvo.gpu.ComputeShaderRenderer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * GL SSBO size-accounting regression tests, run under the Mesa software GL context (Luciferase-ai9tw).
+ *
+ * <p>These exercise the actual {@code glBufferData} resize path that this project's dev hardware
+ * (Apple Silicon, OpenGL 4.1) cannot run — the very paths that {@code z2ysz} had to ship review-only.
+ * Now that CI's {@code mesa-software-test} job provides a software GL 4.5 context, the fix is verified
+ * by execution: after a re-upload with a different far-pointer table size, the
+ * {@link org.lwjgl.system.MemoryUtil}-tracked {@code BufferResource} size must follow the resize.</p>
+ *
+ * @author hal.hildebrand
+ */
+@DisplayName("ai9tw: GL SSBO size-accounting under Mesa software GL")
+class SSBOAccountingGLTest extends GLComputeTestSupport {
+
+    /**
+     * z2ysz: ComputeShaderRenderer.uploadData recreates the far-pointer SSBO on size change so the
+     * tracked BufferResource.sizeBytes follows glBufferData's resize (grow AND shrink), rather than
+     * staying pinned at the first upload's byte count.
+     */
+    @Test
+    @DisplayName("z2ysz: far-pointer SSBO tracked size follows re-upload resize (grow + shrink)")
+    void farPointerSsboTrackedSizeFollowsResize() throws Exception {
+        runWithGLContext(() -> {
+            var renderer = new ComputeShaderRenderer(64, 64);
+            try {
+                renderer.initialize();
+
+                var small = new ESVOOctreeData(4096);
+                small.setFarPointers(new int[4]);            // 16 bytes
+                renderer.uploadData(small);
+                assertEquals(16L, trackedFarPointerBytes(renderer),
+                        "tracked size must match the first upload's far-pointer byte count");
+
+                var large = new ESVOOctreeData(4096);
+                large.setFarPointers(new int[64]);           // 256 bytes
+                renderer.uploadData(large);
+                assertEquals(256L, trackedFarPointerBytes(renderer),
+                        "z2ysz: tracked size must follow the re-upload GROW, not stay at the original 16 bytes");
+
+                var back = new ESVOOctreeData(4096);
+                back.setFarPointers(new int[1]);             // 4 bytes
+                renderer.uploadData(back);
+                assertEquals(4L, trackedFarPointerBytes(renderer),
+                        "z2ysz: tracked size must follow the re-upload SHRINK too");
+            } finally {
+                renderer.dispose();
+            }
+        });
+    }
+
+    /** Read the renderer's private far-pointer SSBO tracked size via reflection. */
+    private static long trackedFarPointerBytes(ComputeShaderRenderer renderer) throws Exception {
+        Field field = ComputeShaderRenderer.class.getDeclaredField("farPointerSSBO");
+        field.setAccessible(true);
+        var ssbo = field.get(renderer);
+        assertNotNull(ssbo, "farPointerSSBO must be allocated after uploadData");
+        var getSizeBytes = ssbo.getClass().getMethod("getSizeBytes");
+        return ((Number) getSizeBytes.invoke(ssbo)).longValue();
+    }
+}


### PR DESCRIPTION
## Summary

Leverages CI's new **mesa-software-test** job (software GL 4.5 via llvmpipe — `LIBGL_ALWAYS_SOFTWARE=1`, `MESA_GL_VERSION_OVERRIDE=4.5`, xvfb) to **execute** the OpenGL 4.3 GL compute paths that the dev hardware (Apple Silicon, GL 4.1) cannot run — so GL compute fixes stop shipping review-only.

## Changes

- **`GLComputeTestSupport`** (new test base): `runWithGLContext(body)` creates a hidden GL-4.3 context current on the calling thread, runs the body, tears down — single-threaded (mirrors `ESVTGPUIntegrationTest`'s proven pattern). Self-skips via `Assumptions` when no GL 4.3 context (macOS 4.1 / no display). `@Tag("gl-software")` + `@EnabledIfEnvironmentVariable(RUN_GPU_TESTS=true)` keep it inert in normal runs.
- **`SSBOAccountingGLTest`** (new): executes the **z2ysz** fix on **both** `ComputeShaderRenderer` and `ESVTComputeRenderer` — far-pointer SSBO tracked `getSizeBytes()` must follow a `glBufferData` re-upload resize (grow 16→256, shrink →4), not stay pinned. This is the regression test the z2ysz reviewers deferred as un-runnable; Mesa makes it runnable.
- **`gpu-shader-validation.yml`**: broaden triggers to GL renderer + data + test sources (not just shaders); add a **GATING** mesa step (`-Dgroups=gl-software -am`) with a **gate-integrity guard** that fails unless ≥1 gl-software test actually executed (Surefire passes on 0-match, and counts an Assumptions-skip as run — so without the guard the "gate" could silently no-op); keep `ESVTGPUIntegrationTest` best-effort; `-am` fixes a pre-existing masked dependency-resolution failure.

## Verification (CI, this branch)

- **mesa-software-test GREEN**: log shows both tests executed under `renderer=llvmpipe version=4.5 (Core Profile)` — `Tests run: 2, Failures: 0, Skipped: 0` — and the guard printed `gl-software gate: tests=2 skipped=0 executed=2`.
- `validate-shaders` green; locally compiles and skips cleanly (RUN_GPU_TESTS unset).
- Stacked review: code-review-expert + substantive-critic, round-2 **justified (0/0)**. The critic's round-1 Critical (gate could silently self-disable) is fixed by the gate-integrity guard.

## Scope

Honest first increment: the harness + the z2ysz fix verified by execution on both renderers. Follow-ups **Luciferase-8pcrt** (nodeSSBO drift) and **Luciferase-z9qq4** (ESVT ContourBuffer wiring) plug into `GLComputeTestSupport` with no new infrastructure.