### PR TITLE
fix(fault): wire notifyRecoveryComplete + stop recovery re-trigger loop (Luciferase-0z68i)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/fault/FaultTolerantDistributedForest.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/fault/FaultTolerantDistributedForest.java
@@ -269,15 +269,28 @@ public class FaultTolerantDistributedForest<Key extends SpatialKey<Key>, ID exte
                     return success;
 
                 } finally {
-                    // Always release lock and exit recovery mode
-                    exitRecoveryMode();
-                    recoveryLock.releaseRecoveryLock(failedPartitionId);
+                    try {
+                        // Complete the two-phase recovery protocol: initiateRecovery() above only runs
+                        // the strategy and (for the handlers) records the attempt/counters; the
+                        // partition status transition (FAILED -> HEALTHY on success) lives in
+                        // notifyRecoveryComplete. Without this call the partition stayed FAILED forever
+                        // after a successful recovery and the success/failure metric was never recorded
+                        // (Luciferase-0z68i). The two methods touch disjoint state for both
+                        // SimpleFaultHandler and DefaultFaultHandler, so there is no double-counting.
+                        faultHandler.notifyRecoveryComplete(failedPartitionId, success);
+                    } finally {
+                        // Always release the recovery lock and exit recovery mode, even if the
+                        // completion notification throws — otherwise the recovery semaphore permit
+                        // leaks and all future recoveries block forever.
+                        exitRecoveryMode();
+                        recoveryLock.releaseRecoveryLock(failedPartitionId);
 
-                    var duration = clock.currentTimeMillis() - startTime;
-                    statsAccumulator.recordRecoveryAttempt(duration, success);
+                        var duration = clock.currentTimeMillis() - startTime;
+                        statsAccumulator.recordRecoveryAttempt(duration, success);
 
-                    log.info("Recovery for partition {} {} in {}ms",
-                        failedPartitionId, success ? "succeeded" : "failed", duration);
+                        log.info("Recovery for partition {} {} in {}ms",
+                            failedPartitionId, success ? "succeeded" : "failed", duration);
+                    }
                 }
 
             } catch (Exception e) {
@@ -464,8 +477,13 @@ public class FaultTolerantDistributedForest<Key extends SpatialKey<Key>, ID exte
             log.info("Partition {} status updated: {} -> {} (previous tracked: {})",
                 event.partitionId(), event.oldStatus(), event.newStatus(), previousStatus);
 
-            if (event.newStatus() == PartitionStatus.FAILED) {
-                // Quorum check and recovery trigger are ATOMIC (inside stateLock)
+            if (event.newStatus() == PartitionStatus.FAILED
+                && event.oldStatus() != PartitionStatus.FAILED) {
+                // Only act on a GENUINE transition into failure. A FAILED -> FAILED event — emitted
+                // e.g. by SimpleFaultHandler.initiateRecovery ("Recovery initiated", same status) or
+                // by a failed recovery completion — must not re-trigger recovery, otherwise a
+                // permanently-failing partition loops unbounded on the recovery executor
+                // (Luciferase-0z68i). Quorum check and recovery trigger are ATOMIC (inside stateLock).
                 handlePartitionFailure(event.partitionId());
             } else if (event.newStatus() == PartitionStatus.HEALTHY
                        && (event.oldStatus() == PartitionStatus.SUSPECTED

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/PhaseA2FaultTolerantDistributedForestTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/PhaseA2FaultTolerantDistributedForestTest.java
@@ -495,6 +495,118 @@ class PhaseA2FaultTolerantDistributedForestTest {
     }
 
     /**
+     * Regression for Luciferase-0z68i: triggerRecovery() (invoked automatically when a partition
+     * fails) ran the recovery strategy but never called faultHandler.notifyRecoveryComplete(), so a
+     * successfully-recovered partition stayed FAILED forever and its success metric was never
+     * recorded. This asserts the FAILED -> HEALTHY transition actually happens (event-driven, so it
+     * is deterministic: under the bug the HEALTHY event never fires and the latch times out).
+     */
+    @Test
+    void testAutomaticRecoveryRestoresPartitionToHealthy() throws Exception {
+        var partitions = new ArrayList<UUID>();
+        for (int i = 0; i < 5; i++) {
+            var partitionId = UUID.randomUUID();
+            partitions.add(partitionId);
+            faultHandler.registerRecovery(partitionId, TestRecoveryStrategy.success("recovery-" + i));
+            faultHandler.markHealthy(partitionId);
+        }
+        var topology = createTestTopology(5, partitions.toArray(UUID[]::new));
+        var testForest = createTestDistributedForest();
+        ftForest = new FaultTolerantDistributedForest<>(
+            testForest,
+            faultHandler,
+            recoveryLock,
+            new DefaultParallelBalancer<>(BalanceConfiguration.defaultConfig()),
+            mockGhostManager,
+            topology,
+            partitions.get(0),
+            FaultConfiguration.defaultConfig(),
+            tracker
+        );
+        ftForest.start();
+
+        var failed = partitions.get(2);
+        var recoveredLatch = new CountDownLatch(1);
+        faultHandler.subscribeToChanges(event -> {
+            if (event.partitionId().equals(failed)
+                && event.newStatus() == PartitionStatus.HEALTHY
+                && event.oldStatus() == PartitionStatus.FAILED) {
+                recoveredLatch.countDown();
+            }
+        });
+
+        // Fail the partition; quorum stays (4/5), so the forest auto-triggers recovery.
+        faultHandler.reportBarrierTimeout(failed); // HEALTHY -> SUSPECTED
+        faultHandler.reportBarrierTimeout(failed); // SUSPECTED -> FAILED (auto-triggers recovery)
+
+        assertTrue(recoveredLatch.await(5, TimeUnit.SECONDS),
+            "successful recovery must restore the failed partition to HEALTHY (Luciferase-0z68i)");
+        assertEquals(PartitionStatus.HEALTHY, faultHandler.checkHealth(failed),
+            "partition status must be HEALTHY after recovery completes");
+        assertTrue(faultHandler.getMetrics(failed).successfulRecoveries() >= 1,
+            "a successful recovery must be recorded in the partition metrics");
+    }
+
+    /**
+     * Regression (Luciferase-0z68i follow-up): a permanently-failing recovery must NOT spin forever.
+     * The fix that wires notifyRecoveryComplete also guards SimpleFaultHandler against emitting a
+     * FAILED -> FAILED no-op event; without that guard, a failed recovery re-enters
+     * handlePartitionFailure -> scheduleRecoveryAsync and loops unbounded.
+     */
+    @Test
+    void testFailedRecoveryDoesNotLoop() throws Exception {
+        var partitions = new ArrayList<UUID>();
+        TestRecoveryStrategy failingRecovery = null;
+        for (int i = 0; i < 5; i++) {
+            var partitionId = UUID.randomUUID();
+            partitions.add(partitionId);
+            var recovery = (i == 2) ? TestRecoveryStrategy.failure("always-fails")
+                                    : TestRecoveryStrategy.success("ok-" + i);
+            if (i == 2) {
+                failingRecovery = recovery;
+            }
+            faultHandler.registerRecovery(partitionId, recovery);
+            faultHandler.markHealthy(partitionId);
+        }
+        var topology = createTestTopology(5, partitions.toArray(UUID[]::new));
+        var testForest = createTestDistributedForest();
+        ftForest = new FaultTolerantDistributedForest<>(
+            testForest,
+            faultHandler,
+            recoveryLock,
+            new DefaultParallelBalancer<>(BalanceConfiguration.defaultConfig()),
+            mockGhostManager,
+            topology,
+            partitions.get(0),
+            FaultConfiguration.defaultConfig(),
+            tracker
+        );
+        ftForest.start();
+
+        var failed = partitions.get(2);
+
+        faultHandler.reportBarrierTimeout(failed); // HEALTHY -> SUSPECTED
+        faultHandler.reportBarrierTimeout(failed); // SUSPECTED -> FAILED (auto-triggers recovery once)
+
+        // Poll until the first recovery attempt has run.
+        var start = System.nanoTime();
+        while (failingRecovery.getAttemptCount() < 1 && (System.nanoTime() - start) < 5_000_000_000L) {
+            Thread.sleep(10);
+        }
+        assertTrue(failingRecovery.getAttemptCount() >= 1, "recovery should be attempted at least once");
+
+        // Give any re-trigger loop ample time to manifest (a loop on the single-thread recovery
+        // executor with 0ms delay would rack up hundreds of attempts). The assertion is an upper
+        // bound, so it is robust to scheduling speed.
+        Thread.sleep(500);
+
+        assertEquals(1, failingRecovery.getAttemptCount(),
+            "a permanently-failing recovery must be attempted exactly once, not loop (Luciferase-0z68i)");
+        assertEquals(PartitionStatus.FAILED, faultHandler.checkHealth(failed),
+            "partition remains FAILED after a failed recovery");
+    }
+
+    /**
      * Test 4: Verify quorum calculation.
      *
      * <p>Validates that quorum is correctly calculated as majority (> 50%).


### PR DESCRIPTION
## Summary
`FaultTolerantDistributedForest.triggerRecovery` ran the recovery strategy but never called `faultHandler.notifyRecoveryComplete`, so a **successfully-recovered partition stayed FAILED forever** and the success/failure metric was never recorded. (Found while fixing `9af5v`.)

The two-phase protocol: `initiateRecovery` runs the strategy + records the *attempt*; `notifyRecoveryComplete` does the *status transition* (FAILED→HEALTHY) + success counter. They touch disjoint state for both handlers, so wiring it in does **not** double-count (verified by both reviewers).

## Three coordinated changes
1. Call `notifyRecoveryComplete(failedPartitionId, success)` (success + exception/timeout paths).
2. Place it in a **nested try** so `releaseRecoveryLock` runs even if the notification throws — otherwise the recovery semaphore permit leaks → permanent deadlock (code-review-expert IMPORTANT).
3. Guard `handlePartitionChange` to re-trigger only on a **genuine transition into FAILED** (`oldStatus != FAILED`). `SimpleFaultHandler` emits `FAILED→FAILED` events (`initiateRecovery`'s "Recovery initiated" Phase-4.2 placeholder, and failed-recovery completion); treating those as fresh failures spun a permanently-failing partition in an **unbounded loop** on the recovery executor — masked on main by a vacuous e2e test (substantive-critic SIGNIFICANT).

## Tests (non-vacuous)
- `testAutomaticRecoveryRestoresPartitionToHealthy` — success → HEALTHY (event-driven; latch times out without the fix)
- `testFailedRecoveryDoesNotLoop` — failing recovery attempted **exactly once** (was **617** without the guard)

285 fault tests green. Stacked review iterated to round-2 clean (critic CONFIRMED-SOUND: loop closed for all event sources, legitimate re-failures still trigger, lock release unconditional).

## Follow-up
Filed a bead for the **unimplemented bounded-retry policy**: `FaultConfiguration.autoRecoveryEnabled` and `maxRecoveryRetries` are declared but never consulted. With this guard a failed recovery is now bounded (no auto-retry) rather than looping; a proper policy should honor those config fields with capped retries + backoff.