### PR TITLE
test(portal): route flaky perf assertion to -Pperformance + median deflake (Luciferase-r389w)

### DIFF
--- a/portal/src/test/java/com/hellblazer/luciferase/portal/overlay/MetricsIntegrationTest.java
+++ b/portal/src/test/java/com/hellblazer/luciferase/portal/overlay/MetricsIntegrationTest.java
@@ -22,6 +22,7 @@ import com.hellblazer.luciferase.esvo.gpu.beam.metrics.MetricsSnapshot;
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -168,7 +169,21 @@ class MetricsIntegrationTest {
     /**
      * T36: testNoPerformanceRegression - Overlay overhead is minimal.
      * Measures overhead of metrics source updates and snapshot retrieval.
+     *
+     * <p>{@code @Tag("performance")} (Luciferase-r389w): the sub-millisecond absolute-timing
+     * assertions below are inherently noise-sensitive (GC, scheduling, JIT) and flaked under
+     * full-suite CPU contention while passing in isolation. Tagging routes it out of the default
+     * run (excluded via {@code test.excluded.groups=performance}); the measurements also take the
+     * MEDIAN of several samples to resist scheduling noise without hiding a real regression (min
+     * would pass on one lucky fast batch).
+     *
+     * <p><b>Execution path (accepted trade-off):</b> the class is already
+     * {@code @DisabledIfEnvironmentVariable(CI)}, so combined with this tag the test runs ONLY
+     * on-demand under {@code mvn -pl portal test -Pperformance} on a developer machine — a deliberate
+     * run-when-checking benchmark, not a per-commit gate. That is the correct home for a
+     * contention-sensitive micro-benchmark; gating it on every run is what caused the flake.
      */
+    @Tag("performance")
     @Test
     void testNoPerformanceRegression() throws InterruptedException {
         // Given: Controller is started
@@ -179,32 +194,53 @@ class MetricsIntegrationTest {
         });
         assertTrue(startLatch.await(2, TimeUnit.SECONDS), "Controller should start");
 
-        // When: Measuring metrics updates overhead
+        // When: Measuring metrics updates overhead. Warm up first (JIT + first-touch), then take the
+        // MEDIAN of several timed batches. Median (not min) is the honest deflaker for a regression
+        // test: it rejects single scheduling/GC outliers (what flaked the old single-shot under load,
+        // Luciferase-r389w) while still rising if the TYPICAL case slows down — min would pass on one
+        // lucky fast batch and hide a real regression.
         var iterations = 1000;
-        var startNs = System.nanoTime();
-
         for (int i = 0; i < iterations; i++) {
-            metricsSource.recordFrame(2);
+            metricsSource.recordFrame(2);  // warmup
         }
+        var avgPerFrameSamples = new double[5];
+        for (int rep = 0; rep < avgPerFrameSamples.length; rep++) {
+            var startNs = System.nanoTime();
+            for (int i = 0; i < iterations; i++) {
+                metricsSource.recordFrame(2);
+            }
+            avgPerFrameSamples[rep] = (System.nanoTime() - startNs) / 1_000_000.0 / iterations;
+        }
+        var medianAvgPerFrameMs = median(avgPerFrameSamples);
 
-        var endNs = System.nanoTime();
-        var totalMs = (endNs - startNs) / 1_000_000.0;
-        var avgPerFrameMs = totalMs / iterations;
+        // Then: Overhead should be minimal (< 0.1ms per frame on average, median batch)
+        assertTrue(medianAvgPerFrameMs < 0.1,
+                  String.format("Median average overhead %.3fms should be < 0.1ms", medianAvgPerFrameMs));
 
-        // Then: Overhead should be minimal (< 0.1ms per frame on average)
-        assertTrue(avgPerFrameMs < 0.1,
-                  String.format("Average overhead %.3fms should be < 0.1ms", avgPerFrameMs));
+        // Verify snapshot retrieval is fast (< 1ms) — warm up, then take the median of several samples.
+        for (int i = 0; i < 100; i++) {
+            metricsSource.get();  // warmup
+        }
+        var snapshotSamples = new double[11];
+        MetricsSnapshot snapshot = null;
+        for (int rep = 0; rep < snapshotSamples.length; rep++) {
+            var snapshotStartNs = System.nanoTime();
+            snapshot = metricsSource.get();
+            snapshotSamples[rep] = (System.nanoTime() - snapshotStartNs) / 1_000_000.0;
+        }
+        var medianSnapshotMs = median(snapshotSamples);
 
-        // Verify snapshot retrieval is fast (< 1ms)
-        // Note: First call may include JVM warmup overhead
-        var snapshotStartNs = System.nanoTime();
-        var snapshot = metricsSource.get();
-        var snapshotEndNs = System.nanoTime();
-        var snapshotMs = (snapshotEndNs - snapshotStartNs) / 1_000_000.0;
-
-        assertTrue(snapshotMs < 1.0,
-                  String.format("Snapshot retrieval %.3fms should be < 1ms", snapshotMs));
+        assertTrue(medianSnapshotMs < 1.0,
+                  String.format("Median snapshot retrieval %.3fms should be < 1ms", medianSnapshotMs));
         assertNotNull(snapshot, "Snapshot should not be null");
+    }
+
+    /** Median of the samples (sorts a copy; for odd length returns the middle element). */
+    private static double median(double[] samples) {
+        var sorted = samples.clone();
+        java.util.Arrays.sort(sorted);
+        int mid = sorted.length / 2;
+        return sorted.length % 2 == 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2.0;
     }
 
     /**


### PR DESCRIPTION
## Summary

`MetricsIntegrationTest.testNoPerformanceRegression` has sub-millisecond absolute-timing assertions (avg `recordFrame` < 0.1ms; snapshot `get()` < 1ms) that flaked under full-suite CPU contention (observed 1.455ms vs <1ms) while passing in isolation. The class is already `@DisabledIfEnvironmentVariable(CI)`, so the flake hit the **local full-portal-suite** run.

## Fix (test-only)

- **`@Tag("performance")`**: excluded from the default run (`test.excluded.groups=performance`) — a contention-sensitive micro-benchmark belongs in the `-Pperformance` profile, not the contended default suite. Documented as an accepted trade-off: the test runs **on-demand** under `mvn -pl portal test -Pperformance`, not as a per-commit gate.
- **Median (not min) of warmed-up samples**: median rejects single scheduling/GC outliers (the flake) while still **rising if the typical case slows** — so a real regression is still caught. `min` would pass on one lucky fast batch, defeating the regression-test purpose (per substantive-critic round-1).

## Verification

- Default run: **excluded** (0 matched) — deflakes the local suite.
- `-Pperformance` run: **1 passed**.
- Stacked review: code-review-expert **APPROVED**, substantive-critic **justified (0/0)** after round-2 (min→median + documented execution trade-off).