### PR TITLE
fix(fault): SimpleFaultHandler.initiateRecovery delegates to recover() not dead deprecated path (Luciferase-9af5v)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/fault/SimpleFaultHandler.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/fault/SimpleFaultHandler.java
@@ -414,10 +414,28 @@ public class SimpleFaultHandler implements FaultHandler {
                 "Recovery initiated"
             ));
 
+            // Honor the strategy's own precondition gate before attempting recovery, matching
+            // DefaultFaultHandler.initiateRecovery.
+            if (!recovery.canRecover(partitionId, this)) {
+                log.warn("Partition {} recovery declined by strategy {} (canRecover=false)",
+                    partitionId, recovery.getStrategyName());
+                return CompletableFuture.completedFuture(false);
+            }
+
             log.info("Partition {} initiating recovery (Phase 4.2)", partitionId);
 
-            // Delegate to recovery strategy
-            return recovery.initiateRecovery(partitionId);
+            // Delegate to the recovery strategy via recover(UUID, FaultHandler). The deprecated
+            // recovery.initiateRecovery(UUID) default always fails with UnsupportedOperationException,
+            // so the prior call meant NO recovery strategy could ever succeed through this handler.
+            // Mirror DefaultFaultHandler.initiateRecovery, which uses recover(...).success() and
+            // contains exceptions so the returned future never completes exceptionally to callers.
+            return recovery.recover(partitionId, this)
+                .thenApply(RecoveryResult::success)
+                .exceptionally(ex -> {
+                    log.error("Partition {} recovery threw via strategy {}: {}",
+                        partitionId, recovery.getStrategyName(), ex.getMessage(), ex);
+                    return false;
+                });
         } else {
             return CompletableFuture.completedFuture(false);
         }

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/SimpleFaultHandlerRecoveryDelegationTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/SimpleFaultHandlerRecoveryDelegationTest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (C) 2025 Hal Hildebrand. All rights reserved.
+ *
+ * This file is part of the Luciferase.
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+ * Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.hellblazer.luciferase.lucien.balancing.fault;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression for Luciferase-9af5v: {@link SimpleFaultHandler#initiateRecovery(UUID)} previously
+ * delegated to the deprecated {@link PartitionRecovery#initiateRecovery(UUID)} default, which always
+ * returns a failed future with {@link UnsupportedOperationException}. As a result, NO registered
+ * recovery strategy could ever succeed through this handler. The fix delegates to
+ * {@code recover(UUID, FaultHandler)}, matching {@link DefaultFaultHandler}.
+ */
+class SimpleFaultHandlerRecoveryDelegationTest {
+
+    /** Recovery strategy parameterized on outcome, recording whether {@code recover} was invoked. */
+    private static final class RecordingRecovery implements PartitionRecovery {
+        enum Outcome { SUCCEED, FAIL, THROW }
+
+        final AtomicBoolean recoverCalled = new AtomicBoolean(false);
+        private final FaultConfiguration configuration;
+        private final Outcome outcome;
+        private final boolean canRecover;
+
+        RecordingRecovery(FaultConfiguration configuration, Outcome outcome, boolean canRecover) {
+            this.configuration = configuration;
+            this.outcome = outcome;
+            this.canRecover = canRecover;
+        }
+
+        @Override
+        public CompletableFuture<RecoveryResult> recover(UUID partitionId, FaultHandler handler) {
+            recoverCalled.set(true);
+            return switch (outcome) {
+                case SUCCEED -> CompletableFuture.completedFuture(
+                    RecoveryResult.success(partitionId, 1L, getStrategyName(), 1));
+                case FAIL -> CompletableFuture.completedFuture(
+                    RecoveryResult.failure(partitionId, 1L, getStrategyName(), 1, "test failure", null));
+                case THROW -> CompletableFuture.failedFuture(new RuntimeException("boom"));
+            };
+        }
+
+        @Override
+        public boolean canRecover(UUID partitionId, FaultHandler handler) {
+            return canRecover;
+        }
+
+        @Override
+        public String getStrategyName() {
+            return "recording-test-recovery";
+        }
+
+        @Override
+        public FaultConfiguration getConfiguration() {
+            return configuration;
+        }
+    }
+
+    private SimpleFaultHandler handlerWith(RecordingRecovery recovery, UUID partitionId) {
+        var handler = new SimpleFaultHandler(recovery.getConfiguration());
+        handler.reportPartitionFailed(partitionId); // registers state in FAILED status
+        handler.registerRecovery(partitionId, recovery);
+        return handler;
+    }
+
+    @Test
+    void initiateRecoveryDelegatesToRecoverAndSucceeds() throws Exception {
+        var config = FaultConfiguration.defaultConfig();
+        var partitionId = UUID.randomUUID();
+        var recovery = new RecordingRecovery(config, RecordingRecovery.Outcome.SUCCEED, true);
+        var handler = handlerWith(recovery, partitionId);
+
+        var result = handler.initiateRecovery(partitionId).get(5, TimeUnit.SECONDS);
+
+        // Under the old code this future completed exceptionally with UnsupportedOperationException
+        // (get() would throw); recover() was never reached.
+        assertTrue(result, "Recovery must succeed via recover(UUID, FaultHandler)");
+        assertTrue(recovery.recoverCalled.get(),
+            "initiateRecovery must delegate to recover(), not the deprecated initiateRecovery default");
+    }
+
+    @Test
+    void initiateRecoveryReturnsFalseWhenStrategyDeclines() throws Exception {
+        var config = FaultConfiguration.defaultConfig();
+        var partitionId = UUID.randomUUID();
+        var recovery = new RecordingRecovery(config, RecordingRecovery.Outcome.SUCCEED, false);
+        var handler = handlerWith(recovery, partitionId);
+
+        var result = handler.initiateRecovery(partitionId).get(5, TimeUnit.SECONDS);
+
+        assertFalse(result, "Recovery must report false when canRecover() is false");
+        assertFalse(recovery.recoverCalled.get(),
+            "recover() must not be called when the strategy declines via canRecover()");
+    }
+
+    @Test
+    void initiateRecoveryContainsExceptionalRecoveryAsFalse() throws Exception {
+        var config = FaultConfiguration.defaultConfig();
+        var partitionId = UUID.randomUUID();
+        var recovery = new RecordingRecovery(config, RecordingRecovery.Outcome.THROW, true);
+        var handler = handlerWith(recovery, partitionId);
+
+        // The returned future must complete normally with false, not propagate the exception.
+        var result = handler.initiateRecovery(partitionId).get(5, TimeUnit.SECONDS);
+
+        assertFalse(result, "An exceptional recover() must be contained and reported as false");
+    }
+
+    @Test
+    void initiateRecoveryReturnsFalseOnRecoveryFailureResult() throws Exception {
+        var config = FaultConfiguration.defaultConfig();
+        var partitionId = UUID.randomUUID();
+        var recovery = new RecordingRecovery(config, RecordingRecovery.Outcome.FAIL, true);
+        var handler = handlerWith(recovery, partitionId);
+
+        var result = handler.initiateRecovery(partitionId).get(5, TimeUnit.SECONDS);
+
+        assertFalse(result, "A RecoveryResult.failure must map to false (non-vacuous success check)");
+        assertTrue(recovery.recoverCalled.get(), "recover() must have been invoked");
+    }
+}


### PR DESCRIPTION
## Summary
`SimpleFaultHandler.initiateRecovery(UUID)` delegated to the **deprecated** `PartitionRecovery.initiateRecovery(UUID)` default, which unconditionally returns `failedFuture(UnsupportedOperationException)`. Through `FaultTolerantDistributedForest.triggerRecovery` this meant **no registered recovery strategy could ever succeed** — the exception was caught and reduced to `false`. `yogvu` fixed the `recover(UUID, FaultHandler)` path but missed this caller.

Found in the 2026-06-14 audit; confirmed by substantive-critic (genuine silent defect, the one real bug among the audited 'stubs').

## Change
- Delegate to `recover(partitionId, this).thenApply(RecoveryResult::success)`, matching `DefaultFaultHandler`.
- Add a `canRecover()` gate before dispatch and an `exceptionally()` handler (both per `DefaultFaultHandler`'s contract) — flagged by stacked review.

## Test rigor
`SimpleFaultHandlerRecoveryDelegationTest` covers success, `canRecover=false`, exceptional `recover()`, and `RecoveryResult.failure`. Proven **non-vacuous** (old delegation makes `get()` throw `UnsupportedOperationException`). 283 fault tests remain green; the new `canRecover` gate broke nothing.

## Scope / follow-up
Stacked review surfaced a **separate, pre-existing** gap: `FaultTolerantDistributedForest.triggerRecovery` never calls `notifyRecoveryComplete`, so partition status (FAILED→HEALTHY) and per-partition recovery metrics are never applied after recovery — affecting **both** handlers. Filed as **Luciferase-0z68i** (not expanded into this PR to avoid the one-phase/two-phase double-count reconciliation).

Stacked review (code-review-expert + substantive-critic): the additions above address their in-scope findings; the metrics/status wiring is deferred to 0z68i with rationale.