### PR TITLE
fix(forest): splitTree() reads entity content before remove (Luciferase-22i71)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/DynamicForestManager.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/DynamicForestManager.java
@@ -556,10 +556,12 @@ public class DynamicForestManager<Key extends SpatialKey<Key>, ID extends Entity
                     // Find best matching split
                     var bestTree = findBestTreeForPosition(position, newTreeIds);
                     if (bestTree != null) {
-                        // Update entity manager to move entity
-                        entityManager.remove(entityId);
+                        // Read content and bounds BEFORE removing the entity: remove() deletes the
+                        // entity from the source spatial index, after which getEntity/getEntityBounds
+                        // return null and the entity would be re-inserted with null content (silent loss).
                         var content = tree.getSpatialIndex().getEntity(entityId);
                         var bounds = tree.getSpatialIndex().getEntityBounds(entityId);
+                        entityManager.remove(entityId);
                         entityManager.insert(entityId, content, position, bounds);
                         migratedCount++;
                     }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/DynamicForestManagerTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/DynamicForestManagerTest.java
@@ -209,6 +209,45 @@ public class DynamicForestManagerTest {
         assertTrue(totalEntities >= 98,
             "Spatial-index entity count after lossy split should be >= 98, but had " + totalEntities);
     }
+
+    @Test
+    void testSplitTreePreservesEntityContent() {
+        // Regression for Luciferase-22i71: splitTree() previously read entity content/bounds AFTER
+        // removing the entity from the source index, re-inserting null content (silent data loss).
+        // Count-only assertions (testSplitTree) did not catch it; this asserts content survives.
+        var originalTree = forest.getAllTrees().get(0);
+
+        var rng = new java.util.Random(42L);
+        for (int i = 0; i < 100; i++) {
+            var id = new LongEntityID(i);
+            var pos = new Point3f((float) (rng.nextDouble() * 100), (float) (rng.nextDouble() * 100),
+                                  (float) (rng.nextDouble() * 100));
+            originalTree.getSpatialIndex().insert(id, pos, (byte) 10, "Entity " + i);
+            entityManager.insert(id, "Entity " + i, pos, new EntityBounds(pos, pos));
+        }
+        originalTree.refreshStatistics();
+
+        assertTrue(dynamicManager.splitTree(originalTree));
+
+        // Scope: this pins the use-after-remove bug (content read AFTER remove -> null re-insert),
+        // which corrupted EVERY migrated entity's content (~98 nulls). It deliberately tolerates the
+        // separate, pre-existing >=98 boundary-drop behavior documented in testSplitTree (entities
+        // whose position finds no best octant are orphaned when the source tree is removed). So:
+        // every entity that SURVIVED the split must carry its original, non-null content; under the
+        // old bug the survivors would all read null content and this count would collapse to ~0.
+        var survivorsWithIntactContent = 0;
+        for (int i = 0; i < 100; i++) {
+            var content = entityManager.getEntityContent(new LongEntityID(i));
+            if (content != null) {
+                assertEquals("Entity " + i, content,
+                    "Entity " + i + " survived the split but its content was corrupted");
+                survivorsWithIntactContent++;
+            }
+        }
+        assertTrue(survivorsWithIntactContent >= 98,
+            "At least 98 entities must survive the split with intact content (use-after-remove "
+                + "regression Luciferase-22i71), but only " + survivorsWithIntactContent + " did");
+    }
     
     @Test
     void testMergeTrees() {


### PR DESCRIPTION
## Summary
`DynamicForestManager.splitTree()` called `entityManager.remove(entityId)` **before** reading `tree.getSpatialIndex().getEntity()/getEntityBounds()`, so every migrated entity was re-inserted with **null content** — silent data loss on every tree split. Production-reachable via the auto-management scheduler (`performAutoManagement → checkAndSplitTrees → splitTree`).

Found in the 2026-06-14 lucien+simulation standing audit; confirmed by substantive-critic.

## Change
- Move the content/bounds reads ahead of `remove()` (6 lines).
- Add `testSplitTreePreservesEntityContent`, scoped to this defect.

## Test rigor
Proven **non-vacuous**: with the buggy ordering the test fails (`only 0 survived with intact content`); with the fix it passes. The `>=98` threshold tolerates the *separate, pre-existing* boundary-drop path (documented in `testSplitTree`) without masking content corruption — the inner `assertEquals` fails on any single corrupted survivor.

## Scope
`mergeTrees`/`migrateEntities` already read-before-remove (verified — no sibling defect). The orphaned-entity path (`findBestTreeForPosition==null` then source tree removed) is tracked separately as **Luciferase-drc6r**.

Stacked review (code-review-expert + substantive-critic): both clear.