### PR TITLE
fix(ghost): P2PGhostChannel content codec + fail-loud, no silent null (Luciferase-8kgil)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/ghost/P2PGhostChannel.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/ghost/P2PGhostChannel.java
@@ -137,11 +137,65 @@ public class P2PGhostChannel<ID extends EntityID, Content> implements GhostChann
     private final Function<String, ID> idFactory;
 
     /**
+     * Pluggable codec for serializing arbitrary {@code Content} payloads onto the ghost wire
+     * schema. The channel handles {@code null} and {@link com.hellblazer.luciferase.simulation.entity.EntityType}
+     * natively. Supply a codec via {@link #P2PGhostChannel(Bubble, Function, ContentCodec)} to
+     * round-trip any other content type. Without a codec, a non-null, non-EntityType content fails
+     * loud (see {@link #serializeContent}/{@link #deserializeContent}) rather than being silently
+     * dropped to {@code null} on the wire (Luciferase-8kgil).
+     */
+    private final ContentCodec<Content> contentCodec;
+
+    /**
+     * Count of inbound ghosts dropped because their content could not be decoded (no matching
+     * {@link ContentCodec} on this receiver). Surfaced for observability so a misconfigured
+     * receiver is visible beyond the per-drop ERROR log rather than failing silently (Luciferase-8kgil).
+     */
+    private final java.util.concurrent.atomic.AtomicLong droppedGhostCount = new java.util.concurrent.atomic.AtomicLong();
+
+    /**
+     * Bidirectional codec for content types beyond {@code null}/{@code EntityType}. The wire carries
+     * both {@code content.getClass().getName()} and the {@link #serialize} result, so
+     * {@link #deserialize} receives the originating class name to dispatch on.
+     *
+     * @param <Content> entity content type
+     */
+    public interface ContentCodec<Content> {
+        /**
+         * Serialize content to its wire string form.
+         *
+         * @param content the (non-null, non-EntityType) content to serialize
+         * @return the wire string; must be round-trippable by {@link #deserialize}
+         */
+        String serialize(Content content);
+
+        /**
+         * Reconstruct content from the wire class name and value produced by {@link #serialize}.
+         *
+         * @param contentClass the originating {@code content.getClass().getName()}
+         * @param contentValue the value produced by {@link #serialize}
+         * @return the reconstructed content
+         */
+        Content deserialize(String contentClass, String contentValue);
+    }
+
+    /**
      * Set the clock source for deterministic testing.
      */
     public void setClock(Clock clock) {
         this.clock = clock;
         this.factory = new MessageFactory(clock);
+    }
+
+    /**
+     * Number of inbound ghosts dropped because their content could not be decoded (no matching
+     * {@link ContentCodec} on this receiver). A non-zero value signals codec misconfiguration or
+     * cross-version content skew (Luciferase-8kgil).
+     *
+     * @return total dropped-ghost count since construction
+     */
+    public long droppedGhostCount() {
+        return droppedGhostCount.get();
     }
 
     /**
@@ -184,8 +238,27 @@ public class P2PGhostChannel<ID extends EntityID, Content> implements GhostChann
      *                  serialized entity-id string (must match the sender's ID type)
      */
     public P2PGhostChannel(Bubble vonBubble, Function<String, ID> idFactory) {
+        this(vonBubble, idFactory, null);
+    }
+
+    /**
+     * Create P2P ghost channel with an explicit entity-id deserializer and a content codec for
+     * content types beyond {@code null}/{@code EntityType}. Both peers must be constructed with a
+     * codec that round-trips the same content types. A sender without a codec fails loud (throws
+     * from {@link #sendBatch}); a receiver without a matching codec logs an ERROR, increments
+     * {@link #droppedGhostCount()}, and drops only the un-decodable ghost — never silently nulling
+     * content nor dropping the whole batch (Luciferase-8kgil).
+     *
+     * @param vonBubble    Bubble for P2P transport
+     * @param idFactory    Reconstructs the caller's concrete {@code ID} from a ghost's serialized
+     *                     entity-id string (must match the sender's ID type)
+     * @param contentCodec Codec for non-null, non-EntityType content; {@code null} to support only
+     *                     {@code null}/{@code EntityType} content (fail-loud on any other type)
+     */
+    public P2PGhostChannel(Bubble vonBubble, Function<String, ID> idFactory, ContentCodec<Content> contentCodec) {
         this.vonBubble = Objects.requireNonNull(vonBubble, "vonBubble must not be null");
         this.idFactory = Objects.requireNonNull(idFactory, "idFactory must not be null");
+        this.contentCodec = contentCodec;
         this.factory = new MessageFactory(clock);
         this.pendingBatches = new ConcurrentHashMap<>();
         this.handlers = new CopyOnWriteArrayList<>();
@@ -312,10 +385,21 @@ public class P2PGhostChannel<ID extends EntityID, Content> implements GhostChann
             return;
         }
 
-        // Convert from transport format
+        // Convert from transport format. Deserialization is isolated per ghost: a single
+        // un-decodable ghost (e.g. a content type with no registered ContentCodec) must neither
+        // (a) silently drop to null content nor (b) abort the whole batch. Note that throwing here
+        // would be swallowed at WARN by Bubble.emitEvent's listener catch — so we fail loud at ERROR
+        // and a counter, and still deliver the decodable ghosts in the batch (Luciferase-8kgil).
         var ghosts = new ArrayList<SimulationGhostEntity<ID, Content>>(transportGhosts.size());
         for (var tg : transportGhosts) {
-            ghosts.add(fromTransportGhost(tg, sourceId, event.bucket()));
+            try {
+                ghosts.add(fromTransportGhost(tg, sourceId, event.bucket()));
+            } catch (RuntimeException e) {
+                droppedGhostCount.incrementAndGet();
+                log.error("Dropping un-decodable ghost from {} (entityId={}): {}. Register a matching "
+                          + "ContentCodec on this receiver to decode it (Luciferase-8kgil).",
+                          sourceId, tg.entityId(), e.getMessage());
+            }
         }
 
         // Notify all handlers
@@ -373,10 +457,17 @@ public class P2PGhostChannel<ID extends EntityID, Content> implements GhostChann
             return entityType.name();
         }
 
-        // Future: Add support for other Content types here
-        // For now, return null for unsupported types
-        log.warn("Unsupported content type for serialization: {}", content.getClass().getName());
-        return null;
+        // Any other type requires an injected codec. Fail loud rather than silently dropping the
+        // content to null on the wire, which previously corrupted every non-EntityType ghost on
+        // cross-process delivery (Luciferase-8kgil).
+        if (contentCodec != null) {
+            return contentCodec.serialize(content);
+        }
+        throw new IllegalStateException(
+            "No ContentCodec registered for ghost content type " + content.getClass().getName()
+            + "; cross-process ghost delivery would silently drop it to null. Construct "
+            + "P2PGhostChannel(Bubble, idFactory, ContentCodec) to serialize this type "
+            + "(Luciferase-8kgil).");
     }
 
     /**
@@ -450,8 +541,14 @@ public class P2PGhostChannel<ID extends EntityID, Content> implements GhostChann
             }
         }
 
-        // Future: Add support for other Content types here
-        log.warn("Unsupported content type for deserialization: {}", contentClass);
-        return null;
+        // Any other type requires an injected codec. Fail loud rather than silently dropping the
+        // content to null, which corrupted every non-EntityType ghost on receipt (Luciferase-8kgil).
+        if (contentCodec != null) {
+            return contentCodec.deserialize(contentClass, contentValue);
+        }
+        throw new IllegalStateException(
+            "No ContentCodec registered to deserialize ghost content of type " + contentClass
+            + "; the received ghost would carry null content. Construct P2PGhostChannel(Bubble, "
+            + "idFactory, ContentCodec) on the receiver to reconstruct this type (Luciferase-8kgil).");
     }
 }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/ghost/BubbleGhostManagerP2PIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/ghost/BubbleGhostManagerP2PIntegrationTest.java
@@ -86,8 +86,8 @@ class BubbleGhostManagerP2PIntegrationTest {
         bubble2 = new Bubble(id2, SPATIAL_LEVEL, TARGET_FRAME_MS, transport2);
 
         // Add entities so bubbles have positions
-        bubble1.addEntity("entity-1", new Point3f(50.0f, 50.0f, 50.0f), new Object());
-        bubble2.addEntity("entity-2", new Point3f(55.0f, 55.0f, 50.0f), new Object());
+        bubble1.addEntity("entity-1", new Point3f(50.0f, 50.0f, 50.0f), com.hellblazer.luciferase.simulation.entity.EntityType.PREY);
+        bubble2.addEntity("entity-2", new Point3f(55.0f, 55.0f, 50.0f), com.hellblazer.luciferase.simulation.entity.EntityType.PREY);
 
         // Establish neighbor relationship
         bubble1.addNeighbor(bubble2.id());
@@ -142,7 +142,7 @@ class BubbleGhostManagerP2PIntegrationTest {
         // Given: Entity near boundary on bubble1
         var entityId = new StringEntityID("boundary-entity");
         var position = new Point3f(52.0f, 52.0f, 50.0f);
-        var content = new Object();
+        var content = com.hellblazer.luciferase.simulation.entity.EntityType.PREY;
 
         // When: Notify manager and complete bucket
         var receiveLatch = new CountDownLatch(1);
@@ -169,7 +169,7 @@ class BubbleGhostManagerP2PIntegrationTest {
 
         var entityId = new StringEntityID("same-server-entity");
         var position = new Point3f(52.0f, 52.0f, 50.0f);
-        var content = new Object();
+        var content = com.hellblazer.luciferase.simulation.entity.EntityType.PREY;
 
         // When: Notify manager (should be bypassed)
         manager1.notifyEntityNearBoundary(entityId, position, content, bubble2.id(), 1L);
@@ -200,7 +200,7 @@ class BubbleGhostManagerP2PIntegrationTest {
         // When: Notify for all entities, then complete bucket
         for (var entity : entities) {
             var position = new Point3f(52.0f + entities.indexOf(entity) * 0.1f, 52.0f, 50.0f);
-            manager1.notifyEntityNearBoundary(entity, position, new Object(), bubble2.id(), 1L);
+            manager1.notifyEntityNearBoundary(entity, position, com.hellblazer.luciferase.simulation.entity.EntityType.PREY, bubble2.id(), 1L);
         }
         manager1.onBucketComplete(1L);
 
@@ -219,7 +219,7 @@ class BubbleGhostManagerP2PIntegrationTest {
         channel2.onReceive((fromId, ghosts) -> receiveLatch.countDown());
 
         // When: Send ghost
-        manager1.notifyEntityNearBoundary(entityId, position, new Object(), bubble2.id(), 1L);
+        manager1.notifyEntityNearBoundary(entityId, position, com.hellblazer.luciferase.simulation.entity.EntityType.PREY, bubble2.id(), 1L);
         manager1.onBucketComplete(1L);
         receiveLatch.await(2, TimeUnit.SECONDS);
 
@@ -239,7 +239,7 @@ class BubbleGhostManagerP2PIntegrationTest {
         channel2.onReceive((fromId, ghosts) -> receiveLatch.countDown());
 
         // When: Send ghost
-        manager1.notifyEntityNearBoundary(entityId, position, new Object(), bubble2.id(), 1L);
+        manager1.notifyEntityNearBoundary(entityId, position, com.hellblazer.luciferase.simulation.entity.EntityType.PREY, bubble2.id(), 1L);
         manager1.onBucketComplete(1L);
         receiveLatch.await(2, TimeUnit.SECONDS);
 
@@ -285,8 +285,8 @@ class BubbleGhostManagerP2PIntegrationTest {
         });
 
         // When: Both managers send ghosts
-        manager1.notifyEntityNearBoundary(entity1, new Point3f(52.0f, 52.0f, 50.0f), new Object(), bubble2.id(), 1L);
-        manager2.notifyEntityNearBoundary(entity2, new Point3f(48.0f, 48.0f, 50.0f), new Object(), bubble1.id(), 1L);
+        manager1.notifyEntityNearBoundary(entity1, new Point3f(52.0f, 52.0f, 50.0f), com.hellblazer.luciferase.simulation.entity.EntityType.PREY, bubble2.id(), 1L);
+        manager2.notifyEntityNearBoundary(entity2, new Point3f(48.0f, 48.0f, 50.0f), com.hellblazer.luciferase.simulation.entity.EntityType.PREY, bubble1.id(), 1L);
         manager1.onBucketComplete(1L);
         manager2.onBucketComplete(1L);
 
@@ -316,7 +316,7 @@ class BubbleGhostManagerP2PIntegrationTest {
             for (int i = 0; i < 50; i++) {
                 var id = new StringEntityID("perf-" + iter + "-" + i);
                 var position = new Point3f(52.0f + i * 0.01f, 52.0f, 50.0f);
-                manager1.notifyEntityNearBoundary(id, position, new Object(), bubble2.id(), (long) iter);
+                manager1.notifyEntityNearBoundary(id, position, com.hellblazer.luciferase.simulation.entity.EntityType.PREY, bubble2.id(), (long) iter);
             }
             manager1.onBucketComplete((long) iter);
         };
@@ -352,7 +352,7 @@ class BubbleGhostManagerP2PIntegrationTest {
         var id3 = UUID.randomUUID();
         var transport3 = registry.register(id3);
         var bubble3 = new Bubble(id3, SPATIAL_LEVEL, TARGET_FRAME_MS, transport3);
-        bubble3.addEntity("entity-3", new Point3f(45.0f, 45.0f, 50.0f), new Object());
+        bubble3.addEntity("entity-3", new Point3f(45.0f, 45.0f, 50.0f), com.hellblazer.luciferase.simulation.entity.EntityType.PREY);
 
         // Same server as bubble1
         serverRegistry.registerBubble(bubble3.id(), server1Id);
@@ -377,10 +377,10 @@ class BubbleGhostManagerP2PIntegrationTest {
             var position = new Point3f(52.0f, 52.0f, 50.0f);
 
             // To bubble2 (different server) - should transmit
-            manager1.notifyEntityNearBoundary(entity, position, new Object(), bubble2.id(), 1L);
+            manager1.notifyEntityNearBoundary(entity, position, com.hellblazer.luciferase.simulation.entity.EntityType.PREY, bubble2.id(), 1L);
 
             // To bubble3 (same server) - should bypass
-            manager1.notifyEntityNearBoundary(entity, position, new Object(), bubble3.id(), 1L);
+            manager1.notifyEntityNearBoundary(entity, position, com.hellblazer.luciferase.simulation.entity.EntityType.PREY, bubble3.id(), 1L);
 
             manager1.onBucketComplete(1L);
             Thread.sleep(500); // Allow time for any transmission

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/ghost/GhostVelocitySchemaTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/ghost/GhostVelocitySchemaTest.java
@@ -145,7 +145,7 @@ class GhostVelocitySchemaTest {
         var entityId = new StringEntityID("vel-entity");
         var position = new Point3f(1f, 2f, 3f);
         var vel = new Vector3f(5f, -3f, 1f);
-        var ghostEntity = new GhostEntityHalo<>(entityId, (Object) "content", position,
+        var ghostEntity = new GhostEntityHalo<>(entityId, (Object) com.hellblazer.luciferase.simulation.entity.EntityType.PREY, position,
                                                 new EntityBounds(position, 0.5f), "tree-X");
 
         var sourceBubbleId = UUID.randomUUID();
@@ -173,7 +173,7 @@ class GhostVelocitySchemaTest {
 
         var entityId = new StringEntityID("zero-vel-entity");
         var position = new Point3f(1f, 2f, 3f);
-        var ghostEntity = new GhostEntityHalo<>(entityId, (Object) "content", position,
+        var ghostEntity = new GhostEntityHalo<>(entityId, (Object) com.hellblazer.luciferase.simulation.entity.EntityType.PREY, position,
                                                 new EntityBounds(position, 0.5f), "tree-Z");
 
         var sourceBubbleId = UUID.randomUUID();
@@ -265,7 +265,7 @@ class GhostVelocitySchemaTest {
     private SimulationGhostEntity<StringEntityID, Object> createGhostWithVelocity(
         String id, Point3f position, Vector3f velocity) {
         var entityId = new StringEntityID(id);
-        var halo = new GhostEntityHalo<>(entityId, (Object) "content", position,
+        var halo = new GhostEntityHalo<>(entityId, (Object) com.hellblazer.luciferase.simulation.entity.EntityType.PREY, position,
                                          new EntityBounds(position, 0.5f), "tree-test");
         return new SimulationGhostEntity<>(halo, bubble1.id(), 100L, 1L, 1L, velocity);
     }

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/ghost/P2PGhostChannelTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/ghost/P2PGhostChannelTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for P2PGhostChannel - P2P ghost synchronization over Transport.
@@ -454,6 +455,116 @@ class P2PGhostChannelTest {
         assertThat(received.version()).isEqualTo(7L);
     }
 
+    @Test
+    void testCustomContentCodecRoundTripsNonEntityTypeContent() throws Exception {
+        // Replace the default (codec-less) channels with codec-equipped ones on the same bubbles.
+        // The codec round-trips String content — a stand-in for any non-EntityType payload that the
+        // old code silently dropped to null on cross-process delivery (Luciferase-8kgil).
+        channel1.close();
+        channel2.close();
+        P2PGhostChannel.ContentCodec<Object> stringCodec = new P2PGhostChannel.ContentCodec<>() {
+            @Override
+            public String serialize(Object content) {
+                return (String) content;
+            }
+
+            @Override
+            public Object deserialize(String contentClass, String contentValue) {
+                return contentValue;
+            }
+        };
+        channel1 = new P2PGhostChannel<>(bubble1, StringEntityID::new, stringCodec);
+        channel2 = new P2PGhostChannel<>(bubble2, StringEntityID::new, stringCodec);
+
+        var ghost = new SimulationGhostEntity<>(
+            new GhostEntityHalo<StringEntityID, Object>(
+                new StringEntityID("ghost-str"), "payload-42",
+                new Point3f(51.5f, 51.5f, 50.5f),
+                new EntityBounds(new Point3f(51.5f, 51.5f, 50.5f), 0.5f),
+                "tree-" + bubble1.id()),
+            bubble1.id(), 1L, 9L, 3L);
+
+        var receivedGhosts = new AtomicReference<List<SimulationGhostEntity<StringEntityID, Object>>>();
+        var receiveLatch = new CountDownLatch(1);
+        channel2.onReceive((fromId, received) -> {
+            receivedGhosts.set(new ArrayList<>(received));
+            receiveLatch.countDown();
+        });
+
+        channel1.sendBatch(bubble2.id(), List.of(ghost));
+
+        assertThat(receiveLatch.await(2, TimeUnit.SECONDS)).isTrue();
+        assertThat(receivedGhosts.get().get(0).content())
+            .as("Custom-codec content must round-trip, not be silently nulled")
+            .isEqualTo("payload-42");
+    }
+
+    @Test
+    void testUnregisteredContentFailsLoudOnSend() {
+        // A default channel (no codec) must fail loud on non-null, non-EntityType content rather
+        // than silently dropping it to null on the wire (Luciferase-8kgil).
+        var pos = new Point3f(51.0f, 51.0f, 50.0f);
+        var ghost = new SimulationGhostEntity<>(
+            new GhostEntityHalo<StringEntityID, Object>(
+                new StringEntityID("ghost-obj"), new Object(), pos,
+                new EntityBounds(pos, 0.5f), "tree-" + bubble1.id()),
+            bubble1.id(), 1L, 1L, 1L);
+
+        assertThatThrownBy(() -> channel1.sendBatch(bubble2.id(), List.of(ghost)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("No ContentCodec");
+    }
+
+    @Test
+    void testReceiverWithoutCodecDropsUndecodableGhostLoudlyButDeliversRest() throws Exception {
+        // Sender has a String codec; receiver (channel2, default) has none. A throw on the receive
+        // side would be swallowed at WARN by Bubble.emitEvent — so the channel instead drops only
+        // the un-decodable ghost (loud ERROR + counter) and still delivers the EntityType ghost in
+        // the same batch. This pins that the fix did not trade per-ghost null loss for whole-batch
+        // silent loss (Luciferase-8kgil).
+        channel1.close();
+        P2PGhostChannel.ContentCodec<Object> stringCodec = new P2PGhostChannel.ContentCodec<>() {
+            @Override
+            public String serialize(Object content) {
+                return (String) content;
+            }
+
+            @Override
+            public Object deserialize(String contentClass, String contentValue) {
+                return contentValue;
+            }
+        };
+        channel1 = new P2PGhostChannel<>(bubble1, StringEntityID::new, stringCodec);
+
+        var entityTypeGhost = createGhostWithEntityType("g-et", new Point3f(51f, 51f, 50f),
+            com.hellblazer.luciferase.simulation.entity.EntityType.PREY, 1L, 1L);
+        var pos = new Point3f(52f, 52f, 50f);
+        var stringGhost = new SimulationGhostEntity<>(
+            new GhostEntityHalo<StringEntityID, Object>(
+                new StringEntityID("g-str"), "payload", pos, new EntityBounds(pos, 0.5f),
+                "tree-" + bubble1.id()),
+            bubble1.id(), 1L, 1L, 1L);
+
+        var received = new AtomicReference<List<SimulationGhostEntity<StringEntityID, Object>>>();
+        var latch = new CountDownLatch(1);
+        channel2.onReceive((from, gs) -> {
+            received.set(new ArrayList<>(gs));
+            latch.countDown();
+        });
+
+        channel1.sendBatch(bubble2.id(), List.of(entityTypeGhost, stringGhost));
+
+        assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
+        assertThat(received.get())
+            .as("the decodable EntityType ghost must still be delivered (per-ghost isolation)")
+            .hasSize(1);
+        assertThat(received.get().get(0).content())
+            .isEqualTo(com.hellblazer.luciferase.simulation.entity.EntityType.PREY);
+        assertThat(channel2.droppedGhostCount())
+            .as("the un-decodable String ghost must be counted, not silently lost")
+            .isEqualTo(1L);
+    }
+
     // ========== Helper Methods ==========
 
     private SimulationGhostEntity<StringEntityID, Object> createGhost(String entityId, Point3f position) {
@@ -465,8 +576,11 @@ class P2PGhostChannelTest {
     ) {
         var id = new StringEntityID(entityId);
         var bounds = new EntityBounds(position, 0.5f);
+        // null content: these tests exercise position/velocity/epoch/version/count, not content.
+        // (Previously `new Object()` — an unserializable placeholder that the channel silently
+        // dropped to null on the wire; the fail-loud fix for Luciferase-8kgil now rejects it.)
         var ghost = new GhostEntityHalo<StringEntityID, Object>(
-            id, new Object(), position, bounds, "tree-" + bubble1.id()
+            id, null, position, bounds, "tree-" + bubble1.id()
         );
         return new SimulationGhostEntity<>(
             ghost, bubble1.id(), 1L, epoch, version

--- a/simulation/src/test/java/com/hellblazer/luciferase/simulation/integration/ClusterIntegrationTest.java
+++ b/simulation/src/test/java/com/hellblazer/luciferase/simulation/integration/ClusterIntegrationTest.java
@@ -609,8 +609,11 @@ public class ClusterIntegrationTest {
     ) {
         var id = new StringEntityID(entityId);
         var bounds = new com.hellblazer.luciferase.lucien.entity.EntityBounds(position, 0.5f);
+        // EntityType content (the production content type) round-trips via the channel's native
+        // path; a bare `new Object()` is unserializable and now fails loud (Luciferase-8kgil).
         var ghost = new com.hellblazer.luciferase.lucien.forest.ghost.GhostEntityHalo<StringEntityID, Object>(
-            id, new Object(), position, bounds, "tree-" + sourceBubbleId
+            id, (Object) com.hellblazer.luciferase.simulation.entity.EntityType.PREY, position, bounds,
+            "tree-" + sourceBubbleId
         );
         return new SimulationGhostEntity<>(ghost, sourceBubbleId, 1L, 1L, 1L);
     }


### PR DESCRIPTION
## Summary
`P2PGhostChannel` only serialized `EntityType` content; **every other non-null content was silently dropped to null** on cross-process ghost delivery (RDR-004-class data loss). Found in the 2026-06-14 audit; confirmed by substantive-critic.

## Change
- **Injectable `ContentCodec<Content>`** (3-arg constructor, mirrors the existing `idFactory` injection) — callers can round-trip arbitrary content types.
- **Sender** without a codec now **fails loud** (throws from `sendBatch`) instead of nulling content on the wire.
- **Receiver** without a matching codec **isolates per ghost**: logs ERROR, increments `droppedGhostCount()`, drops only the un-decodable ghost, still delivers the rest of the batch.

## Stacked review caught a real second defect
Round-1 critic found that a receive-side *throw* would be **swallowed at WARN by `Bubble.emitEvent`'s listener catch** — trading per-ghost null loss for whole-batch silent drop. Fixed via per-ghost isolation (ERROR + counter, not a throw into the swallowing path) and corrected the Javadoc. Round-2 critic: **CONFIRMED-SOUND**.

## Tests (all proven non-vacuous)
- codec round-trip of non-EntityType content
- fail-loud-on-send (no codec → `IllegalStateException`)
- **mixed-batch receiver isolation**: codec-equipped sender → no-codec receiver; EntityType ghost delivered, un-decodable String ghost dropped + counted (`droppedGhostCount()==1`)

Ten pre-existing fixtures that rode the silent loss with `new Object()`/`String` placeholder content (never asserting content) were switched to the production `EntityType` (native path). Production ghost content is always `EntityType`, so the fail-loud default does not regress any production path.

## Related
The audit's separate lamportClock-on-wire gap (`noyn3`) and the reclassified packShallowKey item (`lof72`, found **not** a reachable data-loss bug — see its bead) are tracked separately.