### PR TITLE
feat(render): wire ContourBuffer (binding 6) into ESVTComputeRenderer GL path (Luciferase-z9qq4)

### DIFF
--- a/render/src/main/java/com/hellblazer/luciferase/esvt/gpu/ESVTComputeRenderer.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvt/gpu/ESVTComputeRenderer.java
@@ -206,6 +206,9 @@ public final class ESVTComputeRenderer {
         // is data-driven (contourCount * 4 bytes), so apply the same z2ysz recreate-on-size-change
         // guard as the far-pointer SSBO; upload a 4-byte placeholder when the build has no contours
         // so the shader's readonly ContourBuffer binding slot is always valid.
+        // NOTE: producer-pending (Luciferase-r8jrw) — ESVTBuilder currently emits empty contours, so
+        // this path binds the placeholder in live renders until a contour producer exists. The
+        // encoding contract is verified (matches the OpenCL path + the CPU ESVTTraversal indexing).
         boolean hasContours = data.hasContours();
         int contourBytes = hasContours ? data.contourSizeInBytes() : Integer.BYTES;
         if (contourSSBO == null || contourSSBO.getSizeBytes() != contourBytes) {

--- a/render/src/main/java/com/hellblazer/luciferase/esvt/gpu/ESVTComputeRenderer.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvt/gpu/ESVTComputeRenderer.java
@@ -66,7 +66,7 @@ public final class ESVTComputeRenderer {
     public static final int RENDER_FLAGS_UBO_BINDING = 3;
     public static final int COARSE_OUTPUT_BINDING = 4;
     public static final int COARSE_INPUT_BINDING = 5;
-    // CONTOUR_BUFFER_BINDING = 6 is defined in the shader but not yet wired in Java
+    public static final int CONTOUR_BUFFER_BINDING = 6;       // wired Luciferase-z9qq4
     public static final int FAR_POINTER_BUFFER_BINDING = 7;
 
     // Beam optimization constants
@@ -91,6 +91,10 @@ public final class ESVTComputeRenderer {
     // Far-pointer SSBO (binding 7). Always bound — contains a 4-byte placeholder
     // when no far pointers are present so the shader binding slot is always valid.
     private BufferResource farPointerSSBO;
+
+    // Contour SSBO (binding 6, Luciferase-z9qq4). Always bound — 4-byte placeholder when the build
+    // has no contour data, so the shader's ContourBuffer binding slot is always valid.
+    private BufferResource contourSSBO;
 
     // Camera UBO size: 4 matrices (4x4) + 2 vec4 (position+nearPlane, direction+farPlane)
     private static final int CAMERA_UBO_SIZE = 64 * 4 + 16 * 2;
@@ -197,6 +201,50 @@ public final class ESVTComputeRenderer {
 
         log.debug("Uploaded {} far-pointer entries ({} bytes) to SSBO binding {}",
                   fps != null ? fps.length : 0, byteCount, FAR_POINTER_BUFFER_BINDING);
+
+        // Contour data → ContourBuffer SSBO at binding 6 (Luciferase-z9qq4). The contour table size
+        // is data-driven (contourCount * 4 bytes), so apply the same z2ysz recreate-on-size-change
+        // guard as the far-pointer SSBO; upload a 4-byte placeholder when the build has no contours
+        // so the shader's readonly ContourBuffer binding slot is always valid.
+        boolean hasContours = data.hasContours();
+        int contourBytes = hasContours ? data.contourSizeInBytes() : Integer.BYTES;
+        if (contourSSBO == null || contourSSBO.getSizeBytes() != contourBytes) {
+            if (contourSSBO != null) {
+                contourSSBO.close();
+            }
+            contourSSBO = resourceManager.createStorageBuffer(contourBytes, "ESVTContourSSBO");
+        }
+        ByteBuffer contourBuf;
+        if (hasContours) {
+            contourBuf = data.contoursToByteBuffer();
+        } else {
+            contourBuf = ByteBuffer.allocateDirect(Integer.BYTES).order(ByteOrder.nativeOrder());
+            contourBuf.putInt(0);
+            contourBuf.flip();
+        }
+        glBindBuffer(GL_SHADER_STORAGE_BUFFER, contourSSBO.getOpenGLId());
+        glBufferData(GL_SHADER_STORAGE_BUFFER, contourBuf, GL_STATIC_DRAW);
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, CONTOUR_BUFFER_BINDING, contourSSBO.getOpenGLId());
+
+        log.debug("Uploaded {} contour entries ({} bytes) to SSBO binding {}",
+                  hasContours ? data.contourCount() : 0, contourBytes, CONTOUR_BUFFER_BINDING);
+    }
+
+    /**
+     * Ensure the contour SSBO is bound at {@link #CONTOUR_BUFFER_BINDING} for a render, creating a
+     * 4-byte placeholder if {@code uploadData} has not run yet (Luciferase-z9qq4) — mirrors the
+     * far-pointer placeholder so the shader's ContourBuffer slot is always valid.
+     */
+    private void ensureContourBoundWithPlaceholder() {
+        if (contourSSBO == null) {
+            contourSSBO = resourceManager.createStorageBuffer(Integer.BYTES, "ESVTContourSSBOPlaceholder");
+            ByteBuffer placeholder = ByteBuffer.allocateDirect(Integer.BYTES).order(ByteOrder.nativeOrder());
+            placeholder.putInt(0);
+            placeholder.flip();
+            glBindBuffer(GL_SHADER_STORAGE_BUFFER, contourSSBO.getOpenGLId());
+            glBufferData(GL_SHADER_STORAGE_BUFFER, placeholder, GL_STATIC_DRAW);
+        }
+        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, CONTOUR_BUFFER_BINDING, contourSSBO.getOpenGLId());
     }
 
     /**
@@ -233,6 +281,9 @@ public final class ESVTComputeRenderer {
             glBufferData(GL_SHADER_STORAGE_BUFFER, placeholder, GL_STATIC_DRAW);
         }
         glBindBufferBase(GL_SHADER_STORAGE_BUFFER, FAR_POINTER_BUFFER_BINDING, farPointerSSBO.getOpenGLId());
+
+        // Bind contour SSBO (binding 6) — placeholder if uploadData() has not run (Luciferase-z9qq4).
+        ensureContourBoundWithPlaceholder();
 
         // Update camera uniforms
         updateCameraUniforms(viewMatrix, projMatrix, objectToWorld, tetreeToObject);
@@ -330,6 +381,9 @@ public final class ESVTComputeRenderer {
             glBufferData(GL_SHADER_STORAGE_BUFFER, placeholder, GL_STATIC_DRAW);
         }
         glBindBufferBase(GL_SHADER_STORAGE_BUFFER, FAR_POINTER_BUFFER_BINDING, farPointerSSBO.getOpenGLId());
+
+        // Bind contour SSBO (binding 6) — placeholder if uploadData() has not run (Luciferase-z9qq4).
+        ensureContourBoundWithPlaceholder();
 
         // Update camera uniforms
         updateCameraUniforms(viewMatrix, projMatrix, objectToWorld, tetreeToObject);
@@ -575,6 +629,11 @@ public final class ESVTComputeRenderer {
             if (farPointerSSBO != null) {
                 farPointerSSBO.close();
                 farPointerSSBO = null;
+            }
+
+            if (contourSSBO != null) {
+                contourSSBO.close();
+                contourSSBO = null;
             }
         } catch (Exception e) {
             log.error("Error disposing GPU resources", e);

--- a/render/src/test/java/com/hellblazer/luciferase/gpu/SSBOAccountingGLTest.java
+++ b/render/src/test/java/com/hellblazer/luciferase/gpu/SSBOAccountingGLTest.java
@@ -109,18 +109,64 @@ class SSBOAccountingGLTest extends GLComputeTestSupport {
         });
     }
 
+    /**
+     * z9qq4: ESVTComputeRenderer now wires the ContourBuffer SSBO (binding 6). Its size is
+     * data-driven (contourCount * 4), so it uses the z2ysz recreate-on-size-change guard; with no
+     * contours a 4-byte placeholder keeps the readonly binding slot valid. Verify upload, grow,
+     * shrink, and the placeholder under software GL.
+     */
+    @Test
+    @DisplayName("z9qq4: contour SSBO (binding 6) tracks data-driven size + placeholder (ESVTComputeRenderer)")
+    void esvtContourSsboTracksData() throws Exception {
+        runWithGLContext(() -> {
+            var renderer = new ESVTComputeRenderer(64, 64);
+            try {
+                renderer.initialize();
+
+                renderer.uploadData(esvtWithContours(8));     // 32 bytes
+                assertEquals(32L, trackedSsboBytes(renderer, "contourSSBO"),
+                        "contour SSBO tracked size must match contourCount * 4 on first upload");
+
+                renderer.uploadData(esvtWithContours(64));    // 256 bytes
+                assertEquals(256L, trackedSsboBytes(renderer, "contourSSBO"),
+                        "z9qq4/z2ysz: contour SSBO tracked size must follow the re-upload GROW");
+
+                renderer.uploadData(esvtWithContours(2));     // 8 bytes
+                assertEquals(8L, trackedSsboBytes(renderer, "contourSSBO"),
+                        "z9qq4/z2ysz: contour SSBO tracked size must follow the re-upload SHRINK");
+
+                renderer.uploadData(esvtWithFarPointers(1));  // no contours -> 4-byte placeholder
+                assertEquals(4L, trackedSsboBytes(renderer, "contourSSBO"),
+                        "z9qq4: a build with no contours must bind a 4-byte placeholder, not stay at 8 bytes");
+            } finally {
+                renderer.dispose();
+            }
+        });
+    }
+
     /** Minimal ESVTData carrying a far-pointer table of {@code count} entries. */
     private static ESVTData esvtWithFarPointers(int count) {
         var nodes = new ESVTNodeUnified[] { new ESVTNodeUnified() };
         return new ESVTData(nodes, new int[0], new int[count], 0, 3, 1, 0);
     }
 
+    /** Minimal ESVTData carrying a contour table of {@code count} entries (no far pointers). */
+    private static ESVTData esvtWithContours(int count) {
+        var nodes = new ESVTNodeUnified[] { new ESVTNodeUnified() };
+        return new ESVTData(nodes, new int[count], new int[0], 0, 3, 1, 0);
+    }
+
     /** Read the renderer's private {@code farPointerSSBO} tracked size via reflection. */
     private static long trackedFarPointerBytes(Object renderer) throws Exception {
-        Field field = renderer.getClass().getDeclaredField("farPointerSSBO");
+        return trackedSsboBytes(renderer, "farPointerSSBO");
+    }
+
+    /** Read a renderer's private {@link org.lwjgl}-backed SSBO field's tracked size via reflection. */
+    private static long trackedSsboBytes(Object renderer, String fieldName) throws Exception {
+        Field field = renderer.getClass().getDeclaredField(fieldName);
         field.setAccessible(true);
         var ssbo = field.get(renderer);
-        assertNotNull(ssbo, "farPointerSSBO must be allocated after uploadData");
+        assertNotNull(ssbo, fieldName + " must be allocated after uploadData");
         var getSizeBytes = ssbo.getClass().getMethod("getSizeBytes");
         return ((Number) getSizeBytes.invoke(ssbo)).longValue();
     }

--- a/render/src/test/java/com/hellblazer/luciferase/gpu/SSBOAccountingGLTest.java
+++ b/render/src/test/java/com/hellblazer/luciferase/gpu/SSBOAccountingGLTest.java
@@ -23,11 +23,16 @@ import com.hellblazer.luciferase.esvt.core.ESVTNodeUnified;
 import com.hellblazer.luciferase.esvt.gpu.ESVTComputeRenderer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.lwjgl.system.MemoryStack;
 
 import java.lang.reflect.Field;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.lwjgl.opengl.GL15.glBindBuffer;
+import static org.lwjgl.opengl.GL15.glGetBufferSubData;
+import static org.lwjgl.opengl.GL43.GL_SHADER_STORAGE_BUFFER;
 
 /**
  * GL SSBO size-accounting regression tests, run under the Mesa software GL context (Luciferase-ai9tw).
@@ -130,6 +135,10 @@ class SSBOAccountingGLTest extends GLComputeTestSupport {
                 renderer.uploadData(esvtWithContours(64));    // 256 bytes
                 assertEquals(256L, trackedSsboBytes(renderer, "contourSSBO"),
                         "z9qq4/z2ysz: contour SSBO tracked size must follow the re-upload GROW");
+                // Value-level: the binding-6 buffer must hold exactly what contoursToByteBuffer()
+                // produced (encoding contract), not just be the right size. Read it back via GL.
+                assertArrayEquals(sentinelContours(64), readbackContourInts(renderer, 64),
+                        "z9qq4: contour SSBO contents must round-trip the uploaded int stream (std430 int[])");
 
                 renderer.uploadData(esvtWithContours(2));     // 8 bytes
                 assertEquals(8L, trackedSsboBytes(renderer, "contourSSBO"),
@@ -150,10 +159,36 @@ class SSBOAccountingGLTest extends GLComputeTestSupport {
         return new ESVTData(nodes, new int[0], new int[count], 0, 3, 1, 0);
     }
 
-    /** Minimal ESVTData carrying a contour table of {@code count} entries (no far pointers). */
+    /** Minimal ESVTData carrying a contour table of {@code count} distinct sentinel entries. */
     private static ESVTData esvtWithContours(int count) {
         var nodes = new ESVTNodeUnified[] { new ESVTNodeUnified() };
-        return new ESVTData(nodes, new int[count], new int[0], 0, 3, 1, 0);
+        return new ESVTData(nodes, sentinelContours(count), new int[0], 0, 3, 1, 0);
+    }
+
+    /** Distinct, non-zero contour values so a buffer read-back is a meaningful round-trip check. */
+    private static int[] sentinelContours(int count) {
+        var c = new int[count];
+        for (int i = 0; i < count; i++) {
+            c[i] = (i + 1) * 0x01010101;
+        }
+        return c;
+    }
+
+    /** Read {@code count} ints back from the renderer's contour SSBO via glGetBufferSubData. */
+    private static int[] readbackContourInts(Object renderer, int count) throws Exception {
+        Field field = renderer.getClass().getDeclaredField("contourSSBO");
+        field.setAccessible(true);
+        var ssbo = field.get(renderer);
+        assertNotNull(ssbo, "contourSSBO must be allocated after uploadData");
+        int glId = ((Number) ssbo.getClass().getMethod("getOpenGLId").invoke(ssbo)).intValue();
+        glBindBuffer(GL_SHADER_STORAGE_BUFFER, glId);
+        var out = new int[count];
+        try (var stack = MemoryStack.stackPush()) {
+            var ib = stack.mallocInt(count);
+            glGetBufferSubData(GL_SHADER_STORAGE_BUFFER, 0L, ib);
+            ib.get(out);
+        }
+        return out;
     }
 
     /** Read the renderer's private {@code farPointerSSBO} tracked size via reflection. */


### PR DESCRIPTION
## Summary

Wires the previously **producer-less** ESVT GL contour path. `raycast_esvt.comp` declares a `ContourBuffer` SSBO at binding 6 (the structurally-correct contour side-table, with `getContourMask`/`getContourPtr` readers) but `ESVTComputeRenderer` never bound it. The data already exists via `ESVTData.contoursToByteBuffer()` (consumed by the OpenCL renderer); this wires the GL path to match.

## Changes

- `CONTOUR_BUFFER_BINDING = 6` + `contourSSBO` field.
- `uploadData()`: upload contour data to `contourSSBO` at binding 6. Size is data-driven (`contourCount * 4`), so it reuses the **z2ysz** recreate-on-size-change guard; a 4-byte placeholder is uploaded when `hasContours()` is false so the readonly binding slot is always valid.
- `ensureContourBoundWithPlaceholder()`: binds the contour SSBO (placeholder if `uploadData` hasn't run) in **both** render paths (`renderFrame` + `renderFrameWithBeamOptimization`).
- `dispose()`: close + null `contourSSBO`.

## Verification (CI, mesa software GL)

- `SSBOAccountingGLTest.esvtContourSsboTracksData` (mesa-runnable) uploads **distinct sentinel** contour values, then reads the binding-6 buffer back via `glGetBufferSubData` and `assertArrayEquals` — a genuine **encoding round-trip**, not just a size check. mesa gate `executed=5` green under llvmpipe 4.5.
- The encoding contract is verified: `contoursToByteBuffer()`'s native-order int stream matches std430 `int[]`, and the shader's index arithmetic (`contourPtr + bitCount(mask & ((1<<face)-1))`) is byte-identical to the CPU `ESVTTraversal` reference.
- Stacked review: code-review-expert **APPROVED**, substantive-critic **justified (0/0)** after round-2.

## Scope (honest)

The wiring is **producer-pending**: `ESVTBuilder` currently emits empty contours, so the binding is placeholder-bound in live renders today. Wiring ahead of the producer was an explicit decision; the producer work (make `ESVTBuilder` emit contour masks + the packed int stream) is tracked as **Luciferase-r8jrw**, where a full GPU-render value test becomes possible. Documented in code.