### PR TITLE
fix(simulation): log swallowed migration failures in TetrahedralMigration (Luciferase-9jea5)

### DIFF
--- a/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetrahedralMigration.java
+++ b/simulation/src/main/java/com/hellblazer/luciferase/simulation/bubble/TetrahedralMigration.java
@@ -362,6 +362,13 @@ public class TetrahedralMigration {
             return true;
 
         } catch (Exception e) {
+            // Any failure acquiring the mutation locks or executing phases 1-2 (lookup / add) lands
+            // here. Previously this returned false silently, making migration failures invisible and
+            // indistinguishable from a legitimate not-found/skip — log at WARN with context so they
+            // are observable (Luciferase-9jea5). The inner rollback catch above already logs the
+            // duplicate-state case at ERROR.
+            log.warn("Migration failed unexpectedly for entity {} ({} -> {})",
+                     entityId, srcBubble.id(), dstBubble.id(), e);
             return false;
         }
     }


### PR DESCRIPTION
## Summary
`TetrahedralMigration.executeMigration`'s outer `catch (Exception e) { return false; }` swallowed all exceptions silently — lock-acquisition and phase 1-2 (lookup/add) failures were invisible and indistinguishable from a legitimate not-found/skip. The inner rollback catch already logs the duplicate-state case at ERROR.

## Change
One line: `log.warn` with entity id + source/dest bubble ids + the throwable before `return false`. `srcBubble`/`dstBubble` are provably non-null at the catch site (earlier null guard returns early).

## Test
Observability-only; 31 existing `TetrahedralMigrationTest` pass unchanged. Code-review-expert approved — no forced-exception test warranted (no injection seam without reflection/heavy mocking, against the project's integration-over-mocks value).

Note: the `mergeBubbles`-vs-migration concurrency sub-claim from the audit was already shown unconfirmed (no production caller); and the silent `src/dst==null` early-return is a separate observability finding, not in this bead's scope.