### PR TITLE
fix(collision): SweptSphere parallel-to-plane branch misses/mislocates face contact (Luciferase-uojsv)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/collision/ccd/SweptSphere.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/collision/ccd/SweptSphere.java
@@ -147,12 +147,40 @@ public class SweptSphere {
         float velocityDotNormal = sphereVelocity.dot(triangleNormal);
         
         if (Math.abs(velocityDotNormal) < EPSILON) {
-            // Moving parallel to plane
+            // Moving parallel to the plane: the sphere never crosses it, so the plane-crossing time
+            // computed below divides by ~0 and yields NaN/Inf. That bad t then either (a) is rejected
+            // as t>1 -> the genuine parallel-embedded face contact is silently missed, or (b) for the
+            // exact 0/0 tangent case falls through (NaN escapes the t<0||t>1 guard since NaN compares
+            // false) to the edge/vertex checks, mislocating the contact to a later time. Handle the
+            // parallel case completely and correctly here instead (Luciferase-uojsv).
             if (Math.abs(startDist) > sphereRadius) {
+                // Too far from the plane to ever touch it.
                 return ContinuousCollisionResult.noCollision();
             }
+            // Within plane-contact distance for the whole sweep. If the sphere center already projects
+            // into the triangle, that is a face contact at t=0; otherwise the sphere may still graze a
+            // triangle edge or vertex during the sweep, so defer to those swept checks.
+            var projectedAtStart = new Point3f(sphereStart);
+            var toPlaneStart = new Vector3f(triangleNormal);
+            toPlaneStart.scale(startDist); // closest point on the plane to the sphere center
+            projectedAtStart.sub(toPlaneStart);
+            if (isPointInTriangle(projectedAtStart, v0, v1, v2)) {
+                // Contact point on the sphere surface, using the same convention as the non-parallel
+                // branch below (center - sphereRadius * normal) so CCD consumers see a consistent
+                // contact point regardless of which branch produced it.
+                var contactPoint = new Point3f(sphereStart);
+                var toSurface = new Vector3f(triangleNormal);
+                toSurface.scale(-sphereRadius);
+                contactPoint.add(toSurface);
+                return ContinuousCollisionResult.collision(0.0f, contactPoint, triangleNormal, 0.0f);
+            }
+            var parallelEdge = checkTriangleEdges(sphereStart, sphereVelocity, sphereRadius, v0, v1, v2);
+            if (parallelEdge.collides()) {
+                return parallelEdge;
+            }
+            return checkTriangleVertices(sphereStart, sphereVelocity, sphereRadius, v0, v1, v2);
         }
-        
+
         // Time when sphere touches plane
         float t = (sphereRadius - startDist) / velocityDotNormal;
         if (velocityDotNormal > 0) {

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/collision/ccd/SweptSphereTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/collision/ccd/SweptSphereTest.java
@@ -100,6 +100,69 @@ public class SweptSphereTest {
     }
     
     @Test
+    void testSweptSphereParallelToTriangleEmbedded_faceContactNoNaN() {
+        // Regression for Luciferase-uojsv: a sphere moving parallel to the triangle plane while
+        // tangent/embedded drove (sphereRadius - startDist)/velocityDotNormal = 0/0 = NaN. The NaN
+        // was absorbed downstream (isPointInTriangle(NaN) is false), so rather than a NaN escaping,
+        // the legitimate t=0 face contact was MISLOCATED to a later edge contact (old code returned
+        // t~=0.0999 here). The sphere center projects onto (0,0,0), inside the triangle, so the
+        // correct answer is a face contact at t=0 with a finite contact point.
+        var sphereStart = new Point3f(0, -1, 0); // startDist == +radius on the normal side
+        var velocity = new Vector3f(10, 0, 0);   // parallel to the Y=0 plane
+        float radius = 1.0f;
+        var v0 = new Point3f(-2, 0, -2);
+        var v1 = new Point3f(2, 0, -2);
+        var v2 = new Point3f(0, 0, 2);
+
+        var result = SweptSphere.sweptSphereVsTriangle(sphereStart, velocity, radius, v0, v1, v2);
+
+        assertTrue(result.collides(), "embedded sphere over the triangle is a face contact");
+        assertTrue(Float.isFinite(result.timeOfImpact()), "TOI must be finite, not NaN/Inf");
+        assertEquals(0.0f, result.timeOfImpact(), EPSILON, "contact is at the start of the sweep");
+        var cp = result.contactPoint();
+        assertTrue(Float.isFinite(cp.x) && Float.isFinite(cp.y) && Float.isFinite(cp.z),
+            "contact point must be finite, not NaN");
+    }
+
+    @Test
+    void testSweptSphereParallelToTriangleEmbedded_contactPointOnSphereSurface() {
+        // Embedded sub-case (|startDist| < radius), distinct from the tangent case above. Pins that
+        // the parallel branch reports the contact point on the SPHERE SURFACE (center - radius*normal),
+        // matching the non-parallel branch's convention, not the foot-of-perpendicular on the plane.
+        var sphereStart = new Point3f(0, -0.3f, 0); // startDist = 0.3 < radius
+        var velocity = new Vector3f(10, 0, 0);
+        float radius = 1.0f;
+        var v0 = new Point3f(-2, 0, -2);
+        var v1 = new Point3f(2, 0, -2);
+        var v2 = new Point3f(0, 0, 2);
+
+        var result = SweptSphere.sweptSphereVsTriangle(sphereStart, velocity, radius, v0, v1, v2);
+
+        assertTrue(result.collides(), "embedded sphere over the triangle is a face contact");
+        assertEquals(0.0f, result.timeOfImpact(), EPSILON);
+        // normal is (0,-1,0); center - radius*normal = (0,-0.3,0) - 1*(0,-1,0) = (0,0.7,0)
+        assertEquals(0.7f, result.contactPoint().y, EPSILON,
+            "contact point must be on the sphere surface, not the foot-of-perpendicular (0,0,0)");
+        var cp = result.contactPoint();
+        assertTrue(Float.isFinite(cp.x) && Float.isFinite(cp.y) && Float.isFinite(cp.z));
+    }
+
+    @Test
+    void testSweptSphereParallelToTriangleFar_misses() {
+        // Parallel to the plane but farther than the radius: never touches -> no collision (and no NaN).
+        var sphereStart = new Point3f(0, -5, 0);
+        var velocity = new Vector3f(10, 0, 0);
+        float radius = 1.0f;
+        var v0 = new Point3f(-2, 0, -2);
+        var v1 = new Point3f(2, 0, -2);
+        var v2 = new Point3f(0, 0, 2);
+
+        var result = SweptSphere.sweptSphereVsTriangle(sphereStart, velocity, radius, v0, v1, v2);
+
+        assertFalse(result.collides(), "parallel sphere beyond radius must not collide");
+    }
+
+    @Test
     void testSweptSphereVsCapsule() {
         // Sphere hitting vertical capsule
         var sphereStart = new Point3f(-5, 0, 0);


### PR DESCRIPTION
## Summary
`sweptSphereVsTriangle`'s parallel-to-plane branch (`|velocityDotNormal| < EPSILON`) fell through to `t = (sphereRadius - startDist)/velocityDotNormal` — a division by ~0.

**Severity corrected from the audit:** the original note claimed a NaN TOI "cascades into physics." Verified false — `isPointInTriangle(NaN)` returns false and the `t>1` guard rejects `+Inf`, so **no NaN ever escapes** into a returned result (and no production code reads `contactPoint()` from CCD results). The real bug is a **missed or mislocated parallel-embedded face contact**: a sphere already within `sphereRadius` of the triangle plane and over the triangle should report a `t=0` face contact, but instead got `noCollision` or a later edge contact (old code returned `t≈0.0999` for the tangent case).

## Fix
Handle the parallel case completely: `noCollision` if beyond radius; `t=0` face contact (sphere-surface contact point, matching the non-parallel branch's convention) if the center projects into the triangle; else defer to the existing swept edge/vertex checks. No division, no NaN.

## Tests (non-vacuous)
- tangent face contact at `t=0`, finite
- **embedded sub-case** pinning the sphere-surface contact point (`cp.y==0.7`, not foot-of-perpendicular) — added per stacked review
- parallel-far miss

Old code returned `t≈0.0999` for the tangent case, so the regression is caught.

## Stacked review
code-review-expert + substantive-critic both confirmed the severity correction and flagged a (benign, zero-consumer) contact-point convention inconsistency vs the non-parallel branch — fixed to match + pinned by the new embedded-sub-case test. 63 collision/ccd + consumer tests green.