### PR TITLE
test(render): fix broken DAGOpenCLRenderer GPU tests (Luciferase-7f77k)

### DIFF
--- a/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/DAGOpenCLRenderer.java
+++ b/render/src/main/java/com/hellblazer/luciferase/esvo/gpu/DAGOpenCLRenderer.java
@@ -449,7 +449,9 @@ public class DAGOpenCLRenderer extends AbstractOpenCLRenderer<ESVONodeUnified, D
 
     @Override
     protected void uploadDataBuffers(DAGOctreeData data) {
-        // Validate absolute addressing
+        // Validate absolute addressing. Defensive: currently unreachable via the type contract —
+        // DAGOctreeData.getAddressingMode() defaults to ABSOLUTE and no implementation overrides it
+        // (Luciferase-7f77k). Kept to fail loudly if a non-ABSOLUTE DAGOctreeData is ever introduced.
         if (data.getAddressingMode() != PointerAddressingMode.ABSOLUTE) {
             throw new IllegalArgumentException("DAG must use absolute addressing");
         }

--- a/render/src/test/java/com/hellblazer/luciferase/esvo/gpu/DAGOpenCLRendererTest.java
+++ b/render/src/test/java/com/hellblazer/luciferase/esvo/gpu/DAGOpenCLRendererTest.java
@@ -100,26 +100,24 @@ class DAGOpenCLRendererTest {
     @Test
     @DisplayName("Upload DAG data to GPU buffers")
     void testUploadDAGDataToGPU() {
-        // TDD: Test GPU buffer allocation and data upload
+        // Luciferase-7f77k: uploadDataBuffers allocates CL buffers, so the renderer must be
+        // initialized first (the prior version called it on an uninitialized renderer and failed
+        // with "OpenCL context not initialized"). GPU-gated: needs a real OpenCL context.
+        renderer.initialize();
         assertDoesNotThrow(() -> {
             renderer.uploadDataBuffers(testDAG);
             // Verify upload succeeded (no exception means success)
         });
     }
 
-    @EnabledIfEnvironmentVariable(named = "RUN_GPU_TESTS", matches = "true")
-    @Test
-    @DisplayName("Reject non-DAG data (wrong addressing mode)")
-    void testRejectNonDAGData() {
-        // TDD: Verify GPU renderer only accepts DAG data with absolute addressing
-        // Create an SVO (which uses relative addressing) and try to upload
-        assertThrows(IllegalArgumentException.class, () -> {
-            // Directly create a DAG-compatible object but with wrong addressing
-            // For now, we verify the renderer validates addressing mode
-            renderer.uploadDataBuffers(testDAG); // This should work
-            assertTrue(testDAG.getAddressingMode() == PointerAddressingMode.ABSOLUTE);
-        });
-    }
+    // Luciferase-7f77k: removed the former testRejectNonDAGData. It was misconceived (it wrapped a
+    // VALID absolute-addressed testDAG upload in assertThrows(IllegalArgumentException), which never
+    // throws). The addressing guard it meant to test (DAGOpenCLRenderer.uploadDataBuffers — reject
+    // non-ABSOLUTE) is unreachable via the type contract: DAGOctreeData.getAddressingMode() defaults
+    // to ABSOLUTE and no implementation overrides it. The guard remains as defensive production code;
+    // testing unreachable code through a fabricated mock provides no coverage of any real path and is
+    // not worth a Mockito dependency (YAGNI). Restore a real test if a non-ABSOLUTE DAGOctreeData
+    // implementation is ever introduced.
 
     // ==================== DAG Structure Tests ====================
 
@@ -162,11 +160,12 @@ class DAGOpenCLRendererTest {
     @Test
     @DisplayName("GPU traversal works on NVIDIA hardware")
     void testNvidiaOpenCL() {
-        // TDD: Test NVIDIA GPU execution
-        renderer.uploadDataBuffers(testDAG);
+        // Luciferase-7f77k: initialize() before any upload — uploadDataBuffers allocates CL buffers
+        // and needs the context. The prior order (uploadDataBuffers before initialize) only passed
+        // when a sibling test had already initialized the shared OpenCLContext singleton — flaky.
+        renderer.initialize();
         assertDoesNotThrow(() -> {
-            // Renderer is initialized - data uploaded - ready for frame rendering
-            renderer.initialize();
+            renderer.uploadDataBuffers(testDAG);
             renderer.uploadData(testDAG);
         });
     }
@@ -175,10 +174,10 @@ class DAGOpenCLRendererTest {
     @Test
     @DisplayName("GPU traversal works on AMD hardware")
     void testAmdOpenCL() {
-        // TDD: Test AMD GPU execution
-        renderer.uploadDataBuffers(testDAG);
+        // Luciferase-7f77k: initialize() before any upload (see testNvidiaOpenCL).
+        renderer.initialize();
         assertDoesNotThrow(() -> {
-            renderer.initialize();
+            renderer.uploadDataBuffers(testDAG);
             renderer.uploadData(testDAG);
         });
     }
@@ -187,10 +186,10 @@ class DAGOpenCLRendererTest {
     @Test
     @DisplayName("GPU traversal works on Intel hardware")
     void testIntelOpenCL() {
-        // TDD: Test Intel GPU execution
-        renderer.uploadDataBuffers(testDAG);
+        // Luciferase-7f77k: initialize() before any upload (see testNvidiaOpenCL).
+        renderer.initialize();
         assertDoesNotThrow(() -> {
-            renderer.initialize();
+            renderer.uploadDataBuffers(testDAG);
             renderer.uploadData(testDAG);
         });
     }


### PR DESCRIPTION
## Summary

Five GPU tests in `DAGOpenCLRendererTest` were broken (surfaced during ie6v8 on Apple Silicon — OpenCL works on the M4 via Metal). All shared an **init-order bug**: `uploadDataBuffers` (which allocates CL buffers) was called **before** `initialize()`, so they failed `"OpenCL context not initialized"` — or passed only by luck when a sibling test had already initialized the shared, refcounted `OpenCLContext` singleton (order-dependent flaky).

## Changes

- **`testUploadDAGDataToGPU`, `testNvidiaOpenCL`, `testAmdOpenCL`, `testIntelOpenCL`**: `initialize()` first, then `uploadDataBuffers` + `uploadData` inside the assertion.
- **`testRejectNonDAGData`: deleted.** It was misconceived (`assertThrows(IAE)` around a *valid* absolute upload that never throws), and the addressing guard it meant to test is **unreachable by the type contract** — `DAGOctreeData.getAddressingMode()` defaults to `ABSOLUTE` with no override. Testing unreachable code through a fabricated mock covers no real path and isn't worth a Mockito dependency (YAGNI / "integration over mocks"). The production guard stays, annotated as defensive/contract-unreachable.

## Verification

- Non-GPU: **16 run / 0 fail**; `testRejectNonDAGData` removed; GPU tests skip.
- GPU on Apple Silicon (`RUN_GPU_TESTS=true`): **16 run / 0 fail / 2 skip** (AMD + Intel are `GPU_VENDOR`-gated, unverifiable on Apple — the fix is the identical one-liner; `testNvidiaOpenCL` + `testUploadDAGDataToGPU` now pass).
- Stacked review: code-review-expert **APPROVED**, substantive-critic **justified (0/0)** after round-2 (its round-1 call — delete the unreachable-guard test rather than add Mockito — was taken).