### PR TITLE
test(simulation): deflake StreamingE2ETest via production-faithful retry budget + diagnostic (Luciferase-jifjt)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/viz/render/BuildQueue.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/viz/render/BuildQueue.java
@@ -88,6 +88,11 @@ public final class BuildQueue {
      */
     public void submit(SpatialKey<?> key, RegionBuilder.KeyedBuildRequest.Priority priority) {
         // TODO: wire priority into build executor ordering (Task 6.1 follow-up)
+        // INVARIANT (Luciferase-jifjt): builder.buildKeyed must complete on a pool thread, never
+        // synchronously on the caller. The whenComplete callback calls inFlight.remove(k); if the
+        // future were already complete (e.g. CompletableFuture.completedFuture in a test stub), that
+        // remove would run re-entrantly inside this computeIfAbsent — a forbidden ConcurrentHashMap
+        // self-mutation. Any synchronous/test build path must still resolve asynchronously (supplyAsync).
         inFlight.computeIfAbsent(key, k -> {
             var expectedVersion = dirtyTracker.version(k);
             return builder.buildKeyed(k, facade, expectedVersion)

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/viz/render/StreamingE2ETest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/viz/render/StreamingE2ETest.java
@@ -124,20 +124,28 @@ class StreamingE2ETest {
         // Drive the build→cache→push pipeline to completion rather than asserting on a single shot.
         // A build can fail transiently under heavy CI load — buildKeyed runs on RegionBuilder's
         // buildPool and doBuild/ESVO serialization can throw IOException (e.g. under memory pressure).
-        // BuildQueue.awaitBuilds() shields that exception (.exceptionally(e->null)), so the cache stays
-        // stale and the tick re-submits instead of pushing. The production design is retry-based — a
-        // later tick re-submits and a later awaitBuilds delivers — so re-await + re-tick a bounded
-        // number of times here so a transient build failure self-heals (Luciferase-5ezt5). Once a
-        // RegionUpdate is pushed, the subscription's known version advances, so an extra tick will not
-        // double-push. (Note: the per-region circuit breaker is on RegionBuilder.build(BuildRequest),
-        // NOT this buildKeyed path, so it is not a failure mode here.)
+        // BuildQueue swallows that exception (.exceptionally, counted in totalBuildFailures), so the
+        // cache stays stale and the next tick re-submits instead of pushing. The production design is
+        // retry-based (retries indefinitely); the test just needs a budget large enough to outlast a
+        // run of consecutive transient failures. Luciferase-jifjt: a 10-attempt budget occasionally
+        // ran out under test-batch-1's parallel memory pressure (assertion saw null — builds completed
+        // exceptionally every attempt, not a logic bug), so raise it to 40 and widen the per-attempt
+        // receive window. Once a RegionUpdate is pushed the subscription's known version advances, so a
+        // later tick will not double-push; a later attempt's receive simply drains the queued message.
+        // The build-failure count is surfaced in the assertion so a genuine never-builds logic bug
+        // stays distinguishable from infra flake (Luciferase-8pygn getTotalBuildFailures).
+        // Worst case: 40 * (2s await + 500ms receive) = 100s; normal path: 1-3 attempts. The 2s await
+        // is ~20x the sub-100ms in-memory ESVO build even under load, and a genuine build hang throws
+        // TimeoutException (loud abort) rather than silently continuing — so the budget is for
+        // consecutive transient build FAILURES, not slow builds.
         ServerMessage updateMsg = null;
-        for (int attempt = 0; attempt < 10 && !(updateMsg instanceof ServerMessage.RegionUpdate); attempt++) {
-            buildQueue.awaitBuilds().get(5, TimeUnit.SECONDS); // deliver any (re)submitted build into cache
+        for (int attempt = 0; attempt < 40 && !(updateMsg instanceof ServerMessage.RegionUpdate); attempt++) {
+            buildQueue.awaitBuilds().get(2, TimeUnit.SECONDS); // deliver any (re)submitted build into cache
             cycle.tick(200_000_000L);
-            updateMsg = client.nextServerMessage(200, TimeUnit.MILLISECONDS);
+            updateMsg = client.nextServerMessage(500, TimeUnit.MILLISECONDS);
         }
         assertInstanceOf(ServerMessage.RegionUpdate.class, updateMsg,
-            "moved entity should trigger REGION_UPDATE via streaming cycle");
+            "moved entity should trigger REGION_UPDATE via streaming cycle (lifetime build failures="
+            + buildQueue.getTotalBuildFailures() + ")");
     }
 }


### PR DESCRIPTION
## Summary

`StreamingE2ETest.phaseCAndBFullFlow` flaked under test-batch-1 parallel load (`moved entity should trigger REGION_UPDATE ==> expected RegionUpdate but was null`), passed in isolation.

**Root cause** (by elimination — `keysVisible` divergence and `deliverPending` version-discard are inactive for this fixture): `RegionBuilder.buildKeyed` runs async on `buildPool`; under memory pressure ESVO serialization throws `IOException`; `BuildQueue` swallows it (`.exceptionally`, counted in `totalBuildFailures`), leaving the cache stale so `StreamingCycle.tick` re-submits instead of pushing. The test's `awaitBuilds().get` never timed out (would throw, not null), so builds completed exceptionally repeatedly and the 10-attempt budget occasionally ran out.

## Fix (real build path retained — production retries indefinitely; the test mirrors that)

- Retry budget 10→40, receive window 200ms→500ms, await timeout 5s→2s (in-memory ESVO builds are sub-100ms; worst case `40*(2s+500ms)=100s`, normal 1–3 attempts; a genuine hang throws loudly).
- Surface `getTotalBuildFailures()` in the assertion so a future recurrence distinguishes infra-flake (failures>0) from a logic bug (failures==0).
- `BuildQueue.submit`: documented the re-entrancy invariant — `buildKeyed` must resolve on a pool thread, never synchronously, or `whenComplete`'s `inFlight.remove` runs re-entrantly inside `computeIfAbsent`.

## Why not a deterministic stub?

Attempted (per review) and rejected with evidence: a `completedFuture` stub triggers the re-entrant `computeIfAbsent` violation, and an async fixed-bytes stub still fails because the **real ESVO build output is load-bearing for the binary-frame push** — the streaming push path needs valid region data, so the builder can't be cleanly stubbed without reworking `BuildQueue` + the frame codec (disproportionate for a P4 flake).

## Verification

- 3/3 in isolation after the fix.
- Stacked review: code-review-expert **APPROVED**, substantive-critic **justified (0 Critical)** after round-2 (accepted the budget+diagnostic given the deterministic-stub evidence; the worst-case-duration Significant addressed by the 2s timeout).