### PR TITLE
feat(fault): bounded recovery retry policy honoring autoRecoveryEnabled + maxRecoveryRetries (Luciferase-ca07y)

### DIFF
--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/fault/FaultTolerantDistributedForest.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/fault/FaultTolerantDistributedForest.java
@@ -80,6 +80,11 @@ public class FaultTolerantDistributedForest<Key extends SpatialKey<Key>, ID exte
     // Partitions queued here when no immediate quorum but potential quorum exists
     private final Queue<UUID> recoveryQueue = new ConcurrentLinkedQueue<>();
 
+    // Per-partition count of failed recovery attempts, used to bound retries at
+    // configuration.maxRecoveryRetries() and give up (escalate) rather than retry forever
+    // (Luciferase-ca07y). Cleared on a successful recovery or on give-up.
+    private final Map<UUID, Integer> recoveryAttempts = new ConcurrentHashMap<>();
+
     // Optional callback for testing
     private Consumer<UUID> recoveryCallback;
 
@@ -434,6 +439,11 @@ public class FaultTolerantDistributedForest<Key extends SpatialKey<Key>, ID exte
             Thread.currentThread().interrupt();
         }
 
+        // Drop any in-flight retry bookkeeping so a stopped forest does not retain partition entries
+        // (Luciferase-ca07y).
+        recoveryQueue.clear();
+        recoveryAttempts.clear();
+
         log.info("FaultTolerantDistributedForest stopped");
     }
 
@@ -500,24 +510,41 @@ public class FaultTolerantDistributedForest<Key extends SpatialKey<Key>, ID exte
         int totalCount = topology.totalPartitions();
         int inProgressCount = recoveryLock.getInProgressRecoveryCount();
 
+        // Honor the autoRecoveryEnabled config (Luciferase-ca07y): when disabled, the SCHEDULING /
+        // QUEUEING of automatic recovery is skipped (callers drive recovery explicitly via
+        // triggerRecovery()). Quorum-loss detection + escalation (STATE 3) still fires unconditionally
+        // — disabling auto-recovery must not make a critically-degraded cluster go dark.
+        boolean autoRecover = configuration.autoRecoveryEnabled();
+
         // Check current quorum
         if (recoveryLock.hasQuorum(activeCount, totalCount)) {
-            // STATE 1: Current quorum exists - schedule recovery immediately
-            log.info("Partition {} failed - quorum maintained ({}/{} active). Scheduling recovery",
-                partitionId, activeCount, totalCount);
-            scheduleRecoveryAsync(partitionId);
+            // STATE 1: Current quorum exists - schedule recovery immediately (if auto-recovery is on)
+            if (autoRecover) {
+                log.info("Partition {} failed - quorum maintained ({}/{} active). Scheduling recovery",
+                    partitionId, activeCount, totalCount);
+                scheduleRecoveryAsync(partitionId);
+            } else {
+                log.debug("Partition {} failed - quorum maintained; autoRecoveryEnabled=false, "
+                    + "skipping automatic recovery", partitionId);
+            }
         } else {
             // Check potential quorum (including in-progress recoveries)
             int potentialActive = activeCount + inProgressCount;
 
             if (recoveryLock.hasQuorum(potentialActive, totalCount)) {
                 // STATE 2: Quorum lost NOW but WILL be restored when in-progress recoveries complete
-                log.warn("Partition {} failed - quorum lost but {} in-progress recoveries may restore it ({}/{} active + {}/{} in-progress -> {}/{})",
-                    partitionId, inProgressCount, activeCount, totalCount, inProgressCount, inProgressCount, potentialActive, totalCount);
-                recoveryQueue.offer(partitionId);
-                statsAccumulator.recordRecoveryQueued();
+                if (autoRecover) {
+                    log.warn("Partition {} failed - quorum lost but {} in-progress recoveries may restore it ({}/{} active + {}/{} in-progress -> {}/{})",
+                        partitionId, inProgressCount, activeCount, totalCount, inProgressCount, inProgressCount, potentialActive, totalCount);
+                    recoveryQueue.offer(partitionId);
+                    statsAccumulator.recordRecoveryQueued();
+                } else {
+                    log.warn("Partition {} failed - quorum lost; autoRecoveryEnabled=false, not queueing for recovery",
+                        partitionId);
+                }
             } else {
-                // STATE 3: Quorum permanently lost even with in-progress recoveries
+                // STATE 3: Quorum permanently lost even with in-progress recoveries. Always escalate,
+                // regardless of autoRecoveryEnabled.
                 log.error("QUORUM PERMANENTLY LOST - cannot recover partition {}. System degraded: {}/{} active, {} recovering (potential: {}/{})",
                     partitionId, activeCount, totalCount, inProgressCount, potentialActive, totalCount);
                 statsAccumulator.recordQuorumLoss();
@@ -536,18 +563,38 @@ public class FaultTolerantDistributedForest<Key extends SpatialKey<Key>, ID exte
             .thenAccept(success -> {
                 if (success) {
                     log.info("Async recovery completed successfully for partition {}", partitionId);
+                    recoveryAttempts.remove(partitionId); // reset the retry budget on success
 
                     // Check for queued recoveries when quorum potentially restored
                     synchronized (stateLock) {
                         checkQueuedRecoveries();
                     }
                 } else {
-                    log.warn("Async recovery failed for partition {}", partitionId);
-
-                    // Queue for retry with exponential backoff
-                    if (!recoveryQueue.contains(partitionId)) {
-                        log.debug("Queuing partition {} for retry after failure", partitionId);
-                        recoveryQueue.offer(partitionId);
+                    // Bound retries at configuration.maxRecoveryRetries() RETRIES beyond the initial
+                    // attempt: failedCount counts total failed attempts (1 on the first failure), so
+                    // re-queue while failedCount <= maxRetries (i.e. up to maxRetries retries after the
+                    // initial), otherwise give up loudly rather than retrying forever (Luciferase-ca07y).
+                    // NOTE (Option A): retries are drained ONLY opportunistically by checkQueuedRecoveries()
+                    // when another partition's recovery succeeds. If no other recovery ever succeeds
+                    // (e.g. total cluster failure), a re-queued partition stays queued without consuming
+                    // its budget — the accepted trade-off of the no-timer design. This callback and
+                    // checkQueuedRecoveries() both run on the single-threaded recoveryExecutor, so the
+                    // give-up dequeue cannot race a concurrent drain.
+                    int failedCount = recoveryAttempts.merge(partitionId, 1, Integer::sum);
+                    int maxRetries = configuration.maxRecoveryRetries();
+                    if (failedCount <= maxRetries) {
+                        log.warn("Async recovery failed for partition {} (failure {}, maxRetries {}); queuing for retry",
+                            partitionId, failedCount, maxRetries);
+                        if (!recoveryQueue.contains(partitionId)) {
+                            recoveryQueue.offer(partitionId);
+                        }
+                    } else {
+                        log.error("Async recovery for partition {} gave up after {} failed attempt(s) "
+                                + "(maxRecoveryRetries={}); manual intervention required",
+                            partitionId, failedCount, maxRetries);
+                        recoveryAttempts.remove(partitionId);
+                        recoveryQueue.remove(partitionId);
+                        statsAccumulator.recordRecoveryGivenUp();
                     }
                 }
             })

--- a/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/fault/FaultTolerantForestStats.java
+++ b/lucien/src/main/java/com/hellblazer/luciferase/lucien/balancing/fault/FaultTolerantForestStats.java
@@ -38,6 +38,7 @@ public record FaultTolerantForestStats(
         private final AtomicLong recoveriesBlocked = new AtomicLong();
         private final AtomicLong recoveriesQueued = new AtomicLong();  // Queued due to quorum loss
         private final AtomicLong quorumLosses = new AtomicLong();      // Permanent quorum loss events
+        private final AtomicLong recoveriesGivenUp = new AtomicLong(); // Retry budget exhausted (Luciferase-ca07y)
         private final AtomicLong totalDetectionLatency = new AtomicLong();
         private final AtomicLong totalRecoveryLatency = new AtomicLong();
 
@@ -114,6 +115,21 @@ public record FaultTolerantForestStats(
          */
         public void recordQuorumLossEscalation() {
             // Can be used for alerting metrics
+        }
+
+        /**
+         * Record a recovery that exhausted its retry budget (maxRecoveryRetries) and was abandoned.
+         * Distinct from quorum loss — this is recovery-strategy exhaustion (Luciferase-ca07y).
+         */
+        public void recordRecoveryGivenUp() {
+            recoveriesGivenUp.incrementAndGet();
+        }
+
+        /**
+         * Get count of recoveries abandoned after exhausting their retry budget.
+         */
+        public long getRecoveriesGivenUp() {
+            return recoveriesGivenUp.get();
         }
 
         /**

--- a/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/PhaseA2FaultTolerantDistributedForestTest.java
+++ b/lucien/src/test/java/com/hellblazer/luciferase/lucien/balancing/fault/PhaseA2FaultTolerantDistributedForestTest.java
@@ -607,6 +607,96 @@ class PhaseA2FaultTolerantDistributedForestTest {
     }
 
     /**
+     * Luciferase-ca07y: when autoRecoveryEnabled=false the forest must NOT auto-invoke recovery on
+     * a partition failure (recovery is then caller-driven via triggerRecovery()).
+     */
+    @Test
+    void testAutoRecoveryDisabledDoesNotScheduleRecovery() throws Exception {
+        var config = FaultConfiguration.defaultConfig().withAutoRecovery(false);
+        var partitions = new ArrayList<UUID>();
+        var recovery = TestRecoveryStrategy.success("should-not-run");
+        for (int i = 0; i < 5; i++) {
+            var p = UUID.randomUUID();
+            partitions.add(p);
+            faultHandler.registerRecovery(p, i == 2 ? recovery : TestRecoveryStrategy.success("ok-" + i));
+            faultHandler.markHealthy(p);
+        }
+        var topology = createTestTopology(5, partitions.toArray(UUID[]::new));
+        ftForest = new FaultTolerantDistributedForest<>(createTestDistributedForest(), faultHandler,
+            recoveryLock, new DefaultParallelBalancer<>(BalanceConfiguration.defaultConfig()),
+            mockGhostManager, topology, partitions.get(0), config, tracker);
+        ftForest.start();
+
+        var failed = partitions.get(2);
+        faultHandler.reportBarrierTimeout(failed); // HEALTHY -> SUSPECTED
+        faultHandler.reportBarrierTimeout(failed); // SUSPECTED -> FAILED
+
+        Thread.sleep(400); // generous window for any (incorrect) async recovery to have run
+        // Non-vacuity guard: confirm the failure events were actually processed (so a 0 attempt count
+        // reflects the gate, not undelivered events).
+        assertEquals(PartitionStatus.FAILED, faultHandler.checkHealth(failed),
+            "partition must actually be FAILED (events delivered)");
+        assertEquals(0, recovery.getAttemptCount(),
+            "autoRecoveryEnabled=false must not auto-invoke recovery (Luciferase-ca07y)");
+    }
+
+    /**
+     * Luciferase-ca07y: a permanently-failing recovery must be retried at most maxRecoveryRetries
+     * times (then give up), not retried forever. Retries are drained opportunistically when another
+     * partition recovers, so we pump a healthy partition's failure+recovery to drive them.
+     */
+    @Test
+    void testRecoveryRetriesBoundedByMaxRecoveryRetries() throws Exception {
+        int maxRetries = 2;
+        var config = FaultConfiguration.defaultConfig().withMaxRetries(maxRetries);
+        var partitions = new ArrayList<UUID>();
+        var failing = TestRecoveryStrategy.failure("always-fails");
+        for (int i = 0; i < 5; i++) {
+            var p = UUID.randomUUID();
+            partitions.add(p);
+            faultHandler.registerRecovery(p, i == 2 ? failing : TestRecoveryStrategy.success("ok-" + i));
+            faultHandler.markHealthy(p);
+        }
+        var topology = createTestTopology(5, partitions.toArray(UUID[]::new));
+        ftForest = new FaultTolerantDistributedForest<>(createTestDistributedForest(), faultHandler,
+            recoveryLock, new DefaultParallelBalancer<>(BalanceConfiguration.defaultConfig()),
+            mockGhostManager, topology, partitions.get(0), config, tracker);
+        ftForest.start();
+
+        var failed = partitions.get(2);
+        var pump = partitions.get(3);
+
+        // Initial failure -> attempt 1 (fails), queued for retry.
+        faultHandler.reportBarrierTimeout(failed);
+        faultHandler.reportBarrierTimeout(failed);
+        awaitAtLeast(() -> failing.getAttemptCount(), 1);
+
+        // Pump healthy-partition failures+recoveries; each successful recovery drains the queue and
+        // retries the failing partition. With <= semantics, maxRetries=2 means initial + 2 retries =
+        // 3 total attempts, then give up and dequeue. Pump more than enough times.
+        for (int i = 0; i < maxRetries + 4; i++) {
+            faultHandler.markHealthy(pump);
+            faultHandler.reportBarrierTimeout(pump);
+            faultHandler.reportBarrierTimeout(pump);
+            Thread.sleep(120);
+        }
+
+        int expectedTotal = maxRetries + 1; // initial attempt + maxRetries retries
+        awaitAtLeast(failing::getAttemptCount, expectedTotal);
+        assertEquals(expectedTotal, failing.getAttemptCount(),
+            "failing recovery must be attempted initial + maxRecoveryRetries times then give up "
+                + "(Luciferase-ca07y)");
+    }
+
+    private static void awaitAtLeast(java.util.function.IntSupplier value, int target) throws Exception {
+        var start = System.nanoTime();
+        while (value.getAsInt() < target && (System.nanoTime() - start) < 5_000_000_000L) {
+            Thread.sleep(10);
+        }
+        assertTrue(value.getAsInt() >= target, "expected at least " + target + " but was " + value.getAsInt());
+    }
+
+    /**
      * Test 4: Verify quorum calculation.
      *
      * <p>Validates that quorum is correctly calculated as majority (> 50%).


### PR DESCRIPTION
## Summary
`FaultConfiguration.autoRecoveryEnabled` and `maxRecoveryRetries` were declared but **never consulted**; a failed recovery was re-queued unconditionally (no cap, no give-up). This implements the bounded-retry policy (Option A — cap the existing event-driven retry, no new timer, user-confirmed).

## Change
- **autoRecoveryEnabled**: `handlePartitionFailure` gates STATE 1 (schedule) and STATE 2 (queue) on the flag; **STATE 3 quorum-loss escalation fires unconditionally** so a maintenance-mode cluster losing quorum is never silenced.
- **maxRecoveryRetries**: a per-partition `recoveryAttempts` map bounds retries — re-queue while `failedCount <= maxRecoveryRetries` (initial attempt + N retries), else **give up loudly** (ERROR + new `recordRecoveryGivenUp()` metric, distinct from quorum-loss) and dequeue. Cleared on success, give-up, and in `stop()`.
- Retries stay drained opportunistically by `checkQueuedRecoveries` when another partition recovers; the **stuck-forever** consequence (total cluster failure → never drained) is documented as the accepted no-timer trade-off.

## Tests (non-vacuous)
- `testAutoRecoveryDisabledDoesNotScheduleRecovery` — gate off → recovery not invoked (with a FAILED-state guard so it can't pass vacuously). Proven: without the gate, attempts 1 vs 0.
- `testRecoveryRetriesBoundedByMaxRecoveryRetries` — failing recovery attempted initial + maxRetries times then gives up. Proven: without the cap, 6 attempts vs the bounded 3.

Full fault suite green.

## Stacked review (round-2 clean)
The restructure closed a **CRITICAL** both reviewers caught: the first-cut `autoRecoveryEnabled` early-return had suppressed STATE 3 quorum-loss escalation. Round-2 critic CONFIRMED-SOUND — quorum-loss escalation unconditional, give-up/checkQueuedRecoveries confirmed non-racing (single-thread executor + mutually-exclusive lambda arms), observability + semantics + non-vacuity all resolved.