### PR TITLE
fix(forest): null-guard getGlobalBounds() in split/merge strategies (Luciferase-drc6r)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/DynamicForestManager.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/forest/DynamicForestManager.java
@@ -176,6 +176,14 @@ public class DynamicForestManager<Key extends SpatialKey<Key>, ID extends Entity
         @Override
         public List<SplitSpecification> createSplits(TreeNode<Key, ID, Content> tree) {
             var bounds = tree.getGlobalBounds();
+            if (bounds == null) {
+                // No entity bounds yet -> no spatial extent to partition. globalBounds is expanded
+                // eagerly on every ForestEntityManager.insert, while entityCount is a lazily-refreshed
+                // cached stat; so in normal operation any tree reaching shouldSplit has already had
+                // entities inserted (which set globalBounds) and this branch is not hit. Retained as a
+                // null-safety barrier for direct/custom strategy callers (Luciferase-drc6r).
+                return List.of();
+            }
             var min = bounds.getMin();
             var max = bounds.getMax();
             
@@ -285,7 +293,15 @@ public class DynamicForestManager<Key extends SpatialKey<Key>, ID extends Entity
                                         TreeNode<Key, ID, Content> tree2) {
             var bounds1 = tree1.getGlobalBounds();
             var bounds2 = tree2.getGlobalBounds();
-            
+
+            // An empty tree (no entities) has null globalBounds and thus no spatial extent — it
+            // cannot be "spatially close" to anything. Underutilized selection (entityCount < min)
+            // includes such empty trees, so this is reachable; without the guard getMin() NPEs and
+            // the exception propagates out of checkAndMergeTrees (Luciferase-drc6r).
+            if (bounds1 == null || bounds2 == null) {
+                return false;
+            }
+
             // Check if bounds overlap or are adjacent
             var min1 = bounds1.getMin();
             var max1 = bounds1.getMax();
@@ -768,7 +784,11 @@ public class DynamicForestManager<Key extends SpatialKey<Key>, ID extends Entity
             var tree = forest.getTree(treeId);
             if (tree != null) {
                 var bounds = tree.getGlobalBounds();
-                if (containsPoint(bounds, position)) {
+                // Defensive null guard for consistency with the merge/split paths (Luciferase-drc6r).
+                // Not currently reachable — the sole caller (splitTree) passes octant trees whose
+                // bounds come from SplitSpecification (non-null by construction) — but a future caller
+                // passing a null-bounds tree would otherwise NPE inside containsPoint.
+                if (bounds != null && containsPoint(bounds, position)) {
                     // Prefer trees that tightly contain the position
                     var score = calculateContainmentScore(bounds, position);
                     if (score < bestScore) {

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/DynamicForestManagerTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/forest/DynamicForestManagerTest.java
@@ -248,7 +248,21 @@ public class DynamicForestManagerTest {
             "At least 98 entities must survive the split with intact content (use-after-remove "
                 + "regression Luciferase-22i71), but only " + survivorsWithIntactContent + " did");
     }
-    
+
+    @Test
+    void testCheckAndMergeToleratesNullBoundsTree() {
+        // Regression for Luciferase-drc6r: a tree created without entity bounds has null
+        // globalBounds and is "underutilized" (entityCount 0 < min), so it reaches
+        // UnderutilizedMergeStrategy.areSpatiallyClose, which dereferenced getGlobalBounds() and
+        // NPE'd — the exception propagated out of checkAndMergeTrees (it is called before the
+        // mergeTrees try/catch). The initial tree (with bounds) is paired against these.
+        dynamicManager.addTree(TreeMetadata.TreeType.OCTREE, "null-bounds-1", null);
+        dynamicManager.addTree(TreeMetadata.TreeType.OCTREE, "null-bounds-2", null);
+
+        assertDoesNotThrow(() -> dynamicManager.checkAndMergeTrees(),
+            "merge candidate scan must tolerate trees with null globalBounds");
+    }
+
     @Test
     void testMergeTrees() {
         // Create adjacent trees with few entities


### PR DESCRIPTION
## Summary
`TreeNode.globalBounds` is null until the first entity insert. A tree created without bounds (entityCount 0 < min) is 'underutilized', so `UnderutilizedMergeStrategy.areSpatiallyClose` dereferenced its null `getGlobalBounds()` → **NPE that propagated out of `checkAndMergeTrees`** (findMergeCandidates runs before any try/catch — the bead's "silent no-op" guess was wrong; it actually crashed the merge cycle).

## Change
- `areSpatiallyClose` → `false` when either bounds is null (empty tree has no spatial extent; still merges via the `hasNeighbor` path).
- `createSplits` → `List.of()` on null bounds (splitTree aborts cleanly on empty split list).
- `findBestTreeForPosition` → defensive null-skip for consistency; **verified not currently reachable** (sole caller passes non-null octant bounds).

## Test
`testCheckAndMergeToleratesNullBoundsTree`, proven non-vacuous (NPE on `bounds2.getMin()` without the guard).

## Stacked review
Both reviewers engaged. Code-review flagged the `findBestTreeForPosition` site (verified unreachable, guarded defensively). Critic flagged that the guard entrenches **empty-tree accumulation** (no reaper) — filed as a separate follow-up bead; this PR removes the crash, not the accumulation. createSplits comment corrected (globalBounds is eager, entityCount is a lazy cached stat).